### PR TITLE
 Fix runtime binding bugs for storage_iter

### DIFF
--- a/core/wasm/runtest/src/lib.rs
+++ b/core/wasm/runtest/src/lib.rs
@@ -48,7 +48,7 @@ impl External for MyExt {
         Err(ExtError::NotImplemented)
     }
 
-    fn storage_iter_peek(&mut self, _iter: u32) -> ExtResult<Option<&Vec<u8>>> {
+    fn storage_iter_peek(&mut self, _iter: u32) -> ExtResult<Option<Vec<u8>>> {
         Err(ExtError::NotImplemented)
     }
 

--- a/core/wasm/src/ext.rs
+++ b/core/wasm/src/ext.rs
@@ -91,7 +91,7 @@ pub trait External {
 
     fn storage_iter_next(&mut self, id: u32) -> Result<Option<Vec<u8>>>;
 
-    fn storage_iter_peek(&mut self, id: u32) -> Result<Option<&Vec<u8>>>;
+    fn storage_iter_peek(&mut self, id: u32) -> Result<Option<Vec<u8>>>;
 
     fn promise_create(
         &mut self,

--- a/core/wasm/src/resolver.rs
+++ b/core/wasm/src/resolver.rs
@@ -28,6 +28,22 @@ impl wasmi::ModuleImportResolver for EnvModuleResolver {
                 Signature::new(&[ValueType::I32, ValueType::I32][..], None),
                 ids::STORAGE_READ_INTO_FUNC,
             ),
+            "storage_iter" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32][..], Some(ValueType::I32)),
+                ids::STORAGE_ITER_FUNC,
+            ),
+            "storage_iter_next" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32][..], Some(ValueType::I32)),
+                ids::STORAGE_ITER_NEXT_FUNC,
+            ),
+            "storage_iter_peek_len" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32][..], Some(ValueType::I32)),
+                ids::STORAGE_ITER_PEEK_LEN_FUNC,
+            ),
+            "storage_iter_peek_into" => FuncInstance::alloc_host(
+                Signature::new(&[ValueType::I32, ValueType::I32][..], None),
+                ids::STORAGE_ITER_PEEK_INTO_FUNC,
+            ),
             "storage_write" => FuncInstance::alloc_host(
                 Signature::new(&[ValueType::I32, ValueType::I32][..], None),
                 ids::STORAGE_WRITE_FUNC,

--- a/core/wasm/src/runtime.rs
+++ b/core/wasm/src/runtime.rs
@@ -208,6 +208,7 @@ impl<'a> Runtime<'a> {
             .ext
             .storage_iter(&prefix)
             .map_err(|_| Error::StorageUpdateError)?;
+        debug!(target: "wasm", "storage_iter('{}') -> {}", format_buf(&prefix), id);
         Ok(RuntimeValue::I32(id as i32))
     }
 
@@ -218,6 +219,7 @@ impl<'a> Runtime<'a> {
             .ext
             .storage_iter_next(id)
             .map_err(|_| Error::StorageUpdateError)?;
+        debug!(target: "wasm", "storage_iter_next({}) -> '{}'", id, format_buf(&key.clone().unwrap_or(Vec::new())));
         Ok(RuntimeValue::I32(key.is_some() as i32))
     }
 
@@ -622,7 +624,7 @@ mod ext_impl {
                 STORAGE_READ_LEN_FUNC => some!(self.storage_read_len(&args)),
                 STORAGE_READ_INTO_FUNC => void!(self.storage_read_into(&args)),
                 STORAGE_ITER_FUNC => some!(self.storage_iter(&args)),
-                STORAGE_ITER_NEXT_FUNC => void!(self.storage_iter_next(&args)),
+                STORAGE_ITER_NEXT_FUNC => some!(self.storage_iter_next(&args)),
                 STORAGE_ITER_PEEK_LEN_FUNC => some!(self.storage_iter_peek_len(&args)),
                 STORAGE_ITER_PEEK_INTO_FUNC => void!(self.storage_iter_peek_into(&args)),
                 GAS_FUNC => void!(self.gas(&args)),

--- a/core/wasm/src/runtime.rs
+++ b/core/wasm/src/runtime.rs
@@ -219,7 +219,7 @@ impl<'a> Runtime<'a> {
             .ext
             .storage_iter_next(id)
             .map_err(|_| Error::StorageUpdateError)?;
-        debug!(target: "wasm", "storage_iter_next({}) -> '{}'", id, format_buf(&key.clone().unwrap_or(Vec::new())));
+        debug!(target: "wasm", "storage_iter_next({}) -> '{}'", id, format_buf(&key.clone().unwrap_or_default()));
         Ok(RuntimeValue::I32(key.is_some() as i32))
     }
 

--- a/tests/hello/assembly/main.near.ts
+++ b/tests/hello/assembly/main.near.ts
@@ -16,9 +16,6 @@ export { memory };
 
 import { contractContext, globalStorage, near } from "./near";
 
-// --- contract code goes below
-// --- bigints temporarily stringly typed, need support in bindgen
-
 export function hello(name: string): string {
 
   return "hello " + name;
@@ -30,9 +27,15 @@ export function setValue(value: string): string {
 }
 
 export function getValue(): string {
+  let keys = getAllKeys();
+  assert(keys.length == 1);
+  assert(keys[0] == "name");
   return globalStorage.getItem("name");
 }
 
+export function getAllKeys(): string[] {
+  return globalStorage.keys("n");
+}
 export class __near_ArgsParser_hello extends ThrowingJSONHandler {
         buffer: Uint8Array;
         decoder: JSONDecoder<__near_ArgsParser_hello>;
@@ -207,6 +210,70 @@ if (result != null) {
           } else {
             encoder.setNull("result");
           }
+
+        encoder.popObject();
+        return_value(near.bufferWithSize(encoder.serialize()).buffer.data);
+      
+}
+export class __near_ArgsParser_getAllKeys extends ThrowingJSONHandler {
+        buffer: Uint8Array;
+        decoder: JSONDecoder<__near_ArgsParser_getAllKeys>;
+        handledRoot: boolean = false;
+      
+setNull(name: string): void {
+
+      super.setNull(name);
+    }
+
+      pushObject(name: string): bool {
+if (!this.handledRoot) {
+      assert(name == null);
+      this.handledRoot = true;
+      return true;
+    } else {
+      assert(name != null);
+    }
+
+        return super.pushObject(name);
+      }
+
+      pushArray(name: string): bool {
+
+        return super.pushArray(name);
+      }
+}
+export function __near_encode_Array_String(
+          value: Array<String>,
+          encoder: JSONEncoder): void {
+for (let i = 0; i < value.length; i++) {
+if (value[i] != null) {
+            encoder.setString(null, value[i]);
+          } else {
+            encoder.setNull(null);
+          }
+}
+}
+export function near_func_getAllKeys(): void {
+      let json = new Uint8Array(input_read_len());
+      input_read_into(json.buffer.data);
+      let handler = new __near_ArgsParser_getAllKeys();
+      handler.buffer = json;
+      handler.decoder = new JSONDecoder<__near_ArgsParser_getAllKeys>(handler);
+      handler.decoder.deserialize(json);
+let result = getAllKeys(
+
+);
+
+        let encoder = new JSONEncoder();
+        encoder.pushObject(null);
+      
+if (result != null) {
+          encoder.pushArray("result");
+          __near_encode_Array_String(result, encoder);
+          encoder.popArray();
+        } else {
+          encoder.setNull("result");
+        }
 
         encoder.popObject();
         return_value(near.bufferWithSize(encoder.serialize()).buffer.data);

--- a/tests/hello/assembly/main.ts
+++ b/tests/hello/assembly/main.ts
@@ -3,9 +3,6 @@ export { memory };
 
 import { contractContext, globalStorage, near } from "./near";
 
-// --- contract code goes below
-// --- bigints temporarily stringly typed, need support in bindgen
-
 export function hello(name: string): string {
 
   return "hello " + name;
@@ -17,5 +14,12 @@ export function setValue(value: string): string {
 }
 
 export function getValue(): string {
+  let keys = getAllKeys();
+  assert(keys.length == 1);
+  assert(keys[0] == "name");
   return globalStorage.getItem("name");
+}
+
+export function getAllKeys(): string[] {
+  return globalStorage.keys("n");
 }

--- a/tests/hello/assembly/near.ts
+++ b/tests/hello/assembly/near.ts
@@ -22,6 +22,21 @@ class ContractContext {
 }
 
 export class GlobalStorage {
+  keys(prefix: string): string[] {
+    let result: string[] = [];
+    let iterId = storage_iter(near.utf8(prefix));
+    for (;;) {
+      let len = storage_iter_peek_len(iterId);
+      if (len > 0) {
+        let buf = new Uint8Array(len);
+        storage_iter_peek_into(iterId, buf.buffer.data);
+        let key = String.fromUTF8(buf.buffer.data, buf.byteLength);
+        result.push(key);
+      }
+      storage_iter_next(iterId);
+    }
+    return result;
+  }
   setItem(key: string, value: string): void {
     storage_write(near.utf8(key), near.utf8(value));
   }
@@ -35,6 +50,19 @@ export class GlobalStorage {
     storage_read_into(near.utf8(key), buf.buffer.data);
     let value = String.fromUTF8(buf.buffer.data, buf.byteLength);
     return value;
+  }
+  setBytes(key: string, value: Uint8Array): void {
+    storage_write(near.utf8(key), near.bufferWithSize(value).buffer.data)
+  }
+  getBytes(key: string): Uint8Array {
+    let len = storage_read_len(near.utf8(key));
+    if (len == 0) {
+      return null;
+    }
+
+    let buf = new Uint8Array(len);
+    storage_read_into(near.utf8(key), buf.buffer.data);
+    return buf;
   }
   removeItem(key: string): void {
     assert(false, "storage_remove not implemented yet.");
@@ -183,6 +211,14 @@ declare function storage_write(key: usize, value: usize): void;
 declare function storage_read_len(key: usize): usize;
 @external("env", "storage_read_into")
 declare function storage_read_into(key: usize, value: usize): void;
+@external("env", "storage_iter")
+declare function storage_iter(prefix: usize): u32;
+@external("env", "storage_iter_next")
+declare function storage_iter_next(id: u32): u32;
+@external("env", "storage_iter_peek_len")
+declare function storage_iter_peek_len(id: u32): usize;
+@external("env", "storage_iter_peek_into")
+declare function storage_iter_peek_into(id: u32, value: usize): usize;
 
 @external("env", "input_read_len")
 declare function input_read_len(): usize;
@@ -211,6 +247,7 @@ declare function _near_random32(): u32;
 
 @external("env", "log")
 declare function _near_log(msg_ptr: usize): void;
+
 
 /*
     // TODO(#350): Refactor read/write APIs to unify them.

--- a/tests/hello/assembly/near.ts
+++ b/tests/hello/assembly/near.ts
@@ -25,7 +25,7 @@ export class GlobalStorage {
   keys(prefix: string): string[] {
     let result: string[] = [];
     let iterId = storage_iter(near.utf8(prefix));
-    for (;;) {
+    do {
       let len = storage_iter_peek_len(iterId);
       if (len > 0) {
         let buf = new Uint8Array(len);
@@ -33,8 +33,7 @@ export class GlobalStorage {
         let key = String.fromUTF8(buf.buffer.data, buf.byteLength);
         result.push(key);
       }
-      storage_iter_next(iterId);
-    }
+    } while (storage_iter_next(iterId));
     return result;
   }
   setItem(key: string, value: string): void {
@@ -218,7 +217,7 @@ declare function storage_iter_next(id: u32): u32;
 @external("env", "storage_iter_peek_len")
 declare function storage_iter_peek_len(id: u32): usize;
 @external("env", "storage_iter_peek_into")
-declare function storage_iter_peek_into(id: u32, value: usize): usize;
+declare function storage_iter_peek_into(id: u32, value: usize): void;
 
 @external("env", "input_read_len")
 declare function input_read_len(): usize;


### PR DESCRIPTION
@ilblackdragon  looks like `storage_iter` doesn't work as expected.

I'm getting such output:

```
2019-01-23T09:18:08Z DEBUG node_http::api] Schedule function call transaction "test_contract"."setValue"
[2019-01-23T09:18:08Z DEBUG node_http::api] Received transaction SignedTransaction { body: FunctionCall(FunctionCallTransaction { nonce: 138, originator: alice.near, contract_id: test_contract, method_name: Ok("setValue"), args: ..., amount: 0 }), signature: C568ttsRdLBH33bcYQNJbiXFvoUAPS1xqyYdpbiNnWxH9k7C3n6g7jLQ71HNoYonNRf1NDjHebQSVjS2Afvsca1 }
[2019-01-23T09:18:08Z DEBUG consensus::adapters::transaction_to_payload] Received transaction! SignedTransaction(SignedTransaction { body: FunctionCall(FunctionCallTransaction { nonce: 138, originator: alice.near, contract_id: test_contract, method_name: Ok("setValue"), args: ..., amount: 0 }), signature: C568ttsRdLBH33bcYQNJbiXFvoUAPS1xqyYdpbiNnWxH9k7C3n6g7jLQ71HNoYonNRf1NDjHebQSVjS2Afvsca1 })
[2019-01-23T09:18:08Z INFO  client] Block body: BeaconBlock { header: BeaconBlockHeader { parent_hash: 8Euo7CZE9cVTyws1TGidWZXoxnGNv9zod4omesJcpGYC, index: 319, authority_proposal: [], shard_block_hash: Db9LeiCn6zft8Rf2ifLn9T1Pe47biC8MTRypTPHSCWCK } }
[2019-01-23T09:18:08Z INFO  client] Shard block body: ShardBlock { header: ShardBlockHeader { parent_hash: 5xFDtfcWjP9BmGdesue3Kb27yfXUbfXUTZ5yq5StPek1, shard_id: 0, index: 319, merkle_root_state: 4rrkA6XmEqfxx8gNM3DRKWogSGBs61vwpA1PCC89utoy }, transactions: [SignedTransaction(SignedTransaction { body: FunctionCall(FunctionCallTransaction { nonce: 138, originator: alice.near, contract_id: test_contract, method_name: Ok("setValue"), args: ..., amount: 0 }), signature: C568ttsRdLBH33bcYQNJbiXFvoUAPS1xqyYdpbiNnWxH9k7C3n6g7jLQ71HNoYonNRf1NDjHebQSVjS2Afvsca1 })], new_receipts: [Receipt(ReceiptTransaction { originator: "alice.near", receiver: "test_contract", nonce: [199, 127, 59, 31, 51, 139, 11, 200, 157, 104, 34, 16, 104, 235, 246, 241, 209, 195, 206, 203, 73, 31, 13, 230, 51, 124, 209, 255, 15, 64, 45, 217], body: NewCall(AsyncCall { amount: 0, mana: 19, method_name: Ok("setValue"), args: ..., callback: None, accounting_info: AccountingInfo { originator: "alice.near", contract_id: None } }) })] }
[2019-01-23T09:18:08Z DEBUG consensus::adapters::transaction_to_payload] Received transaction! Receipt(ReceiptTransaction { originator: "alice.near", receiver: "test_contract", nonce: [199, 127, 59, 31, 51, 139, 11, 200, 157, 104, 34, 16, 104, 235, 246, 241, 209, 195, 206, 203, 73, 31, 13, 230, 51, 124, 209, 255, 15, 64, 45, 217], body: NewCall(AsyncCall { amount: 0, mana: 19, method_name: Ok("setValue"), args: ..., callback: None, accounting_info: AccountingInfo { originator: "alice.near", contract_id: None } }) })
[2019-01-23T09:18:08Z DEBUG wasm::runtime] storage_write('name', 'setCallPrefix137')
[2019-01-23T09:18:08Z INFO  client] Block body: BeaconBlock { header: BeaconBlockHeader { parent_hash: H8YLvHVZc4Xgtp31eTnxwGPwcAuW95UXTgZ2tKxdEG8F, index: 320, authority_proposal: [], shard_block_hash: 99cPPfhMtkZmsZ6uEA8ut7jiPSP8NTTbDD3LEbecWX8v } }
[2019-01-23T09:18:08Z INFO  client] Shard block body: ShardBlock { header: ShardBlockHeader { parent_hash: Db9LeiCn6zft8Rf2ifLn9T1Pe47biC8MTRypTPHSCWCK, shard_id: 0, index: 320, merkle_root_state: G17Amck6QutxGryruiKcnRqGLtWCTWXtjJd1grrBVQSD }, transactions: [Receipt(ReceiptTransaction { originator: "alice.near", receiver: "test_contract", nonce: [199, 127, 59, 31, 51, 139, 11, 200, 157, 104, 34, 16, 104, 235, 246, 241, 209, 195, 206, 203, 73, 31, 13, 230, 51, 124, 209, 255, 15, 64, 45, 217], body: NewCall(AsyncCall { amount: 0, mana: 19, method_name: Ok("setValue"), args: ..., callback: None, accounting_info: AccountingInfo { originator: "alice.near", contract_id: None } }) })], new_receipts: [Receipt(ReceiptTransaction { originator: "test_contract", receiver: "alice.near", nonce: [13, 76, 22, 20, 179, 238, 54, 47, 177, 251, 67, 74, 112, 119, 103, 133, 15, 136, 94, 212, 189, 212, 55, 188, 59, 86, 149, 52, 218, 220, 184, 172], body: ManaAccounting(ManaAccounting { accounting_info: AccountingInfo { originator: "alice.near", contract_id: None }, mana_refund: 19, gas_used: 25903 }) })] }
[2019-01-23T09:18:08Z DEBUG consensus::adapters::transaction_to_payload] Received transaction! Receipt(ReceiptTransaction { originator: "test_contract", receiver: "alice.near", nonce: [13, 76, 22, 20, 179, 238, 54, 47, 177, 251, 67, 74, 112, 119, 103, 133, 15, 136, 94, 212, 189, 212, 55, 188, 59, 86, 149, 52, 218, 220, 184, 172], body: ManaAccounting(ManaAccounting { accounting_info: AccountingInfo { originator: "alice.near", contract_id: None }, mana_refund: 19, gas_used: 25903 }) })
[2019-01-23T09:18:08Z INFO  client] Block body: BeaconBlock { header: BeaconBlockHeader { parent_hash: 4ZPYo5XcRXdQsYDhPgRukZ3xJ9NFDaGeByq152ERGtSJ, index: 321, authority_proposal: [], shard_block_hash: HmsvYCWTXLMXr32EbBrtJXDNS2hAkSzHGrKadJhNs3p3 } }
[2019-01-23T09:18:08Z INFO  client] Shard block body: ShardBlock { header: ShardBlockHeader { parent_hash: 99cPPfhMtkZmsZ6uEA8ut7jiPSP8NTTbDD3LEbecWX8v, shard_id: 0, index: 321, merkle_root_state: 5Bf5Uyhr6aW2DK1PxdruCmPhdsDC6csCafxLJwfbtjJc }, transactions: [Receipt(ReceiptTransaction { originator: "test_contract", receiver: "alice.near", nonce: [13, 76, 22, 20, 179, 238, 54, 47, 177, 251, 67, 74, 112, 119, 103, 133, 15, 136, 94, 212, 189, 212, 55, 188, 59, 86, 149, 52, 218, 220, 184, 172], body: ManaAccounting(ManaAccounting { accounting_info: AccountingInfo { originator: "alice.near", contract_id: None }, mana_refund: 19, gas_used: 25903 }) })], new_receipts: [] }
[2019-01-23T09:18:08Z DEBUG node_http::api] Call view function "test_contract""getValue"
[2019-01-23T09:18:08Z DEBUG wasm::runtime] storage_iter('n') -> 0
[2019-01-23T09:18:08Z DEBUG wasm::runtime] storage_iter_next(0) -> ''
[2019-01-23T09:18:08Z DEBUG wasm::runtime] ABORT: "" filename: "main.near.ts" line: 31 col: 2
[2019-01-23T09:18:08Z DEBUG node_runtime::state_viewer] result of execution: ExecutionOutcome { gas_used: 2109, mana_used: 0, mana_left: 0, return_data: Err(Interpreter(Trap(Trap { kind: Host(AssertFailed) }))), balance: 0, random_seed: [96, 166, 189, 131, 242, 190, 218, 95, 107, 23, 120, 72, 244, 127, 31, 176, 81, 50, 208, 216, 127, 150, 110, 129, 0, 196, 88, 72, 84, 218, 222, 173], logs: ["ABORT: \"\" filename: \"main.near.ts\" line: 31 col: 2"] }
[2019-01-23T09:18:08Z DEBUG node_runtime::state_viewer] wasm view call execution failed with error: Interpreter(Trap(Trap { kind: Host(AssertFailed) }))
```

Basically after writing `name` key I expect `n` prefix to match something, but looks like it doesn't.