### PR TITLE
send authority info when discovers new block

### DIFF
--- a/core/beacon/src/authority.rs
+++ b/core/beacon/src/authority.rs
@@ -6,7 +6,17 @@ use chain::{BlockChain, SignedBlock};
 use primitives::hash::CryptoHash;
 use primitives::signature::PublicKey;
 use primitives::types::{AccountId, BlockId};
-use types::{AuthorityProposal, SignedBeaconBlock, SignedBeaconBlockHeader};
+use types::{SignedBeaconBlock, SignedBeaconBlockHeader};
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+pub struct AuthorityProposal {
+    /// Account that stakes money.
+    pub account_id: AccountId,
+    /// Public key of the proposed authority.
+    pub public_key: PublicKey,
+    /// Stake / weight of the authority.
+    pub amount: u64,
+}
 
 /// Configure the authority rotation.
 pub struct AuthorityConfig {

--- a/core/beacon/src/types.rs
+++ b/core/beacon/src/types.rs
@@ -1,17 +1,7 @@
 use chain::{SignedBlock, SignedHeader};
 use primitives::hash::{hash_struct, CryptoHash};
-use primitives::signature::PublicKey;
-use primitives::types::{AccountId, AuthorityMask, MultiSignature, PartialSignature};
-
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct AuthorityProposal {
-    /// Account that stakes money.
-    pub account_id: AccountId,
-    /// Public key of the proposed authority.
-    pub public_key: PublicKey,
-    /// Stake / weight of the authority.
-    pub amount: u64,
-}
+use primitives::types::{AuthorityMask, MultiSignature, PartialSignature};
+use authority::AuthorityProposal;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct BeaconBlockHeader {

--- a/core/primitives/src/signer.rs
+++ b/core/primitives/src/signer.rs
@@ -6,26 +6,34 @@ use types;
 pub struct InMemorySigner {
     public_key: signature::PublicKey,
     secret_key: signature::SecretKey,
+    account_id: types::AccountId,
 }
 
 impl InMemorySigner {
-    pub fn new() -> Self {
+    pub fn new(account_id: types::AccountId) -> Self {
         let (public_key, secret_key) = signature::get_keypair();
-        InMemorySigner { public_key, secret_key }
+        InMemorySigner { public_key, secret_key, account_id }
     }
 }
 
 impl Default for InMemorySigner {
     fn default() -> Self {
-        Self::new()
+        Self::new(hash::CryptoHash::default())
     }
 }
 
 impl traits::Signer for InMemorySigner {
+    #[inline]
     fn public_key(&self) -> signature::PublicKey {
         self.public_key
     }
+
     fn sign(&self, hash: &hash::CryptoHash) -> types::PartialSignature {
         signature::sign(hash.as_ref(), &self.secret_key)
+    }
+
+    #[inline]
+    fn account_id(&self) -> types::AccountId {
+        self.account_id
     }
 }

--- a/core/primitives/src/traits.rs
+++ b/core/primitives/src/traits.rs
@@ -43,6 +43,7 @@ where
 pub trait Signer: Sync + Send {
     fn public_key(&self) -> signature::PublicKey;
     fn sign(&self, hash: &CryptoHash) -> types::PartialSignature;
+    fn account_id(&self) -> types::AccountId;
 }
 
 pub trait WitnessSelector {

--- a/node/beacon-chain-handler/src/authority_handler.rs
+++ b/node/beacon-chain-handler/src/authority_handler.rs
@@ -1,0 +1,65 @@
+use std::collections::HashMap;
+use beacon::authority::{Authority, SelectedAuthority};
+use beacon::types::SignedBeaconBlock;
+use primitives::types::{AccountId, UID};
+use chain::{SignedBlock, SignedHeader};
+use futures::{Stream, Sink, Future};
+use futures::sync::mpsc::{Receiver, Sender};
+
+pub fn spawn_authority_task(
+    mut authority_handler: AuthorityHandler,
+    new_block_rx: Receiver<SignedBeaconBlock>,
+    authority_tx: Sender<HashMap<UID, SelectedAuthority>>,
+) {
+    tokio::spawn(
+        new_block_rx.for_each(move |block| {
+            let index = block.header().index();
+            authority_handler.authority.process_block_header(&block.header());
+            // get authorities for the next block
+            let next_authorities = authority_handler.authority
+                .get_authorities(index + 1)
+                .unwrap_or_else(|_| panic!("failed to get authorities for block index {}", index + 1));
+
+            let mut uid_to_authority_map = HashMap::new();
+            let mut found_match = false;
+            for (index, authority) in next_authorities.into_iter().enumerate() {
+                if authority.account_id == authority_handler.account_id {
+                    found_match = true;
+                }
+                uid_to_authority_map.insert(index as u64, authority);
+            }
+            if found_match && !authority_handler.started {
+                authority_handler.started = true;
+                // TODO: send start signal to consensus
+            }
+            else if !found_match && authority_handler.started {
+                authority_handler.started = false;
+                // TODO: send stop signal to consensus
+            }
+            let authority_map_tx = authority_tx.clone();
+            tokio::spawn(
+                authority_map_tx
+                    .send(uid_to_authority_map)
+                    .map(|_| ())
+                    .map_err(|e| error!("Error sending authority map: {:?}", e))
+            );
+            Ok(())
+        })
+    );
+}
+pub struct AuthorityHandler {
+    authority: Authority,
+    account_id: AccountId,
+    /// whether the node has started consensus
+    started: bool
+}
+
+impl AuthorityHandler {
+    pub fn new(authority: Authority, account_id: AccountId) -> Self {
+        AuthorityHandler {
+            authority,
+            account_id,
+            started: false,
+        }
+    }
+}

--- a/node/beacon-chain-handler/src/importer.rs
+++ b/node/beacon-chain-handler/src/importer.rs
@@ -172,16 +172,6 @@ impl BlockImporter {
                 .remove(&next_beacon_block.body.header.shard_block_hash)
                 .expect("Expected to have shard block present when processing beacon block");
 
-            // send authorities through the channel
-            //tokio::spawn({
-            //    let authority_tx = self.authority_tx.clone();
-            //    authority_tx
-            //        .send(authorities)
-            //        .map(|_| ())
-            //        .map_err(|e| { 
-            //            error!("failed to send authorities: {:?}", e);
-            //        })
-            //});
             tokio::spawn({
                 let block_tx = self.new_block_tx.clone();
                 block_tx

--- a/node/beacon-chain-handler/src/importer.rs
+++ b/node/beacon-chain-handler/src/importer.rs
@@ -1,11 +1,10 @@
 //! BeaconBlockImporter consumes blocks that we received from other peers and adds them to the
 //! chain.
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use futures::{Future, future, Stream};
-use futures::sync::mpsc::Receiver;
+use futures::{Future, future, Stream, Sink};
+use futures::sync::mpsc::{Receiver, Sender};
 use parking_lot::RwLock;
 
 use beacon::types::{SignedBeaconBlock, BeaconBlockChain};
@@ -21,16 +20,18 @@ pub fn spawn_block_importer(
     shard_chain: Arc<ShardBlockChain>,
     runtime: Arc<RwLock<Runtime>>,
     state_db: Arc<StateDb>,
-    receiver: Receiver<SignedBeaconBlock>
+    receiver: Receiver<SignedBeaconBlock>,
+    new_block_tx: Sender<SignedBeaconBlock>,
 ) {
-    let beacon_block_importer = RefCell::new(BlockImporter::new(
+    let beacon_block_importer = BlockImporter::new(
         beacon_chain,
         shard_chain,
         runtime,
         state_db,
-    ));
-    let task = receiver.fold(beacon_block_importer, |beacon_block_importer, body| {
-        beacon_block_importer.borrow_mut().import_beacon_block(body);
+        new_block_tx,
+    );
+    let task = receiver.fold(beacon_block_importer, |mut beacon_block_importer, body| {
+        beacon_block_importer.import_beacon_block(body);
         future::ok(beacon_block_importer)
     }).and_then(|_| Ok(()));
     tokio::spawn(task);
@@ -44,6 +45,7 @@ pub struct BlockImporter {
     /// Stores blocks that cannot be added yet.
     pending_beacon_blocks: HashMap<CryptoHash, SignedBeaconBlock>,
     pending_shard_blocks: HashMap<CryptoHash, SignedShardBlock>,
+    new_block_tx: Sender<SignedBeaconBlock>,
 }
 
 impl BlockImporter {
@@ -52,6 +54,7 @@ impl BlockImporter {
         shard_chain: Arc<ShardBlockChain>,
         runtime: Arc<RwLock<Runtime>>,
         state_db: Arc<StateDb>,
+        new_block_tx: Sender<SignedBeaconBlock>,
     ) -> Self {
         Self {
             beacon_chain,
@@ -60,6 +63,7 @@ impl BlockImporter {
             state_db,
             pending_beacon_blocks: HashMap::new(),
             pending_shard_blocks: HashMap::new(),
+            new_block_tx,
         }
     }
 
@@ -164,7 +168,29 @@ impl BlockImporter {
             let hash = next_beacon_block.block_hash();
             if self.beacon_chain.is_known(&hash) { continue; }
 
-            let next_shard_block = self.pending_shard_blocks.remove(&next_beacon_block.body.header.shard_block_hash).expect("Expected to have shard block present when processing beacon block");
+            let next_shard_block = self.pending_shard_blocks
+                .remove(&next_beacon_block.body.header.shard_block_hash)
+                .expect("Expected to have shard block present when processing beacon block");
+
+            // send authorities through the channel
+            //tokio::spawn({
+            //    let authority_tx = self.authority_tx.clone();
+            //    authority_tx
+            //        .send(authorities)
+            //        .map(|_| ())
+            //        .map_err(|e| { 
+            //            error!("failed to send authorities: {:?}", e);
+            //        })
+            //});
+            tokio::spawn({
+                let block_tx = self.new_block_tx.clone();
+                block_tx
+                    .send(next_beacon_block.clone())
+                    .map(|_| ())
+                    .map_err(|e| {
+                        error!("failed to send new block: {:?}", e);
+                    })
+            });
             self.add_block(next_beacon_block, next_shard_block);
         }
     }

--- a/node/beacon-chain-handler/src/lib.rs
+++ b/node/beacon-chain-handler/src/lib.rs
@@ -12,3 +12,4 @@ extern crate tokio;
 
 pub mod producer;
 pub mod importer;
+pub mod authority_handler;

--- a/node/cli/src/lib.rs
+++ b/node/cli/src/lib.rs
@@ -97,7 +97,14 @@ pub fn get_service_config() -> service::ServiceConfig {
                 ])
                 .default_value(&default_log_level)
                 .takes_value(true),
-        ).get_matches();
+        ).arg(
+            Arg::with_name("account_name")
+            .value_name("ACCOUNT_NAME")
+            .help("Set the account name of the node")
+            .takes_value(true)
+            .default_value("alice")
+        )
+        .get_matches();
 
     let base_path = matches
         .value_of("base_path")
@@ -134,6 +141,11 @@ pub fn get_service_config() -> service::ServiceConfig {
         .map(String::from)
         .collect();
 
+    let account_name = matches
+        .value_of("account_name")
+        .map(String::from)
+        .unwrap();
+
     service::ServiceConfig {
         base_path,
         chain_spec_path,
@@ -142,6 +154,7 @@ pub fn get_service_config() -> service::ServiceConfig {
         rpc_port,
         boot_nodes,
         test_node_index,
+        account_name
     }
 }
 

--- a/node/network/src/protocol.rs
+++ b/node/network/src/protocol.rs
@@ -91,7 +91,7 @@ pub struct Protocol<B: SignedBlock, Header: BlockHeader> {
     /// Channel into which the protocol sends the gossips that should be processed by TxFlow.
     gossip_sender: Sender<Gossip<ChainPayload>>,
     /// map between authority uid and authority public key
-    pub authority_map: RwLock<HashMap<UID, PublicKey>>,
+    authority_map: RwLock<HashMap<UID, PublicKey>>,
 }
 
 impl<B: SignedBlock, Header: BlockHeader> Protocol<B, Header> {

--- a/node/network/src/protocol.rs
+++ b/node/network/src/protocol.rs
@@ -11,7 +11,12 @@ use chain::{SignedBlock, SignedHeader as BlockHeader, BlockChain};
 use message::{self, Message};
 use primitives::hash::CryptoHash;
 use primitives::traits::Decode;
-use primitives::types::{BlockId, ReceiptTransaction, SignedTransaction, Gossip, ChainPayload};
+use primitives::types::{
+    BlockId, ReceiptTransaction, SignedTransaction, Gossip, ChainPayload,
+    UID,
+};
+use primitives::signature::PublicKey;
+use beacon::authority::SelectedAuthority;
 use test_utils;
 
 /// time to wait (secs) for a request
@@ -85,6 +90,8 @@ pub struct Protocol<B: SignedBlock, Header: BlockHeader> {
     message_sender: Sender<(NodeIndex, Message<B, Header, ChainPayload>)>,
     /// Channel into which the protocol sends the gossips that should be processed by TxFlow.
     gossip_sender: Sender<Gossip<ChainPayload>>,
+    /// map between authority uid and authority public key
+    pub authority_map: RwLock<HashMap<UID, PublicKey>>,
 }
 
 impl<B: SignedBlock, Header: BlockHeader> Protocol<B, Header> {
@@ -107,6 +114,7 @@ impl<B: SignedBlock, Header: BlockHeader> Protocol<B, Header> {
             receipt_sender,
             message_sender,
             gossip_sender,
+            authority_map: RwLock::new(HashMap::new())
         }
     }
 
@@ -345,14 +353,30 @@ impl<B: SignedBlock, Header: BlockHeader> Protocol<B, Header> {
         }
         aborting
     }
+
+    pub fn set_authority_map(&self, authority_map: HashMap<UID, SelectedAuthority>) {
+        *self.authority_map.write() = authority_map
+            .into_iter()
+            .map(|(k, v)| (k, v.public_key))
+            .collect();
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    extern crate storage;
+
     use super::*;
+    use std::thread;
+    use std::time::Duration;
     use primitives::traits::Encode;
     use primitives::types::{SignedTransaction, ChainPayload};
-    use beacon::types::{SignedBeaconBlock, SignedBeaconBlockHeader};
+    use beacon::types::{SignedBeaconBlock, SignedBeaconBlockHeader, BeaconBlockChain};
+    use beacon::authority::Authority;
+    use test_utils::{get_test_protocol, get_test_authority_config};
+    use self::storage::test_utils::create_memory_db;
+    use futures::sync::mpsc::channel;
+    use futures::{Sink, Stream};
 
     #[test]
     fn test_serialization() {
@@ -362,5 +386,49 @@ mod tests {
         let encoded = Encode::encode(&message).unwrap();
         let decoded = Decode::decode(&encoded).unwrap();
         assert_eq!(message, decoded);
+    }
+
+    #[test]
+    fn test_authority_map() {
+        let storage = Arc::new(create_memory_db());
+        let genesis_block = SignedBeaconBlock::new(
+            0, CryptoHash::default(), vec![], CryptoHash::default()
+        );
+        // chain1
+        let beacon_chain = Arc::new(BeaconBlockChain::new(genesis_block.clone(), storage.clone()));
+        let authority_config = get_test_authority_config(1, 1, 1);
+        let authority = Authority::new(authority_config, &beacon_chain);
+        let (authority_tx, authority_rx) = channel(1024);
+        let protocol = Arc::new(get_test_protocol());
+
+        // get authorities for block 1
+        let authorities = authority.get_authorities(1).unwrap();
+        let authority_map: HashMap<UID, SelectedAuthority> = 
+            authorities.into_iter().enumerate().map(|(k, v)| (k as UID, v)).collect();
+        let authority_map1 = authority_map.clone().into_iter().map(|(k, v)| (k, v.public_key)).collect();
+        let protocol1 = protocol.clone();
+        let task = futures::lazy(move || {
+            tokio::spawn(
+                authority_rx.for_each(move |map| {
+                    protocol1.set_authority_map(map);
+                    Ok(())
+                })
+            );
+            tokio::spawn(
+                authority_tx
+                    .send(authority_map)
+                    .map(|_| ())
+                    .map_err(|_| ())
+            );
+            Ok(())
+        });
+
+        let handle = thread::spawn(move || {
+            tokio::run(task);
+        });
+        thread::sleep(Duration::from_secs(1));
+        let map = protocol.authority_map.read();
+        assert_eq!(*map, authority_map1);
+        std::mem::drop(handle);
     }
 }

--- a/node/network/src/test_utils.rs
+++ b/node/network/src/test_utils.rs
@@ -19,12 +19,14 @@ use substrate_network_libp2p::{
 use tokio::timer::Interval;
 
 use beacon::types::{SignedBeaconBlock, SignedBeaconBlockHeader, BeaconBlockChain};
+use beacon::authority::{AuthorityConfig, AuthorityProposal};
 use chain::{SignedBlock, SignedHeader};
 use error::Error;
 use message::Message;
-use primitives::hash::CryptoHash;
+use primitives::hash::{CryptoHash, hash_struct};
 use primitives::traits::GenericResult;
 use primitives::types;
+use primitives::signature::get_keypair;
 use protocol::{CURRENT_VERSION, ProtocolConfig, Protocol};
 use self::storage::test_utils::create_memory_db;
 
@@ -120,4 +122,18 @@ pub fn get_test_protocol() -> Protocol<SignedBeaconBlock, SignedBeaconBlockHeade
         message_tx,
         gossip_tx,
     )
+}
+
+pub fn get_test_authority_config(
+        num_authorities: u32,
+        epoch_length: u64,
+        num_seats_per_slot: u64,
+) -> AuthorityConfig {
+    let mut initial_authorities = vec![];
+    for _ in 0..num_authorities {
+        let (public_key, _) = get_keypair();
+        let account_id = hash_struct(&public_key);
+        initial_authorities.push(AuthorityProposal { account_id, public_key, amount: 100 });
+    }
+    AuthorityConfig { initial_authorities, epoch_length, num_seats_per_slot }
 }

--- a/node/network/tests/integration_test.rs
+++ b/node/network/tests/integration_test.rs
@@ -92,6 +92,7 @@ fn test_block_catch_up_from_start() {
     let (block_tx1, _) = channel(1024);
     let (_, block_outgoing_rx1) = channel(1024);
     let (message_tx1, message_rx1) = channel(1024);
+    let (_, authority_rx1) = channel(1024);
     let protocol1 = get_test_protocol(
         beacon_chain1.clone(),
         block_tx1,
@@ -111,6 +112,7 @@ fn test_block_catch_up_from_start() {
     let (block_tx2, block_rx2) = channel(1024);
     let (_, block_outgoing_rx2) = channel(1024);
     let (message_tx2, message_rx2) = channel(1024);
+    let (_, authority_rx2) = channel(1024);
     let protocol2 = get_test_protocol(
         beacon_chain2.clone(),
         block_tx2,
@@ -126,8 +128,8 @@ fn test_block_catch_up_from_start() {
     let task = futures::lazy({
         let chain = beacon_chain2.clone();
         move || {
-        spawn_network_tasks(network_service1, protocol1, message_rx1, block_outgoing_rx1);
-        spawn_network_tasks(network_service2, protocol2, message_rx2, block_outgoing_rx2);
+        spawn_network_tasks(network_service1, protocol1, message_rx1, block_outgoing_rx1, authority_rx1);
+        spawn_network_tasks(network_service2, protocol2, message_rx2, block_outgoing_rx2, authority_rx2);
         spawn_simple_block_import_task(chain, block_rx2);
         Ok(())
     }});
@@ -145,7 +147,6 @@ fn test_block_catch_up_from_start() {
 // this test is expensive to run. should be ignored when running
 // all tests
 #[test]
-#[ignore]
 fn test_block_catchup_from_network_interruption() {
     let storage1 = Arc::new(create_memory_db());
     let genesis_block = SignedBeaconBlock::new(
@@ -156,12 +157,13 @@ fn test_block_catchup_from_network_interruption() {
     let (block_tx1, _) = channel(1024);
     let (_, block_outgoing_rx1) = channel(1024);
     let (message_tx1, message_rx1) = channel(1024);
+    let (_, authority_rx1) = channel(1024);
     let protocol1 = get_test_protocol(
         beacon_chain1.clone(),
         block_tx1,
         message_tx1
     );
-    let addr = "/ip4/127.0.0.1/tcp/30000";
+    let addr = "/ip4/127.0.0.1/tcp/30002";
     let secret = create_secret();
     let config1 = test_config_with_secret(addr, vec![], secret);
     let network_service1 = Arc::new(Mutex::new(
@@ -174,13 +176,14 @@ fn test_block_catchup_from_network_interruption() {
     let (block_tx2, block_rx2) = channel(1024);
     let (_, block_outgoing_rx2) = channel(1024);
     let (message_tx2, message_rx2) = channel(1024);
+    let (_, authority_rx2) = channel(1024);
     let protocol2 = get_test_protocol(
         beacon_chain2.clone(),
         block_tx2,
         message_tx2
     );
-    let boot_node = "/ip4/127.0.0.1/tcp/30000/p2p/".to_string() + &raw_key_to_peer_id_str(secret);
-    let config2 = test_config("/ip4/127.0.0.1/tcp/30001", vec![boot_node]);
+    let boot_node = "/ip4/127.0.0.1/tcp/30002/p2p/".to_string() + &raw_key_to_peer_id_str(secret);
+    let config2 = test_config("/ip4/127.0.0.1/tcp/30003", vec![boot_node]);
     let network_service2 = Arc::new(Mutex::new(
         new_network_service(&ProtocolConfig::default(), config2)
     ));
@@ -226,8 +229,20 @@ fn test_block_catchup_from_network_interruption() {
     let task = futures::lazy({
         let chain = beacon_chain2.clone();
         move || {
-        spawn_network_tasks(network_service1, protocol1, message_rx1, block_outgoing_rx1);
-        spawn_network_tasks(network_service2.clone(), protocol2, message_rx2, block_outgoing_rx2);
+        spawn_network_tasks(
+            network_service1,
+            protocol1,
+            message_rx1,
+            block_outgoing_rx1,
+            authority_rx1
+        );
+        spawn_network_tasks(
+            network_service2.clone(),
+            protocol2,
+            message_rx2,
+            block_outgoing_rx2,
+            authority_rx2
+        );
         spawn_simple_block_import_task(chain, block_rx2);
         block_task
     }}).map(|_| ()).map_err(|_| ());
@@ -256,12 +271,13 @@ fn test_block_announce() {
     let (block_tx1, _) = channel(1024);
     let (block_outgoing_tx1, block_outgoing_rx1) = channel(1024);
     let (message_tx1, message_rx1) = channel(1024);
+    let (_, authority_rx1) = channel(1024);
     let protocol1 = get_test_protocol(
         beacon_chain1.clone(),
         block_tx1,
         message_tx1
     );
-    let addr = "/ip4/127.0.0.1/tcp/30000";
+    let addr = "/ip4/127.0.0.1/tcp/30004";
     let secret = create_secret();
     let config1 = test_config_with_secret(addr, vec![], secret);
     let network_service1 = Arc::new(Mutex::new(
@@ -274,13 +290,14 @@ fn test_block_announce() {
     let (block_tx2, block_rx2) = channel(1024);
     let (_, block_outgoing_rx2) = channel(1024);
     let (message_tx2, message_rx2) = channel(1024);
+    let (_, authority_rx2) = channel(1024);
     let protocol2 = get_test_protocol(
         beacon_chain2.clone(),
         block_tx2,
         message_tx2
     );
-    let boot_node = "/ip4/127.0.0.1/tcp/30000/p2p/".to_string() + &raw_key_to_peer_id_str(secret);
-    let config2 = test_config("/ip4/127.0.0.1/tcp/30001", vec![boot_node]);
+    let boot_node = "/ip4/127.0.0.1/tcp/30004/p2p/".to_string() + &raw_key_to_peer_id_str(secret);
+    let config2 = test_config("/ip4/127.0.0.1/tcp/30005", vec![boot_node]);
     let network_service2 = Arc::new(Mutex::new(
         new_network_service(&ProtocolConfig::default(), config2)
     ));
@@ -291,10 +308,10 @@ fn test_block_announce() {
         let service1 = network_service1.clone();
         let service2 = network_service2.clone();
         move || {
-        spawn_network_tasks(service1.clone(), protocol1, message_rx1, block_outgoing_rx1);
-        spawn_network_tasks(service2.clone(), protocol2, message_rx2, block_outgoing_rx2);
+        spawn_network_tasks(service1.clone(), protocol1, message_rx1, block_outgoing_rx1, authority_rx1);
+        spawn_network_tasks(service2.clone(), protocol2, message_rx2, block_outgoing_rx2, authority_rx2);
         spawn_simple_block_import_task(chain2, block_rx2);
-        thread::sleep(Duration::from_secs(4));
+        thread::sleep(Duration::from_secs(3));
         spawn_simple_block_prod_task(chain1, block_outgoing_tx1);
         Ok(())
     }});
@@ -307,5 +324,4 @@ fn test_block_announce() {
         thread::sleep(Duration::from_secs(1));
     }
     std::mem::drop(handle);
-
 }

--- a/node/runtime/src/chain_spec.rs
+++ b/node/runtime/src/chain_spec.rs
@@ -9,7 +9,7 @@ pub struct ChainSpec {
     pub genesis_wasm: Vec<u8>,
 
     /// Genesis state authorities that bootstrap the chain.
-    pub initial_authorities: Vec<(ReadablePublicKey, u64)>,
+    pub initial_authorities: Vec<(AccountAlias, ReadablePublicKey, u64)>,
 
     pub beacon_chain_epoch_length: u64,
     pub beacon_chain_num_seats_per_slot: u64,

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use serde::{de::DeserializeOwned, Serialize};
 
-use beacon::types::AuthorityProposal;
+use beacon::authority::AuthorityProposal;
 use ext::RuntimeExt;
 use primitives::hash::{CryptoHash, hash};
 use primitives::signature::{PublicKey, Signature, verify};
@@ -947,7 +947,7 @@ impl Runtime {
         &self,
         balances: &[(AccountAlias, ReadablePublicKey, u64)],
         wasm_binary: &[u8],
-        initial_authorities: &[(ReadablePublicKey, u64)]
+        initial_authorities: &[(AccountAlias, ReadablePublicKey, u64)]
     ) -> MerkleHash {
         let mut state_db_update =
             StateDbUpdate::new(self.state_db.clone(), MerkleHash::default());
@@ -970,7 +970,7 @@ impl Runtime {
                 .collect();
         let stake = initial_authorities
             .iter()
-            .map(|(pk, amount)| (*pk_to_acc_id.get(pk).expect("Missing account for public key"), *amount))
+            .map(|(_, pk, amount)| (*pk_to_acc_id.get(pk).expect("Missing account for public key"), *amount))
             .collect();
         let runtime_data = RuntimeData {
             stake,

--- a/node/runtime/src/test_utils.rs
+++ b/node/runtime/src/test_utils.rs
@@ -21,7 +21,7 @@ pub fn generate_test_chain_spec() -> ChainSpec {
             ("bob".to_string(), public_keys[1].to_string(), 0),
             ("system".to_string(), public_keys[2].to_string(), 0),
         ],
-        initial_authorities: vec![(public_keys[0].to_string(), 50)],
+        initial_authorities: vec![("alice".to_string(), public_keys[0].to_string(), 50)],
         genesis_wasm,
         beacon_chain_epoch_length: 2,
         beacon_chain_num_seats_per_slot: 10,

--- a/scripts/run_clippy.sh
+++ b/scripts/run_clippy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-cargo clippy --all  -- -A clippy::while-let-loop -A clippy::too-many-arguments -A clippy::unit_arg -A clippy::if_same_then_else -A clippy::collapsible_if -A clippy::useless-let-if-seq -A clippy::map-entry -D warnings
+cargo clippy --all  -- -A clippy::while-let-loop -A clippy::too-many-arguments -A clippy::unit_arg -A clippy::if_same_then_else -A clippy::collapsible_if -A clippy::useless-let-if-seq -A clippy::map-entry -D warnings -A clippy::implicit-hasher


### PR DESCRIPTION
When a block is imported or produced, we send the authority information for the next block to consensus and network.