### PR TITLE
Benchmarks for WASM

### DIFF
--- a/node/runtime/benches/bench.rs
+++ b/node/runtime/benches/bench.rs
@@ -3,52 +3,30 @@ extern crate bencher;
 
 use bencher::Bencher;
 
-extern crate primitives;
-extern crate node_runtime;
-extern crate transaction;
-
-use primitives::hash::CryptoHash;
-use primitives::signature::{DEFAULT_SIGNATURE, get_key_pair};
-
-use transaction::{TransactionBody, SendMoneyTransaction, SignedTransaction, Transaction};
-use node_runtime::ApplyState;
-use node_runtime::test_utils::{generate_test_chain_spec, get_runtime_and_state_db_viewer_from_chain_spec};
+use node_runtime::test_utils::{get_runtime_and_state_db_viewer, User, setup_test_contract};
 
 fn runtime_send_money(bench: &mut Bencher) {
-    let (mut chain_spec, _) = generate_test_chain_spec();
-    let public_key = get_key_pair().0;
-    for i in 0..100 {
-        chain_spec.accounts.push((format!("account{}", i), public_key.to_string(), 10000, 10000));
-    }
-    let (mut runtime, viewer) = get_runtime_and_state_db_viewer_from_chain_spec(&chain_spec);
-    let mut root = viewer.get_root();
+    let (runtime, _, mut root) = get_runtime_and_state_db_viewer();
+    let mut user = User::new(runtime, "alice.near");
     bench.iter(|| {
-        for _ in 0..100 {
-            let mut transactions = vec![];
-            for i in 0..100 {
-                transactions.push(Transaction::SignedTransaction(SignedTransaction::new(
-                    DEFAULT_SIGNATURE,
-                    TransactionBody::SendMoney(SendMoneyTransaction {
-                        nonce: 1,
-                        originator: format!("account{}", i % 100),
-                        receiver: format!("account{}", ((i + 1) % 100)),
-                        amount: 1,
-                    }))));
-            }
-            let apply_state = ApplyState {
-                root,
-                shard_id: 0,
-                parent_block_hash: CryptoHash::default(),
-                block_index: 0
-            };
-            let apply_result = runtime.apply_all(
-                apply_state, transactions
-            );
-            runtime.state_db.commit(apply_result.db_changes).unwrap();
-            root = apply_result.root;
-        }
-    })
+        root = user.send_money(root, "bob.near", 1);
+    });
 }
 
-benchmark_group!(benches, runtime_send_money);
-benchmark_main!(benches);
+fn runtime_wasm_set_value(bench: &mut Bencher) {
+    let (mut user, mut root) = setup_test_contract(include_bytes!("../../../tests/hello.wasm"));
+    bench.iter(|| {
+        root = user.call_function(root, "test", "setValue", "{\"value\": \"123\"}");
+    });
+}
+
+fn runtime_wasm_benchmark(bench: &mut Bencher) {
+    let (mut user, mut root) = setup_test_contract(include_bytes!("../../../tests/hello.wasm"));
+    bench.iter(|| {
+        root = user.call_function(root, "test", "benchmark", "{}");
+    });
+}
+
+benchmark_group!(runtime_benches, runtime_send_money);
+benchmark_group!(wasm_benches, runtime_wasm_set_value, runtime_wasm_benchmark);
+benchmark_main!(runtime_benches, wasm_benches);

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -1019,9 +1019,10 @@ impl Runtime {
                         result.status = TransactionStatus::Completed;
                     }
                     Err(s) => {
-                        debug!(target: "runtime", "{}", s);
                         state_update.rollback();
                         result.status = TransactionStatus::Failed;
+                        result.logs.push(format!("Runtime error: {}", s));
+                        debug!(target: "runtime", "{}", s);
                     }
                 }
             }
@@ -1041,16 +1042,18 @@ impl Runtime {
                             result.status = TransactionStatus::Completed;
                         }
                         Err(s) => {
-                            debug!(target: "runtime", "{}", s);
                             state_update.rollback();
                             new_receipts.append(&mut tmp_new_receipts);
                             result.status = TransactionStatus::Failed;
+                            result.logs.push(format!("Runtime error: {}", s));
+                            debug!(target: "runtime", "{}", s);
                         }
                     };
                 } else {
                     // wrong receipt
-                    debug!(target: "runtime", "receipt sent to the wrong shard");
                     result.status = TransactionStatus::Failed;
+                    result.logs.push("Runtime error: receipt sent to the wrong shard".to_string());
+                    debug!(target: "runtime", "receipt sent to the wrong shard");
                 }
             }
         };

--- a/node/runtime/src/test_utils.rs
+++ b/node/runtime/src/test_utils.rs
@@ -3,11 +3,13 @@ use std::sync::Arc;
 use byteorder::{ByteOrder, LittleEndian};
 
 use primitives::types::MerkleHash;
+use primitives::signature::{get_key_pair, DEFAULT_SIGNATURE};
 use primitives::signer::InMemorySigner;
+use primitives::hash::CryptoHash;
 use primitives::test_utils::get_key_pair_from_seed;
 use storage::StateDb;
 use storage::test_utils::create_memory_db;
-use transaction::Transaction;
+use transaction::{Transaction, TransactionBody, SignedTransaction, DeployContractTransaction, TransactionStatus, FunctionCallTransaction, SendMoneyTransaction};
 
 use configs::ChainSpec;
 use crate::state_viewer::StateDbViewer;
@@ -102,4 +104,82 @@ impl Runtime {
     ) -> ApplyResult {
         self.apply_all_vec(apply_state, transactions).pop().unwrap()
     }
+}
+
+pub struct User {
+    runtime: Runtime,
+    account_id: String,
+    nonce: u64,
+}
+
+impl User {
+    pub fn new(runtime: Runtime, account_id: &str) -> Self {
+        User {
+            runtime, account_id: account_id.to_string(), nonce: 1
+        }
+    }
+
+    fn send_tx(&mut self, root: CryptoHash, tx_body: TransactionBody) -> MerkleHash {
+        let transaction = SignedTransaction::new(DEFAULT_SIGNATURE, tx_body);
+        let apply_state = ApplyState {
+            root,
+            shard_id: 0,
+            parent_block_hash: CryptoHash::default(),
+            block_index: 0
+        };
+        let apply_results = self.runtime.apply_all_vec(
+            apply_state, vec![Transaction::SignedTransaction(transaction)]
+        );
+        for apply_result in apply_results.iter() {
+            assert_eq!(apply_result.tx_result[0].status, TransactionStatus::Completed, "{:?}", apply_result);
+        }
+        let last_apply_result = apply_results[apply_results.len() - 1].clone();
+        self.runtime.state_db.commit(last_apply_result.db_changes).unwrap();
+        last_apply_result.root
+    }
+
+    pub fn send_money(&mut self, root: MerkleHash, destination: &str, amount: u64) -> MerkleHash {
+        let tx_body = TransactionBody::SendMoney(SendMoneyTransaction {
+            nonce: self.nonce,
+            originator: self.account_id.clone(),
+            receiver: destination.to_string(),
+            amount,
+        });
+        self.nonce += 1;
+        self.send_tx(root, tx_body)
+    }
+
+    pub fn deploy_contract(&mut self, root: MerkleHash, contract_id: &str, wasm_binary: &[u8]) -> MerkleHash {
+        let (pk, _) = get_key_pair();
+        let tx_body = TransactionBody::DeployContract(DeployContractTransaction {
+            nonce: self.nonce,
+            originator: self.account_id.clone(),
+            contract_id: contract_id.to_string(),
+            public_key: pk.0[..].to_vec(),
+            wasm_byte_array: wasm_binary.to_vec(),
+        });
+        self.nonce += 1;
+        self.send_tx(root, tx_body)
+    }
+
+    pub fn call_function(&mut self, root: MerkleHash, contract_id: &str, method_name: &str, args: &str) -> MerkleHash {
+        let tx_body = TransactionBody::FunctionCall(FunctionCallTransaction {
+                nonce: self.nonce,
+                originator: self.account_id.clone(),
+                contract_id: contract_id.to_string(),
+                method_name: method_name.as_bytes().to_vec(),
+                args: args.as_bytes().to_vec(),
+                amount: 0
+        });
+        self.nonce += 1;
+        self.send_tx(root, tx_body)
+    }
+}
+
+pub fn setup_test_contract(wasm_binary: &[u8]) -> (User, CryptoHash) {
+    let (runtime, _, genesis_root) = get_runtime_and_state_db_viewer();
+    let mut user = User::new(runtime, "alice.near");
+    let root = user.deploy_contract(genesis_root, "test", wasm_binary);
+    assert_ne!(root, genesis_root);
+    (user, root)
 }

--- a/tests/hello/assembly/main.near.ts
+++ b/tests/hello/assembly/main.near.ts
@@ -2,7 +2,6 @@
       import { near } from "./near";
       import { JSONEncoder} from "./json/encoder"
       import { JSONDecoder, ThrowingJSONHandler, DecoderState  } from "./json/decoder"
-      import {hello as wrapped_hello, setValue as wrapped_setValue, getValue as wrapped_getValue, getAllKeys as wrapped_getAllKeys, generateLogs as wrapped_generateLogs, triggerAssert as wrapped_triggerAssert} from "./main";
 
       // Runtime functions
       @external("env", "return_value")
@@ -12,7 +11,53 @@
       @external("env", "input_read_into")
       declare function input_read_into(ptr: usize): void;
     
-import {contractContext as contractContext,globalStorage as globalStorage,near as near} from "./near";
+import "allocator/arena";
+export { memory };
+
+import { contractContext, globalStorage, near } from "./near";
+
+export function hello(name: string): string {
+
+  return "hello " + name;
+}
+
+export function setValue(value: string): string {
+  globalStorage.setItem("name", value);
+  return value;
+}
+
+export function getValue(): string {
+  return globalStorage.getItem("name");
+}
+
+export function getAllKeys(): string[] {
+  let keys = globalStorage.keys("n");
+  // assert(keys.length == 1);
+  // assert(keys[0] == "name");
+  return keys;
+}
+
+export function benchmark(): string[] {
+    let i = 0;
+  while (i < 10) {
+    globalStorage.setItem("n" + i.toString(), "123123");
+    i += 1;
+  }
+  return getAllKeys();
+}
+
+export function generateLogs(): void {
+  globalStorage.setItem("item", "value");
+  near.log("log1");
+  near.log("log2");
+}
+
+export function triggerAssert(): void {
+  near.log("log before assert");
+  assert(false, "expected to fail");
+}
+
+
 export class __near_ArgsParser_hello extends ThrowingJSONHandler {
         buffer: Uint8Array;
         decoder: JSONDecoder<__near_ArgsParser_hello>;
@@ -60,7 +105,7 @@ export function near_func_hello(): void {
       handler.buffer = json;
       handler.decoder = new JSONDecoder<__near_ArgsParser_hello>(handler);
       handler.decoder.deserialize(json);
-let result = wrapped_hello(
+let result = hello(
 handler.__near_param_name
 );
 
@@ -124,7 +169,7 @@ export function near_func_setValue(): void {
       handler.buffer = json;
       handler.decoder = new JSONDecoder<__near_ArgsParser_setValue>(handler);
       handler.decoder.deserialize(json);
-let result = wrapped_setValue(
+let result = setValue(
 handler.__near_param_value
 );
 
@@ -175,7 +220,7 @@ export function near_func_getValue(): void {
       handler.buffer = json;
       handler.decoder = new JSONDecoder<__near_ArgsParser_getValue>(handler);
       handler.decoder.deserialize(json);
-let result = wrapped_getValue(
+let result = getValue(
 
 );
 
@@ -237,7 +282,7 @@ export function near_func_getAllKeys(): void {
       handler.buffer = json;
       handler.decoder = new JSONDecoder<__near_ArgsParser_getAllKeys>(handler);
       handler.decoder.deserialize(json);
-let result = wrapped_getAllKeys(
+let result = getAllKeys(
 
 );
 
@@ -246,7 +291,60 @@ let result = wrapped_getAllKeys(
       
 if (result != null) {
           encoder.pushArray("result");
-          __near_encode_Array_String(<Array<String>>result, encoder);
+          __near_encode_Array_String(result, encoder);
+          encoder.popArray();
+        } else {
+          encoder.setNull("result");
+        }
+
+        encoder.popObject();
+        return_value(near.bufferWithSize(encoder.serialize()).buffer.data);
+      
+}
+export class __near_ArgsParser_benchmark extends ThrowingJSONHandler {
+        buffer: Uint8Array;
+        decoder: JSONDecoder<__near_ArgsParser_benchmark>;
+        handledRoot: boolean = false;
+      
+setNull(name: string): void {
+
+      super.setNull(name);
+    }
+
+      pushObject(name: string): bool {
+if (!this.handledRoot) {
+      assert(name == null);
+      this.handledRoot = true;
+      return true;
+    } else {
+      assert(name != null);
+    }
+
+        return super.pushObject(name);
+      }
+
+      pushArray(name: string): bool {
+
+        return super.pushArray(name);
+      }
+}
+export function near_func_benchmark(): void {
+      let json = new Uint8Array(input_read_len());
+      input_read_into(json.buffer.data);
+      let handler = new __near_ArgsParser_benchmark();
+      handler.buffer = json;
+      handler.decoder = new JSONDecoder<__near_ArgsParser_benchmark>(handler);
+      handler.decoder.deserialize(json);
+let result = benchmark(
+
+);
+
+        let encoder = new JSONEncoder();
+        encoder.pushObject(null);
+      
+if (result != null) {
+          encoder.pushArray("result");
+          __near_encode_Array_String(result, encoder);
           encoder.popArray();
         } else {
           encoder.setNull("result");
@@ -290,7 +388,7 @@ export function near_func_generateLogs(): void {
       handler.buffer = json;
       handler.decoder = new JSONDecoder<__near_ArgsParser_generateLogs>(handler);
       handler.decoder.deserialize(json);
-wrapped_generateLogs(
+generateLogs(
 
 );
 }
@@ -328,7 +426,7 @@ export function near_func_triggerAssert(): void {
       handler.buffer = json;
       handler.decoder = new JSONDecoder<__near_ArgsParser_triggerAssert>(handler);
       handler.decoder.deserialize(json);
-wrapped_triggerAssert(
+triggerAssert(
 
 );
 }

--- a/tests/hello/assembly/main.ts
+++ b/tests/hello/assembly/main.ts
@@ -24,6 +24,15 @@ export function getAllKeys(): string[] {
   return keys;
 }
 
+export function benchmark(): string[] {
+  let i = 0;
+  while (i < 10) {
+    globalStorage.setItem(i.toString(), "123123");
+    i += 1;
+  }
+  return globalStorage.keys("");
+}
+
 export function generateLogs(): void {
   globalStorage.setItem("item", "value");
   near.log("log1");


### PR DESCRIPTION
Current stats:
```
test runtime_send_money     ... bench:     314,230 ns/iter (+/- 119,284)
test runtime_wasm_benchmark ... bench:   9,437,774 ns/iter (+/- 1,584,444)
test runtime_wasm_set_value ... bench:   7,642,102 ns/iter (+/- 430,233)
```
Per 1 op/call:
  - send money: 3184 per second
  - wasm benchmark: 105 per second
  - wasm set value: 130 per second
