### PR TITLE
Enable lto (link time optimizations) and set codegen-units to 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,3 +51,7 @@ keystore = { path = "./test-utils/keygen" }
 node-http = { path = "./node/http" }
 primitives = { path = "./core/primitives" }
 configs = { path = "./node/configs" }
+
+[profile.release]
+lto = true        # Enable full link-time optimization.
+codegen-units = 1 # Use only 1 codegen-unit to enable full optimizations.


### PR DESCRIPTION
Benchmarks before:
```
test runtime_send_money                 ... bench:     474,562 ns/iter (+/- 31,684)
test runtime_wasm_benchmark_10_reads    ... bench:   1,835,657 ns/iter (+/- 134,443)
test runtime_wasm_benchmark_sum_1000    ... bench:   1,709,746 ns/iter (+/- 95,359)
test runtime_wasm_benchmark_sum_1000000 ... bench:  22,743,437 ns/iter (+/- 406,030)
test runtime_wasm_set_value             ... bench:   1,688,506 ns/iter (+/- 158,844)
```

Benchmarks after:
```
test runtime_send_money                 ... bench:     470,033 ns/iter (+/- 15,350)
test runtime_wasm_benchmark_10_reads    ... bench:   1,743,149 ns/iter (+/- 102,474)
test runtime_wasm_benchmark_sum_1000    ... bench:   1,591,865 ns/iter (+/- 88,726)
test runtime_wasm_benchmark_sum_1000000 ... bench:  18,217,341 ns/iter (+/- 296,310)
test runtime_wasm_set_value             ... bench:   1,594,832 ns/iter (+/- 114,640)
```