### PR TITLE
Txflow fork detection

### DIFF
--- a/core/txflow/src/dag/message/group.rs
+++ b/core/txflow/src/dag/message/group.rs
@@ -9,7 +9,7 @@ use super::Message;
 /// * representative message(s) of epoch X (there are more than one if there is a fork);
 /// * kickout message(s) that kickout epoch X (again, more than one if there is a fork);
 /// * messages of epoch X (it is perfectly normal to have multiple of them).
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Group<'a, P: 'a + Payload> {
     /// Messages aggregated by owner uid.
     pub messages_by_owner: HashMap<UID, HashSet<&'a Message<'a, P>>>,
@@ -62,7 +62,7 @@ impl<'a, P: 'a + Payload> Clone for Group<'a, P> {
 }
 
 /// Mapping of groups to epochs.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct GroupsPerEpoch<'a, P: 'a + Payload> {
     pub messages_by_epoch: HashMap<u64, Group<'a, P>>,
 }

--- a/core/txflow/src/dag/message/group.rs
+++ b/core/txflow/src/dag/message/group.rs
@@ -10,11 +10,16 @@ use super::Message;
 /// * kickout message(s) that kickout epoch X (again, more than one if there is a fork);
 /// * messages of epoch X (it is perfectly normal to have multiple of them).
 #[derive(Debug)]
-#[derive(Default)]
 pub struct Group<'a, P: 'a + Payload> {
     /// Messages aggregated by owner uid.
     pub messages_by_owner: HashMap<UID, HashSet<&'a Message<'a, P>>>,
     pub v: HashSet<&'a Message<'a, P>>,
+}
+
+impl<'a, P: 'a + Payload> Default for Group<'a, P> {
+    fn default() -> Self{
+        Group::new()
+    }
 }
 
 // TODO: Create alternative of Group called SingleOwnerGroup with {owner_uid: u64, messages: HashSet<...>}
@@ -64,9 +69,14 @@ impl<'a, P: 'a + Payload> Clone for Group<'a, P> {
 
 /// Mapping of groups to epochs.
 #[derive(Debug)]
-#[derive(Default)]
 pub struct GroupsPerEpoch<'a, P: 'a + Payload> {
     pub messages_by_epoch: HashMap<u64, Group<'a, P>>,
+}
+
+impl<'a, P: 'a + Payload> Default for GroupsPerEpoch<'a, P> {
+    fn default() -> Self{
+        GroupsPerEpoch::new()
+    }
 }
 
 impl<'a, P: 'a + Payload> GroupsPerEpoch<'a, P> {

--- a/core/txflow/src/dag/message/group.rs
+++ b/core/txflow/src/dag/message/group.rs
@@ -113,4 +113,14 @@ impl<'a, P: 'a + Payload> GroupsPerEpoch<'a, P> {
     pub fn contains_epoch(&self, epoch: u64) -> bool {
         self.messages_by_epoch.contains_key(&epoch)
     }
+
+    pub fn contains_message(&self, message: &Message<'a, P>) -> bool {
+        if let Some(group) = self.messages_by_epoch.get(&message.computed_epoch) {
+            if let Some(messages) = group.filter_by_owner(message.data.body.owner_uid) {
+                return messages.contains(message);
+            }
+        };
+
+        false
+    }
 }

--- a/core/txflow/src/dag/message/group.rs
+++ b/core/txflow/src/dag/message/group.rs
@@ -9,7 +9,8 @@ use super::Message;
 /// * representative message(s) of epoch X (there are more than one if there is a fork);
 /// * kickout message(s) that kickout epoch X (again, more than one if there is a fork);
 /// * messages of epoch X (it is perfectly normal to have multiple of them).
-#[derive(Debug, Default)]
+#[derive(Debug)]
+#[derive(Default)]
 pub struct Group<'a, P: 'a + Payload> {
     /// Messages aggregated by owner uid.
     pub messages_by_owner: HashMap<UID, HashSet<&'a Message<'a, P>>>,
@@ -62,7 +63,8 @@ impl<'a, P: 'a + Payload> Clone for Group<'a, P> {
 }
 
 /// Mapping of groups to epochs.
-#[derive(Debug, Default)]
+#[derive(Debug)]
+#[derive(Default)]
 pub struct GroupsPerEpoch<'a, P: 'a + Payload> {
     pub messages_by_epoch: HashMap<u64, Group<'a, P>>,
 }

--- a/core/txflow/src/dag/message/mod.rs
+++ b/core/txflow/src/dag/message/mod.rs
@@ -3,7 +3,7 @@ mod group_approvals;
 
 use std::borrow::Borrow;
 use std::collections::hash_map::DefaultHasher;
-use std::collections::HashSet;
+use std::collections::{HashSet, HashMap};
 use std::hash::{Hash, Hasher};
 
 use primitives::traits::{Payload, WitnessSelector};
@@ -44,8 +44,10 @@ pub struct Message<'a, P: 'a + Payload> {
     computed_complete_epochs: GroupsPerEpoch<'a, P>,
 
     // The following are the approved messages, grouped by different criteria.
+    /// UID -> most recent message from that owner
+    approved_most_recent: HashMap<types::UID, Message<'a, P>>,
     /// Epoch -> messages that have that epoch.
-    approved_epochs: GroupsPerEpoch<'a, P>,
+    pub approved_epochs: GroupsPerEpoch<'a, P>,
     /// Epoch -> a/all representatives of that epoch (supports forks).
     approved_representatives: GroupsPerEpoch<'a, P>,
     /// Epoch -> a/all kickouts of that epoch (supports forks).
@@ -125,6 +127,7 @@ impl<'a, P: Payload> Message<'a, P> {
             computed_promises: GroupsPerEpoch::new(),
             computed_complete_epochs: GroupsPerEpoch::new(),
 
+            approved_most_recent: HashMap::new(),
             approved_epochs: GroupsPerEpoch::new(),
             approved_representatives: GroupsPerEpoch::new(),
             approved_kickouts: GroupsPerEpoch::new(),

--- a/core/txflow/src/dag/message/mod.rs
+++ b/core/txflow/src/dag/message/mod.rs
@@ -3,7 +3,7 @@ mod group_approvals;
 
 use std::borrow::Borrow;
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{HashSet, HashMap};
+use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 
 use primitives::traits::{Payload, WitnessSelector};
@@ -44,8 +44,6 @@ pub struct Message<'a, P: 'a + Payload> {
     computed_complete_epochs: GroupsPerEpoch<'a, P>,
 
     // The following are the approved messages, grouped by different criteria.
-    /// UID -> most recent message from that owner
-    approved_most_recent: HashMap<types::UID, Message<'a, P>>,
     /// Epoch -> messages that have that epoch.
     pub approved_epochs: GroupsPerEpoch<'a, P>,
     /// Epoch -> a/all representatives of that epoch (supports forks).
@@ -127,7 +125,6 @@ impl<'a, P: Payload> Message<'a, P> {
             computed_promises: GroupsPerEpoch::new(),
             computed_complete_epochs: GroupsPerEpoch::new(),
 
-            approved_most_recent: HashMap::new(),
             approved_epochs: GroupsPerEpoch::new(),
             approved_representatives: GroupsPerEpoch::new(),
             approved_kickouts: GroupsPerEpoch::new(),
@@ -198,6 +195,10 @@ impl<'a, P: Payload> Message<'a, P> {
         }
         self.approved_complete_epochs.union_update(&self.approved_endorsements.superapproved_messages(witness_selector));
         self.approved_complete_epochs.union_update(&self.approved_promises.superapproved_messages(witness_selector));
+    }
+
+    pub fn approve(&self, message: &Message<'a, P>) -> bool{
+        self.approved_epochs.contains_message(message)
     }
 
     /// Determines the previous epoch of the current owner. Otherwise returns the starting_epoch.

--- a/core/txflow/src/dag/reporter.rs
+++ b/core/txflow/src/dag/reporter.rs
@@ -37,18 +37,19 @@ impl MisbehaviorReporter for NoopMisbehaviorReporter{
     }
 }
 
-/// TODO: Enumerate all violations and implement evidence to check that the
-/// misbehavior really took place.
+/// Enumeration of all TxFlow protocol violations.
+/// Discussion at: https://github.com/nearprotocol/nearcore/issues/131
 #[derive(Debug)]
 pub enum ViolationType {
-    BadEpoch {
-        message: TxFlowHash,
-    },
-
-    InvalidSignature,
-
-    ForkAttempt {
-        message_0: TxFlowHash,
-        message_1: TxFlowHash,
-    },
+    /// Message with incorrect epoch
+    BadEpoch(TxFlowHash),
+    /// There is no BLS signature for representative when there must be one
+    MissingEndorsement(TxFlowHash),
+    /// Invalid part of the BLS signature
+    InvalidEndorsement(TxFlowHash),
+    /// Message contains invalid signature from participant.
+    /// Someone pretending being another participant maybe.
+    InvalidSignature(TxFlowHash),
+    /// Two messages from the same participant that are not approved by each other.
+    ForkAttempt(TxFlowHash, TxFlowHash),
 }


### PR DESCRIPTION
Detecting forks: store the last message from each participant on the DAG, it must be the case that each new message from Alice must approve its previous last message stored otherwise its a fork.