### PR TITLE
Making network code more flexible

### DIFF
--- a/core/beacon/src/authority.rs
+++ b/core/beacon/src/authority.rs
@@ -265,7 +265,7 @@ mod test {
             BeaconBlock::new(0, CryptoHash::default(), MerkleHash::default(), vec![], vec![]);
         let bc = BlockChain::new(last_block.clone(), storage);
         for i in 1..num_blocks {
-            let block = BeaconBlock::new(i, last_block.hash(), MerkleHash::default(), vec![], vec![]);
+            let block = BeaconBlock::new(i, last_block.header_hash(), MerkleHash::default(), vec![], vec![]);
             bc.insert_block(block.clone());
             last_block = block;
         }

--- a/core/chain/src/lib.rs
+++ b/core/chain/src/lib.rs
@@ -245,7 +245,7 @@ mod tests {
         );
         let bc = BlockChain::new(genesis.clone(), storage.clone());
         let block1 = BeaconBlock::new(
-            1, genesis.hash(), MerkleHash::default(), vec![], vec![]
+            1, genesis.header_hash(), MerkleHash::default(), vec![], vec![]
         );
         assert_eq!(bc.insert_block(block1.clone()), false);
         assert_eq!(bc.best_block().header_hash(), block1.header_hash());

--- a/core/chain/src/lib.rs
+++ b/core/chain/src/lib.rs
@@ -73,7 +73,7 @@ fn read_with_cache<T: Clone + Decode>(
 
 impl<B: Block> BlockChain<B> {
     pub fn new(genesis: B, storage: Arc<Storage>) -> Self {
-        let genesis_hash = genesis.hash();
+        let genesis_hash = genesis.header_hash();
         let bc = BlockChain {
             storage,
             genesis_hash,
@@ -127,7 +127,7 @@ impl<B: Block> BlockChain<B> {
     }
 
     fn update_best_block(&self, block: B) {
-        let block_hash = block.hash();
+        let block_hash = block.header_hash();
         let mut best_block = self.best_block.write();
         *best_block = block;
         let mut db_transaction = self.storage.transaction();
@@ -138,7 +138,7 @@ impl<B: Block> BlockChain<B> {
     /// Inserts a verified block.
     /// Returns true if block is disconnected.
     pub fn insert_block(&self, block: B) -> bool {
-        let block_hash = block.hash();
+        let block_hash = block.header_hash();
         if self.is_known(&block_hash) {
             // TODO: known header but not known block.
             return false;
@@ -233,7 +233,7 @@ mod tests {
             0, CryptoHash::default(), MerkleHash::default(), vec![], vec![]
         );
         let bc = BlockChain::new(genesis.clone(), storage);
-        assert_eq!(bc.get_block(&BlockId::Hash(genesis.hash())).unwrap(), genesis);
+        assert_eq!(bc.get_block(&BlockId::Hash(genesis.header_hash())).unwrap(), genesis);
         assert_eq!(bc.get_block(&BlockId::Number(0)).unwrap(), genesis);
     }
 
@@ -248,12 +248,12 @@ mod tests {
             1, genesis.hash(), MerkleHash::default(), vec![], vec![]
         );
         assert_eq!(bc.insert_block(block1.clone()), false);
-        assert_eq!(bc.best_block().hash(), block1.hash());
+        assert_eq!(bc.best_block().header_hash(), block1.header_hash());
         assert_eq!(bc.best_block().header().index(), 1);
         // Create new BlockChain that reads from the same storage.
         let other_bc = BlockChain::new(genesis.clone(), storage.clone());
-        assert_eq!(other_bc.best_block().hash(), block1.hash());
+        assert_eq!(other_bc.best_block().header_hash(), block1.header_hash());
         assert_eq!(other_bc.best_block().header().index(), 1);
-        assert_eq!(other_bc.get_block(&BlockId::Hash(block1.hash())).unwrap(), block1);
+        assert_eq!(other_bc.get_block(&BlockId::Hash(block1.header_hash())).unwrap(), block1);
     }
 }

--- a/core/primitives/src/traits.rs
+++ b/core/primitives/src/traits.rs
@@ -60,7 +60,7 @@ pub trait Block: Debug + Clone + Send + Sync + Serialize + DeserializeOwned + Eq
     fn body(&self) -> &Self::Body;
     fn deconstruct(self) -> (Self::Header, Self::Body);
     fn new(header: Self::Header, body: Self::Body) -> Self;
-    fn hash(&self) -> CryptoHash;
+    fn header_hash(&self) -> CryptoHash;
 }
 
 /// Trait to abstract the way signing happens.

--- a/node/beacon-chain-handler/Cargo.toml
+++ b/node/beacon-chain-handler/Cargo.toml
@@ -8,5 +8,6 @@ chain = { path = "../../core/chain" }
 primitives = { path = "../../core/primitives" }
 node-runtime = { path = "../runtime" }
 storage = { path = "../../core/storage" }
-
 parking_lot = "0.6"
+futures = "0.1.25"
+tokio = "0.1.11"

--- a/node/beacon-chain-handler/src/importer.rs
+++ b/node/beacon-chain-handler/src/importer.rs
@@ -1,0 +1,122 @@
+//! BeaconBlockImporter consumes blocks that we received from other peers and adds them to the
+//! chain.
+use beacon::types::BeaconBlock;
+use chain::BlockChain;
+use node_runtime::{ApplyState, Runtime};
+use primitives::traits::{Block, Header};
+use primitives::types::BlockId;
+use std::sync::Arc;
+use std::cell::RefCell;
+use storage::StateDb;
+use parking_lot::RwLock;
+use futures::sync::mpsc::Receiver;
+use futures::{Future, Stream, future};
+use std::collections::HashSet;
+
+
+pub fn create_beacon_block_importer_task(
+    beacon_chain: Arc<BlockChain<BeaconBlock>>,
+    runtime: Arc<RwLock<Runtime>>,
+    state_db: Arc<StateDb>,
+    receiver: Receiver<BeaconBlock>
+) -> impl Future<Item = (), Error = ()> {
+    let beacon_block_importer = RefCell::new(BeaconBlockImporter::new(
+        beacon_chain,
+        runtime,
+        state_db,
+    ));
+    receiver.fold(beacon_block_importer, |beacon_block_importer, body| {
+        beacon_block_importer.borrow_mut().import_block(body);
+        future::ok(beacon_block_importer)
+    }).and_then(|_| Ok(()))
+}
+
+pub struct BeaconBlockImporter {
+    beacon_chain: Arc<BlockChain<BeaconBlock>>,
+    runtime: Arc<RwLock<Runtime>>,
+    state_db: Arc<StateDb>,
+    /// Stores blocks that cannot be added yet.
+    pending_blocks: HashSet<BeaconBlock>,
+}
+
+impl BeaconBlockImporter {
+    pub fn new(
+        beacon_chain: Arc<BlockChain<BeaconBlock>>,
+        runtime: Arc<RwLock<Runtime>>,
+        state_db: Arc<StateDb>,
+    ) -> Self {
+        Self {
+            beacon_chain,
+            runtime,
+            state_db,
+            pending_blocks: HashSet::new(),
+        }
+    }
+
+    fn validate_signature(&self, _block: &BeaconBlock) -> bool {
+        // TODO: validate multisig
+        true
+    }
+
+    pub fn import_block(&mut self, block: BeaconBlock) {
+        // Check if this block was either already added, or it is already pending, or it has
+        // invalid signature.
+        let hash = &block.header_hash();
+        if self.beacon_chain.is_known(hash)
+            || self.pending_blocks.contains(&block)
+            || !self.validate_signature(&block) {
+            return
+        }
+        let mut blocks_to_add;
+        let parent_hash = block.header().parent_hash();
+        if self.beacon_chain.is_known(&parent_hash) {
+            blocks_to_add = vec![];
+            blocks_to_add.push(block);
+        } else {
+            self.pending_blocks.insert(block);
+            return;
+        }
+
+        // Loop until we run out of blocks to add.
+        loop {
+            // Get the next block to add, unless there are no more blocks left.
+            let next_b = match blocks_to_add.pop() {
+                Some(b) => b,
+                None => break,
+            };
+            let hash = next_b.header_hash();
+            if self.beacon_chain.is_known(&hash) { continue; }
+
+            let (header, transactions) = next_b.deconstruct();
+            let num_transactions = transactions.len();
+            // we can unwrap because parent is guaranteed to exist
+            let prev_header = self.beacon_chain
+                .get_header(&BlockId::Hash(parent_hash))
+                .expect("Parent is known but header not found.");
+            let apply_state = ApplyState {
+                root: prev_header.body.merkle_root_state,
+                block_index: prev_header.body.index,
+                parent_block_hash: parent_hash,
+            };
+            let (filtered_transactions, mut apply_result) =
+                self.runtime.write().apply(&apply_state, transactions);
+            assert_eq!(apply_result.root, header.body.merkle_root_state,
+                       "Merkle roots are not equal after applying the transactions.");
+            // TODO: This should be handled.
+            assert_eq!(filtered_transactions.len(), num_transactions,
+                       "Imported block has transactions that were filtered out.");
+            self.state_db.commit(&mut apply_result.transaction).ok();
+            // TODO: figure out where to store apply_result.authority_change_set.
+            let block = Block::new(header, filtered_transactions);
+            self.beacon_chain.insert_block(block);
+
+            // Only keep those blocks in `pending_blocks` that are still pending.
+            // Otherwise put it in `blocks_to_add`.
+            let (mut part_add, part_pending): (HashSet<BeaconBlock>, HashSet<BeaconBlock>) =
+                self.pending_blocks.drain().partition(|other|
+                    other.header().parent_hash() == hash );
+            self.pending_blocks = part_pending;
+            blocks_to_add.extend(part_add.drain());
+        }
+    }
+}

--- a/node/beacon-chain-handler/src/lib.rs
+++ b/node/beacon-chain-handler/src/lib.rs
@@ -3,75 +3,8 @@ extern crate chain;
 extern crate node_runtime;
 extern crate primitives;
 extern crate storage;
+extern crate futures;
 extern crate parking_lot;
+extern crate tokio;
 
-use beacon::types::BeaconBlock;
-use chain::BlockChain;
-use node_runtime::{ApplyState, Runtime};
-use primitives::traits::{Block, Header};
-use primitives::traits::Signer;
-use primitives::types::ConsensusBlockBody;
-use primitives::types::SignedTransaction;
-use std::sync::Arc;
-use parking_lot::RwLock;
-use storage::StateDb;
-
-pub trait ConsensusHandler<B: Block, P>: Send + Sync {
-    fn produce_block(&self, body: ConsensusBlockBody<P>) -> B;
-}
-
-pub struct BeaconBlockProducer {
-    beacon_chain: Arc<BlockChain<BeaconBlock>>,
-    runtime: Arc<RwLock<Runtime>>,
-    signer: Arc<Signer>,
-    state_db: Arc<StateDb>,
-}
-
-impl BeaconBlockProducer {
-    pub fn new(
-        beacon_chain: Arc<BlockChain<BeaconBlock>>,
-        runtime: Runtime,
-        signer: Arc<Signer>,
-        state_db: Arc<StateDb>,
-    ) -> Self {
-        BeaconBlockProducer {
-            beacon_chain,
-            runtime: Arc::new(RwLock::new(runtime)),
-            signer,
-            state_db,
-        }
-    }
-}
-
-pub type BeaconChainConsensusBlockBody = ConsensusBlockBody<Vec<SignedTransaction>>;
-
-impl ConsensusHandler<BeaconBlock, Vec<SignedTransaction>> for BeaconBlockProducer {
-    fn produce_block(&self, body: BeaconChainConsensusBlockBody) -> BeaconBlock {
-        // TODO: verify signature
-        let transactions = body.messages.iter()
-            .flat_map(|message| message.clone().body.payload)
-            .collect();
-
-        // TODO: compute actual merkle root and state, as well as signature, and
-        // use some reasonable fork-choice rule
-        let last_block = self.beacon_chain.best_block();
-        let apply_state = ApplyState {
-            root: last_block.header().body.merkle_root_state,
-            parent_block_hash: last_block.hash(),
-            block_index: last_block.header().index() + 1,
-        };
-        let (filtered_transactions, filtered_receipts, mut apply_result) =
-            self.runtime.write().apply(&apply_state, transactions, &mut vec![]);
-        self.state_db.commit(&mut apply_result.transaction).ok();
-        let mut block = BeaconBlock::new(
-            last_block.header().index() + 1,
-            last_block.hash(),
-            apply_result.root,
-            filtered_transactions,
-            filtered_receipts,
-        );
-        block.sign(&self.signer);
-        self.beacon_chain.insert_block(block.clone());
-        block
-    }
-}
+pub mod producer;

--- a/node/beacon-chain-handler/src/lib.rs
+++ b/node/beacon-chain-handler/src/lib.rs
@@ -8,3 +8,4 @@ extern crate parking_lot;
 extern crate tokio;
 
 pub mod producer;
+pub mod importer;

--- a/node/beacon-chain-handler/src/producer.rs
+++ b/node/beacon-chain-handler/src/producer.rs
@@ -20,13 +20,13 @@ pub fn create_beacon_block_producer_task(
     state_db: Arc<StateDb>,
     receiver: Receiver<BeaconChainConsensusBlockBody>
 ) -> impl Future<Item = (), Error = ()> {
-    let beacon_block_producer = Arc::new(BeaconBlockProducer::new(
+    let beacon_block_producer = BeaconBlockProducer::new(
         beacon_chain,
         runtime,
         signer,
         state_db,
-    ));
-    receiver.fold(beacon_block_producer.clone(), |beacon_block_producer, body| {
+    );
+    receiver.fold(beacon_block_producer, |beacon_block_producer, body| {
         beacon_block_producer.produce_block(body);
         future::ok(beacon_block_producer)
     }).and_then(|_| Ok(()))

--- a/node/beacon-chain-handler/src/producer.rs
+++ b/node/beacon-chain-handler/src/producer.rs
@@ -1,0 +1,90 @@
+use beacon::types::BeaconBlock;
+use chain::BlockChain;
+use node_runtime::{ApplyState, Runtime};
+use primitives::traits::{Block, Header};
+use primitives::traits::Signer;
+use primitives::types::ConsensusBlockBody;
+use primitives::types::SignedTransaction;
+use std::sync::Arc;
+use storage::StateDb;
+use parking_lot::RwLock;
+use futures::sync::mpsc::Receiver;
+use futures::{Future, Stream, Sink, future};
+
+pub fn create_beacon_block_producer_task(
+    beacon_chain: Arc<BlockChain<BeaconBlock>>,
+    runtime: Arc<RwLock<Runtime>>,
+    signer: Arc<Signer>,
+    state_db: Arc<StateDb>,
+    receiver: Receiver<BeaconChainConsensusBlockBody>
+) -> impl Future<Item = (), Error = ()> {
+    let beacon_block_producer = Arc::new(BeaconBlockProducer::new(
+        beacon_chain,
+        runtime,
+        signer,
+        state_db,
+    ));
+    receiver.fold(beacon_block_producer.clone(), |beacon_block_producer, body| {
+        beacon_block_producer.produce_block(body);
+        future::ok(beacon_block_producer)
+    }).and_then(|_| Ok(()))
+}
+
+pub trait ConsensusHandler<B: Block, P>: Send + Sync {
+    fn produce_block(&self, body: ConsensusBlockBody<P>) -> B;
+}
+
+pub struct BeaconBlockProducer {
+    beacon_chain: Arc<BlockChain<BeaconBlock>>,
+    runtime: Arc<RwLock<Runtime>>,
+    signer: Arc<Signer>,
+    state_db: Arc<StateDb>,
+}
+
+impl BeaconBlockProducer {
+    pub fn new(
+        beacon_chain: Arc<BlockChain<BeaconBlock>>,
+        runtime: Arc<RwLock<Runtime>>,
+        signer: Arc<Signer>,
+        state_db: Arc<StateDb>,
+    ) -> Self {
+        BeaconBlockProducer {
+            beacon_chain,
+            runtime,
+            signer,
+            state_db,
+        }
+    }
+}
+
+pub type BeaconChainConsensusBlockBody = ConsensusBlockBody<Vec<SignedTransaction>>;
+
+impl ConsensusHandler<BeaconBlock, Vec<SignedTransaction>> for BeaconBlockProducer {
+    fn produce_block(&self, body: BeaconChainConsensusBlockBody) -> BeaconBlock {
+        // TODO: verify signature
+        let transactions = body.messages.iter()
+            .flat_map(|message| message.clone().body.payload)
+            .collect();
+
+        // TODO: compute actual merkle root and state, as well as signature, and
+        // use some reasonable fork-choice rule
+        let last_block = self.beacon_chain.best_block();
+        let apply_state = ApplyState {
+            root: last_block.header().body.merkle_root_state,
+            parent_block_hash: last_block.hash(),
+            block_index: last_block.header().index() + 1,
+        };
+        let (filtered_transactions, mut apply_result) =
+            self.runtime.write().apply(&apply_state, transactions);
+        self.state_db.commit(&mut apply_result.transaction).ok();
+        let mut block = BeaconBlock::new(
+            last_block.header().index() + 1,
+            last_block.hash(),
+            apply_result.root,
+            filtered_transactions,
+        );
+        block.sign(&self.signer);
+        self.beacon_chain.insert_block(block.clone());
+        block
+    }
+}

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -15,4 +15,5 @@ network = { path = "../network", features = ["test-utils"] }
 node-runtime = { path = "../runtime" }
 primitives = { path = "../../core/primitives" }
 storage = { path = "../../core/storage" }
+parking_lot = "0.6"
 service = { path = "../service" }

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -4,6 +4,7 @@ extern crate client;
 extern crate network;
 extern crate node_runtime;
 extern crate primitives;
+extern crate parking_lot;
 extern crate serde;
 #[macro_use]
 extern crate serde_derive;
@@ -31,6 +32,7 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
+use parking_lot::RwLock;
 
 pub mod chain_spec;
 
@@ -57,7 +59,7 @@ fn start_service(base_path: &Path, chain_spec_path: Option<&Path>) -> GenericRes
     info!("Public key: {}", signer.public_key());
     let storage_path = get_storage_path(base_path);
     let storage = Arc::new(storage::open_database(&storage_path.to_string_lossy()));
-    let client = Arc::new(Client::new(&chain_spec, storage, signer));
+    let client = Arc::new(RwLock::new(Client::new(&chain_spec, storage, signer)));
     let network_handler = NetworkHandler { client: client.clone() };
     let network = NetworkService::new(
         ProtocolConfig::default(),

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -68,8 +68,8 @@ fn start_service(base_path: &Path, chain_spec_path: Option<&Path>) -> GenericRes
         client.clone(),
     ).unwrap();
     let network_task = generate_service_task::<_, _, BeaconBlockHeader>(
-        network.network.clone(),
-        network.protocol.clone(),
+        &network.network,
+        &network.protocol,
     );
     let produce_blocks_interval = Duration::from_secs(2);
     run_service(&client, network_task, produce_blocks_interval)

--- a/node/cli2/Cargo.toml
+++ b/node/cli2/Cargo.toml
@@ -11,8 +11,10 @@ beacon = { path = "../../core/beacon" }
 beacon-chain-handler = { path = "../beacon-chain-handler" }
 chain = { path = "../../core/chain" }
 client = { path = "../client" }
+network = { path = "../network", features = ["test-utils"] }
 node-runtime = { path = "../runtime" }
 node-rpc = { path = "../rpc" }
+parking_lot = "0.6"
 primitives = { path = "../../core/primitives" }
 storage = { path = "../../core/storage" }
 service = { path = "../service" }

--- a/node/cli2/src/lib.rs
+++ b/node/cli2/src/lib.rs
@@ -120,10 +120,10 @@ fn start_service(base_path: &Path, chain_spec_path: Option<&Path>) {
         client.clone(),
     ).unwrap();
     let network_task = generate_service_task::<_, _, BeaconBlockHeader>(
-        network.network.clone(),
-        network.protocol.clone(),
+        &network.network,
+        &network.protocol,
     );
-    
+
     tokio::run(network_task);
 }
 

--- a/node/cli2/src/lib.rs
+++ b/node/cli2/src/lib.rs
@@ -70,6 +70,7 @@ fn start_service(base_path: &Path, chain_spec_path: Option<&Path>) {
     let state_db_viewer = StateDbViewer::new(beacon_chain.clone(), state_db.clone());
     // TODO: TxFlow should be listening on these transactions.
     let (submit_txn_tx, _submit_txn_rx) = channel(1024);
+    let (submit_receipt_tx, _submit_receipt_rx) = channel(1024);
     let rpc_impl = RpcImpl::new(state_db_viewer, submit_txn_tx.clone());
     let rpc_handler = node_rpc::api::get_handler(rpc_impl);
     let server = node_rpc::server::get_server(rpc_handler);
@@ -104,7 +105,7 @@ fn start_service(base_path: &Path, chain_spec_path: Option<&Path>) {
     tokio::spawn(block_importer_task);
 
     // Create network task.
-    let network_handler = ChannelNetworkHandler::new(submit_txn_tx.clone());
+    let network_handler = ChannelNetworkHandler::new(submit_txn_tx.clone(), submit_receipt_tx.clone());
     let client = Arc::new(RwLock::new(Client::new(&chain_spec, storage, signer)));
     let network = NetworkService::new(
         ProtocolConfig::default(),

--- a/node/cli2/src/lib.rs
+++ b/node/cli2/src/lib.rs
@@ -36,7 +36,7 @@ use node_rpc::api::RpcImpl;
 use node_runtime::{Runtime, StateDbViewer};
 use primitives::hash::CryptoHash;
 use primitives::signer::InMemorySigner;
-use service::network_handler::ChannelNetworkHandler;
+use network::network_handler::ChannelNetworkHandler;
 use std::path::Path;
 use std::sync::Arc;
 use storage::{StateDb, Storage};

--- a/node/client/src/chain.rs
+++ b/node/client/src/chain.rs
@@ -7,7 +7,7 @@ use primitives::types::BlockId;
 
 /// Chain Backend trait
 /// an abstraction that communicates chain info to network
-pub trait Chain<B: Block> {
+pub trait Chain<B: Block>: Send + Sync {
     // get block from id
     fn get_block(&self, id: &BlockId) -> Option<B>;
     // get block header from id

--- a/node/client/src/chain.rs
+++ b/node/client/src/chain.rs
@@ -76,7 +76,7 @@ impl Chain<BeaconBlock> for Client {
             block_index: last_block.header().index() + 1,
         };
         let (filtered_transactions, filtered_receipts, mut apply_result) =
-            self.runtime.borrow_mut().apply(&apply_state, transactions, &mut receipts);
+            self.runtime.write().apply(&apply_state, transactions, &mut receipts);
         self.state_db.commit(&mut apply_result.transaction).ok();
         let mut block = BeaconBlock::new(
             last_block.header().index() + 1,

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -103,7 +103,7 @@ impl Client {
 
     /// Import a block. Returns true if it is successfully inserted into the chain
     fn import_block(&self, block: BeaconBlock) -> bool {
-        if self.beacon_chain.is_known(&block.hash()) {
+        if self.beacon_chain.is_known(&block.header_hash()) {
             return false;
         }
         let parent_hash = block.header().parent_hash();
@@ -156,7 +156,7 @@ mod tests {
         let genesis_block = client.beacon_chain.best_block();
         let block1 = BeaconBlock::new(
             1,
-            genesis_block.hash(),
+            genesis_block.header_hash(),
             genesis_block.header().body.merkle_root_state,
             vec![],
             vec![]
@@ -171,14 +171,14 @@ mod tests {
         let genesis_block = client.beacon_chain.best_block();
         let block1 = BeaconBlock::new(
             1,
-            genesis_block.hash(),
+            genesis_block.header_hash(),
             genesis_block.header().body.merkle_root_state,
             vec![],
             vec![]
         );
         let block2 = BeaconBlock::new(
             2,
-            block1.hash(),
+            block1.header_hash(),
             genesis_block.header().body.merkle_root_state,
             vec![],
             vec![]
@@ -207,14 +207,14 @@ mod tests {
         let genesis_block = client.beacon_chain.best_block();
         let block1 = BeaconBlock::new(
             1,
-            genesis_block.hash(),
+            genesis_block.header_hash(),
             genesis_block.header().body.merkle_root_state,
             vec![],
             vec![],
         );
         let block2 = BeaconBlock::new(
             2,
-            block1.hash(),
+            block1.header_hash(),
             genesis_block.header().body.merkle_root_state,
             vec![],
             vec![],

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -34,7 +34,7 @@ pub mod test_utils;
 pub struct Client {
     signer: Arc<Signer>,
     state_db: Arc<StateDb>,
-    runtime: Rc<RefCell<Runtime>>,
+    runtime: Arc<RwLock<Runtime>>,
     authority: Authority,
     beacon_chain: BlockChain<BeaconBlock>,
     // transaction pool (put here temporarily)
@@ -71,7 +71,7 @@ impl Client {
             signer,
             state_db,
             beacon_chain,
-            runtime: Rc::new(RefCell::new(runtime)),
+            runtime: Arc::new(RwLock::new(runtime)),
             authority,
             tx_pool: RwLock::new(TransactionPool::new()),
             import_queue: RwLock::new(ImportQueue::new()),
@@ -122,7 +122,7 @@ impl Client {
                 parent_block_hash: parent_hash,
             };
             let (filtered_transactions, filtered_receipts, mut apply_result) =
-                self.runtime.borrow_mut().apply(&apply_state, body.transactions, &mut body.receipts);
+                self.runtime.write().apply(&apply_state, body.transactions, &mut body.receipts);
             if apply_result.root != header.body.merkle_root_state
                 || filtered_transactions.len() != num_transactions
                 || filtered_receipts.len() != num_receipts

--- a/node/network/src/io.rs
+++ b/node/network/src/io.rs
@@ -32,7 +32,7 @@ impl NetSyncIo {
     }
 
     /// Report a peer for misbehaviour.
-    fn report_peer(&mut self, who: NodeIndex, reason: Severity) {
+    pub fn report_peer(&mut self, who: NodeIndex, reason: Severity) {
         info!("Purposefully dropping {} ; reason: {:?}", who, reason);
         match reason {
             Severity::Bad(_) => self.network.lock().ban_node(who),
@@ -42,17 +42,17 @@ impl NetSyncIo {
     }
 
     /// Send a packet to a peer.
-    fn send(&mut self, who: NodeIndex, data: Vec<u8>) {
+    pub fn send(&mut self, who: NodeIndex, data: Vec<u8>) {
         self.network.lock().send_custom_message(who, self.protocol, data)
     }
 
     /// Returns information on p2p session
-    fn peer_id(&self, who: NodeIndex) -> Option<PeerId> {
+    pub fn peer_id(&self, who: NodeIndex) -> Option<PeerId> {
         self.network.lock().peer_id_of_node(who).cloned()
     }
 
     /// Returns peer identifier string
-    fn peer_debug_info(&self, who: NodeIndex) -> String {
+    pub fn peer_debug_info(&self, who: NodeIndex) -> String {
         let net = self.network.lock();
         if let (Some(peer_id), Some(addr)) = (net.peer_id_of_node(who), net.node_endpoint(who)) {
             format!("{:?} through {:?}", peer_id, addr)

--- a/node/network/src/io.rs
+++ b/node/network/src/io.rs
@@ -14,47 +14,46 @@
 // You should have received a copy of the GNU General Public License
 // along with Substrate.  If not, see <http://www.gnu.org/licenses/>.
 
-use std::cell::RefCell;
-use std::rc::Rc;
+use parking_lot::Mutex;
+use std::sync::Arc;
 use substrate_network_libp2p::{NodeIndex, PeerId, ProtocolId, Service, Severity};
-
 
 /// Wraps the network service. IO interface for the syncing handler.
 /// Provides peer connection management and an interface to the BlockChain client.
 pub struct NetSyncIo {
-    network: Rc<RefCell<Service>>,
+    network: Arc<Mutex<Service>>,
     protocol: ProtocolId,
 }
 
 impl NetSyncIo {
     /// Creates a new instance.
-    pub fn new(network: Rc<RefCell<Service>>, protocol: ProtocolId) -> NetSyncIo {
+    pub fn new(network: Arc<Mutex<Service>>, protocol: ProtocolId) -> NetSyncIo {
         NetSyncIo { network, protocol }
     }
 
     /// Report a peer for misbehaviour.
-    pub fn report_peer(&mut self, who: NodeIndex, reason: Severity) {
+    fn report_peer(&mut self, who: NodeIndex, reason: Severity) {
         info!("Purposefully dropping {} ; reason: {:?}", who, reason);
         match reason {
-            Severity::Bad(_) => self.network.borrow_mut().ban_node(who),
-            Severity::Useless(_) => self.network.borrow_mut().drop_node(who),
-            Severity::Timeout => self.network.borrow_mut().drop_node(who),
+            Severity::Bad(_) => self.network.lock().ban_node(who),
+            Severity::Useless(_) => self.network.lock().drop_node(who),
+            Severity::Timeout => self.network.lock().drop_node(who),
         }
     }
 
     /// Send a packet to a peer.
-    pub fn send(&mut self, who: NodeIndex, data: Vec<u8>) {
-        self.network.borrow_mut().send_custom_message(who, self.protocol, data)
+    fn send(&mut self, who: NodeIndex, data: Vec<u8>) {
+        self.network.lock().send_custom_message(who, self.protocol, data)
     }
 
     /// Returns information on p2p session
-    pub fn peer_id(&self, who: NodeIndex) -> Option<PeerId> {
-        self.network.borrow_mut().peer_id_of_node(who).cloned()
+    fn peer_id(&self, who: NodeIndex) -> Option<PeerId> {
+        self.network.lock().peer_id_of_node(who).cloned()
     }
 
     /// Returns peer identifier string
-    pub fn peer_debug_info(&self, who: NodeIndex) -> String {
-        let net = self.network.borrow_mut();
+    fn peer_debug_info(&self, who: NodeIndex) -> String {
+        let net = self.network.lock();
         if let (Some(peer_id), Some(addr)) = (net.peer_id_of_node(who), net.node_endpoint(who)) {
             format!("{:?} through {:?}", peer_id, addr)
         } else {

--- a/node/network/src/network_handler.rs
+++ b/node/network/src/network_handler.rs
@@ -3,14 +3,42 @@ use protocol::ProtocolHandler;
 use primitives::traits::GenericResult;
 use primitives::types::{SignedTransaction, ReceiptTransaction};
 use std::sync::Arc;
+use parking_lot::RwLock;
+
+use futures::sync::mpsc;
+use futures::{Future, Sink};
 
 pub struct NetworkHandler {
-    pub client: Arc<Client>,
+    pub client: Arc<RwLock<Client>>,
 }
 
 impl ProtocolHandler for NetworkHandler {
     fn handle_transaction(&self, t: SignedTransaction) -> GenericResult {
-        self.client.handle_signed_transaction(t)
+        self.client.write().handle_signed_transaction(t)
+    }
+}
+
+/// Reports transactions received from a network into the given channel.
+pub struct ChannelNetworkHandler {
+    transactions_sender: mpsc::Sender<SignedTransaction>,
+}
+
+impl ChannelNetworkHandler {
+    pub fn new(transactions_sender: mpsc::Sender<SignedTransaction>) -> Self {
+        Self { transactions_sender }
+    }
+}
+
+impl ProtocolHandler for ChannelNetworkHandler {
+    fn handle_transaction(&self, transaction: SignedTransaction) -> Result<(), &'static str> {
+        let copied_tx = self.transactions_sender.clone();
+        tokio::spawn(
+            copied_tx
+                .send(transaction)
+                .map(|_| ())
+                .map_err(|e| error!("Failure to send the transactions {:?}", e)),
+        );
+        Ok(())
     }
 
     fn handle_receipt(&self, receipt: ReceiptTransaction) -> GenericResult {

--- a/node/network/src/protocol.rs
+++ b/node/network/src/protocol.rs
@@ -352,9 +352,6 @@ mod tests {
     use client::test_utils::*;
     use primitives::hash::hash;
     use primitives::types::{SignedTransaction, TransactionBody};
-    use std::cell::RefCell;
-    use std::rc::Rc;
-    use primitives::types;
     use test_utils::*;
     use primitives::signature::DEFAULT_SIGNATURE;
     use parking_lot::Mutex;

--- a/node/network/src/protocol.rs
+++ b/node/network/src/protocol.rs
@@ -73,7 +73,7 @@ pub struct Protocol<B: Block, H: ProtocolHandler> {
     // info about peers
     peer_info: RwLock<HashMap<NodeIndex, PeerInfo>>,
     // backend client
-    chain: Arc<Chain<B>>,
+    chain: Arc<RwLock<Chain<B>>>,
     // callbacks
     handler: Option<Box<H>>,
     // phantom data for keep T
@@ -85,7 +85,7 @@ pub trait ProtocolHandler: 'static {
 }
 
 impl<B: Block, H: ProtocolHandler> Protocol<B, H> {
-    pub fn new(config: ProtocolConfig, handler: H, chain: Arc<Chain<B>>) -> Protocol<B, H> {
+    pub fn new(config: ProtocolConfig, handler: H, chain: Arc<RwLock<Chain<B>>>) -> Protocol<B, H> {
         Protocol {
             config,
             handshaking_peers: RwLock::new(HashMap::new()),
@@ -143,12 +143,12 @@ impl<B: Block, H: ProtocolHandler> Protocol<B, H> {
             );
             return;
         }
-        if status.genesis_hash != self.chain.genesis_hash() {
+        if status.genesis_hash != self.chain.read().genesis_hash() {
             net_sync.report_peer(
                 peer,
                 Severity::Bad(&format!(
                     "peer has different genesis hash (ours {:?}, theirs {:?})",
-                    self.chain.genesis_hash(),
+                    self.chain.read().genesis_hash(),
                     status.genesis_hash
                 )),
             );
@@ -156,7 +156,7 @@ impl<B: Block, H: ProtocolHandler> Protocol<B, H> {
         }
 
         // request blocks to catch up if necessary
-        let best_index = self.chain.best_index();
+        let best_index = self.chain.read().best_index();
         let mut next_request_id = 0;
         if status.best_index > best_index {
             let request = message::BlockRequest {
@@ -191,12 +191,12 @@ impl<B: Block, H: ProtocolHandler> Protocol<B, H> {
         let mut blocks = Vec::new();
         let mut id = request.from;
         let max = std::cmp::min(request.max.unwrap_or(u64::max_value()), MAX_BLOCK_DATA_RESPONSE);
-        while let Some(block) = self.chain.get_block(&id) {
+        while let Some(block) = self.chain.read().get_block(&id) {
             blocks.push(block);
             if blocks.len() as u64 >= max {
                 break;
             }
-            let header = self.chain.get_header(&id).unwrap();
+            let header = self.chain.read().get_header(&id).unwrap();
             let block_index = header.index();
             let block_hash = header.hash();
             let reach_end = match request.to {
@@ -221,7 +221,7 @@ impl<B: Block, H: ProtocolHandler> Protocol<B, H> {
         response: message::BlockResponse<B>,
     ) {
         // TODO: validate response
-        self.chain.import_blocks(response.blocks);
+        self.chain.write().import_blocks(response.blocks);
     }
 
     pub fn on_message<Header: BlockHeader>(
@@ -281,7 +281,7 @@ impl<B: Block, H: ProtocolHandler> Protocol<B, H> {
                 // header is actually block for now
                 match ann {
                     message::BlockAnnounce::Block(b) => {
-                        self.chain.import_blocks(vec![b]);
+                        self.chain.write().import_blocks(vec![b]);
                     }
                     _ => unimplemented!(),
                 }
@@ -333,7 +333,7 @@ impl<B: Block, H: ProtocolHandler> Protocol<B, H> {
     pub fn prod_block<Header: BlockHeader>(&self, net_sync: &mut NetSyncIo) {
         let special_secret = test_utils::special_secret();
         if special_secret == self.config.secret {
-            let block = self.chain.prod_block();
+            let block = self.chain.write().prod_block();
             let block_announce = message::BlockAnnounce::Block(block.clone());
             let message: Message<_, Header> =
                 Message::new(MessageBody::BlockAnnounce(block_announce));
@@ -341,7 +341,7 @@ impl<B: Block, H: ProtocolHandler> Protocol<B, H> {
             for peer in peer_info.keys() {
                 self.send_message(net_sync, *peer, &message);
             }
-            self.chain.import_blocks(vec![block]);
+            self.chain.write().import_blocks(vec![block]);
         }
     }
 }
@@ -354,8 +354,10 @@ mod tests {
     use primitives::types::{SignedTransaction, TransactionBody};
     use std::cell::RefCell;
     use std::rc::Rc;
+    use primitives::types;
     use test_utils::*;
     use primitives::signature::DEFAULT_SIGNATURE;
+    use parking_lot::Mutex;
 
     impl<B: Block, H: ProtocolHandler> Protocol<B, H> {
         fn _on_message(&self, data: &[u8]) -> Message<B, B::Header> {
@@ -372,7 +374,7 @@ mod tests {
         let message: Message<MockBlock, MockBlockHeader> =
             Message::new(MessageBody::Transaction(Box::new(tx)));
         let config = ProtocolConfig::default();
-        let mock_client = Arc::new(MockClient::default());
+        let mock_client = Arc::new(RwLock::new(MockClient::default()));
         let protocol = Protocol::new(config, MockProtocolHandler::default(), mock_client);
         let decoded = protocol._on_message(&Encode::encode(&message).unwrap());
         assert_eq!(message, decoded);
@@ -381,7 +383,7 @@ mod tests {
     #[test]
     fn test_on_transaction_message() {
         let config = ProtocolConfig::default();
-        let mock_client = Arc::new(MockClient::default());
+        let mock_client = Arc::new(RwLock::new(MockClient::default()));
         let protocol = Protocol::new(config, MockProtocolHandler::default(), mock_client);
         let tx = SignedTransaction::empty();
         protocol.on_transaction_message(tx);
@@ -389,21 +391,21 @@ mod tests {
 
     #[test]
     fn test_protocol_and_client() {
-        let client = Arc::new(generate_test_client());
+        let client = Arc::new(RwLock::new(generate_test_client()));
         let handler = MockHandler { client: client.clone() };
         let config = ProtocolConfig::new_with_default_id(special_secret());
         let protocol = Protocol::new(config, handler, client.clone());
-        let network_service = Rc::new(RefCell::new(default_network_service()));
+        let network_service = Arc::new(Mutex::new(default_network_service()));
         let mut net_sync = NetSyncIo::new(network_service, protocol.config.protocol_id);
         protocol.on_transaction_message(SignedTransaction::new(
             DEFAULT_SIGNATURE,
             TransactionBody::new(1, hash(b"bob"), hash(b"alice"), 10, String::new(), vec![]),
         ));
-        assert_eq!(client.num_transactions(), 1);
-        assert_eq!(client.num_blocks_in_queue(), 0);
+        assert_eq!(client.read().num_transactions(), 1);
+        assert_eq!(client.read().num_blocks_in_queue(), 0);
         protocol.prod_block::<MockBlockHeader>(&mut net_sync);
-        assert_eq!(client.num_transactions(), 0);
-        assert_eq!(client.num_blocks_in_queue(), 0);
-        assert_eq!(client.best_index(), 1);
+        assert_eq!(client.read().num_transactions(), 0);
+        assert_eq!(client.read().num_blocks_in_queue(), 0);
+        assert_eq!(client.read().best_index(), 1);
     }
 }

--- a/node/network/src/service.rs
+++ b/node/network/src/service.rs
@@ -1,14 +1,12 @@
 use client::chain::Chain;
 use error::Error;
-use futures::{self, stream, Future, Stream};
+use futures::{stream, Future, Stream};
 use io::NetSyncIo;
 use primitives::traits::{Block, Header as BlockHeader};
 use protocol::ProtocolHandler;
 use protocol::{self, Protocol, ProtocolConfig};
-use std::cell::RefCell;
-use std::io;
-use std::rc::Rc;
 use std::sync::Arc;
+use parking_lot::{Mutex, RwLock};
 use std::time::Duration;
 pub use substrate_network_libp2p::NetworkConfiguration;
 use substrate_network_libp2p::{
@@ -17,11 +15,10 @@ use substrate_network_libp2p::{
 use tokio::timer::Interval;
 
 const TICK_TIMEOUT: Duration = Duration::from_millis(1000);
-const BLOCK_PROD_TIMEOUT: Duration = Duration::from_secs(2);
 
 pub struct Service<B: Block, H: ProtocolHandler> {
-    pub network: Rc<RefCell<NetworkService>>,
-    pub protocol: Rc<Protocol<B, H>>,
+    pub network: Arc<Mutex<NetworkService>>,
+    pub protocol: Arc<Protocol<B, H>>,
 }
 
 impl<B: Block, H: ProtocolHandler> Service<B, H> {
@@ -29,13 +26,13 @@ impl<B: Block, H: ProtocolHandler> Service<B, H> {
         config: ProtocolConfig,
         net_config: NetworkConfiguration,
         handler: H,
-        chain: Arc<Chain<B>>,
+        chain: Arc<RwLock<Chain<B>>>,
     ) -> Result<Service<B, H>, Error> {
         let version = [protocol::CURRENT_VERSION as u8];
         let registered = RegisteredProtocol::new(config.protocol_id, &version);
-        let protocol = Rc::new(Protocol::new(config, handler, chain));
+        let protocol = Arc::new(Protocol::new(config, handler, chain));
         let service = match start_service(net_config, Some(registered)) {
-            Ok(s) => Rc::new(RefCell::new(s)),
+            Ok(s) => Arc::new(Mutex::new(s)),
             Err(e) => return Err(e.into()),
         };
         Ok(Service { network: service, protocol })
@@ -43,9 +40,10 @@ impl<B: Block, H: ProtocolHandler> Service<B, H> {
 }
 
 pub fn generate_service_task<B, H, Header>(
-    network_service: Rc<RefCell<NetworkService>>,
-    protocol: Rc<Protocol<B, H>>,
-) -> impl Future<Item = (), Error = ()>
+    network_service: Arc<Mutex<NetworkService>>,
+    protocol: Arc<Protocol<B, H>>,
+//) -> impl Future<Item = (), Error = ()>
+) -> Box<impl Future<Item=(), Error=()>>
 where
     B: Block,
     H: ProtocolHandler,
@@ -74,7 +72,7 @@ where
     // events handler
     let network = stream::poll_fn({
         let network_service1 = network_service.clone();
-        move || network_service1.borrow_mut().poll()
+        move || network_service1.lock().poll()
     }).for_each({
         let network_service1 = network_service.clone();
         let protocol1 = protocol.clone();
@@ -101,33 +99,10 @@ where
         }
     });
 
-    // block producing logic (fake for now)
-    let block_production = Interval::new_interval(BLOCK_PROD_TIMEOUT)
-        .for_each({
-            move |_| {
-                let mut net_sync =
-                    NetSyncIo::new(network_service.clone(), protocol.config.protocol_id);
-                protocol.prod_block::<Header>(&mut net_sync);
-                Ok(())
-            }
-        }).then(|res| {
-            match res {
-                Ok(()) => (),
-                Err(err) => error!("Error in the block_production {:?}", err),
-            };
-            Ok(())
-        });
-
-    let futures: Vec<Box<Future<Item = (), Error = io::Error>>> =
-        vec![Box::new(timer), Box::new(network), Box::new(block_production)];
-    futures::select_all(futures)
-        .and_then(move |_| {
-            info!("Networking ended");
-            Ok(())
-        }).map_err(|(r, _, _)| r)
-        .map_err(|e| {
-            debug!(target: "sub-libp2p", "service error: {:?}", e);
-        })
+    Box::new(network.select(timer).and_then(|_| {
+        info!("Networking stopped");
+        Ok(())
+    }).map_err(|(e, _)| debug!("Networking/Maintenance error {:?}", e)))
 }
 
 #[cfg(test)]

--- a/node/network/src/service.rs
+++ b/node/network/src/service.rs
@@ -40,8 +40,8 @@ impl<B: Block, H: ProtocolHandler> Service<B, H> {
 }
 
 pub fn generate_service_task<B, H, Header>(
-    network_service: Arc<Mutex<NetworkService>>,
-    protocol: Arc<Protocol<B, H>>,
+    network_service: &Arc<Mutex<NetworkService>>,
+    protocol: &Arc<Protocol<B, H>>,
 //) -> impl Future<Item = (), Error = ()>
 ) -> Box<impl Future<Item=(), Error=()>>
 where
@@ -118,8 +118,8 @@ mod tests {
         let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
         for service in services.iter() {
             let task = generate_service_task::<MockBlock, MockProtocolHandler, MockBlockHeader>(
-                service.network.clone(),
-                service.protocol.clone(),
+                &service.network,
+                &service.protocol,
             );
             runtime.spawn(task);
         }

--- a/node/network/src/test_utils.rs
+++ b/node/network/src/test_utils.rs
@@ -189,7 +189,7 @@ impl ProtocolHandler for MockHandler {
     }
     
     fn handle_receipt(&self, receipt: types::ReceiptTransaction) -> GenericResult {
-        self.client.handle_receipt_transaction(receipt)
+        self.client.write().handle_receipt_transaction(receipt)
     }
 }
 

--- a/node/network/src/test_utils.rs
+++ b/node/network/src/test_utils.rs
@@ -15,6 +15,7 @@ use service::Service;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
+use parking_lot::RwLock;
 use substrate_network_libp2p::{
     NetworkConfiguration, PeerId, ProtocolId, RegisteredProtocol,
     Secret, Service as NetworkService, start_service,
@@ -108,7 +109,7 @@ pub fn create_test_services(num_services: u32) -> Vec<Service<MockBlock, MockPro
     let secret = create_secret();
     let root_config = test_config_with_secret(&addresses[0], vec![], secret);
     let handler = MockProtocolHandler::default();
-    let mock_client = Arc::new(MockClient::default());
+    let mock_client = Arc::new(RwLock::new(MockClient::default()));
     let root_service =
         Service::new(ProtocolConfig::default(), root_config, handler, mock_client.clone()).unwrap();
     let boot_node = addresses[0].clone() + "/p2p/" + &raw_key_to_peer_id_str(secret);
@@ -179,12 +180,12 @@ pub struct MockClient {
 }
 
 pub struct MockHandler {
-    pub client: Arc<Client>,
+    pub client: Arc<RwLock<Client>>,
 }
 
 impl ProtocolHandler for MockHandler {
     fn handle_transaction(&self, t: types::SignedTransaction) -> GenericResult {
-        self.client.handle_signed_transaction(t)
+        self.client.write().handle_signed_transaction(t)
     }
     
     fn handle_receipt(&self, receipt: types::ReceiptTransaction) -> GenericResult {

--- a/node/network/src/test_utils.rs
+++ b/node/network/src/test_utils.rs
@@ -169,7 +169,7 @@ impl Block for MockBlock {
     fn new(_header: Self::Header, _body: Self::Body) -> Self {
         MockBlock {}
     }
-    fn hash(&self) -> CryptoHash {
+    fn header_hash(&self) -> CryptoHash {
         CryptoHash::default()
     }
 }

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -17,13 +17,14 @@ use produce_blocks::generate_produce_blocks_task;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::runtime;
+use parking_lot::RwLock;
 
 mod produce_blocks;
 #[cfg(feature = "test-utils")]
 pub mod test_utils;
 
 pub fn run_service(
-    client: &Arc<Client>,
+    client: &Arc<RwLock<Client>>,
     network_task: impl Future<Item=(), Error=()>,
     produce_blocks_interval: Duration,
 ) -> GenericResult {

--- a/node/service/src/produce_blocks.rs
+++ b/node/service/src/produce_blocks.rs
@@ -5,11 +5,12 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::timer::Interval;
 use client::chain::Chain;
+use parking_lot::RwLock;
 
 // should take in a chain rather than a client
 // https://github.com/nearprotocol/nearcore/issues/110
 pub fn generate_produce_blocks_task(
-    client: &Arc<Client>,
+    client: &Arc<RwLock<Client>>,
     interval: Duration,
 ) -> impl Future<Item = (), Error = ()> {
     Interval::new_interval(interval)
@@ -17,7 +18,7 @@ pub fn generate_produce_blocks_task(
             let client = client.clone();
             move |_| {
                 // relies specifically on Chain trait
-                let block = client.prod_block();
+                let block = client.write().prod_block();
                 // relies specifically on BeaconBlock Body type
                 if !block.body.is_empty() {
                     info!(target: "service", "Block body: {:?}", block.body);

--- a/node/service/src/test_utils.rs
+++ b/node/service/src/test_utils.rs
@@ -3,9 +3,10 @@ use run_service;
 use std::sync::Arc;
 use std::time::Duration;
 use network::test_utils::get_noop_network_task;
+use parking_lot::RwLock;
 
 pub fn run_test_service() {
-    let client = Arc::new(generate_test_client());
+    let client = Arc::new(RwLock::new(generate_test_client()));
     let network_task = get_noop_network_task();
     let produce_blocks_interval_duration = Duration::from_secs(2);
     run_service(

--- a/test-utils/node/src/main.rs
+++ b/test-utils/node/src/main.rs
@@ -79,8 +79,8 @@ pub fn main() {
     let service =
         Service::new(protocol_config, net_config, network_handler, client.clone()).unwrap();
     let task = generate_service_task::<_, _, BeaconBlockHeader>(
-        service.network.clone(),
-        service.protocol.clone(),
+        &service.network,
+        &service.protocol,
     );
     // produce some fake transactions once in a while
     let tx_period = Duration::from_millis(1000);


### PR DESCRIPTION
In the original substrate code there are Mutex/RwLock/Arc around the following structs. After we copied some the code we deleted them and replaced runner with a single_thread runner. This however prevents us from using the network concurrently and also reduces flexibility on where we can spawn the network. We need this change so that we can send stuff to network from anywhere in our codebase.

At some point we have to revisit the whole design of the libp2p library and the fact that their network is one singleton with a lock.