### PR TITLE
add release devnet artifact to gitlab build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,3 +54,6 @@ test_nearlib:
     - ./scripts/kill_devnet.sh
     after_script:
     - *cleanup_obsolete_cache
+    artifacts:
+      paths:
+      - target/release/devnet


### PR DESCRIPTION
this allows us to just point to a specific branch and grab this file rather than downloading rust + compiling everything from scratch via salt