### PR TITLE
Update WASM cache to store Result instead

### DIFF
--- a/core/wasm/src/cache.rs
+++ b/core/wasm/src/cache.rs
@@ -9,8 +9,8 @@ use crate::types::{Config, Error};
 /// Cache size in number of cached modules to hold.
 const CACHE_SIZE: usize = 1024;
 
-cached_key_result! {
-    MODULES: SizedCache<String, wasmer_runtime::Cache> = SizedCache::with_size(CACHE_SIZE);
+cached_key! {
+    MODULES: SizedCache<String, Result<wasmer_runtime::Cache, Error>> = SizedCache::with_size(CACHE_SIZE);
     Key = {
         format!("{}:{}",
             hash(code),

--- a/core/wasm/src/executor.rs
+++ b/core/wasm/src/executor.rs
@@ -46,7 +46,7 @@ pub fn execute<'a>(
     // that this cache was not tampered with or corrupted.
     // In our case the cache is cloned from memory, so it's safe to use.
     let module = unsafe { wasm_cache.into_module() }
-        .map_err(Error::Cache)?;
+        .map_err(|e| Error::Cache(format!("Cache error: {:?}", e)))?;
 
     let memory = Memory::new(MemoryDescriptor {
         minimum: Pages(config.initial_memory_pages),

--- a/core/wasm/src/lib.rs
+++ b/core/wasm/src/lib.rs
@@ -22,6 +22,6 @@ extern crate log;
 mod cache;
 pub mod executor;
 pub mod ext;
-mod prepare;
+pub mod prepare;
 mod runtime;
 pub mod types;

--- a/core/wasm/src/prepare.rs
+++ b/core/wasm/src/prepare.rs
@@ -176,7 +176,7 @@ impl<'a> ContractModule<'a> {
 /// - all imported functions from the external environment matches defined by `env` module,
 ///
 /// The preprocessing includes injecting code for gas metering and metering the height of stack.
-pub(super) fn prepare_contract(
+pub fn prepare_contract(
     original_code: &[u8],
     config: &Config,
 ) -> Result<Vec<u8>, Error> {

--- a/core/wasm/src/types.rs
+++ b/core/wasm/src/types.rs
@@ -1,7 +1,7 @@
 use primitives::types::{PromiseId, AccountId, Balance, Mana, BlockIndex};
 use wasmer_runtime::error as WasmerError;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Error that can occur while preparing or executing wasm smart-contract.
 pub enum PrepareError {
     /// Error happened while serializing the module.
@@ -146,7 +146,7 @@ impl ::std::fmt::Display for RuntimeError {
 }
 
 /// Wrapped error
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Error {
     /// Method name can't be decoded to UTF8.
     BadUtf8,
@@ -163,7 +163,7 @@ pub enum Error {
 
     Prepare(PrepareError),
 
-    Cache(WasmerError::CacheError),
+    Cache(String),
 }
 
 impl From<WasmerError::Error> for Error {

--- a/node/runtime/benches/bench.rs
+++ b/node/runtime/benches/bench.rs
@@ -14,6 +14,18 @@ fn runtime_send_money(bench: &mut Bencher) {
     });
 }
 
+fn runtime_wasm_bad_code(bench: &mut Bencher) {
+    let code = include_bytes!("../../../tests/hello.wasm");
+    let code = wasm::prepare::prepare_contract(code, &wasm::types::Config::default()).unwrap();
+    let (mut user, mut root) = setup_test_contract(&code);
+    bench.iter(|| {
+        let (new_root, _) = user.call_function(
+            root, "test_contract", "benchmark", b"{}".to_vec(), 0
+        );
+        root = new_root;
+    });
+}
+
 fn runtime_wasm_set_value(bench: &mut Bencher) {
     let (mut user, mut root) = setup_test_contract(include_bytes!("../../../tests/hello.wasm"));
     bench.iter(|| {
@@ -61,6 +73,7 @@ fn runtime_wasm_benchmark_sum_1000000(bench: &mut Bencher) {
 benchmark_group!(runtime_benches, runtime_send_money);
 benchmark_group!(wasm_benches,
     runtime_wasm_set_value,
+    runtime_wasm_bad_code,
     runtime_wasm_benchmark_10_reads,
     runtime_wasm_benchmark_sum_1000,
     runtime_wasm_benchmark_sum_1000000);


### PR DESCRIPTION
Fixes #568 
Also adding a benchmark to try run some bad code.

Before this commit:
```
test runtime_send_money                 ... bench:     472,202 ns/iter (+/- 27,107)
test runtime_wasm_bad_code              ... bench:   4,042,358 ns/iter (+/- 269,702)
test runtime_wasm_benchmark_10_reads    ... bench:   1,441,188 ns/iter (+/- 168,624)
test runtime_wasm_benchmark_sum_1000    ... bench:   1,257,166 ns/iter (+/- 118,543)
test runtime_wasm_benchmark_sum_1000000 ... bench:  14,212,002 ns/iter (+/- 328,197)
test runtime_wasm_set_value             ... bench:   1,286,205 ns/iter (+/- 52,033)
```

After this commit:
```
test runtime_send_money                 ... bench:     473,913 ns/iter (+/- 42,013)
test runtime_wasm_bad_code              ... bench:     804,576 ns/iter (+/- 46,408)
test runtime_wasm_benchmark_10_reads    ... bench:   1,424,945 ns/iter (+/- 133,040)
test runtime_wasm_benchmark_sum_1000    ... bench:   1,306,655 ns/iter (+/- 188,243)
test runtime_wasm_benchmark_sum_1000000 ... bench:  14,121,906 ns/iter (+/- 1,260,672)
test runtime_wasm_set_value             ... bench:   1,274,420 ns/iter (+/- 66,046)
```