### PR TITLE
add rpc block calls

### DIFF
--- a/core/shard/src/lib.rs
+++ b/core/shard/src/lib.rs
@@ -1,5 +1,5 @@
-extern crate chain;
 extern crate parking_lot;
+extern crate chain;
 extern crate primitives;
 extern crate rand;
 #[macro_use]

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -51,11 +51,12 @@ fn spawn_rpc_server_task(
     rpc_port: Option<u16>,
     shard_chain: Arc<ShardBlockChain>,
     state_db: Arc<StateDb>,
+    beacon_chain: Arc<BeaconBlockChain>,
 ) {
     let state_db_viewer = StateDbViewer::new(shard_chain, state_db);
     let rpc_port = rpc_port.unwrap_or(DEFAULT_P2P_PORT);
     let http_addr = Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port));
-    let http_api = HttpApi::new(state_db_viewer, transactions_tx);
+    let http_api = HttpApi::new(state_db_viewer, transactions_tx, beacon_chain);
     node_http::server::spawn_server(http_api, http_addr);
 }
 
@@ -208,6 +209,7 @@ where
             Some(config.rpc_port),
             shard_chain.clone(),
             state_db.clone(),
+            beacon_chain.clone(),
         );
 
         // Create a task that receives new blocks from importer/producer

--- a/node/cli/src/service.rs
+++ b/node/cli/src/service.rs
@@ -49,14 +49,19 @@ fn get_storage(base_path: &Path) -> Arc<Storage> {
 fn spawn_rpc_server_task(
     transactions_tx: Sender<SignedTransaction>,
     rpc_port: Option<u16>,
-    shard_chain: Arc<ShardBlockChain>,
+    shard_chain: &Arc<ShardBlockChain>,
     state_db: Arc<StateDb>,
     beacon_chain: Arc<BeaconBlockChain>,
 ) {
-    let state_db_viewer = StateDbViewer::new(shard_chain, state_db);
+    let state_db_viewer = StateDbViewer::new(shard_chain.clone(), state_db);
     let rpc_port = rpc_port.unwrap_or(DEFAULT_P2P_PORT);
     let http_addr = Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), rpc_port));
-    let http_api = HttpApi::new(state_db_viewer, transactions_tx, beacon_chain);
+    let http_api = HttpApi::new(
+        state_db_viewer,
+        transactions_tx,
+        beacon_chain,
+        shard_chain.clone(),
+    );
     node_http::server::spawn_server(http_api, http_addr);
 }
 
@@ -207,7 +212,7 @@ where
         spawn_rpc_server_task(
             transactions_tx.clone(),
             Some(config.rpc_port),
-            shard_chain.clone(),
+            &shard_chain.clone(),
             state_db.clone(),
             beacon_chain.clone(),
         );

--- a/node/http/Cargo.toml
+++ b/node/http/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = "1.0"
 beacon = { path = "../../core/beacon" }
 node-runtime = { path = "../runtime" }
 primitives = { path = "../../core/primitives" }
+shard = { path = "../../core/shard" }

--- a/node/http/Cargo.toml
+++ b/node/http/Cargo.toml
@@ -10,5 +10,6 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 
+beacon = { path = "../../core/beacon" }
 node-runtime = { path = "../runtime" }
 primitives = { path = "../../core/primitives" }

--- a/node/http/src/api.rs
+++ b/node/http/src/api.rs
@@ -19,6 +19,8 @@ use types::{
     SignedBeaconBlockResponse, SignedShardBlockResponse, StakeRequest, SwapKeyRequest,
     ViewAccountRequest, ViewAccountResponse, ViewStateRequest, ViewStateResponse,
 };
+use types::GetBeaconBlockByHashRequest;
+use primitives::types::BlockId;
 
 pub struct HttpApi {
     state_db_viewer: StateDbViewer,
@@ -199,5 +201,15 @@ impl HttpApi {
 
     pub fn view_latest_shard_block(&self) -> Result<SignedShardBlockResponse, ()> {
         Ok(self.shard_chain.best_block().into())
+    }
+
+    pub fn get_beacon_block_by_hash(
+        &self,
+        r: &GetBeaconBlockByHashRequest,
+    ) -> Result<SignedBeaconBlockResponse, &str> {
+        match self.beacon_chain.get_block(&BlockId::Hash(r.hash)) {
+            Some(block) => Ok(block.into()),
+            None => Err("block not found"),
+        }
     }
 }

--- a/node/http/src/api.rs
+++ b/node/http/src/api.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use futures::sync::mpsc::Sender;
 
+use beacon::types::BeaconBlockChain;
 use node_runtime::state_viewer::StateDbViewer;
 use primitives::traits::Encode;
 use primitives::types::{
@@ -12,7 +15,7 @@ use types::{
     CallViewFunctionRequest, CallViewFunctionResponse,
     CreateAccountRequest, DeployContractRequest,
     PreparedTransactionBodyResponse, ScheduleFunctionCallRequest, SendMoneyRequest,
-    StakeRequest, SwapKeyRequest, ViewAccountRequest,
+    SignedBeaconBlockResponse, StakeRequest, SwapKeyRequest, ViewAccountRequest,
     ViewAccountResponse, ViewStateRequest,
     ViewStateResponse,
 };
@@ -20,16 +23,19 @@ use types::{
 pub struct HttpApi {
     state_db_viewer: StateDbViewer,
     submit_txn_sender: Sender<SignedTransaction>,
+    beacon_chain: Arc<BeaconBlockChain>,
 }
 
 impl HttpApi {
     pub fn new(
         state_db_viewer: StateDbViewer,
         submit_txn_sender: Sender<SignedTransaction>,
+        beacon_chain: Arc<BeaconBlockChain>,
     ) -> HttpApi {
         HttpApi {
             state_db_viewer,
             submit_txn_sender,
+            beacon_chain,
         }
     }
 }
@@ -182,5 +188,9 @@ impl HttpApi {
             values: result.values.iter().map(|(k, v)| (bs58_vec2str(k), v.clone())).collect()
         };
         Ok(response)
+    }
+
+    pub fn view_latest_beacon_block(&self) -> Result<SignedBeaconBlockResponse, ()> {
+        Ok(self.beacon_chain.best_block().into())
     }
 }

--- a/node/http/src/api.rs
+++ b/node/http/src/api.rs
@@ -11,19 +11,20 @@ use primitives::types::{
     StakeTransaction, SwapKeyTransaction, TransactionBody,
 };
 use primitives::utils::bs58_vec2str;
+use shard::ShardBlockChain;
 use types::{
     CallViewFunctionRequest, CallViewFunctionResponse,
     CreateAccountRequest, DeployContractRequest,
     PreparedTransactionBodyResponse, ScheduleFunctionCallRequest, SendMoneyRequest,
-    SignedBeaconBlockResponse, StakeRequest, SwapKeyRequest, ViewAccountRequest,
-    ViewAccountResponse, ViewStateRequest,
-    ViewStateResponse,
+    SignedBeaconBlockResponse, SignedShardBlockResponse, StakeRequest, SwapKeyRequest,
+    ViewAccountRequest, ViewAccountResponse, ViewStateRequest, ViewStateResponse,
 };
 
 pub struct HttpApi {
     state_db_viewer: StateDbViewer,
     submit_txn_sender: Sender<SignedTransaction>,
     beacon_chain: Arc<BeaconBlockChain>,
+    shard_chain: Arc<ShardBlockChain>,
 }
 
 impl HttpApi {
@@ -31,11 +32,13 @@ impl HttpApi {
         state_db_viewer: StateDbViewer,
         submit_txn_sender: Sender<SignedTransaction>,
         beacon_chain: Arc<BeaconBlockChain>,
+        shard_chain: Arc<ShardBlockChain>,
     ) -> HttpApi {
         HttpApi {
             state_db_viewer,
             submit_txn_sender,
             beacon_chain,
+            shard_chain,
         }
     }
 }
@@ -192,5 +195,9 @@ impl HttpApi {
 
     pub fn view_latest_beacon_block(&self) -> Result<SignedBeaconBlockResponse, ()> {
         Ok(self.beacon_chain.best_block().into())
+    }
+
+    pub fn view_latest_shard_block(&self) -> Result<SignedShardBlockResponse, ()> {
+        Ok(self.shard_chain.best_block().into())
     }
 }

--- a/node/http/src/api.rs
+++ b/node/http/src/api.rs
@@ -6,7 +6,7 @@ use beacon::types::BeaconBlockChain;
 use node_runtime::state_viewer::StateDbViewer;
 use primitives::traits::Encode;
 use primitives::types::{
-    CreateAccountTransaction, DeployContractTransaction,
+    BlockId, CreateAccountTransaction, DeployContractTransaction,
     FunctionCallTransaction, SendMoneyTransaction, SignedTransaction,
     StakeTransaction, SwapKeyTransaction, TransactionBody,
 };
@@ -14,13 +14,11 @@ use primitives::utils::bs58_vec2str;
 use shard::ShardBlockChain;
 use types::{
     CallViewFunctionRequest, CallViewFunctionResponse,
-    CreateAccountRequest, DeployContractRequest,
+    CreateAccountRequest, DeployContractRequest, GetBlockByHashRequest,
     PreparedTransactionBodyResponse, ScheduleFunctionCallRequest, SendMoneyRequest,
     SignedBeaconBlockResponse, SignedShardBlockResponse, StakeRequest, SwapKeyRequest,
     ViewAccountRequest, ViewAccountResponse, ViewStateRequest, ViewStateResponse,
 };
-use types::GetBeaconBlockByHashRequest;
-use primitives::types::BlockId;
 
 pub struct HttpApi {
     state_db_viewer: StateDbViewer,
@@ -199,15 +197,25 @@ impl HttpApi {
         Ok(self.beacon_chain.best_block().into())
     }
 
+    pub fn get_beacon_block_by_hash(
+        &self,
+        r: &GetBlockByHashRequest,
+    ) -> Result<SignedBeaconBlockResponse, &str> {
+        match self.beacon_chain.get_block(&BlockId::Hash(r.hash)) {
+            Some(block) => Ok(block.into()),
+            None => Err("block not found"),
+        }
+    }
+
     pub fn view_latest_shard_block(&self) -> Result<SignedShardBlockResponse, ()> {
         Ok(self.shard_chain.best_block().into())
     }
 
-    pub fn get_beacon_block_by_hash(
+    pub fn get_shard_block_by_hash(
         &self,
-        r: &GetBeaconBlockByHashRequest,
-    ) -> Result<SignedBeaconBlockResponse, &str> {
-        match self.beacon_chain.get_block(&BlockId::Hash(r.hash)) {
+        r: &GetBlockByHashRequest,
+    ) -> Result<SignedShardBlockResponse, &str> {
+        match self.shard_chain.get_block(&BlockId::Hash(r.hash)) {
             Some(block) => Ok(block.into()),
             None => Err("block not found"),
         }

--- a/node/http/src/lib.rs
+++ b/node/http/src/lib.rs
@@ -9,6 +9,7 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
+extern crate shard;
 
 pub mod api;
 pub mod server;

--- a/node/http/src/lib.rs
+++ b/node/http/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate beacon;
 extern crate hyper;
 extern crate futures;
 #[macro_use]

--- a/node/http/src/server.rs
+++ b/node/http/src/server.rs
@@ -252,6 +252,18 @@ fn serve(http_api: Arc<HttpApi>, req: Request<Body>) -> BoxFut {
                 }
             }))
         }
+        (&Method::POST, "/view_latest_beacon_block") => {
+            Box::new(future::ok(
+                match http_api.view_latest_beacon_block() {
+                    Ok(response) => {
+                        Response::builder()
+                            .body(Body::from(serde_json::to_string(&response).unwrap()))
+                            .unwrap()
+                    }
+                    Err(_) => unreachable!()
+                }
+            ))
+        }
 
         _ => {
             Box::new(future::ok(

--- a/node/http/src/server.rs
+++ b/node/http/src/server.rs
@@ -264,6 +264,18 @@ fn serve(http_api: Arc<HttpApi>, req: Request<Body>) -> BoxFut {
                 }
             ))
         }
+        (&Method::POST, "/view_latest_shard_block") => {
+            Box::new(future::ok(
+                match http_api.view_latest_shard_block() {
+                    Ok(response) => {
+                        Response::builder()
+                            .body(Body::from(serde_json::to_string(&response).unwrap()))
+                            .unwrap()
+                    }
+                    Err(_) => unreachable!()
+                }
+            ))
+        }
 
         _ => {
             Box::new(future::ok(

--- a/node/http/src/server.rs
+++ b/node/http/src/server.rs
@@ -264,6 +264,33 @@ fn serve(http_api: Arc<HttpApi>, req: Request<Body>) -> BoxFut {
                 }
             ))
         }
+        (&Method::POST, "/get_beacon_block_by_hash") => {
+            Box::new(req.into_body().concat2().map(move |chunk| {
+                match serde_json::from_slice(&chunk) {
+                    Ok(data) => {
+                        match http_api.get_beacon_block_by_hash(&data) {
+                            Ok(response) => {
+                                Response::builder()
+                                    .body(Body::from(serde_json::to_string(&response).unwrap()))
+                                    .unwrap()
+                            }
+                            Err(e) => {
+                                Response::builder()
+                                    .status(StatusCode::BAD_REQUEST)
+                                    .body(Body::from(e.to_string()))
+                                    .unwrap()
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        Response::builder()
+                            .status(StatusCode::BAD_REQUEST)
+                            .body(Body::from(e.to_string()))
+                            .unwrap()
+                    }
+                }
+            }))
+        }
         (&Method::POST, "/view_latest_shard_block") => {
             Box::new(future::ok(
                 match http_api.view_latest_shard_block() {

--- a/node/http/src/server.rs
+++ b/node/http/src/server.rs
@@ -303,6 +303,33 @@ fn serve(http_api: Arc<HttpApi>, req: Request<Body>) -> BoxFut {
                 }
             ))
         }
+        (&Method::POST, "/get_shard_block_by_hash") => {
+            Box::new(req.into_body().concat2().map(move |chunk| {
+                match serde_json::from_slice(&chunk) {
+                    Ok(data) => {
+                        match http_api.get_shard_block_by_hash(&data) {
+                            Ok(response) => {
+                                Response::builder()
+                                    .body(Body::from(serde_json::to_string(&response).unwrap()))
+                                    .unwrap()
+                            }
+                            Err(e) => {
+                                Response::builder()
+                                    .status(StatusCode::BAD_REQUEST)
+                                    .body(Body::from(e.to_string()))
+                                    .unwrap()
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        Response::builder()
+                            .status(StatusCode::BAD_REQUEST)
+                            .body(Body::from(e.to_string()))
+                            .unwrap()
+                    }
+                }
+            }))
+        }
 
         _ => {
             Box::new(future::ok(

--- a/node/http/src/types.rs
+++ b/node/http/src/types.rs
@@ -229,7 +229,9 @@ impl From<ShardBlockHeader> for ShardBlockHeaderResponse {
 #[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct ShardBlockResponse {
     pub header: ShardBlockHeaderResponse,
+    // TODO(#301): should have a bs58 format for TransactionResponse
     pub transactions: Vec<Transaction>,
+    // TODO(#301): should have a bs58 format for TransactionResponse
     pub new_receipts: Vec<Transaction>,
 }
 

--- a/node/http/src/types.rs
+++ b/node/http/src/types.rs
@@ -125,7 +125,7 @@ pub struct ViewStateResponse {
     pub values: HashMap<String, Vec<u8>>,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct AuthorityProposalResponse {
     #[serde(with = "bs58_format")]
     pub account_id: AccountId,
@@ -144,7 +144,7 @@ impl From<AuthorityProposal> for AuthorityProposalResponse {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct BeaconBlockHeaderResponse {
     #[serde(with = "bs58_format")]
     pub parent_hash: CryptoHash,
@@ -168,7 +168,7 @@ impl From<BeaconBlockHeader> for BeaconBlockHeaderResponse {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct BeaconBlockResponse {
     pub header: BeaconBlockHeaderResponse,
 }
@@ -181,7 +181,7 @@ impl From<BeaconBlock> for BeaconBlockResponse {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct SignedBeaconBlockResponse {
     pub body: BeaconBlockResponse,
     #[serde(with = "bs58_format")]
@@ -265,4 +265,10 @@ impl From<SignedShardBlock> for SignedShardBlockResponse {
             signature,
         }
     }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct GetBeaconBlockByHashRequest {
+    #[serde(with = "bs58_format")]
+    pub hash: CryptoHash,
 }

--- a/node/http/src/types.rs
+++ b/node/http/src/types.rs
@@ -205,7 +205,7 @@ impl From<SignedBeaconBlock> for SignedBeaconBlockResponse {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct ShardBlockHeaderResponse {
     #[serde(with = "bs58_format")]
     pub parent_hash: CryptoHash,
@@ -226,7 +226,7 @@ impl From<ShardBlockHeader> for ShardBlockHeaderResponse {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct ShardBlockResponse {
     pub header: ShardBlockHeaderResponse,
     pub transactions: Vec<Transaction>,
@@ -243,7 +243,7 @@ impl From<ShardBlock> for ShardBlockResponse {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
 pub struct SignedShardBlockResponse {
     pub body: ShardBlockResponse,
     #[serde(with = "bs58_format")]
@@ -268,7 +268,7 @@ impl From<SignedShardBlock> for SignedShardBlockResponse {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct GetBeaconBlockByHashRequest {
+pub struct GetBlockByHashRequest {
     #[serde(with = "bs58_format")]
     pub hash: CryptoHash,
 }

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -257,6 +257,10 @@ class NearRPC(object):
     def view_latest_beacon_block(self):
         return self._call_rpc('view_latest_beacon_block')
 
+    def get_beacon_block_by_hash(self, _hash):
+        params = {'hash': _hash}
+        return self._call_rpc('get_beacon_block_by_hash', params)
+
     def view_latest_shard_block(self):
         return self._call_rpc('view_latest_shard_block')
 
@@ -341,6 +345,7 @@ stake                     {}
 create_account            {}
 swap_key                  {}
 view_latest_beacon_block  {}
+get_beacon_block_by_hash  {}
 view_latest_shard_block   {}
             """.format(
                 self.call_view_function.__doc__,
@@ -353,6 +358,7 @@ view_latest_shard_block   {}
                 self.create_account.__doc__,
                 self.swap_key.__doc__,
                 self.view_latest_beacon_block.__doc__,
+                self.get_beacon_block_by_hash.__doc__,
                 self.view_latest_shard_block.__doc__,
             )
         )
@@ -578,9 +584,7 @@ view_latest_shard_block   {}
         parser.add_argument('contract_name', type=str)
         args = self._get_command_args(parser)
         client = self._get_rpc_client(args)
-        return client.view_state(
-            args.contract_name,
-        )
+        return client.view_state(args.contract_name)
 
     def view_latest_beacon_block(self):
         """View latest beacon block."""
@@ -588,6 +592,14 @@ view_latest_shard_block   {}
         args = self._get_command_args(parser)
         client = self._get_rpc_client(args)
         return client.view_latest_beacon_block()
+
+    def get_beacon_block_by_hash(self):
+        """Get beacon block by hash."""
+        parser = self._get_command_parser(self.view_state.__doc__)
+        parser.add_argument('hash', type=str)
+        args = self._get_command_args(parser)
+        client = self._get_rpc_client(args)
+        return client.get_beacon_block_by_hash(args.hash)
 
     def view_latest_shard_block(self):
         """View latest shard block."""

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -257,6 +257,9 @@ class NearRPC(object):
     def view_latest_beacon_block(self):
         return self._call_rpc('view_latest_beacon_block')
 
+    def view_latest_shard_block(self):
+        return self._call_rpc('view_latest_shard_block')
+
     def create_account(
         self,
         sender,
@@ -338,6 +341,7 @@ stake                     {}
 create_account            {}
 swap_key                  {}
 view_latest_beacon_block  {}
+view_latest_shard_block   {}
             """.format(
                 self.call_view_function.__doc__,
                 self.deploy.__doc__,
@@ -349,6 +353,7 @@ view_latest_beacon_block  {}
                 self.create_account.__doc__,
                 self.swap_key.__doc__,
                 self.view_latest_beacon_block.__doc__,
+                self.view_latest_shard_block.__doc__,
             )
         )
         parser.add_argument('command', help='Command to run')
@@ -583,6 +588,13 @@ view_latest_beacon_block  {}
         args = self._get_command_args(parser)
         client = self._get_rpc_client(args)
         return client.view_latest_beacon_block()
+
+    def view_latest_shard_block(self):
+        """View latest shard block."""
+        parser = self._get_command_parser(self.view_state.__doc__)
+        args = self._get_command_args(parser)
+        client = self._get_rpc_client(args)
+        return client.view_latest_shard_block()
 
 
 if __name__ == "__main__":

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -264,6 +264,10 @@ class NearRPC(object):
     def view_latest_shard_block(self):
         return self._call_rpc('view_latest_shard_block')
 
+    def get_shard_block_by_hash(self, _hash):
+        params = {'hash': _hash}
+        return self._call_rpc('get_shard_block_by_hash', params)
+
     def create_account(
         self,
         sender,
@@ -347,6 +351,7 @@ swap_key                  {}
 view_latest_beacon_block  {}
 get_beacon_block_by_hash  {}
 view_latest_shard_block   {}
+get_beacon_block_by_hash  {}
             """.format(
                 self.call_view_function.__doc__,
                 self.deploy.__doc__,
@@ -360,6 +365,7 @@ view_latest_shard_block   {}
                 self.view_latest_beacon_block.__doc__,
                 self.get_beacon_block_by_hash.__doc__,
                 self.view_latest_shard_block.__doc__,
+                self.get_shard_block_by_hash.__doc__,
             )
         )
         parser.add_argument('command', help='Command to run')
@@ -607,6 +613,14 @@ view_latest_shard_block   {}
         args = self._get_command_args(parser)
         client = self._get_rpc_client(args)
         return client.view_latest_shard_block()
+
+    def get_shard_block_by_hash(self):
+        """Get shard block by hash."""
+        parser = self._get_command_parser(self.view_state.__doc__)
+        parser.add_argument('hash', type=str)
+        args = self._get_command_args(parser)
+        client = self._get_rpc_client(args)
+        return client.get_shard_block_by_hash(args.hash)
 
 
 if __name__ == "__main__":

--- a/scripts/rpc.py
+++ b/scripts/rpc.py
@@ -22,9 +22,18 @@ except ImportError:
     exit(1)
 
 
-def _post(url, data):
-    request = Request(url, data=json.dumps(data).encode('utf-8'))
-    request.add_header('Content-Type', 'application/json')
+# Data is empty string instead of None because method is
+# defined by whether or not data is None and cannot be
+# specified otherwise in py2
+def _post(url, data=""):
+    if data != "":
+        data = json.dumps(data).encode('utf-8')
+
+    request = Request(url, data=data)
+
+    if data is not None:
+        request.add_header('Content-Type', 'application/json')
+
     connection = urlopen(request)
     return connection
 
@@ -99,7 +108,7 @@ class NearRPC(object):
     def _update_nonce(self, sender):
         self._nonces[sender] += 1
 
-    def _call_rpc(self, method_name, params):
+    def _call_rpc(self, method_name, params=None):
         data = params
         if self._debug:
             print(data)
@@ -245,6 +254,9 @@ class NearRPC(object):
         params = {'contract_account_id': _get_account_id(contract_name)}
         return self._call_rpc('view_state', params)
 
+    def view_latest_beacon_block(self):
+        return self._call_rpc('view_latest_beacon_block')
+
     def create_account(
         self,
         sender,
@@ -316,15 +328,16 @@ class MultiCommandParser(object):
             usage="""python rpc.py <command> [<args>]
 
 Commands:
-call_view_function       {}
-deploy                   {}
-send_money               {}
-schedule_function_call   {}
-view_account             {}
-view_state               {}
-stake                    {}
-create_account           {}
-swap_key                 {}
+call_view_function        {}
+deploy                    {}
+send_money                {}
+schedule_function_call    {}
+view_account              {}
+view_state                {}
+stake                     {}
+create_account            {}
+swap_key                  {}
+view_latest_beacon_block  {}
             """.format(
                 self.call_view_function.__doc__,
                 self.deploy.__doc__,
@@ -335,6 +348,7 @@ swap_key                 {}
                 self.stake.__doc__,
                 self.create_account.__doc__,
                 self.swap_key.__doc__,
+                self.view_latest_beacon_block.__doc__,
             )
         )
         parser.add_argument('command', help='Command to run')
@@ -562,6 +576,13 @@ swap_key                 {}
         return client.view_state(
             args.contract_name,
         )
+
+    def view_latest_beacon_block(self):
+        """View latest beacon block."""
+        parser = self._get_command_parser(self.view_state.__doc__)
+        args = self._get_command_args(parser)
+        client = self._get_rpc_client(args)
+        return client.view_latest_beacon_block()
 
 
 if __name__ == "__main__":

--- a/tests/test_rpc_cli.rs
+++ b/tests/test_rpc_cli.rs
@@ -294,12 +294,7 @@ fn get_latest_shard_block() -> SignedShardBlockResponse {
 
 fn test_view_latest_shard_block_inner() {
     if !*DEVNET_STARTED { panic!() }
-    let output = Command::new("./scripts/rpc.py")
-        .arg("view_latest_shard_block")
-        .output()
-        .expect("view_latest_shard_block command failed to process");
-    let result = check_result(output).unwrap();
-    let _: SignedShardBlockResponse = serde_json::from_str(&result).unwrap();
+    let _ = get_latest_shard_block();
 }
 
 test! { fn test_view_latest_shard_block() { test_view_latest_shard_block_inner() } }

--- a/tests/test_rpc_cli.rs
+++ b/tests/test_rpc_cli.rs
@@ -283,6 +283,15 @@ fn test_get_beacon_block_by_hash_inner() {
 
 test! { fn test_get_beacon_block_by_hash() { test_get_beacon_block_by_hash_inner() } }
 
+fn get_latest_shard_block() -> SignedShardBlockResponse {
+    let output = Command::new("./scripts/rpc.py")
+        .arg("view_latest_shard_block")
+        .output()
+        .expect("view_latest_shard_block command failed to process");
+    let result = check_result(output).unwrap();
+    serde_json::from_str(&result).unwrap()
+}
+
 fn test_view_latest_shard_block_inner() {
     if !*DEVNET_STARTED { panic!() }
     let output = Command::new("./scripts/rpc.py")
@@ -294,3 +303,18 @@ fn test_view_latest_shard_block_inner() {
 }
 
 test! { fn test_view_latest_shard_block() { test_view_latest_shard_block_inner() } }
+
+fn test_get_shard_block_by_hash_inner() {
+    if !*DEVNET_STARTED { panic!() }
+    let latest_block = get_latest_shard_block();
+    let output = Command::new("./scripts/rpc.py")
+        .arg("get_shard_block_by_hash")
+        .arg(String::from(&latest_block.hash))
+        .output()
+        .expect("view_latest_shard_block command failed to process");
+    let result = check_result(output).unwrap();
+    let block: SignedShardBlockResponse = serde_json::from_str(&result).unwrap();
+    assert_eq!(latest_block, block);
+}
+
+test! { fn test_get_shard_block_by_hash() { test_get_shard_block_by_hash_inner() } }

--- a/tests/test_rpc_cli.rs
+++ b/tests/test_rpc_cli.rs
@@ -20,7 +20,8 @@ use rand::Rng;
 use serde_json::Value;
 
 use node_http::types::{
-    CallViewFunctionResponse, ViewAccountResponse, ViewStateResponse
+    CallViewFunctionResponse, SignedBeaconBlockResponse, ViewAccountResponse,
+    ViewStateResponse,
 };
 use primitives::signer::write_key_file;
 
@@ -250,3 +251,15 @@ fn test_swap_key_inner() {
 }
 
 test! { fn test_swap_key() { test_swap_key_inner() } }
+
+fn test_view_latest_beacon_block_inner() {
+    if !*DEVNET_STARTED { panic!() }
+    let output = Command::new("./scripts/rpc.py")
+        .arg("view_latest_beacon_block")
+        .output()
+        .expect("view_latest_beacon_block command failed to process");
+    let result = check_result(output).unwrap();
+    let _: SignedBeaconBlockResponse = serde_json::from_str(&result).unwrap();
+}
+
+test! { fn test_view_latest_beacon_block() { test_view_latest_beacon_block_inner() } }

--- a/tests/test_rpc_cli.rs
+++ b/tests/test_rpc_cli.rs
@@ -20,8 +20,8 @@ use rand::Rng;
 use serde_json::Value;
 
 use node_http::types::{
-    CallViewFunctionResponse, SignedBeaconBlockResponse, ViewAccountResponse,
-    ViewStateResponse,
+    CallViewFunctionResponse, SignedBeaconBlockResponse, SignedShardBlockResponse,
+    ViewAccountResponse, ViewStateResponse,
 };
 use primitives::signer::write_key_file;
 
@@ -263,3 +263,15 @@ fn test_view_latest_beacon_block_inner() {
 }
 
 test! { fn test_view_latest_beacon_block() { test_view_latest_beacon_block_inner() } }
+
+fn test_view_latest_shard_block_inner() {
+    if !*DEVNET_STARTED { panic!() }
+    let output = Command::new("./scripts/rpc.py")
+        .arg("view_latest_shard_block")
+        .output()
+        .expect("view_latest_shard_block command failed to process");
+    let result = check_result(output).unwrap();
+    let _: SignedShardBlockResponse = serde_json::from_str(&result).unwrap();
+}
+
+test! { fn test_view_latest_shard_block() { test_view_latest_shard_block_inner() } }

--- a/tests/test_rpc_cli.rs
+++ b/tests/test_rpc_cli.rs
@@ -252,17 +252,36 @@ fn test_swap_key_inner() {
 
 test! { fn test_swap_key() { test_swap_key_inner() } }
 
-fn test_view_latest_beacon_block_inner() {
-    if !*DEVNET_STARTED { panic!() }
+fn get_latest_beacon_block() -> SignedBeaconBlockResponse {
     let output = Command::new("./scripts/rpc.py")
         .arg("view_latest_beacon_block")
         .output()
-        .expect("view_latest_beacon_block command failed to process");
+        .expect("view_latest_shard_block command failed to process");
     let result = check_result(output).unwrap();
-    let _: SignedBeaconBlockResponse = serde_json::from_str(&result).unwrap();
+    serde_json::from_str(&result).unwrap()
+}
+
+fn test_view_latest_beacon_block_inner() {
+    if !*DEVNET_STARTED { panic!() }
+    let _ = get_latest_beacon_block();
 }
 
 test! { fn test_view_latest_beacon_block() { test_view_latest_beacon_block_inner() } }
+
+fn test_get_beacon_block_by_hash_inner() {
+    if !*DEVNET_STARTED { panic!() }
+    let latest_block = get_latest_beacon_block();
+    let output = Command::new("./scripts/rpc.py")
+        .arg("get_beacon_block_by_hash")
+        .arg(String::from(&latest_block.hash))
+        .output()
+        .expect("view_latest_shard_block command failed to process");
+    let result = check_result(output).unwrap();
+    let block: SignedBeaconBlockResponse = serde_json::from_str(&result).unwrap();
+    assert_eq!(latest_block, block);
+}
+
+test! { fn test_get_beacon_block_by_hash() { test_get_beacon_block_by_hash_inner() } }
 
 fn test_view_latest_shard_block_inner() {
     if !*DEVNET_STARTED { panic!() }


### PR DESCRIPTION
fixes https://github.com/nearprotocol/nearcore/issues/277
fixes https://github.com/nearprotocol/nearcore/issues/278

this adds the following calls:
- view_latest_beacon_block
- get_beacon_block_by_hash
- view_latest_shard_block
- get_shard_block_by_hash

this also:
- fixes CryptoHash deserialization.. the old implementation was not working for truncated values including the default hash
- adds a Signature struct that wraps the sodiumoxide signature as we do for PublicKey and SecretKey