### PR TITLE
State viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ $ ./scripts/rpc.py send_money -r bob -a 1
 
 # Create an account
 ./scripts/rpc.py create_account cindy 1
+
+# View full state db of the contract
+./scripts/rpc.py view_state test_contract
 ```
 
 ## Development

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -87,6 +87,8 @@ pub struct StateDb {
     null_node_data: DBValue,
 }
 
+type StateDbIterator<'a> = Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a>;
+
 impl StateDb {
     pub fn new(storage: Arc<KeyValueDB>) -> Self {
         StateDb {
@@ -105,6 +107,10 @@ impl StateDb {
             }
         }
         self.storage.write(db_transaction)
+    }
+
+    pub fn iter_prefix<'a>(&'a self, prefix: &'a [u8]) -> StateDbIterator<'a> {
+        self.storage.iter_from_prefix(COL_STATE, prefix)
     }
 }
 

--- a/core/storage/src/lib.rs
+++ b/core/storage/src/lib.rs
@@ -18,7 +18,7 @@ use kvdb_rocksdb::{Database, DatabaseConfig};
 use primitives::hash::CryptoHash;
 use primitives::types::MerkleHash;
 use std::sync::Arc;
-use substrate_storage::{CryptoHasher, Externalities, OverlayedChanges, StateExt, TrieBackend};
+use substrate_storage::{CryptoHasher, Externalities, OverlayedChanges, StateExt, TrieBackend, Backend};
 pub use substrate_storage::TrieBackendTransaction;
 
 mod substrate_storage;
@@ -62,6 +62,9 @@ impl<'a> StateDbUpdate<'a> {
     pub fn delete(&mut self, key: &[u8]) {
         self.ext.clear_storage(key);
     }
+    pub fn for_keys_with_prefix<F: FnMut(&[u8])>(&self, prefix: &[u8], f: F) {
+        self._backend.for_keys_with_prefix(prefix, f);
+    }
     pub fn commit(&mut self) {
         self.overlay.commit_prospective();
     }
@@ -87,8 +90,6 @@ pub struct StateDb {
     null_node_data: DBValue,
 }
 
-type StateDbIterator<'a> = Box<Iterator<Item=(Box<[u8]>, Box<[u8]>)> + 'a>;
-
 impl StateDb {
     pub fn new(storage: Arc<KeyValueDB>) -> Self {
         StateDb {
@@ -107,10 +108,6 @@ impl StateDb {
             }
         }
         self.storage.write(db_transaction)
-    }
-
-    pub fn iter_prefix<'a>(&'a self, prefix: &'a [u8]) -> StateDbIterator<'a> {
-        self.storage.iter_from_prefix(COL_STATE, prefix)
     }
 }
 
@@ -144,10 +141,13 @@ mod tests {
         let mut state_db_update = StateDbUpdate::new(state_db.clone(), root);
         state_db_update.set(b"dog", &DBValue::from_slice(b"puppy"));
         state_db_update.set(b"dog2", &DBValue::from_slice(b"puppy"));
-        state_db_update.set(b"dog3", &DBValue::from_slice(b"puppy"));
+        state_db_update.set(b"xxx", &DBValue::from_slice(b"puppy"));
         let (mut transaction, new_root) = state_db_update.finalize();
         state_db.commit(&mut transaction).ok();
         let state_db_update2 = StateDbUpdate::new(state_db.clone(), new_root);
         assert_eq!(state_db_update2.get(b"dog").unwrap(), DBValue::from_slice(b"puppy"));
+        let mut values = vec![];
+        state_db_update2.for_keys_with_prefix(b"dog", |key| { values.push(key.to_vec()) });
+        assert_eq!(values, vec![b"dog".to_vec(), b"dog2".to_vec()]);
     }
 }

--- a/node/rpc/src/api.rs
+++ b/node/rpc/src/api.rs
@@ -228,7 +228,7 @@ impl TransactionApi for RpcImpl {
     }
 
     fn rpc_view_state(&self, r: ViewStateRequest) -> JsonRpcResult<ViewStateResponse> {
-        let result = self.state_db_viewer.view_state(&r.contract_account_id);
+        let result = self.state_db_viewer.view_state(r.contract_account_id);
         let response = ViewStateResponse {
             contract_account_id: r.contract_account_id,
             values: result.values

--- a/node/rpc/src/types.rs
+++ b/node/rpc/src/types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use primitives::hash::bs58_format;
 use primitives::signature::{bs58_pub_key_format, PublicKey};
 use primitives::types::{AccountId, Balance, TransactionBody};
@@ -98,4 +100,17 @@ pub struct CallViewFunctionResponse {
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct PreparedTransactionBodyResponse {
     pub body: TransactionBody,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ViewStateRequest {
+    #[serde(with = "bs58_format")]
+    pub contract_account_id: AccountId,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ViewStateResponse {
+    #[serde(with = "bs58_format")]
+    pub contract_account_id: AccountId,
+    pub values: HashMap<String, String>,
 }

--- a/node/rpc/src/types.rs
+++ b/node/rpc/src/types.rs
@@ -112,5 +112,5 @@ pub struct ViewStateRequest {
 pub struct ViewStateResponse {
     #[serde(with = "bs58_format")]
     pub contract_account_id: AccountId,
-    pub values: HashMap<String, String>,
+    pub values: HashMap<Vec<u8>, Vec<u8>>,
 }

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -214,6 +214,10 @@ class NearRPC(object):
         response = self._call_rpc('schedule_function_call', params)
         return self._handle_prepared_transaction_body_response(response)
 
+    def view_state(self, contract_name):
+        params = {'contract_account_id': _get_account_id(contract_name)}
+        return self._call_rpc('view_state', params)
+
     def create_account(
         self,
         sender,
@@ -282,6 +286,7 @@ deploy                   {}
 send_money               {}
 schedule_function_call   {}
 view_account             {}
+view_state               {}
 stake                    {}
 create_account           {}
 swap_key                 {}
@@ -291,6 +296,7 @@ swap_key                 {}
                 self.send_money.__doc__,
                 self.schedule_function_call.__doc__,
                 self.view_account.__doc__,
+                self.view_state.__doc__,
                 self.stake.__doc__,
                 self.create_account.__doc__,
                 self.swap_key.__doc__,
@@ -492,6 +498,16 @@ swap_key                 {}
         args = self._get_command_args(parser)
         client = self._get_rpc_client(args)
         return client.stake(args.sender, args.amount)
+
+    def view_state(self):
+        """View state of the contract."""
+        parser = self._get_command_parser(self.view_state.__doc__)
+        parser.add_argument('contract_name', type=str)
+        args = self._get_command_args(parser)
+        client = self._get_rpc_client(args)
+        return client.view_state(
+            args.contract_name,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_rpc_cli.rs
+++ b/tests/test_rpc_cli.rs
@@ -6,9 +6,10 @@ extern crate node_rpc;
 extern crate primitives;
 extern crate serde_json;
 
+use std::collections::HashMap;
 use serde_json::Value;
 use node_rpc::types::{
-    CallViewFunctionResponse, ViewAccountResponse,
+    CallViewFunctionResponse, ViewAccountResponse, ViewStateResponse
 };
 use std::borrow::Cow;
 use std::path::Path;
@@ -81,6 +82,7 @@ fn test_deploy() {
         .arg(&*PUBLIC_KEY)
         .output()
         .expect("deploy command failed to process");
+    println!("{:?}", output);
     let result = check_result(&output);
     let data: Value = serde_json::from_str(&result).unwrap();
     assert_eq!(data, Value::Null);
@@ -117,6 +119,20 @@ fn test_call_view_function() {
         .expect("call_view_function command failed to process");
     let result = check_result(&output);
     let _: CallViewFunctionResponse = serde_json::from_str(&result).unwrap();
+}
+
+#[test]
+fn test_view_state() {
+    if !*DEVNET_STARTED { panic!() }
+    test_deploy();
+    let output = Command::new("./scripts/rpc.py")
+        .arg("view_state")
+        .arg("test_contract_name")
+        .output()
+        .expect("view_state command failed to process");
+    let result = check_result(&output);
+    let response: ViewStateResponse = serde_json::from_str(&result).unwrap();
+    assert_eq!(response.values, HashMap::default());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #212 allows to retrieve state of the current contract via RPC.
Useful for initial debugging and in future can be extended to query parts of the contract state (e.g. logs / events / notifications / etc).