### PR TITLE
ops: set up boot nodes in docker via new network

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -41,6 +41,10 @@ FROM phusion/baseimage:0.11
 # Args must be defined for every stage
 ARG PACKAGE="devnet"
 
+RUN apt-get update -qq && apt-get install -y \
+    dnsutils \
+    && rm -rf /var/lib/apt/lists/*
+
 RUN mkdir -p /root/.local/share/nearcore && \
 	ln -s /root/.local/share/nearcore /data
 

--- a/ops/k8s/run.yaml
+++ b/ops/k8s/run.yaml
@@ -32,8 +32,14 @@ spec:
         - "-c"
         - |
           NODE_ID=${HOSTNAME##*-}
-          ./docker_command -b {{ boot_node }} --test-network-key-seed ${NODE_ID}
-
+          if [ ${NODE_ID} -eq 0 ]; then
+            ./docker_command --addr 0.0.0.0:3000 --test-network-key-seed ${NODE_ID}
+          else
+            sleep 30
+            BOOT_NODE_IP=$(host {{ boot_node_host }} | head -n 1 | cut -f4 -d ' ')
+            BOOT_NODE=${BOOT_NODE_IP}:3000/{{ boot_node_peer_id }}
+            ./docker_command --addr 0.0.0.0:3000 -b ${BOOT_NODE} --test-network-key-seed ${NODE_ID}
+          fi
 ---
 
 apiVersion: v1

--- a/ops/utils/build_and_run
+++ b/ops/utils/build_and_run
@@ -134,11 +134,10 @@ class Executor(object):
         self._kubectl_create_from_yaml(ingress_yaml)
 
     @staticmethod
-    def _generate_boot_node_address(namespace, node_index):
+    def _generate_boot_node_info(namespace, node_index):
         host_name = "node-{}.node.{}.svc.cluster.local".format(node_index, namespace)
-        port = 3000
         peer_id = b58encode(hashlib.sha256(node_index.to_bytes(32, byteorder='big')).digest()).decode('utf-8')
-        return "{}:{}/{}".format(host_name, port, peer_id)
+        return host_name, peer_id
 
     def execute(
             self,
@@ -170,7 +169,7 @@ class Executor(object):
         self._push_image(push_tag)
 
         namespace = "nearcore-{}".format(_uuid)
-        boot_node = self._generate_boot_node_address(namespace, node_index=0)
+        boot_node_host, boot_node_peer_id = self._generate_boot_node_info(namespace, node_index=0)
         print('Deploying build...')
         env = jinja2.Environment(loader=jinja2.FileSystemLoader('../k8s/'))
         template = env.get_template('run.yaml')
@@ -178,7 +177,8 @@ class Executor(object):
             namespace=namespace,
             image_tag=deploy_tag,
             node_count=node_count,
-            boot_node=boot_node,
+            boot_node_host=boot_node_host,
+            boot_node_peer_id=boot_node_peer_id,
         )
         self._kubectl_create_from_yaml(run_yaml)
 

--- a/ops/utils/requirements.txt
+++ b/ops/utils/requirements.txt
@@ -2,4 +2,4 @@ boto3==1.9.37
 click==7.0
 -e git://github.com/azban/delegator.py.git@91f74a007992cc2cf4bd73ee76962616d7e199ce#egg=delegator-py
 jinja2==2.10
-requests==1.24.1
+requests==2.21.0


### PR DESCRIPTION
1) generates PeerId in python based on hash, rather than using chainspecbuilder tool
2) adds DNS to k8s run command, so that we can pass IP via cli until we have DNS support in network