### PR TITLE
Put transaction and receipt together

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -291,7 +291,7 @@ impl CallbackResult {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[derive(Hash, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct ReceiptTransaction {
     // sender is the immediate predecessor
     pub sender: AccountId,
@@ -315,6 +315,12 @@ impl ReceiptTransaction {
             body,
         }
     }
+}
+
+#[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Clone, Debug)]
+pub enum Transaction {
+    Transaction(SignedTransaction),
+    Receipt(ReceiptTransaction),
 }
 
 // 2. State structs.

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -319,7 +319,7 @@ impl ReceiptTransaction {
 
 #[derive(Serialize, Deserialize, Hash, PartialEq, Eq, Clone, Debug)]
 pub enum Transaction {
-    Transaction(SignedTransaction),
+    SignedTransaction(SignedTransaction),
     Receipt(ReceiptTransaction),
 }
 

--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -8,13 +8,17 @@ extern crate storage;
 
 use chain::{SignedBlock, SignedHeader};
 use primitives::hash::{CryptoHash, hash_struct};
-use primitives::types::{AuthorityMask, MerkleHash, MultiSignature, PartialSignature, ReceiptTransaction, SignedTransaction};
+use primitives::types::{
+    AuthorityMask, MerkleHash, MultiSignature, PartialSignature,
+    Transaction, ShardId
+};
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ShardBlockHeader {
     pub parent_hash: CryptoHash,
     pub index: u64,
     pub merkle_root_state: MerkleHash,
+    pub shard_id: ShardId,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -28,8 +32,7 @@ pub struct SignedShardBlockHeader {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ShardBlock {
     pub header: ShardBlockHeader,
-    pub transactions: Vec<SignedTransaction>,
-    pub receipts: Vec<ReceiptTransaction>,
+    pub transactions: Vec<Transaction>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -56,8 +59,15 @@ impl SignedHeader for SignedShardBlockHeader {
 }
 
 impl SignedShardBlock {
-    pub fn new(index: u64, parent_hash: CryptoHash, merkle_root_state: MerkleHash, transactions: Vec<SignedTransaction>, receipts: Vec<ReceiptTransaction>) -> Self {
+    pub fn new(
+        shard_id: ShardId,
+        index: u64,
+        parent_hash: CryptoHash,
+        merkle_root_state: MerkleHash,
+        transactions: Vec<Transaction>,
+    ) -> Self {
         let header = ShardBlockHeader {
+            shard_id,
             index,
             parent_hash,
             merkle_root_state,
@@ -67,7 +77,6 @@ impl SignedShardBlock {
             body: ShardBlock {
                 header,
                 transactions,
-                receipts,
             },
             hash,
             signature: vec![],
@@ -76,7 +85,7 @@ impl SignedShardBlock {
     }
 
     pub fn genesis(merkle_root_state: MerkleHash) -> SignedShardBlock {
-        SignedShardBlock::new(0, CryptoHash::default(), merkle_root_state, vec![], vec![])
+        SignedShardBlock::new(0, 0, CryptoHash::default(), merkle_root_state, vec![])
     }
 }
 

--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -16,9 +16,9 @@ use primitives::types::{
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ShardBlockHeader {
     pub parent_hash: CryptoHash,
+    pub shard_id: ShardId,
     pub index: u64,
     pub merkle_root_state: MerkleHash,
-    pub shard_id: ShardId,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -33,6 +33,7 @@ pub struct SignedShardBlockHeader {
 pub struct ShardBlock {
     pub header: ShardBlockHeader,
     pub transactions: Vec<Transaction>,
+    pub new_receipts: Vec<Transaction>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -65,6 +66,7 @@ impl SignedShardBlock {
         parent_hash: CryptoHash,
         merkle_root_state: MerkleHash,
         transactions: Vec<Transaction>,
+        new_receipts: Vec<Transaction>,
     ) -> Self {
         let header = ShardBlockHeader {
             shard_id,
@@ -77,6 +79,7 @@ impl SignedShardBlock {
             body: ShardBlock {
                 header,
                 transactions,
+                new_receipts,
             },
             hash,
             signature: vec![],
@@ -85,7 +88,9 @@ impl SignedShardBlock {
     }
 
     pub fn genesis(merkle_root_state: MerkleHash) -> SignedShardBlock {
-        SignedShardBlock::new(0, 0, CryptoHash::default(), merkle_root_state, vec![])
+        SignedShardBlock::new(
+            0, 0, CryptoHash::default(), merkle_root_state, vec![], vec![]
+        )
     }
 }
 

--- a/node/beacon-chain-handler/src/importer.rs
+++ b/node/beacon-chain-handler/src/importer.rs
@@ -81,9 +81,13 @@ impl BlockImporter {
         let prev_header = self.beacon_chain
             .get_header(&BlockId::Hash(parent_hash))
             .expect("Parent is known but header not found.");
-        let prev_shard_header = self.shard_chain
-            .get_header(&BlockId::Hash(parent_shard_hash))
+        let prev_shard_block = self.shard_chain
+            .get_block(&BlockId::Hash(parent_shard_hash))
             .expect("At this moment shard chain should be present together with beacon chain");
+        //let prev_shard_header = self.shard_chain
+        //    .get_header(&BlockId::Hash(parent_shard_hash))
+        //    .expect("At this moment shard chain should be present together with beacon chain");
+        let prev_shard_header = prev_shard_block.header();
         let apply_state = ApplyState {
             root: prev_shard_header.body.merkle_root_state,
             block_index: prev_header.body.index,
@@ -92,6 +96,7 @@ impl BlockImporter {
         };
         let mut apply_result = self.runtime.write().apply(
             &apply_state,
+            prev_shard_block.body.new_receipts.clone(),
             shard_block.body.transactions.clone()
         );
         if apply_result.root != prev_shard_header.body.merkle_root_state {

--- a/node/beacon-chain-handler/src/importer.rs
+++ b/node/beacon-chain-handler/src/importer.rs
@@ -96,7 +96,7 @@ impl BlockImporter {
         };
         let mut apply_result = self.runtime.write().apply(
             &apply_state,
-            prev_shard_block.body.new_receipts.clone(),
+            &prev_shard_block.body.new_receipts,
             shard_block.body.transactions.clone()
         );
         if apply_result.root != prev_shard_header.body.merkle_root_state {

--- a/node/beacon-chain-handler/src/importer.rs
+++ b/node/beacon-chain-handler/src/importer.rs
@@ -84,9 +84,6 @@ impl BlockImporter {
         let prev_shard_block = self.shard_chain
             .get_block(&BlockId::Hash(parent_shard_hash))
             .expect("At this moment shard chain should be present together with beacon chain");
-        //let prev_shard_header = self.shard_chain
-        //    .get_header(&BlockId::Hash(parent_shard_hash))
-        //    .expect("At this moment shard chain should be present together with beacon chain");
         let prev_shard_header = prev_shard_block.header();
         let apply_state = ApplyState {
             root: prev_shard_header.body.merkle_root_state,

--- a/node/beacon-chain-handler/src/producer.rs
+++ b/node/beacon-chain-handler/src/producer.rs
@@ -90,7 +90,7 @@ impl ConsensusHandler<SignedBeaconBlock, ShardChainPayload> for BlockProducer {
         };
         let mut apply_result = self.runtime.write().apply(
             &apply_state,
-            last_shard_block.body.new_receipts.clone(),
+            &last_shard_block.body.new_receipts,
             transactions
         );
         self.state_db.commit(&mut apply_result.transaction).ok();

--- a/node/beacon-chain-handler/src/producer.rs
+++ b/node/beacon-chain-handler/src/producer.rs
@@ -10,7 +10,7 @@ use beacon::types::{SignedBeaconBlock, BeaconBlockChain};
 use chain::{SignedBlock, SignedHeader};
 use node_runtime::{ApplyState, Runtime};
 use primitives::traits::Signer;
-use primitives::types::{BlockId, ReceiptTransaction, SignedTransaction};
+use primitives::types::{BlockId, Transaction};
 use primitives::types::ConsensusBlockBody;
 use shard::{SignedShardBlock, ShardBlockChain};
 use storage::StateDb;
@@ -67,37 +67,37 @@ impl BlockProducer {
     }
 }
 
-pub type ShardChainPayload = (Vec<SignedTransaction>, Vec<ReceiptTransaction>);
+pub type ShardChainPayload = Vec<Transaction>;
 pub type ChainConsensusBlockBody = ConsensusBlockBody<ShardChainPayload>;
 
 impl ConsensusHandler<SignedBeaconBlock, ShardChainPayload> for BlockProducer {
     fn produce_block(&self, body: ChainConsensusBlockBody) {
         // TODO: verify signature
         let transactions = body.messages.iter()
-            .flat_map(|message| message.body.payload.0.clone())
-            .collect();
-        let receipts = body.messages.iter()
-            .flat_map(|message| message.body.payload.1.clone())
+            .flat_map(|message| message.body.payload.clone())
             .collect();
 
         // TODO: compute actual merkle root and state, as well as signature, and
         // use some reasonable fork-choice rule
         let last_block = self.beacon_chain.best_block();
-        let last_shard_block = self.shard_chain.get_header(&BlockId::Hash(last_block.body.header.shard_block_hash)).expect("At the moment we should have shard blocks accompany beacon blocks");
+        let last_shard_block = self.shard_chain
+            .get_header(&BlockId::Hash(last_block.body.header.shard_block_hash))
+            .expect("At the moment we should have shard blocks accompany beacon blocks");
+        let shard_id = last_shard_block.body.shard_id;
         let apply_state = ApplyState {
             root: last_shard_block.body.merkle_root_state,
             parent_block_hash: last_block.block_hash(),
             block_index: last_block.body.header.index + 1,
+            shard_id,
         };
-        let (filtered_transactions, filtered_receipts, mut apply_result) =
-            self.runtime.write().apply(&apply_state, transactions, receipts);
+        let mut apply_result = self.runtime.write().apply(&apply_state, transactions);
         self.state_db.commit(&mut apply_result.transaction).ok();
         let mut shard_block = SignedShardBlock::new(
+            shard_id,
             last_shard_block.body.index + 1,
             last_shard_block.block_hash(),
             apply_result.root,
-            filtered_transactions,
-            filtered_receipts
+            apply_result.filtered_transactions,
         );
         let mut block = SignedBeaconBlock::new(
             last_block.body.header.index + 1,
@@ -112,5 +112,6 @@ impl ConsensusHandler<SignedBeaconBlock, ShardChainPayload> for BlockProducer {
         self.shard_chain.insert_block(shard_block.clone());
         self.beacon_chain.insert_block(block.clone());
         info!(target: "block_producer", "Block body: {:?}", block.body);
+        //TODO: send new receipts in apply_result
     }
 }

--- a/node/beacon-chain-handler/src/producer.rs
+++ b/node/beacon-chain-handler/src/producer.rs
@@ -125,7 +125,7 @@ impl ConsensusHandler<SignedBeaconBlock, ShardChainPayload> for BlockProducer {
                 parent_block_hash: shard_block.block_hash(),
                 block_index: shard_block.body.header.index + 1,
             };
-            transactions = shard_block.body.new_receipts.clone();
+            transactions = shard_block.body.transactions.clone();
             last_shard_block = shard_block;
         }
     }

--- a/node/beacon-chain-handler/src/producer.rs
+++ b/node/beacon-chain-handler/src/producer.rs
@@ -73,47 +73,60 @@ pub type ChainConsensusBlockBody = ConsensusBlockBody<ShardChainPayload>;
 impl ConsensusHandler<SignedBeaconBlock, ShardChainPayload> for BlockProducer {
     fn produce_block(&self, body: ChainConsensusBlockBody) {
         // TODO: verify signature
-        let transactions = body.messages.iter()
+        let mut transactions = body.messages.iter()
             .flat_map(|message| message.body.payload.clone())
             .collect();
 
         let last_block = self.beacon_chain.best_block();
-        let last_shard_block = self.shard_chain
+        let mut last_shard_block = self.shard_chain
             .get_block(&BlockId::Hash(last_block.body.header.shard_block_hash))
             .expect("At the moment we should have shard blocks accompany beacon blocks");
         let shard_id = last_shard_block.body.header.shard_id;
-        let apply_state = ApplyState {
+        let mut apply_state = ApplyState {
             root: last_shard_block.body.header.merkle_root_state,
             parent_block_hash: last_block.block_hash(),
             block_index: last_block.body.header.index + 1,
             shard_id,
         };
-        let mut apply_result = self.runtime.write().apply(
-            &apply_state,
-            &last_shard_block.body.new_receipts,
-            transactions
-        );
-        self.state_db.commit(&mut apply_result.transaction).ok();
-        let mut shard_block = SignedShardBlock::new(
-            shard_id,
-            last_shard_block.body.header.index + 1,
-            last_shard_block.block_hash(),
-            apply_result.root,
-            apply_result.filtered_transactions,
-            apply_result.new_receipts,
-        );
-        let mut block = SignedBeaconBlock::new(
-            last_block.body.header.index + 1,
-            last_block.block_hash(),
-            apply_result.authority_proposals,
-            shard_block.block_hash()
-        );
-        let signature = shard_block.sign(self.signer.clone());
-        shard_block.add_signature(signature);
-        let signature = block.sign(self.signer.clone());
-        block.add_signature(signature);
-        self.shard_chain.insert_block(shard_block.clone());
-        self.beacon_chain.insert_block(block.clone());
-        info!(target: "block_producer", "Block body: {:?}", block.body);
+        loop {
+            let mut apply_result = self.runtime.write().apply(
+                &apply_state,
+                &last_shard_block.body.new_receipts,
+                transactions
+            );
+            self.state_db.commit(&mut apply_result.transaction).ok();
+            let mut shard_block = SignedShardBlock::new(
+                shard_id,
+                last_shard_block.body.header.index + 1,
+                last_shard_block.block_hash(),
+                apply_result.root,
+                apply_result.filtered_transactions,
+                apply_result.new_receipts,
+            );
+            let mut block = SignedBeaconBlock::new(
+                last_block.body.header.index + 1,
+                last_block.block_hash(),
+                apply_result.authority_proposals,
+                shard_block.block_hash()
+            );
+            let signature = shard_block.sign(self.signer.clone());
+            shard_block.add_signature(signature);
+            let signature = block.sign(self.signer.clone());
+            block.add_signature(signature);
+            self.shard_chain.insert_block(shard_block.clone());
+            self.beacon_chain.insert_block(block.clone());
+            info!(target: "block_producer", "Block body: {:?}", block.body);
+            if shard_block.body.new_receipts.is_empty() {
+                break;
+            }
+            apply_state = ApplyState {
+                root: shard_block.body.header.merkle_root_state,
+                shard_id,
+                parent_block_hash: shard_block.block_hash(),
+                block_index: shard_block.body.header.index + 1,
+            };
+            transactions = shard_block.body.new_receipts.clone();
+            last_shard_block = shard_block;
+        }
     }
 }

--- a/node/cli/src/test_utils.rs
+++ b/node/cli/src/test_utils.rs
@@ -2,7 +2,7 @@ use beacon_chain_handler::producer::{ChainConsensusBlockBody, ShardChainPayload}
 use futures::sync::mpsc::{Receiver, Sender};
 use futures::{future, Future, Sink, Stream};
 use primitives::signature::DEFAULT_SIGNATURE;
-use primitives::types::{MessageDataBody, SignedMessageData, SignedTransaction};
+use primitives::types::{MessageDataBody, SignedMessageData, SignedTransaction, Transaction};
 use std::collections::HashSet;
 use tokio;
 
@@ -20,7 +20,7 @@ pub fn spawn_pasthrough_consensus(
                         owner_uid: 0,
                         parents: HashSet::new(),
                         epoch: 0,
-                        payload: (vec![t], vec![]),
+                        payload: vec![Transaction::SignedTransaction(t)],
                         endorsements: vec![],
                     },
                 };

--- a/node/runtime/src/ext.rs
+++ b/node/runtime/src/ext.rs
@@ -3,7 +3,7 @@ use kvdb::DBValue;
 
 use primitives::types::{
     ReceiptId, Balance, Mana, CallbackId, ReceiptTransaction, Callback,
-    AccountId, PromiseId, ReceiptBody, AsyncCall, CallbackInfo
+    AccountId, PromiseId, ReceiptBody, AsyncCall, CallbackInfo, Transaction
 };
 use storage::StateDbUpdate;
 use wasm::ext::{External, Result as ExtResult, Error as ExtError};
@@ -50,8 +50,8 @@ impl<'a, 'b: 'a> RuntimeExt<'a, 'b> {
         nonce
     }
 
-    pub fn get_receipts(&mut self) -> Vec<ReceiptTransaction> {
-        self.receipts.drain().map(|(_, v)| v).collect()
+    pub fn get_receipts(&mut self) -> Vec<Transaction> {
+        self.receipts.drain().map(|(_, v)| Transaction::Receipt(v)).collect()
     }
 }
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -594,11 +594,6 @@ impl Runtime {
     ) -> Result<Vec<Transaction>, String> {
         let staked = runtime_data.at_stake(receiver_id);
         assert!(receiver.amount >= staked);
-        let mut runtime_ext = RuntimeExt::new(
-            state_update,
-            sender_id,
-            nonce,
-        );
         let mut needs_removal = false;
         let receipts = {
             let mut runtime_ext = RuntimeExt::new(

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -13,7 +13,7 @@ extern crate shard;
 extern crate storage;
 extern crate wasm;
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -27,7 +27,7 @@ use primitives::types::{
     AccountAlias, AccountId, MerkleHash, ReadablePublicKey, SignedTransaction, TransactionBody,
     ReceiptTransaction, ReceiptBody, AsyncCall, CallbackResult, CallbackInfo, Callback,
     PromiseId, CallbackId, StakeTransaction, SendMoneyTransaction, CreateAccountTransaction,
-    SwapKeyTransaction, DeployContractTransaction, Balance
+    SwapKeyTransaction, DeployContractTransaction, Balance, Transaction, ShardId,
 };
 use primitives::utils::{
     account_to_shard_id, index_to_bytes
@@ -93,14 +93,18 @@ fn create_nonce_with_nonce(base: &[u8], salt: u64) -> Vec<u8> {
 
 pub struct ApplyState {
     pub root: MerkleHash,
+    pub shard_id: ShardId,
     pub block_index: u64,
     pub parent_block_hash: CryptoHash,
 }
 
 pub struct ApplyResult {
     pub root: MerkleHash,
+    pub shard_id: ShardId,
     pub transaction: storage::TrieBackendTransaction,
     pub authority_proposals: Vec<AuthorityProposal>,
+    pub filtered_transactions: Vec<Transaction>,
+    pub new_receipts: Vec<Transaction>,
 }
 
 fn get<T: DeserializeOwned>(state_update: &mut StateDbUpdate, key: &[u8]) -> Option<T> {
@@ -131,7 +135,7 @@ impl Runtime {
         hash: CryptoHash,
         sender: &mut Account,
         runtime_data: &mut RuntimeData,
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         let staked = runtime_data.at_stake(transaction.sender);
         if sender.amount - staked >= transaction.amount {
             sender.amount -= transaction.amount;
@@ -147,7 +151,7 @@ impl Runtime {
                     1,
                 ))
             );
-            Ok(vec![receipt])
+            Ok(vec![Transaction::Receipt(receipt)])
         } else {
             Err(
                 format!(
@@ -168,7 +172,7 @@ impl Runtime {
         sender: &mut Account,
         runtime_data: &mut RuntimeData,
         authority_proposals: &mut Vec<AuthorityProposal>,
-    ) -> Result<Vec<ReceiptTransaction>, String>{
+    ) -> Result<Vec<Transaction>, String>{
         if sender.amount >= body.amount && sender.public_keys.is_empty() {
             runtime_data.put_stake(body.staker, body.amount);
             authority_proposals.push(AuthorityProposal {
@@ -197,7 +201,7 @@ impl Runtime {
         hash: CryptoHash,
         sender: &mut Account,
         runtime_data: &mut RuntimeData,
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         let staked = runtime_data.at_stake(body.sender);
         if sender.amount >= staked + body.amount {
             sender.amount -= body.amount;
@@ -218,7 +222,7 @@ impl Runtime {
                     0
                 ))
             );
-            Ok(vec![receipt])
+            Ok(vec![Transaction::Receipt(receipt)])
         } else {
             Err(
                 format!(
@@ -239,7 +243,8 @@ impl Runtime {
         signature: &Signature,
         data: &[u8],
         account: &mut Account,
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
+        // TODO: verify signature
         let cur_key = Decode::decode(&body.cur_key).ok_or("cannot decode public key")?;
         if !verify(data, signature, &cur_key) {
             return Err("Invalid signature. Cannot swap key".to_string());
@@ -264,7 +269,7 @@ impl Runtime {
         state_update: &mut StateDbUpdate,
         body: &DeployContractTransaction,
         account: &mut Account,
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         // TODO: check signature
         let pub_key = Decode::decode(&body.public_key).ok_or("cannot decode public key")?;
         if account.public_keys.contains(&pub_key) {
@@ -289,7 +294,7 @@ impl Runtime {
         hash: CryptoHash,
         method_name: &[u8],
         args: &[u8],
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         let staked = runtime_data.at_stake(sender_account_id);
         // sender.amount cannot be less than staked
         // otherwise staking would have failed
@@ -326,7 +331,7 @@ impl Runtime {
             &sender
         );        
         Ok(receipts)
-    }
+    }   
 
     /// node receives signed_transaction, processes it
     /// and generates the receipt to send to receiver
@@ -335,7 +340,7 @@ impl Runtime {
         state_update: &mut StateDbUpdate,
         transaction: &SignedTransaction,
         authority_proposals: &mut Vec<AuthorityProposal>,
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         let runtime_data: Option<RuntimeData> = get(state_update, RUNTIME_DATA);
         let sender: Option<Account> =
             get(state_update, &account_id_to_bytes(transaction.body.get_sender()));
@@ -418,7 +423,7 @@ impl Runtime {
         amount: u64,
         receiver_id: AccountId,
         receiver: &mut Account
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         receiver.amount += amount;
         set(
             state_update,
@@ -433,11 +438,12 @@ impl Runtime {
         state_update: &mut StateDbUpdate,
         call: &AsyncCall,
         account_id: AccountId,
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         let account_id_bytes = account_id_to_bytes(account_id);
         match get::<Account>(state_update, &account_id_bytes) {
             Some(_) => {
-                Err(format!("account {} already exists", account_id))
+                // this case should already be handled
+                unreachable!()
             }
             _ => {
                 let public_key = Decode::decode(&call.args).ok_or("cannot decode public key")?;
@@ -462,7 +468,7 @@ impl Runtime {
         callback_info: &Option<CallbackInfo>,
         sender_id: AccountId,
         receiver_id: AccountId,
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         let callback_info = match callback_info {
             Some(info) => info,
             _ => {
@@ -518,7 +524,7 @@ impl Runtime {
                 runtime_ext.create_nonce(),
                 ReceiptBody::Callback(callback_res),
             );
-            receipts.push(new_receipt);
+            receipts.push(Transaction::Receipt(new_receipt));
         }
         Ok(receipts)
     }
@@ -532,7 +538,7 @@ impl Runtime {
         receiver_id: AccountId,
         nonce: Vec<u8>,
         receiver: &mut Account,
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         let staked = runtime_data.at_stake(receiver_id);
         assert!(receiver.amount >= staked);
         let result = {
@@ -585,9 +591,14 @@ impl Runtime {
         receiver_id: AccountId,
         nonce: Vec<u8>,
         receiver: &mut Account,
-    ) -> Result<Vec<ReceiptTransaction>, String> {
+    ) -> Result<Vec<Transaction>, String> {
         let staked = runtime_data.at_stake(receiver_id);
         assert!(receiver.amount >= staked);
+        let mut runtime_ext = RuntimeExt::new(
+            state_update,
+            sender_id,
+            nonce,
+        );
         let mut needs_removal = false;
         let receipts = {
             let mut runtime_ext = RuntimeExt::new(
@@ -655,7 +666,7 @@ impl Runtime {
         &mut self,
         state_update: &mut StateDbUpdate,
         receipt: &ReceiptTransaction,
-        new_receipts: &mut Vec<ReceiptTransaction>,
+        new_receipts: &mut Vec<Transaction>,
     ) -> Result<(), String> {
         let receiver_id = account_id_to_bytes(receipt.receiver);
         let receiver: Option<Account> = get(state_update, &receiver_id);
@@ -677,8 +688,14 @@ impl Runtime {
                                 &mut receiver
                             )
                         } else if async_call.method_name == b"create_account".to_vec() {
-                            // account already exists, an error
-                            Err(format!("account {} already exists", receipt.receiver))
+                            debug!(target: "runtime", "account {} already exists", receipt.receiver);
+                            let receipt = ReceiptTransaction::new(
+                                system_account(),
+                                receipt.sender,
+                                create_nonce_with_nonce(&receipt.nonce, 0),
+                                ReceiptBody::Refund(async_call.amount)
+                            );
+                            Ok(vec![Transaction::Receipt(receipt)])
                         } else {
                             callback_info = async_call.callback.clone();
                             self.apply_async_call(
@@ -752,7 +769,7 @@ impl Runtime {
                         create_nonce_with_nonce(&receipt.nonce, 0),
                         ReceiptBody::Refund(amount)
                     );
-                    new_receipts.push(new_receipt);
+                    new_receipts.push(Transaction::Receipt(new_receipt));
                 }
                 if let Some(callback_info) = callback_info {
                     let new_receipt = ReceiptTransaction::new(
@@ -764,7 +781,7 @@ impl Runtime {
                             None,
                         ))
                     );
-                    new_receipts.push(new_receipt);
+                    new_receipts.push(Transaction::Receipt(new_receipt));
                 }
                 Err(s)
             }
@@ -774,54 +791,65 @@ impl Runtime {
     pub fn apply(
         &mut self,
         apply_state: &ApplyState,
-        transactions: Vec<SignedTransaction>,
-        mut receipts: Vec<ReceiptTransaction>,
-    ) -> (Vec<SignedTransaction>, Vec<ReceiptTransaction>, ApplyResult) {
-        let mut filtered_transactions = vec![];
+        mut transactions: Vec<Transaction>,
+    ) -> ApplyResult {
+        let mut new_receipts = vec![];
         let mut state_update = StateDbUpdate::new(self.state_db.clone(), apply_state.root);
         let mut authority_proposals = vec![];
-        for t in transactions {
-            match self.apply_signed_transaction(&mut state_update, &t, &mut authority_proposals) {
-                Ok(mut new_receipts) => {
-                    receipts.append(&mut new_receipts);
-                    state_update.commit();
-                    filtered_transactions.push(t);
-                }
-                Err(s) => {
-                    debug!(target: "runtime", "{}", s);
-                    state_update.rollback();
-                }
-            }
-        }
-        // receipts to be recorded in the block
-        let mut filtered_receipts = vec![];
-        let mut receipts: VecDeque<_> = receipts.into();
-        while let Some(receipt) = receipts.pop_front() {
-            // execute same shard receipts
-            if account_to_shard_id(receipt.sender) == account_to_shard_id(receipt.receiver) {
-                let mut new_receipts = vec![];
-                match self.apply_receipt(&mut state_update, &receipt, &mut new_receipts) {
-                    Ok(()) => {
-                        state_update.commit();
-                    }
-                    Err(s) => {
-                        debug!(target: "runtime", "{}", s);
-                        state_update.rollback();
+        let shard_id = apply_state.shard_id;
+        transactions.retain(|t| {
+            match t {
+                Transaction::Transaction(ref tx) => {
+                    match self.apply_signed_transaction(
+                        &mut state_update,
+                        tx,
+                        &mut authority_proposals
+                    ) {
+                        Ok(mut receipts) => {
+                            new_receipts.append(&mut receipts);
+                            state_update.commit();
+                            true
+                        }
+                        Err(s) => {
+                            debug!(target: "runtime", "{}", s);
+                            state_update.rollback();
+                            false
+                        }
                     }
                 }
-                receipts.append(&mut new_receipts.into());
-            } else {
-                filtered_receipts.push(receipt);
+                Transaction::Receipt(ref r) => {
+                    if account_to_shard_id(r.receiver) == shard_id {
+                        let mut tmp_new_receipts = vec![];
+                        match self.apply_receipt(&mut state_update, r, &mut tmp_new_receipts) {
+                            Ok(()) => {
+                                state_update.commit();
+                                new_receipts.append(&mut tmp_new_receipts);
+                                true
+                            }
+                            Err(s) => {
+                                debug!(target: "runtime", "{}", s);
+                                state_update.rollback();
+                                new_receipts.append(&mut tmp_new_receipts);
+                                false
+                            }
+                        }
+                    } else {
+                        // wrong receipt
+                        debug!(target: "runtime", "receipt sent to the wrong shard");
+                        false
+                    }
+                }
             }
-        }
+        });
         let (transaction, new_root) = state_update.finalize();
-        // Since we only have one shard, all receipts will be executed,
-        // filtered_receipts should be empty
-        (
-            filtered_transactions,
-            filtered_receipts,
-            ApplyResult { root: new_root, transaction, authority_proposals },
-        )
+        ApplyResult { 
+            root: new_root, 
+            transaction,
+            authority_proposals,
+            shard_id,
+            filtered_transactions: transactions,
+            new_receipts,
+        }
     }
 
     pub fn apply_genesis_state(
@@ -946,13 +974,16 @@ mod tests {
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
         let apply_state = ApplyState {
-            root, parent_block_hash: CryptoHash::default(), block_index: 0
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
         };
-        let (filtered_tx, filtered_receipts, apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Transaction(transaction)]
         );
-        assert_eq!(filtered_tx.len(), 1);
-        assert_eq!(filtered_receipts.len(), 0);
+        assert_eq!(apply_result.filtered_transactions.len(), 1);
+        assert_eq!(apply_result.new_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
     }
 
@@ -969,13 +1000,16 @@ mod tests {
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
         let apply_state = ApplyState { 
-            root, parent_block_hash: CryptoHash::default(), block_index: 0
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
         };
-        let (filtered_tx, filtered_receipts, apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Transaction(transaction)],
         );
-        assert_eq!(filtered_tx.len(), 1);
-        assert_eq!(filtered_receipts.len(), 0);
+        assert_eq!(apply_result.filtered_transactions.len(), 1);
+        assert_eq!(apply_result.new_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
     }
 
@@ -995,13 +1029,17 @@ mod tests {
             public_key: pub_key.encode().unwrap(),
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (filtered_tx, filtered_receipts, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_state = ApplyState { 
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let mut apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Transaction(transaction)]
         );
-        assert_eq!(filtered_tx.len(), 1);
-        assert_eq!(filtered_receipts.len(), 0);
+        assert_eq!(apply_result.filtered_transactions.len(), 1);
+        assert_eq!(apply_result.new_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         // deploy contract
@@ -1013,13 +1051,14 @@ mod tests {
             public_key: pub_key.encode().unwrap(),
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
-        let apply_state = ApplyState { 
+        let apply_state = ApplyState {
+            shard_id: 0,
             root: apply_result.root,
             parent_block_hash: CryptoHash::default(),
             block_index: 0 
         };
-        let (_, _, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let mut apply_result = runtime.apply(
+            &apply_state, vec![Transaction::Transaction(transaction)],
         );
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         let mut new_state_update = StateDbUpdate::new(runtime.state_db, apply_result.root);
@@ -1047,13 +1086,17 @@ mod tests {
             public_key: account.public_keys[0].encode().unwrap(),
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (filtered_tx, filtered_receipts, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let mut apply_result = runtime.apply(
+            &apply_state, vec![Transaction::Transaction(transaction)],
         );
-        assert_eq!(filtered_tx.len(), 1);
-        assert_eq!(filtered_receipts.len(), 0);
+        assert_eq!(apply_result.filtered_transactions.len(), 1);
+        assert_eq!(apply_result.new_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         let mut new_state_update = StateDbUpdate::new(runtime.state_db, apply_result.root);
@@ -1075,13 +1118,17 @@ mod tests {
             amount: 10,
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (filtered_tx, filtered_receipts, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let mut apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Transaction(transaction)]
         );
-        assert_eq!(filtered_tx.len(), 1);
-        assert_eq!(filtered_receipts.len(), 0);
+        assert_eq!(apply_result.filtered_transactions.len(), 1);
+        assert_eq!(apply_result.new_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         let result1 = viewer.view_at(
@@ -1125,13 +1172,17 @@ mod tests {
             amount: 1000,
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (filtered_tx, filtered_receipts, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let mut apply_result = runtime.apply(
+            &apply_state, vec![Transaction::Transaction(transaction)]
         );
-        assert_eq!(filtered_tx.len(), 0);
-        assert_eq!(filtered_receipts.len(), 0);
+        assert_eq!(apply_result.filtered_transactions.len(), 0);
+        assert_eq!(apply_result.new_receipts.len(), 0);
         assert_eq!(root, apply_result.root);
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         let result1 = viewer.view_at(
@@ -1175,13 +1226,15 @@ mod tests {
             amount: 10,
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (filtered_tx, filtered_receipts, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let mut apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Transaction(transaction)]
         );
-        assert_eq!(filtered_tx.len(), 1);
-        assert_eq!(filtered_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         let result1 = viewer.view_at(
@@ -1227,13 +1280,15 @@ mod tests {
             public_key: pub_key.encode().unwrap()
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (filtered_tx, filtered_receipts, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let mut apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Transaction(transaction)]
         );
-        assert_eq!(filtered_tx.len(), 1);
-        assert_eq!(filtered_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         let result1 = viewer.view_at(
@@ -1279,15 +1334,30 @@ mod tests {
             public_key: pub_key.encode().unwrap()
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (filtered_tx, filtered_receipts, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let mut apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Transaction(transaction)]
         );
-        assert_eq!(filtered_tx.len(), 1);
-        assert_eq!(filtered_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
+        //let apply_state = ApplyState {
+        //    root: apply_result.root,
+        //    shard_id: 0,
+        //    parent_block_hash: CryptoHash::default(),
+        //    block_index: 0
+        //};
+        //let mut apply_result = runtime.apply(
+        //    &apply_state, apply_result.new_receipts
+        //);
+        //assert_eq!(apply_result.filtered_transactions.len(), 0);
+        //assert_eq!(apply_result.new_receipts.len(), 0);
+        //assert_ne!(root, apply_result.root);
+        //runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         let result1 = viewer.view_at(
             &ViewCall::balance(hash(b"alice")),
             apply_result.root,
@@ -1332,13 +1402,17 @@ mod tests {
             public_key: pub_key1.encode().unwrap()
         });
         let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (filtered_tx, filtered_receipts, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction], vec![]
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let mut apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Transaction(transaction)]
         );
-        assert_eq!(filtered_tx.len(), 1);
-        assert_eq!(filtered_receipts.len(), 0);
+        assert_eq!(apply_result.filtered_transactions.len(), 1);
+        assert_eq!(apply_result.new_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         let tx_body = TransactionBody::SwapKey(SwapKeyTransaction {
@@ -1351,12 +1425,13 @@ mod tests {
         let signature = sign(&data, &secret_key1);
         let transaction1 = SignedTransaction::new(signature, tx_body);
         let apply_state = ApplyState {
+            shard_id: 0,
             root: apply_result.root,
             parent_block_hash: CryptoHash::default(),
             block_index: 0,
         };
-        let (_, _, mut apply_result) = runtime.apply(
-            &apply_state, vec![transaction1], vec![]
+        let mut apply_result = runtime.apply(
+            &apply_state, vec![Transaction::Transaction(transaction1)],
         );
         runtime.state_db.commit(&mut apply_result.transaction).unwrap();
         let mut new_state_update = StateDbUpdate::new(runtime.state_db.clone(), apply_result.root);
@@ -1382,12 +1457,17 @@ mod tests {
                 0,
             ))
         );
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (_, filtered_receipts, apply_result) = runtime.apply(
-            &apply_state, vec![], vec![receipt]
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Receipt(receipt)]
         );
-        assert_eq!(filtered_receipts.len(), 0);
+        assert_eq!(apply_result.filtered_transactions.len(), 1);
+        assert_eq!(apply_result.new_receipts.len(), 0);
         assert_ne!(root, apply_result.root);
     }
 
@@ -1412,11 +1492,17 @@ mod tests {
         let mut new_receipts = vec![];
         runtime.apply_receipt(&mut state_update, &receipt, &mut new_receipts).unwrap();
         assert_eq!(new_receipts.len(), 1);
-        let new_receipt = &new_receipts[0];
-        assert_eq!(new_receipt.sender, hash(b"bob"));
-        assert_eq!(new_receipt.receiver, hash(b"alice"));
-        let callback_res = CallbackResult::new(callback_info.clone(), Some(encode_int(20).to_vec()));
-        assert_eq!(new_receipt.body, ReceiptBody::Callback(callback_res));
+        if let Transaction::Receipt(new_receipt) = &new_receipts[0] {
+            assert_eq!(new_receipt.sender, hash(b"bob"));
+            assert_eq!(new_receipt.receiver, hash(b"alice"));
+            let callback_res = CallbackResult::new(
+                callback_info.clone(), Some(encode_int(20).to_vec())
+            );
+            assert_eq!(new_receipt.body, ReceiptBody::Callback(callback_res));
+        } else {
+            assert!(false);
+        }
+        
     }
 
     #[test]
@@ -1437,12 +1523,15 @@ mod tests {
                 None,
             ))
         );
-        let apply_state =
-            ApplyState { root, parent_block_hash: CryptoHash::default(), block_index: 0 };
-        let (_, filtered_receipts, apply_result) = runtime.apply(
-            &apply_state, vec![], vec![receipt]
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let apply_result = runtime.apply_all(
+            apply_state, vec![Transaction::Receipt(receipt)]
         );
-        assert_eq!(filtered_receipts.len(), 0);
         assert_eq!(runtime.callbacks.len(), 0);
         assert_eq!(root, apply_result.root);
     }

--- a/node/runtime/src/test_utils.rs
+++ b/node/runtime/src/test_utils.rs
@@ -67,7 +67,7 @@ impl Runtime {
         let mut cur_apply_state = apply_state;
         let mut cur_transactions = transactions;
         loop {
-            let mut apply_result = self.apply(&cur_apply_state, cur_transactions);
+            let mut apply_result = self.apply(&cur_apply_state, vec![], cur_transactions);
             if apply_result.new_receipts.is_empty() {
                 return apply_result;
             }

--- a/node/runtime/src/test_utils.rs
+++ b/node/runtime/src/test_utils.rs
@@ -67,7 +67,7 @@ impl Runtime {
         let mut cur_apply_state = apply_state;
         let mut cur_transactions = transactions;
         loop {
-            let mut apply_result = self.apply(&cur_apply_state, vec![], cur_transactions);
+            let mut apply_result = self.apply(&cur_apply_state, &[], cur_transactions);
             if apply_result.new_receipts.is_empty() {
                 return apply_result;
             }

--- a/node/runtime/src/test_utils.rs
+++ b/node/runtime/src/test_utils.rs
@@ -1,21 +1,23 @@
 use state_viewer::StateDbViewer;
 use chain_spec::ChainSpec;
 use primitives::signature::{PublicKey, get_keypair};
+use primitives::types::Transaction;
 use std::sync::Arc;
 use storage::test_utils::create_memory_db;
-use Runtime;
 use storage::StateDb;
 use shard::SignedShardBlock;
 use chain::BlockChain;
 use byteorder::{ByteOrder, LittleEndian};
+use super::{Runtime, ApplyResult, ApplyState};
 
 pub fn generate_test_chain_spec() -> ChainSpec {
     let genesis_wasm = include_bytes!("../../../core/wasm/runtest/res/wasm_with_mem.wasm").to_vec();
-    let public_keys: Vec<PublicKey> = (0..2).map(|_| get_keypair().0).collect();
+    let public_keys: Vec<PublicKey> = (0..3).map(|_| get_keypair().0).collect();
     ChainSpec {
         accounts: vec![
             ("alice".to_string(), public_keys[0].to_string(), 100),
             ("bob".to_string(), public_keys[1].to_string(), 0),
+            ("system".to_string(), public_keys[2].to_string(), 0),
         ],
         initial_authorities: vec![(public_keys[0].to_string(), 50)],
         genesis_wasm,
@@ -54,4 +56,29 @@ pub fn encode_int(val: i32) -> [u8; 4] {
     let mut tmp = [0u8; 4];
     LittleEndian::write_i32(&mut tmp, val);
     tmp
+}
+
+impl Runtime {
+    pub fn apply_all(
+        &mut self,
+        apply_state: ApplyState,
+        transactions: Vec<Transaction>,
+    ) -> ApplyResult {
+        let mut cur_apply_state = apply_state;
+        let mut cur_transactions = transactions;
+        loop {
+            let mut apply_result = self.apply(&cur_apply_state, cur_transactions);
+            if apply_result.new_receipts.is_empty() {
+                return apply_result;
+            }
+            self.state_db.commit(&mut apply_result.transaction).unwrap();
+            cur_apply_state = ApplyState {
+                root: apply_result.root,
+                shard_id: cur_apply_state.shard_id,
+                block_index: cur_apply_state.block_index,
+                parent_block_hash: cur_apply_state.parent_block_hash,
+            };
+            cur_transactions = apply_result.new_receipts;
+        }
+    }
 }


### PR DESCRIPTION
Add Transaction enum to put transaction and receipt in one data type so that the order of transactions in a block can be preserved. Fixes https://github.com/nearprotocol/nearcore/issues/174