### PR TITLE
rpc: make api semantics more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ ./scripts/rpc.py send_money -rec bob -amt 1
 ./scripts/rpc.py call_method test_contract run_test
 
 # View state for Bob's account
-./scripts/rpc.py view bob
+./scripts/rpc.py view -a bob
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ ./scripts/rpc.py --help
 $ ./scripts/rpc.py send_money --help
 
 # Send money
-$ ./scripts/rpc.py send_money -rec bob -amt 1
+$ ./scripts/rpc.py send_money -r bob -a 1
 
 # Deploy a smart contract
 ./scripts/rpc.py deploy test_contract core/wasm/runtest/res/wasm_with_mem.wasm

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -4,12 +4,15 @@ version = "0.0.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 
 [dependencies]
+bincode = "1.0.0"
+bs58 = "0.2.0"
+byteorder = "1.2"
+exonum_sodiumoxide = "0.0.20"
 futures = "0.1"
+heapsize = "0.4"
 serde = "1.0"
 serde_derive = "1.0"
 sha2 = "0.7.0"
-exonum_sodiumoxide = "0.0.20"
-bincode = "1.0.0"
-heapsize = "0.4"
-byteorder = "1.2"
-bs58 = "0.2.0"
+
+[dev-dependencies]
+serde_json = "1.0"

--- a/core/primitives/src/hash.rs
+++ b/core/primitives/src/hash.rs
@@ -1,6 +1,8 @@
-use exonum_sodiumoxide::{self as sodiumoxide, crypto::hash::sha256::Digest};
+use bs58;
+use exonum_sodiumoxide as sodiumoxide;
+use exonum_sodiumoxide::crypto::hash::sha256::Digest;
+use heapsize;
 use std::fmt;
-
 use traits::Encode;
 
 #[derive(Copy, Clone, Eq, PartialOrd, Ord, PartialEq, Serialize, Deserialize, Hash)]
@@ -10,7 +12,13 @@ impl CryptoHash {
     pub fn new(data: &[u8]) -> Self {
         let mut d = [0; 32];
         d.copy_from_slice(data);
-        CryptoHash { 0: Digest(d) }
+        CryptoHash(Digest(d))
+    }
+}
+
+impl<'a> From<&'a CryptoHash> for String {
+    fn from(h: &'a CryptoHash) -> Self {
+        bs58::encode(h.0).into_string()
     }
 }
 
@@ -34,13 +42,50 @@ impl AsMut<[u8]> for CryptoHash {
 
 impl fmt::Debug for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", bs58::encode(self.0).into_string())
+        write!(f, "{}", String::from(self))
     }
 }
 
 impl fmt::Display for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", bs58::encode(self.0).into_string())
+        write!(f, "{}", String::from(self))
+    }
+}
+
+pub mod bs58_format {
+    use super::{bs58, CryptoHash};
+    use serde::{Deserialize, Serializer, Deserializer};
+    use serde::de;
+
+    pub fn serialize<S>(
+        crypto_hash: &CryptoHash,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+    {
+        serializer.serialize_str(String::from(crypto_hash).as_str())
+    }
+
+    pub fn deserialize<'de, D>(
+        deserializer: D,
+    ) -> Result<CryptoHash, D::Error>
+        where
+            D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match bs58::decode(s).into_vec() {
+            Ok(vec) => {
+                let mut array = [0; 32];
+                if vec.len() == array.len() {
+                    let bytes = &vec[..array.len()];
+                    Ok(CryptoHash::new(bytes))
+                } else {
+                    Err(de::Error::custom("invalid byte array length"))
+                }
+            }
+            Err(_) => Err(de::Error::custom("invalid base58 string")),
+        }
     }
 }
 
@@ -67,5 +112,51 @@ pub fn hash_struct<T: Encode>(obj: &T) -> CryptoHash {
 impl heapsize::HeapSizeOf for CryptoHash {
     fn heap_size_of_children(&self) -> usize {
         0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate serde_json;
+
+    use super::*;
+
+    #[derive(Deserialize, Serialize)]
+    struct Struct {
+        #[serde(with = "bs58_format")]
+        hash: CryptoHash,
+    }
+
+    #[test]
+    fn test_serialize_success() {
+        let hash = hash(&[0, 1, 2]);
+        let s = Struct { hash };
+        let encoded = serde_json::to_string(&s).unwrap();
+        assert_eq!(encoded, "{\"hash\":\"CjNSmWXTWhC3EhRVtqLhRmWMTkRbU96wUACqxMtV1uGf\"}");
+    }
+
+    #[test]
+    fn test_deserialize_success() {
+        let encoded = "{\"hash\":\"CjNSmWXTWhC3EhRVtqLhRmWMTkRbU96wUACqxMtV1uGf\"}";
+        let decoded: Struct = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.hash, hash(&[0, 1, 2]));
+    }
+
+    #[test]
+    fn test_deserialize_not_base58() {
+        let encoded = "\"---\"";
+        match serde_json::from_str(&encoded) {
+            Ok(CryptoHash(_)) => assert!(false, "should have failed"),
+            Err(_) => (),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_not_crypto_hash() {
+        let encoded = "\"CjNSmWXTWhC3ELhRmWMTkRbU96wUACqxMtV1uGf\"";
+        match serde_json::from_str(&encoded) {
+            Ok(CryptoHash(_)) => assert!(false, "should have failed"),
+            Err(_) => (),
+        }
     }
 }

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -198,13 +198,13 @@ impl Runtime {
                         if sender.amount < transaction.body.amount {
                             debug!(
                                 target: "runtime",
-                                "Account {} tries to stake {}, but only has {}",
+                                "Account {:?} tries to stake {:?}, but only has {}",
                                 transaction.body.sender,
                                 transaction.body.amount,
                                 sender.amount
                             );
                         } else {
-                            debug!(target: "runtime", "Account {} already staked", transaction.body.sender);
+                            debug!(target: "runtime", "Account {:?} already staked", transaction.body.sender);
                         }
                         false
                     }
@@ -224,7 +224,7 @@ impl Runtime {
                     } else {
                         debug!(
                             target: "runtime",
-                            "Account {} tries to send {}, but has staked {} and has {} in the account",
+                            "Account {:?} tries to send {:?}, but has staked {} and has {} in the account",
                             transaction.body.sender,
                             transaction.body.amount,
                             staked,
@@ -240,13 +240,13 @@ impl Runtime {
                     set(state_update, &account_id_to_bytes(transaction.body.receiver), &account);
                     true
                 } else {
-                    debug!("Receiver {} does not exist", transaction.body.receiver);
+                    debug!("Receiver {:?} does not exist", transaction.body.receiver);
                     false
                 }
             }
             _ => {
                 debug!(
-                    "Neither sender {} nor receiver {} exists",
+                    "Neither sender {:?} nor receiver {:?} exists",
                     transaction.body.sender, transaction.body.receiver
                 );
                 false

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -8,6 +8,8 @@ jsonrpc-core = { git = "https://github.com/paritytech/jsonrpc" }
 jsonrpc-macros = { git = "https://github.com/paritytech/jsonrpc" }
 jsonrpc-http-server = { git = "https://github.com/paritytech/jsonrpc" }
 parking_lot = "0.6.4"
+serde = "1.0"
+serde_derive = "1.0"
 tokio = "0.1.11"
 
 client = { path = "../client" }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -10,6 +10,7 @@ extern crate primitives;
 #[macro_use]
 extern crate serde_derive;
 extern crate tokio;
+extern crate serde;
 
 use client::Client;
 use futures::future;

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -7,6 +7,8 @@ extern crate jsonrpc_macros;
 extern crate network;
 extern crate parking_lot;
 extern crate primitives;
+#[macro_use]
+extern crate serde_derive;
 extern crate tokio;
 
 use client::Client;

--- a/node/service/src/rpc/api.rs
+++ b/node/service/src/rpc/api.rs
@@ -1,18 +1,26 @@
-use std::sync::Arc;
-
-use jsonrpc_core::{IoHandler, Result as JsonRpcResult};
-
 use client::Client;
+use jsonrpc_core::{IoHandler, Result as JsonRpcResult};
 use primitives::types::{SignedTransaction, TransactionBody, ViewCall, ViewCallResult};
+use rpc::types::SendMoneyRequest;
+use rpc::types::ViewAccountRequest;
+use std::sync::Arc;
+use rpc::types::DeployContractRequest;
+use rpc::types::CallMethodRequest;
 
 build_rpc_trait! {
     pub trait TransactionApi {
         /// Receive new transaction.
-        #[rpc(name = "receive_transaction")]
-        fn rpc_receive_transaction(&self, TransactionBody) -> JsonRpcResult<()>;
+        #[rpc(name = "send_money")]
+        fn rpc_send_money(&self, SendMoneyRequest) -> JsonRpcResult<()>;
         /// Call view function.
-        #[rpc(name = "view")]
-        fn rpc_view(&self, ViewCall) -> JsonRpcResult<ViewCallResult>;
+        #[rpc(name = "view_account")]
+        fn rpc_view_account(&self, ViewAccountRequest) -> JsonRpcResult<ViewCallResult>;
+        /// Deploy smart contract.
+        #[rpc(name = "deploy_contract")]
+        fn rpc_deploy_contract(&self, DeployContractRequest) -> JsonRpcResult<()>;
+        /// Call method on smart contract.
+        #[rpc(name = "call_method")]
+        fn rpc_call_method(&self, CallMethodRequest) -> JsonRpcResult<()>;
     }
 }
 
@@ -20,14 +28,57 @@ pub struct RpcImpl {
     pub client: Arc<Client>,
 }
 
+fn _generate_fake_signed_transaction(body: TransactionBody) -> SignedTransaction {
+    SignedTransaction::new(123, body)
+}
+
 impl TransactionApi for RpcImpl {
-    fn rpc_receive_transaction(&self, t: TransactionBody) -> JsonRpcResult<()> {
-        let transaction = SignedTransaction::new(123, t);
+    fn rpc_send_money(&self, r: SendMoneyRequest) -> JsonRpcResult<()> {
+        let body = TransactionBody {
+            nonce: r.nonce,
+            sender: r.sender_account_id,
+            receiver: r.receiver_account_id,
+            amount: r.amount,
+            method_name: String::new(),
+            args: Vec::new()
+        };
+        let transaction = _generate_fake_signed_transaction(body);
         Ok(self.client.receive_transaction(transaction))
     }
 
-    fn rpc_view(&self, v: ViewCall) -> JsonRpcResult<ViewCallResult> {
-        Ok(self.client.view_call(&v))
+    fn rpc_view_account(&self, r: ViewAccountRequest) -> JsonRpcResult<ViewCallResult> {
+        let call = ViewCall {
+            account: r.account_id,
+            method_name: String::new(),
+            args: Vec::new(),
+        };
+        Ok(self.client.view_call(&call))
+    }
+
+    fn rpc_deploy_contract(&self, r: DeployContractRequest) -> JsonRpcResult<()> {
+        let body = TransactionBody {
+            nonce: r.nonce,
+            sender: r.sender_account_id,
+            receiver: r.contract_account_id,
+            amount: 0,
+            method_name: "deploy".into(),
+            args: vec![r.wasm_byte_array],
+        };
+        let transaction = _generate_fake_signed_transaction(body);
+        Ok(self.client.receive_transaction(transaction))
+    }
+
+    fn rpc_call_method(&self, r: CallMethodRequest) -> JsonRpcResult<()> {
+        let body = TransactionBody {
+            nonce: r.nonce,
+            sender: r.sender_account_id,
+            receiver: r.contract_account_id,
+            amount: 0,
+            method_name: r.method_name,
+            args: r.args,
+        };
+        let transaction = _generate_fake_signed_transaction(body);
+        Ok(self.client.receive_transaction(transaction))
     }
 }
 
@@ -39,16 +90,12 @@ pub fn get_handler(rpc_impl: RpcImpl) -> IoHandler {
 
 #[cfg(test)]
 mod tests {
+    extern crate jsonrpc_test;
+
     use client::test_utils::generate_test_client;
     use primitives::hash::hash;
-    use primitives::types::TransactionBody;
-
-    use super::*;
-
     use self::jsonrpc_test::Rpc;
-
-    extern crate jsonrpc_test;
-    extern crate primitives;
+    use super::*;
 
     #[test]
     fn test_call() {
@@ -56,14 +103,12 @@ mod tests {
         let rpc_impl = RpcImpl { client };
         let handler = get_handler(rpc_impl);
         let rpc = Rpc::from(handler);
-        let t = TransactionBody {
+        let t = SendMoneyRequest {
             nonce: 0,
-            sender: hash(b"bob"),
-            receiver: hash(b"alice"),
-            amount: 0,
-            method_name: String::new(),
-            args: vec![],
+            sender_account_id: hash(b"alice"),
+            receiver_account_id: hash(b"bob"),
+            amount: 1,
         };
-        assert_eq!(rpc.request("receive_transaction", &[t]), "null");
+        assert_eq!(rpc.request("send_money", &[t]), "null");
     }
 }

--- a/node/service/src/rpc/mod.rs
+++ b/node/service/src/rpc/mod.rs
@@ -1,2 +1,3 @@
 pub mod api;
 pub mod server;
+mod types;

--- a/node/service/src/rpc/types.rs
+++ b/node/service/src/rpc/types.rs
@@ -1,9 +1,12 @@
+use primitives::hash::bs58_format;
 use primitives::types::AccountId;
 
 #[derive(Serialize, Deserialize)]
 pub struct SendMoneyRequest {
     pub nonce: u64,
+    #[serde(with = "bs58_format")]
     pub sender_account_id: AccountId,
+    #[serde(with = "bs58_format")]
     pub receiver_account_id: AccountId,
     pub amount: u64,
 }
@@ -11,7 +14,9 @@ pub struct SendMoneyRequest {
 #[derive(Serialize, Deserialize)]
 pub struct DeployContractRequest {
     pub nonce: u64,
+    #[serde(with = "bs58_format")]
     pub sender_account_id: AccountId,
+    #[serde(with = "bs58_format")]
     pub contract_account_id: AccountId,
     pub wasm_byte_array: Vec<u8>,
 }
@@ -19,7 +24,9 @@ pub struct DeployContractRequest {
 #[derive(Serialize, Deserialize)]
 pub struct CallMethodRequest {
     pub nonce: u64,
+    #[serde(with = "bs58_format")]
     pub sender_account_id: AccountId,
+    #[serde(with = "bs58_format")]
     pub contract_account_id: AccountId,
     pub method_name: String,
     pub args: Vec<Vec<u8>>,
@@ -27,5 +34,13 @@ pub struct CallMethodRequest {
 
 #[derive(Serialize, Deserialize)]
 pub struct ViewAccountRequest {
+    #[serde(with = "bs58_format")]
     pub account_id: AccountId,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ViewAccountResponse {
+    #[serde(with = "bs58_format")]
+    pub account_id: AccountId,
+    pub nonce: u64,
 }

--- a/node/service/src/rpc/types.rs
+++ b/node/service/src/rpc/types.rs
@@ -1,0 +1,31 @@
+use primitives::types::AccountId;
+
+#[derive(Serialize, Deserialize)]
+pub struct SendMoneyRequest {
+    pub nonce: u64,
+    pub sender_account_id: AccountId,
+    pub receiver_account_id: AccountId,
+    pub amount: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct DeployContractRequest {
+    pub nonce: u64,
+    pub sender_account_id: AccountId,
+    pub contract_account_id: AccountId,
+    pub wasm_byte_array: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CallMethodRequest {
+    pub nonce: u64,
+    pub sender_account_id: AccountId,
+    pub contract_account_id: AccountId,
+    pub method_name: String,
+    pub args: Vec<Vec<u8>>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ViewAccountRequest {
+    pub account_id: AccountId,
+}

--- a/node/service/src/rpc/types.rs
+++ b/node/service/src/rpc/types.rs
@@ -22,7 +22,7 @@ pub struct DeployContractRequest {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct CallMethodRequest {
+pub struct ScheduleFunctionCallRequest {
     pub nonce: u64,
     #[serde(with = "bs58_format")]
     pub sender_account_id: AccountId,
@@ -42,5 +42,23 @@ pub struct ViewAccountRequest {
 pub struct ViewAccountResponse {
     #[serde(with = "bs58_format")]
     pub account_id: AccountId,
+    pub amount: u64,
     pub nonce: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CallViewFunctionRequest {
+    #[serde(with = "bs58_format")]
+    pub contract_account_id: AccountId,
+    pub method_name: String,
+    pub args: Vec<Vec<u8>>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct CallViewFunctionResponse {
+    #[serde(with = "bs58_format")]
+    pub account_id: AccountId,
+    pub amount: u64,
+    pub nonce: u64,
+    pub result: Vec<u8>,
 }

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -12,12 +12,12 @@ except ImportError:
     import json as json_lib
 
 
-    def post(url, json):
+    def _post(url, json):
         """This is alternative to requests.post"""
         handler = urllib2.HTTPHandler()
         opener = urllib2.build_opener(handler)
         request = urllib2.Request(url, data=json_lib.dumps(json))
-        request.add_header("Content-Type", "application/json")
+        request.add_header('Content-Type', 'application/json')
         try:
             connection = opener.open(request)
         except urllib2.HTTPError as e:
@@ -26,75 +26,89 @@ except ImportError:
             data = connection.read()
             return json_lib.loads(data)
         else:
-            return {"error": connection}
+            return {'error': connection}
 else:
     import requests
 
 
-    def post(url, json):
+    def _post(url, json):
         return requests.post(url, json=json).json()
 
 
-def near_hash(s):
-    digest = hashlib.sha256(s.encode('utf-8')).digest()
+def _get_account_id(account_alias):
+    digest = hashlib.sha256(account_alias.encode('utf-8')).digest()
     return list(bytearray(digest))
 
 
 class NearRPC(object):
     def __init__(self, server_url):
         self.server_url = server_url
-        self.nonce = None
+        self._nonces = {}
 
-    def view(self, account_id):
+    def _get_nonce(self, sender):
+        if sender not in self._nonces:
+            view_result = self.view_account(sender)
+            self._nonces[sender] = view_result['result'].get('nonce', 0) + 1
+
+        return self._nonces[sender]
+
+    def _update_nonce(self, sender):
+        self._nonces[sender] += 1
+
+    def _call_rpc(self, method_name, params):
         data = {
-            "jsonrpc": "2.0", "id": 1, "method": "view",
-            "params": [{"account": near_hash(account_id), "method_name": "", "args": []}]
+            'jsonrpc': '2.0',
+            'id': 1,
+            'method': method_name,
+            'params': [params],
         }
-        return post(self.server_url, json=data)
-
-    def _send_transaction(self, sender, receiver, amount, method_name, args):
-        if self.nonce is None:
-            view_result = self.view(sender)
-            self.nonce = view_result['result'].get('nonce', 0) + 1
-
-        data = {
-            "jsonrpc": "2.0", "id": 1, "method": "receive_transaction",
-            "params": [
-                {
-                    "nonce": self.nonce,
-                    "sender": near_hash(sender),
-                    "receiver": near_hash(receiver),
-                    "amount": amount,
-                    "method_name": method_name,
-                    "args": args
-                }
-            ]
-        }
-        self.nonce += 1
-        return post(self.server_url, json=data)
+        return _post(self.server_url, data)
 
     def send_money(self, sender, receiver, amount):
-        return self._send_transaction(sender, receiver, amount, '', [])
+        nonce = self._get_nonce(sender)
+        params = {
+            'nonce': nonce,
+            'sender_account_id': _get_account_id(sender),
+            'receiver_account_id': _get_account_id(receiver),
+            'amount': amount,
+        }
+        self._update_nonce(sender)
+        return self._call_rpc('send_money', params)
 
-    def call_function(self, contract_name, method_name, args):
-        return self._send_transaction(
-            contract_name,
-            contract_name,
-            0,
-            method_name,
-            args,
-        )
+    def view_account(self, account_alias):
+        params = {
+            'account_id': _get_account_id(account_alias),
+        }
+        return self._call_rpc('view_account', params)
 
-    def deploy_contract(self, contract_name, wasm_file):
+    def call_method(self, sender, contract_name, method_name, args=None):
+        if args is None:
+            args = [[]]
+
+        nonce = self._get_nonce(sender)
+        params = {
+            'nonce': nonce,
+            'sender_account_id': _get_account_id(sender),
+            'contract_account_id': _get_account_id(contract_name),
+            'method_name': method_name,
+            'args': args,
+        }
+        self._update_nonce(sender)
+        return self._call_rpc('call_method', params)
+
+    def deploy_contract(self, sender, contract_name, wasm_file):
         with open(wasm_file, 'rb') as f:
-            content = list(bytearray(f.read()))
-        return self._send_transaction(
-            contract_name,
-            contract_name,
-            0,
-            'deploy',
-            [content],
-        )
+            wasm_byte_array = list(bytearray(f.read()))
+
+        nonce = self._get_nonce(sender)
+        params = {
+            'nonce': nonce,
+            'sender_account_id': _get_account_id(sender),
+            'contract_account_id': _get_account_id(contract_name),
+            'wasm_byte_array':  wasm_byte_array,
+        }
+        self._update_nonce(sender)
+        return self._call_rpc('deploy_contract', params)
 
 
 class MultiCommandParser(object):
@@ -126,7 +140,7 @@ view            {}
             print(getattr(self, args.command)())
 
     @staticmethod
-    def _get_command_parser(description):
+    def _get_command_parser(description, include_sender=True):
         parser = argparse.ArgumentParser(
             description=description,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -138,6 +152,15 @@ view            {}
             default='http://127.0.0.1:3030',
             help='url of RPC server',
         )
+        if include_sender:
+            parser.add_argument(
+                '-s',
+                '--sender',
+                type=str,
+                default='alice',
+                help='account alias of sender',
+            )
+
         return parser
 
     @staticmethod
@@ -153,13 +176,6 @@ view            {}
     def send_money(self):
         """Send money from one account to another"""
         parser = self._get_command_parser(self.send_money.__doc__)
-        parser.add_argument(
-            '-s',
-            '--sender',
-            type=str,
-            default='alice',
-            help='account alias of issuer',
-        )
         parser.add_argument(
             '-r',
             '--receiver',
@@ -186,6 +202,7 @@ view            {}
         args = self._get_command_args(parser)
         client = self._get_rpc_client(args)
         return client.deploy_contract(
+            args.sender,
             args.contract_name,
             args.wasm_file_location,
         )
@@ -197,15 +214,15 @@ view            {}
         parser.add_argument('method_name', type=str)
         args = self._get_command_args(parser)
         client = self._get_rpc_client(args)
-        return client.call_function(
+        return client.call_method(
+            args.sender,
             args.contract_name,
             args.method_name,
-            args=[],
         )
 
     def view(self):
         """View an account"""
-        parser = self._get_command_parser(self.view.__doc__)
+        parser = self._get_command_parser(self.view.__doc__, include_sender=False)
         parser.add_argument(
             '-a',
             '--account',
@@ -215,7 +232,7 @@ view            {}
         )
         args = self._get_command_args(parser)
         client = self._get_rpc_client(args)
-        return client.view(args.account)
+        return client.view_account(args.account)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes https://github.com/nearprotocol/nearcore/issues/92

i think this is a step in the right direction of https://github.com/nearprotocol/nearcore/issues/93 .. it would  be nice if the client could have these interfaces also, but that seems like it will require a bit more massaging.

note: this also fixes the breaking changes i made to the script you were seeing @ilblackdragon 