### PR TITLE
Improving WASM instance spawn performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "cached"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "cast"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1213,6 +1221,14 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "once_cell"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2282,21 +2298,22 @@ version = "0.0.2"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cached 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.1.0",
  "pwasm-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime 0.1.4 (git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc)",
+ "wasmer-runtime 0.1.4 (git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-clif-backend"
 version = "0.1.2"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc#1886b3d3c1c78a47ffd6a83bc5b639c637e862bc"
+source = "git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128#ad7b3e4cbc60a9bbbac5587234c1707ec2a16128"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cranelift-codegen 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2311,24 +2328,24 @@ dependencies = [
  "serde_bytes 0.10.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "target-lexicon 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-runtime-core 0.1.2 (git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc)",
+ "wasmer-runtime-core 0.1.2 (git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128)",
  "wasmparser 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wasmer-runtime"
 version = "0.1.4"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc#1886b3d3c1c78a47ffd6a83bc5b639c637e862bc"
+source = "git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128#ad7b3e4cbc60a9bbbac5587234c1707ec2a16128"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmer-clif-backend 0.1.2 (git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc)",
- "wasmer-runtime-core 0.1.2 (git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc)",
+ "wasmer-clif-backend 0.1.2 (git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128)",
+ "wasmer-runtime-core 0.1.2 (git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128)",
 ]
 
 [[package]]
 name = "wasmer-runtime-core"
 version = "0.1.2"
-source = "git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc#1886b3d3c1c78a47ffd6a83bc5b639c637e862bc"
+source = "git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128#ad7b3e4cbc60a9bbbac5587234c1707ec2a16128"
 dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hashbrown 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2466,6 +2483,7 @@ dependencies = [
 "checksum bytes 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)" = "40ade3d27603c2cb345eb0912aec461a6dec7e06a4ae48589904e808335c7afa"
 "checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
+"checksum cached 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f13d7a614340cc6be5df8a69063c421716c10c0c9e79f85d0a446ae40f078b44"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.29 (registry+https://github.com/rust-lang/crates.io-index)" = "4390a3b5f4f6bce9c1d0c00128379df433e53777fdd30e92f16a529332baec4e"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
@@ -2560,6 +2578,7 @@ dependencies = [
 "checksum num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "e83d528d2677f0518c570baf2b7abdcf0cd2d248860b68507bdcb3e91d4c0cea"
 "checksum num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0b3a5d7cc97d6d30d8b9bc8fa19bf45349ffe46241e8816f50f62f6d6aaabee1"
 "checksum num_cpus 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5a69d464bdc213aaaff628444e99578ede64e9c854025aa43b9796530afa9238"
+"checksum once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "532c29a261168a45ce28948f9537ddd7a5dd272cc513b3017b1e82a88f962c37"
 "checksum opaque-debug 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "93f5bb2e8e8dec81642920ccff6b61f1eb94fa3020c5a325c9851ff604152409"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum page_size 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f89ef58b3d32420dbd1a43d2f38ae92f6239ef12bb556ab09ca55445f5a67242"
@@ -2665,9 +2684,9 @@ dependencies = [
 "checksum wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "74e463a508e390cc7447e70f640fbf44ad52e1bd095314ace1fdf99516d32add"
 "checksum wabt-sys 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a6265b25719e82598d104b3717375e37661d41753e2c84cde3f51050c7ed7e3c"
 "checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
-"checksum wasmer-clif-backend 0.1.2 (git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc)" = "<none>"
-"checksum wasmer-runtime 0.1.4 (git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc)" = "<none>"
-"checksum wasmer-runtime-core 0.1.2 (git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc)" = "<none>"
+"checksum wasmer-clif-backend 0.1.2 (git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128)" = "<none>"
+"checksum wasmer-runtime 0.1.4 (git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128)" = "<none>"
+"checksum wasmer-runtime-core 0.1.2 (git+https://github.com/nearprotocol/wasmer.git?rev=ad7b3e4cbc60a9bbbac5587234c1707ec2a16128)" = "<none>"
 "checksum wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "21ef487a11df1ed468cf613c78798c26282da5c30e9d49f824872d4c77b47d1d"
 "checksum wasmparser 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46e666ecb4a406483a59a49f9d0c17f327e70da53a128eccddae2eadb95865c"
 "checksum wasmparser 0.23.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5e01c420bc7d36e778bd242e1167b079562ba8b34087122cc9057187026d060"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,10 +2282,12 @@ version = "0.0.2"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.1.0",
  "pwasm-utils 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmer-runtime 0.1.4 (git+https://github.com/wasmerio/wasmer.git?rev=1886b3d3c1c78a47ffd6a83bc5b639c637e862bc)",
  "wasmi 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/wasm/Cargo.toml
+++ b/core/wasm/Cargo.toml
@@ -8,11 +8,12 @@ edition = "2018"
 wasmi = { version = "0.4.1" }
 pwasm-utils = "0.6.2"
 parity-wasm = "0.31"
-wasmer-runtime = {git = "https://github.com/wasmerio/wasmer.git", rev="1886b3d3c1c78a47ffd6a83bc5b639c637e862bc"}
+wasmer-runtime = {git = "https://github.com/nearprotocol/wasmer.git", rev="ad7b3e4cbc60a9bbbac5587234c1707ec2a16128"}
 byteorder = "1.2"
 log = "0.4"
-tempfile = "3.0.6"
-lazy_static = "1.2.0"
+cached = "0.8.0"
+serde = "1.0"
+serde_derive = "1.0"
 
 primitives = { path = "../primitives" }
 

--- a/core/wasm/Cargo.toml
+++ b/core/wasm/Cargo.toml
@@ -11,6 +11,8 @@ parity-wasm = "0.31"
 wasmer-runtime = {git = "https://github.com/wasmerio/wasmer.git", rev="1886b3d3c1c78a47ffd6a83bc5b639c637e862bc"}
 byteorder = "1.2"
 log = "0.4"
+tempfile = "3.0.6"
+lazy_static = "1.2.0"
 
 primitives = { path = "../primitives" }
 

--- a/core/wasm/src/cache.rs
+++ b/core/wasm/src/cache.rs
@@ -1,0 +1,13 @@
+use tempfile::TempDir;
+use std::sync::Mutex;
+use std::path::{Path, PathBuf};
+
+lazy_static! {
+    static ref CACHE_TEMP_DIR: Mutex<TempDir> =
+        Mutex::new(TempDir::new()
+            .expect("create wasm cache temp directory"));
+}
+
+pub(crate) fn get_cached_path<P: AsRef<Path>>(filename: P) -> PathBuf {
+    CACHE_TEMP_DIR.lock().unwrap().path().join(filename)
+}

--- a/core/wasm/src/lib.rs
+++ b/core/wasm/src/lib.rs
@@ -1,6 +1,9 @@
 extern crate parity_wasm;
 extern crate pwasm_utils;
 extern crate wasmi;
+extern crate tempfile;
+#[macro_use]
+extern crate lazy_static;
 
 #[cfg(test)]
 #[macro_use]
@@ -14,6 +17,7 @@ extern crate primitives;
 #[macro_use]
 extern crate log;
 
+mod cache;
 pub mod executor;
 pub mod ext;
 mod prepare;

--- a/core/wasm/src/lib.rs
+++ b/core/wasm/src/lib.rs
@@ -1,9 +1,11 @@
 extern crate parity_wasm;
 extern crate pwasm_utils;
 extern crate wasmi;
-extern crate tempfile;
 #[macro_use]
-extern crate lazy_static;
+extern crate cached;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 
 #[cfg(test)]
 #[macro_use]

--- a/core/wasm/src/prepare.rs
+++ b/core/wasm/src/prepare.rs
@@ -5,11 +5,6 @@ use parity_wasm::elements::{self, External, MemoryType, Type, MemorySection};
 use parity_wasm::builder;
 use pwasm_utils::{self, rules};
 use crate::types::{Config, PrepareError as Error};
-use wasmer_runtime::{
-    memory::Memory,
-    wasm::MemoryDescriptor,
-    units::Pages,
-};
 
 struct ContractModule<'a> {
     // An `Option` is used here for loaning (`take()`-ing) the module.
@@ -29,7 +24,7 @@ impl<'a> ContractModule<'a> {
         })
     }
 
-    fn externalize_mem(&mut self) {
+    fn standardize_mem(&mut self) {
         let mut module = self
             .module
             .take()
@@ -37,30 +32,23 @@ impl<'a> ContractModule<'a> {
 
         let mut tmp = MemorySection::default();
 
-        let entry = module.memory_section_mut()
+        module.memory_section_mut()
             .unwrap_or_else(|| &mut tmp)
             .entries_mut()
             .pop();
 
-        match entry {
-            Some(mut entry) => {
-                if entry.limits().maximum().is_none() {
-                    entry = elements::MemoryType::new(
-                        entry.limits().initial(),
-                        Some(self.config.max_memory_pages));
-                }
+        let entry = elements::MemoryType::new(
+            self.config.initial_memory_pages,
+            Some(self.config.max_memory_pages));
 
-                let mut builder = builder::from_module(module);
-                builder.push_import(elements::ImportEntry::new(
-                    "env".to_owned(),
-                    "memory".to_owned(),
-                    elements::External::Memory(entry),
-                ));
+        let mut builder = builder::from_module(module);
+        builder.push_import(elements::ImportEntry::new(
+            "env".to_owned(),
+            "memory".to_owned(),
+            elements::External::Memory(entry),
+        ));
 
-                self.module = Some(builder.build());
-            }
-            None => self.module = Some(module)
-        };
+        self.module = Some(builder.build());
     }
 
     /// Ensures that module doesn't declare internal memories.
@@ -178,11 +166,6 @@ impl<'a> ContractModule<'a> {
     }
 }
 
-pub(super) struct PreparedContract {
-    pub instrumented_code: Vec<u8>,
-    pub memory: Option<Memory>,
-}
-
 /// Loads the given module given in `original_code`, performs some checks on it and
 /// does some preprocessing.
 ///
@@ -196,60 +179,32 @@ pub(super) struct PreparedContract {
 pub(super) fn prepare_contract(
     original_code: &[u8],
     config: &Config,
-) -> Result<PreparedContract, Error> {
+) -> Result<Vec<u8>, Error> {
     let mut contract_module = ContractModule::init(original_code, config)?;
-    contract_module.externalize_mem();
+    contract_module.standardize_mem();
     contract_module.ensure_no_internal_memory()?;
     contract_module.inject_gas_metering()?;
     contract_module.inject_stack_height_metering()?;
 
-    let memory = if let Some(memory_type) = contract_module.scan_imports()? {
+    if let Some(memory_type) = contract_module.scan_imports()? {
         // Inspect the module to extract the initial and maximum page count.
         let limits = memory_type.limits();
-        match (limits.initial(), limits.maximum()) {
-            (initial, Some(maximum)) if initial > maximum => {
-                // Requested initial number of pages should not exceed the requested maximum.
-                return Err(Error::MemoryInitialExceedMaximum);
-            }
-            (_, Some(maximum)) if maximum > config.max_memory_pages => {
-                // Maximum number of pages should not exceed the configured maximum.
-                return Err(Error::MemoryMaximumExceedConfig);
-            }
-            (_, None) => {
-                // Maximum number of pages should be always declared.
-                // This isn't a hard requirement and can be treated as a maxiumum set
-                // to configured maximum.
-                return Err(Error::MemoryNoMaximum);
-            }
-            (initial, Some(maximum)) => Some(Memory::new(MemoryDescriptor {
-                minimum: Pages(initial),
-                maximum: Some(Pages(maximum)),
-                shared: false,
-            }).map_err(Error::MemoryWasmer)?)
+        if limits.initial() != config.initial_memory_pages || limits.maximum() != Some(config.max_memory_pages) {
+            return Err(Error::Memory);
         }
     } else {
-        None
+        return Err(Error::Memory);
     };
 
-    Ok(PreparedContract {
-        instrumented_code: contract_module.into_wasm_code()?,
-        memory,
-    })
+    contract_module.into_wasm_code()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fmt;
     use wabt;
 
-    impl fmt::Debug for PreparedContract {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-            write!(f, "PreparedContract {{ .. }}")
-        }
-    }
-
-    fn parse_and_prepare_wat(wat: &str) -> Result<PreparedContract, Error> {
+    fn parse_and_prepare_wat(wat: &str) -> Result<Vec<u8>, Error> {
         let wasm = wabt::Wat2Wasm::new().validate(false).convert(wat).unwrap();
         let config = Config::default();
         prepare_contract(wasm.as_ref(), &config)
@@ -275,15 +230,15 @@ mod tests {
 
         // initial exceed maximum
         let r = parse_and_prepare_wat(r#"(module (import "env" "memory" (memory 17 1)))"#);
-        assert_matches!(r, Err(Error::MemoryInitialExceedMaximum));
+        assert_matches!(r, Ok(_));
 
         // no maximum
         let r = parse_and_prepare_wat(r#"(module (import "env" "memory" (memory 1)))"#);
-        assert_matches!(r, Err(Error::MemoryNoMaximum));
+        assert_matches!(r, Ok(_));
 
         // requested maximum exceed configured maximum
         let r = parse_and_prepare_wat(r#"(module (import "env" "memory" (memory 1 33)))"#);
-        assert_matches!(r, Err(Error::MemoryMaximumExceedConfig));
+        assert_matches!(r, Ok(_));
     }
 
     #[test]

--- a/core/wasm/src/prepare.rs
+++ b/core/wasm/src/prepare.rs
@@ -43,8 +43,8 @@ impl<'a> ContractModule<'a> {
 
         let mut builder = builder::from_module(module);
         builder.push_import(elements::ImportEntry::new(
-            "env".to_owned(),
-            "memory".to_owned(),
+            "env".to_string(),
+            "memory".to_string(),
             elements::External::Memory(entry),
         ));
 

--- a/core/wasm/src/runtime.rs
+++ b/core/wasm/src/runtime.rs
@@ -33,7 +33,7 @@ pub struct Runtime<'a> {
     pub random_seed: Vec<u8>,
     random_buffer_offset: usize,
     pub logs: Vec<String>,
-    memory: Option<Memory>,
+    memory: Memory,
 }
 
 impl<'a> Runtime<'a> {
@@ -43,7 +43,7 @@ impl<'a> Runtime<'a> {
         result_data: &'a [Option<Vec<u8>>],
         context: &'a RuntimeContext,
         gas_limit: Gas,
-        memory: Option<Memory>,
+        memory: Memory,
     ) -> Runtime<'a> {
         Runtime {
             ext,
@@ -64,13 +64,9 @@ impl<'a> Runtime<'a> {
     }
 
     fn memory_can_fit(&self, offset: usize, len: usize) -> bool {
-        if let Some(ref memory) = self.memory {
-            match offset.checked_add(len) {
-                None => false,
-                Some(end) => memory.size().bytes() >= Bytes(end),
-            }
-        } else {
-            false
+        match offset.checked_add(len) {
+            None => false,
+            Some(end) => self.memory.size().bytes() >= Bytes(end),
         }
     }
 
@@ -79,14 +75,12 @@ impl<'a> Runtime<'a> {
             Err(Error::MemoryAccessViolation)
         } else if len == 0 {
             Ok(Vec::new())
-        } else if let Some(ref memory) = self.memory {
-            Ok(memory
+        } else {
+            Ok(self.memory
                 .view()[offset..(offset + len)]
                 .iter()
                 .map(|cell| cell.get())
                 .collect())
-        } else {
-            Err(Error::MemoryAccessViolation)
         }
     }
 
@@ -95,15 +89,13 @@ impl<'a> Runtime<'a> {
             Err(Error::MemoryAccessViolation)
         } else if buf.is_empty() {
             Ok(())
-        } else if let Some(ref memory) = self.memory {
-            memory
+        } else {
+            self.memory
                 .view()[offset..(offset + buf.len())]
                 .iter()
                 .zip(buf.iter())
                 .for_each(|(cell, v)| cell.set(*v));
             Ok(())
-        } else {
-            Err(Error::MemoryAccessViolation)
         }
     }
 
@@ -583,24 +575,14 @@ pub mod imports {
                 }
             )*
 
-            pub(crate) fn build(memory: Option<Memory>) -> ImportObject {
-                if let Some(memory) = memory {
-                    imports! {
-                        "env" => {
-                            "memory" => memory,
-                            $(
-                                $import_name => func!($func),
-                            )*
-                        },
-                    }
-                } else {
-                    imports! {
-                        "env" => {
-                            $(
-                                $import_name => func!($func),
-                            )*
-                        },
-                    }
+            pub(crate) fn build(memory: Memory) -> ImportObject {
+                imports! {
+                    "env" => {
+                        "memory" => memory,
+                        $(
+                            $import_name => func!($func),
+                        )*
+                    },
                 }
             }
         }

--- a/core/wasm/src/runtime.rs
+++ b/core/wasm/src/runtime.rs
@@ -562,7 +562,7 @@ pub mod imports {
     macro_rules! wrapped_imports {
         ( $( $import_name:expr => $func:ident < [ $( $arg_name:ident : $arg_type:ident ),* ] -> [ $( $returns:ident ),* ] >, )* ) => {
             $(
-                fn $func( $( $arg_name: $arg_type, )* ctx: &mut Ctx) -> Result<($( $returns )*)> {
+                fn $func( ctx: &mut Ctx, $( $arg_name: $arg_type ),* ) -> Result<($( $returns )*)> {
                     // TODO(542): Currently we need to check that the ctx.data is initialized and return to default
                     // when it's not initialized. It's because wasmer is currently calls start_func before
                     // the ctx.data is assigned to the runtime. 

--- a/core/wasm/src/types.rs
+++ b/core/wasm/src/types.rs
@@ -192,7 +192,7 @@ pub enum ReturnData {
 }
 
 // TODO: Extract it to the root of the crate
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct Config {
     /// Gas cost of a growing memory by single page.
     pub grow_mem_cost: u32,

--- a/core/wasm/src/types.rs
+++ b/core/wasm/src/types.rs
@@ -162,6 +162,8 @@ pub enum Error {
     Runtime(RuntimeError),
 
     Prepare(PrepareError),
+
+    Cache(WasmerError::CacheError),
 }
 
 impl From<WasmerError::Error> for Error {

--- a/core/wasm/src/types.rs
+++ b/core/wasm/src/types.rs
@@ -34,25 +34,8 @@ pub enum PrepareError {
     /// instantiable and/or unlinkable.
     Instantiate,
 
-    /// Memory creation error.
-    ///
-    /// The initial memory is higher than the maximum.
-    MemoryInitialExceedMaximum,
-
-    /// Memory creation error.
-    ///
-    /// The maximum memory is higher than allowed by configuration.
-    MemoryMaximumExceedConfig,
-
-    /// Memory creation error.
-    ///
-    /// The maximum memory is not specified.
-    MemoryNoMaximum,
-
-    /// Memory creation error.
-    ///
-    /// The creation of memory failed by wasmer.
-    MemoryWasmer(WasmerError::CreationError),
+    /// Memory error.
+    Memory,
 }
 
 /// User trap in native code
@@ -224,6 +207,9 @@ pub struct Config {
     /// how the stack frame cost is calculated.
     pub max_stack_height: u32,
 
+    // The initial number of memory pages.
+    pub initial_memory_pages: u32,
+
     /// What is the maximal memory pages amount is allowed to have for
     /// a contract.
     pub max_memory_pages: u32,
@@ -239,6 +225,7 @@ impl Default for Config {
             regular_op_cost: 1,
             return_data_per_byte_cost: 1,
             max_stack_height: 64 * 1024,
+            initial_memory_pages: 17,
             max_memory_pages: 32,
             gas_limit: 10 * 1024 * 1024,
         }


### PR DESCRIPTION
- Standardize memory so we can initiate memory without code inspection
- Adding file cache that stores compiled code into temporary directory

Caveats:
- Disk Cache is insecure.
- It uses lazy static init, that might crash if temp dir is failed to create.
- Wasmer cache has one of the functions as unsafe. We should probably change this cache to be LRU memory cache. I'll explore it next.
- It also has assumption about config for execution being the same.

But this change improves WASM benchmarks from 93ms overhead to much less:
```
test runtime_send_money                 ... bench:     541,875 ns/iter (+/- 225,776)
test runtime_wasm_benchmark_10_reads    ... bench:   1,941,265 ns/iter (+/- 298,672)
test runtime_wasm_benchmark_sum_1000    ... bench:   1,877,210 ns/iter (+/- 502,444)
test runtime_wasm_benchmark_sum_1000000 ... bench:  24,895,845 ns/iter (+/- 3,931,008)
test runtime_wasm_set_value             ... bench:   1,758,437 ns/iter (+/- 588,113)
```