### PR TITLE
Add Misbehaviour trait

### DIFF
--- a/core/txflow/src/dag/mod.rs
+++ b/core/txflow/src/dag/mod.rs
@@ -7,7 +7,7 @@ use primitives::types::*;
 use std::collections::HashSet;
 
 use self::message::Message;
-pub use self::reporter::*;
+pub use self::reporter::{MisbehaviourReporter, DAGMisbehaviourReporter, NoopMisbehaviourReporter, ViolationType};
 use typed_arena::Arena;
 
 /// The data-structure of the TxFlow DAG that supports adding messages and updating counters/flags,
@@ -202,16 +202,6 @@ mod tests {
         }
     }
 
-    /// MisbehaviourReporter that ignore all information stored
-    struct FakeMisbehaviourReporter{
-    }
-
-    impl MisbehaviourReporter for FakeMisbehaviourReporter{
-        fn new() -> Self{}
-
-        fn report(&mut self, violation: ViolationType) {}
-    }
-
     #[test]
     fn incorrect_epoch_simple() {
         let selector = FakeWitnessSelector::new();
@@ -249,7 +239,7 @@ mod tests {
         // with smaller epochs it creates them.
 
         let selector = FakeWitnessSelector::new();
-        let mut misbehaviour = FakeMisbehaviourReporter::new();
+        let mut misbehaviour = NoopMisbehaviourReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
         let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
@@ -274,7 +264,7 @@ mod tests {
 
     fn feed_complex_topology() {
         let selector = FakeWitnessSelector::new();
-        let mut misbehaviour = FakeMisbehaviourReporter::new();
+        let mut misbehaviour = NoopMisbehaviourReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
         let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
@@ -292,7 +282,7 @@ mod tests {
     #[test]
     fn check_missing_messages_as_feeding() {
         let selector = FakeWitnessSelector::new();
-        let mut misbehaviour = FakeMisbehaviourReporter::new();
+        let mut misbehaviour = NoopMisbehaviourReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
         let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
@@ -321,7 +311,7 @@ mod tests {
     #[test]
     fn create_roots() {
         let selector = FakeWitnessSelector::new();
-        let mut misbehaviour = FakeMisbehaviourReporter::new();
+        let mut misbehaviour = NoopMisbehaviourReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
         let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
@@ -346,7 +336,7 @@ mod tests {
     #[test]
     fn movable() {
         let selector = FakeWitnessSelector::new();
-        let mut misbehaviour = FakeMisbehaviourReporter::new();
+        let mut misbehaviour = NoopMisbehaviourReporter::new();
         let data_arena = Arena::new();
         let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
         let (a, b);

--- a/core/txflow/src/dag/mod.rs
+++ b/core/txflow/src/dag/mod.rs
@@ -207,12 +207,9 @@ mod tests {
     }
 
     impl MisbehaviourReporter for FakeMisbehaviourReporter{
-        fn new() -> Self{
-            FakeMisbehaviourReporter {}
-        }
+        fn new() -> Self{}
 
-        fn report(&mut self, violation: ViolationType) {
-        }
+        fn report(&mut self, violation: ViolationType) {}
     }
 
     #[test]

--- a/core/txflow/src/dag/mod.rs
+++ b/core/txflow/src/dag/mod.rs
@@ -9,13 +9,14 @@ use std::collections::HashSet;
 use self::message::Message;
 pub use self::reporter::{MisbehaviorReporter, DAGMisbehaviorReporter, NoopMisbehaviorReporter, ViolationType};
 use typed_arena::Arena;
+use std::cell::RefCell;
 
 /// The data-structure of the TxFlow DAG that supports adding messages and updating counters/flags,
 /// but does not support communication-related logic. Also does verification of the messages
 /// received from other nodes and store detected violations.
 /// It uses unsafe code to implement a self-referential struct and the interface makes sure that
 /// the references never outlive the instances.
-pub struct DAG<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + MisbehaviorReporter> {
+pub struct DAG<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + MisbehaviorReporter = NoopMisbehaviorReporter> {
     /// UID of the node.
     owner_uid: UID,
     arena: Arena<Box<Message<'a, P>>>,
@@ -27,13 +28,11 @@ pub struct DAG<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + Misbehavior
     witness_selector: &'a W,
     starting_epoch: u64,
 
-    misbehavior: &'a mut M,
+    misbehavior: RefCell<M>,
 }
 
 impl<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + MisbehaviorReporter> DAG<'a, P, W, M> {
-    pub fn new(owner_uid: UID, starting_epoch: u64, witness_selector: &'a W,
-                misbehavior: &'a mut M,
-                ) -> Self {
+    pub fn new(owner_uid: UID, starting_epoch: u64, witness_selector: &'a W, misbehavior: RefCell<M>) -> Self {
         DAG {
             owner_uid,
             arena: Arena::new(),
@@ -92,7 +91,7 @@ impl<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + MisbehaviorReporter> 
                 message: message.computed_hash.clone(),
             };
 
-            self.misbehavior.report(mb);
+            self.misbehavior.borrow_mut().report(mb);
         }
 
         Ok({})
@@ -205,10 +204,10 @@ mod tests {
     #[test]
     fn incorrect_epoch_simple() {
         let selector = FakeWitnessSelector::new();
-        let mut misbehavior = DAGMisbehaviorReporter::new();
+        let misbehavior = DAGMisbehaviorReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
-        let mut dag = DAG::new(0, 0, &selector, &mut misbehavior);
+        let mut dag = DAG::new(0, 0, &selector, RefCell::new(misbehavior));
 
         // Parent have greater epoch than children
         let (a, b);
@@ -222,9 +221,9 @@ mod tests {
         }
 
         // Both messages have invalid epoch number so two reports were made
-        assert_eq!(dag.misbehavior.violations.len(), 2);
+        assert_eq!(dag.misbehavior.borrow().violations.len(), 2);
 
-        for violation in &dag.misbehavior.violations {
+        for violation in &dag.misbehavior.borrow().violations {
             if let ViolationType::BadEpoch { message: _ } = violation {
                 // expected violation type
             } else {
@@ -239,10 +238,10 @@ mod tests {
         // with smaller epochs it creates them.
 
         let selector = FakeWitnessSelector::new();
-        let mut misbehavior = NoopMisbehaviorReporter::new();
+        let misbehavior = NoopMisbehaviorReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
-        let mut dag = DAG::new(0, 0, &selector, &mut misbehavior);
+        let mut dag = DAG::new(0, 0, &selector, RefCell::new(misbehavior));
 
         let (a, b);
         simple_bare_messages!(data_arena, all_messages [[0, 0; 1, 0; 3, 0;] => 0, 1 => a;]);
@@ -264,10 +263,10 @@ mod tests {
 
     fn feed_complex_topology() {
         let selector = FakeWitnessSelector::new();
-        let mut misbehavior = NoopMisbehaviorReporter::new();
+        let misbehavior = NoopMisbehaviorReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
-        let mut dag = DAG::new(0, 0, &selector, &mut misbehavior);
+        let mut dag = DAG::new(0, 0, &selector, RefCell::new(misbehavior));
         let (a, b);
         simple_bare_messages!(data_arena, all_messages [[0, 0 => a; 1, 2;] => 2, 3 => b;]);
         simple_bare_messages!(data_arena, all_messages [[=> a; 3, 4;] => 4, 5;]);
@@ -282,10 +281,10 @@ mod tests {
     #[test]
     fn check_missing_messages_as_feeding() {
         let selector = FakeWitnessSelector::new();
-        let mut misbehavior = NoopMisbehaviorReporter::new();
+        let misbehavior = NoopMisbehaviorReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
-        let mut dag = DAG::new(0, 0, &selector, &mut misbehavior);
+        let mut dag = DAG::new(0, 0, &selector, RefCell::new(misbehavior));
         let (a, b, c, d, e);
         simple_bare_messages!(data_arena, all_messages [[0, 0 => a; 1, 2 => b;] => 2, 3 => c;]);
         simple_bare_messages!(data_arena, all_messages [[=> a; 3, 4 => d;] => 4, 5 => e;]);
@@ -311,10 +310,10 @@ mod tests {
     #[test]
     fn create_roots() {
         let selector = FakeWitnessSelector::new();
-        let mut misbehavior = NoopMisbehaviorReporter::new();
+        let misbehavior = NoopMisbehaviorReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
-        let mut dag = DAG::new(0, 0, &selector, &mut misbehavior);
+        let mut dag = DAG::new(0, 0, &selector, RefCell::new(misbehavior));
         let (a, b, c, d, e);
         simple_bare_messages!(data_arena, all_messages [[0, 0 => a; 1, 2 => b;] => 2, 3 => c;]);
 
@@ -336,9 +335,9 @@ mod tests {
     #[test]
     fn movable() {
         let selector = FakeWitnessSelector::new();
-        let mut misbehavior = NoopMisbehaviorReporter::new();
+        let misbehavior = NoopMisbehaviorReporter::new();
         let data_arena = Arena::new();
-        let mut dag = DAG::new(0, 0, &selector, &mut misbehavior);
+        let mut dag = DAG::new(0, 0, &selector, RefCell::new(misbehavior));
         let (a, b);
         // Add some messages.
         {

--- a/core/txflow/src/dag/mod.rs
+++ b/core/txflow/src/dag/mod.rs
@@ -88,13 +88,13 @@ impl<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + MisbehaviorReporter> 
         // Check epoch
         if message.computed_epoch != message.data.body.epoch {
             let mb = ViolationType::BadEpoch {
-                message: message.computed_hash.clone(),
+                message: message.computed_hash,
             };
 
             self.misbehavior.borrow_mut().report(mb);
         }
 
-        Ok({})
+        Ok(())
     }
 
     // Takes ownership of the message.
@@ -104,7 +104,7 @@ impl<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + MisbehaviorReporter> 
     ) -> Result<(), &'static str> {
         // Check whether this is a new message.
         if self.messages.contains(&message_data.hash) {
-            return Ok({});
+            return Ok(());
         }
 
         // Wrap message data and connect to the parents so that the verification can be run.
@@ -135,7 +135,7 @@ impl<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + MisbehaviorReporter> 
         let message_ptr = self.arena.alloc(message).as_ref() as *const Message<'a, P>;
         self.messages.insert(unsafe{&*message_ptr});
         self.roots.insert(unsafe{&*message_ptr});
-        Ok({})
+        Ok(())
     }
 
     /// Creates a new message that points to all existing roots. Takes ownership of the payload and

--- a/core/txflow/src/dag/mod.rs
+++ b/core/txflow/src/dag/mod.rs
@@ -1,4 +1,5 @@
 mod message;
+mod reporter;
 
 use primitives::traits::{Payload, WitnessSelector};
 use primitives::types::*;
@@ -6,14 +7,15 @@ use primitives::types::*;
 use std::collections::HashSet;
 
 use self::message::Message;
+pub use self::reporter::*;
 use typed_arena::Arena;
 
 /// The data-structure of the TxFlow DAG that supports adding messages and updating counters/flags,
 /// but does not support communication-related logic. Also does verification of the messages
-/// received from other nodes.
+/// received from other nodes and store detected violations.
 /// It uses unsafe code to implement a self-referential struct and the interface makes sure that
 /// the references never outlive the instances.
-pub struct DAG<'a, P: 'a + Payload, W: 'a + WitnessSelector> {
+pub struct DAG<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + MisbehaviourReporter> {
     /// UID of the node.
     owner_uid: UID,
     arena: Arena<Box<Message<'a, P>>>,
@@ -24,10 +26,14 @@ pub struct DAG<'a, P: 'a + Payload, W: 'a + WitnessSelector> {
 
     witness_selector: &'a W,
     starting_epoch: u64,
+
+    misbehaviour: &'a mut M,
 }
 
-impl<'a, P: 'a + Payload, W: 'a + WitnessSelector> DAG<'a, P, W> {
-    pub fn new(owner_uid: UID, starting_epoch: u64, witness_selector: &'a W) -> Self {
+impl<'a, P: 'a + Payload, W: 'a + WitnessSelector, M: 'a + MisbehaviourReporter> DAG<'a, P, W, M> {
+    pub fn new(owner_uid: UID, starting_epoch: u64, witness_selector: &'a W,
+                misbehaviour: &'a mut M,
+                ) -> Self {
         DAG {
             owner_uid,
             arena: Arena::new(),
@@ -35,6 +41,7 @@ impl<'a, P: 'a + Payload, W: 'a + WitnessSelector> DAG<'a, P, W> {
             roots: HashSet::new(),
             witness_selector,
             starting_epoch,
+            misbehaviour,
         }
     }
 
@@ -76,7 +83,18 @@ impl<'a, P: 'a + Payload, W: 'a + WitnessSelector> DAG<'a, P, W> {
     }
 
     /// Verify that this message does not violate the protocol.
-    fn verify_message(&mut self, _message: &Message<'a, P>) -> Result<(), &'static str> {
+    fn verify_message(
+        &mut self, message: &Message<'a, P>) -> Result<(), &'static str> {
+
+        // Check epoch
+        if message.computed_epoch != message.data.body.epoch {
+            let mb = ViolationType::BadEpoch {
+                message: message.computed_hash.clone(),
+            };
+
+            self.misbehaviour.report(mb);
+        }
+
         Ok({})
     }
 
@@ -184,12 +202,85 @@ mod tests {
         }
     }
 
+    /// MisbehaviourReporter that ignore all information stored
+    struct FakeMisbehaviourReporter{
+    }
+
+    impl MisbehaviourReporter for FakeMisbehaviourReporter{
+        fn new() -> Self{
+            FakeMisbehaviourReporter {}
+        }
+
+        fn report(&mut self, violation: ViolationType) {
+        }
+    }
+
     #[test]
-    fn feed_complex_topology() {
+    fn incorrect_epoch_simple() {
         let selector = FakeWitnessSelector::new();
+        let mut misbehaviour = DAGMisbehaviourReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
-        let mut dag = DAG::new(0, 0, &selector);
+        let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
+
+        // Parent have greater epoch than children
+        let (a, b);
+        simple_bare_messages!(data_arena, all_messages [[1, 2 => a;] => 1, 1 => b;]);
+
+        assert!(dag.add_existing_message((*a).clone()).is_ok());
+        assert!(dag.add_existing_message((*b).clone()).is_ok());
+
+        for message in &dag.messages {
+            assert_eq!(message.computed_epoch, 0);
+        }
+
+        // Both messages have invalid epoch number so two reports were made
+        assert_eq!(dag.misbehaviour.violations.len(), 2);
+
+        for violation in &dag.misbehaviour.violations {
+            if let ViolationType::BadEpoch { message: _ } = violation {
+                // expected violation type
+            } else {
+                assert!(false);
+            }
+        }
+    }
+
+    #[test]
+    fn correct_epoch_complex() {
+        // When a message can have epoch k, but since it doesn't have messages
+        // with smaller epochs it creates them.
+
+        let selector = FakeWitnessSelector::new();
+        let mut misbehaviour = FakeMisbehaviourReporter::new();
+        let data_arena = Arena::new();
+        let mut all_messages = vec![];
+        let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
+
+        let (a, b);
+        simple_bare_messages!(data_arena, all_messages [[0, 0; 1, 0; 3, 0;] => 0, 1 => a;]);
+        simple_bare_messages!(data_arena, all_messages [[=> a;] => 3, 2 => b;]);
+
+        for m in &all_messages {
+            assert!(dag.add_existing_message((*m).clone()).is_ok());
+        }
+
+        for message in &dag.messages {
+            if message.computed_hash != b.hash {
+                assert_eq!(message.computed_epoch, message.data.body.epoch);
+            }
+            else{
+                assert_eq!(message.computed_epoch, 1);
+            }
+        }
+    }
+
+    fn feed_complex_topology() {
+        let selector = FakeWitnessSelector::new();
+        let mut misbehaviour = FakeMisbehaviourReporter::new();
+        let data_arena = Arena::new();
+        let mut all_messages = vec![];
+        let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
         let (a, b);
         simple_bare_messages!(data_arena, all_messages [[0, 0 => a; 1, 2;] => 2, 3 => b;]);
         simple_bare_messages!(data_arena, all_messages [[=> a; 3, 4;] => 4, 5;]);
@@ -204,9 +295,10 @@ mod tests {
     #[test]
     fn check_missing_messages_as_feeding() {
         let selector = FakeWitnessSelector::new();
+        let mut misbehaviour = FakeMisbehaviourReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
-        let mut dag = DAG::new(0, 0, &selector);
+        let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
         let (a, b, c, d, e);
         simple_bare_messages!(data_arena, all_messages [[0, 0 => a; 1, 2 => b;] => 2, 3 => c;]);
         simple_bare_messages!(data_arena, all_messages [[=> a; 3, 4 => d;] => 4, 5 => e;]);
@@ -232,9 +324,10 @@ mod tests {
     #[test]
     fn create_roots() {
         let selector = FakeWitnessSelector::new();
+        let mut misbehaviour = FakeMisbehaviourReporter::new();
         let data_arena = Arena::new();
         let mut all_messages = vec![];
-        let mut dag = DAG::new(0, 0, &selector);
+        let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
         let (a, b, c, d, e);
         simple_bare_messages!(data_arena, all_messages [[0, 0 => a; 1, 2 => b;] => 2, 3 => c;]);
 
@@ -255,9 +348,10 @@ mod tests {
     // Test whether our implementation of a self-referential struct is movable.
     #[test]
     fn movable() {
-        let data_arena = Arena::new();
         let selector = FakeWitnessSelector::new();
-        let mut dag = DAG::new(0, 0, &selector);
+        let mut misbehaviour = FakeMisbehaviourReporter::new();
+        let data_arena = Arena::new();
+        let mut dag = DAG::new(0, 0, &selector, &mut misbehaviour);
         let (a, b);
         // Add some messages.
         {

--- a/core/txflow/src/dag/reporter.rs
+++ b/core/txflow/src/dag/reporter.rs
@@ -33,8 +33,7 @@ impl MisbehaviorReporter for NoopMisbehaviorReporter{
         Self {}
     }
 
-    fn report(&mut self, violation: ViolationType) {
-
+    fn report(&mut self, _violation: ViolationType) {
     }
 }
 

--- a/core/txflow/src/dag/reporter.rs
+++ b/core/txflow/src/dag/reporter.rs
@@ -23,6 +23,21 @@ impl MisbehaviourReporter for DAGMisbehaviourReporter{
     }
 }
 
+
+/// MisbehaviourReporter that ignore all information stored
+pub struct NoopMisbehaviourReporter{
+}
+
+impl MisbehaviourReporter for NoopMisbehaviourReporter{
+    fn new() -> Self{
+        Self {}
+    }
+
+    fn report(&mut self, violation: ViolationType) {
+
+    }
+}
+
 /// TODO: Enumerate all violations and implement evidence to check that the
 /// misbehaviour really took place.
 #[derive(Debug)]

--- a/core/txflow/src/dag/reporter.rs
+++ b/core/txflow/src/dag/reporter.rs
@@ -3,18 +3,18 @@ use primitives::types::*;
 /// This structure is used to keep track of all violations detected on the network.
 /// Not necessarily restricted to violations regarding TxFlow protocol,
 /// but any kind of violation as enumerated in ViolationType
-pub trait MisbehaviourReporter {
+pub trait MisbehaviorReporter {
     fn new() -> Self;
     fn report(&mut self, violation: ViolationType);
 }
 
-pub struct DAGMisbehaviourReporter {
+pub struct DAGMisbehaviorReporter {
     pub violations: Vec<ViolationType>,
 }
 
-impl MisbehaviourReporter for DAGMisbehaviourReporter{
+impl MisbehaviorReporter for DAGMisbehaviorReporter{
     fn new() -> Self {
-        DAGMisbehaviourReporter { violations: vec![] }
+        DAGMisbehaviorReporter { violations: vec![] }
     }
 
     /// Take ownership of the violation
@@ -24,11 +24,11 @@ impl MisbehaviourReporter for DAGMisbehaviourReporter{
 }
 
 
-/// MisbehaviourReporter that ignore all information stored
-pub struct NoopMisbehaviourReporter{
+/// MisbehaviorReporter that ignore all information stored
+pub struct NoopMisbehaviorReporter{
 }
 
-impl MisbehaviourReporter for NoopMisbehaviourReporter{
+impl MisbehaviorReporter for NoopMisbehaviorReporter{
     fn new() -> Self{
         Self {}
     }
@@ -39,7 +39,7 @@ impl MisbehaviourReporter for NoopMisbehaviourReporter{
 }
 
 /// TODO: Enumerate all violations and implement evidence to check that the
-/// misbehaviour really took place.
+/// misbehavior really took place.
 #[derive(Debug)]
 pub enum ViolationType {
     BadEpoch {

--- a/core/txflow/src/dag/reporter.rs
+++ b/core/txflow/src/dag/reporter.rs
@@ -1,18 +1,24 @@
 use primitives::types::*;
 
-pub struct MisbehaviourReporter {
-    /// TODO: Implement a better way to access violations than
-    /// making this field public
+/// This structure is used to keep track of all violations detected on the network.
+/// Not necessarily restricted to violations regarding TxFlow protocol,
+/// but any kind of violation as enumerated in ViolationType
+pub trait MisbehaviourReporter {
+    fn new() -> Self;
+    fn report(&mut self, violation: ViolationType);
+}
+
+pub struct DAGMisbehaviourReporter {
     pub violations: Vec<ViolationType>,
 }
 
-impl MisbehaviourReporter {
-    pub fn new() -> MisbehaviourReporter {
-        MisbehaviourReporter { violations: vec![] }
+impl MisbehaviourReporter for DAGMisbehaviourReporter{
+    fn new() -> Self {
+        DAGMisbehaviourReporter { violations: vec![] }
     }
 
     /// Take ownership of the violation
-    pub fn report(&mut self, violation: ViolationType) {
+    fn report(&mut self, violation: ViolationType) {
         self.violations.push(violation);
     }
 }


### PR DESCRIPTION
Following up PR #61 

All requested changes at #61 were made.
1. Remove declaration of computed_signature
2. Store MisbehaviourReporter as a reference in the DAG

IMPORTANT: It doesn't work yet because txflow_task DAG usage needs an update.