### PR TITLE
Fix CI. Make it work for benches inside nightshade

### DIFF
--- a/core/nightshade/src/lib.rs
+++ b/core/nightshade/src/lib.rs
@@ -3,7 +3,7 @@ extern crate serde_derive;
 extern crate serde;
 extern crate bs58;
 
-mod nightshade;
+pub mod nightshade;
 mod verifier;
 pub mod nightshade_task;
 


### PR DESCRIPTION
Error in CI:
```
error[E0603]: module `nightshade` is private
 --> core/nightshade/benches/bench.rs:6:17
  |
6 | use nightshade::nightshade::BareState;
  |                 ^^^^^^^^^^

error: aborting due to previous error
```