### PR TITLE
Integrate mempool with shard chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,16 +994,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "mempool"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-protos 0.1.0",
+ "chain 0.0.1",
  "node-runtime 0.0.1",
  "primitives 0.1.0",
  "serde 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.87 (registry+https://github.com/rust-lang/crates.io-index)",
- "shard 0.0.1",
  "storage 0.0.1",
- "tokio 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1836,6 +1832,7 @@ dependencies = [
  "configs 0.1.0",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mempool 0.1.0",
  "node-runtime 0.0.1",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.1.0",

--- a/core/chain/src/lib.rs
+++ b/core/chain/src/lib.rs
@@ -2,10 +2,6 @@ use std::sync::{Arc, RwLock};
 
 use primitives::hash::CryptoHash;
 use primitives::types::BlockId;
-use primitives::transaction::{
-    TransactionAddress, TransactionResult, TransactionLogs, TransactionStatus,
-    FinalTransactionResult, FinalTransactionStatus
-};
 use primitives::block_traits::{SignedBlock, SignedHeader};
 use storage::GenericStorage;
 use std::marker::PhantomData;
@@ -124,68 +120,5 @@ where
             }
         }
         Ok(blocks)
-    }
-
-    pub fn get_transaction_result(&self, hash: &CryptoHash) -> TransactionResult {
-        self.storage
-            .write()
-            .expect(POISONED_LOCK_ERR)
-            .blockchain_storage_mut()
-            .transaction_result(hash)
-            .unwrap()
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    pub fn get_transaction_address(&self, hash: &CryptoHash) -> Option<TransactionAddress> {
-        self.storage
-            .write()
-            .expect(POISONED_LOCK_ERR)
-            .blockchain_storage_mut()
-            .transaction_address(hash)
-            .unwrap()
-            .cloned()
-    }
-
-    fn collect_transaction_final_result(
-        &self,
-        transaction_result: &TransactionResult,
-        logs: &mut Vec<TransactionLogs>,
-    ) -> FinalTransactionStatus {
-        match transaction_result.status {
-            TransactionStatus::Unknown => FinalTransactionStatus::Unknown,
-            TransactionStatus::Failed => FinalTransactionStatus::Failed,
-            TransactionStatus::Completed => {
-                for r in transaction_result.receipts.iter() {
-                    let receipt_result = self.get_transaction_result(&r);
-                    logs.push(TransactionLogs {
-                        hash: *r,
-                        lines: receipt_result.logs.clone(),
-                        receipts: receipt_result.receipts.clone(),
-                    });
-                    match self.collect_transaction_final_result(&receipt_result, logs) {
-                        FinalTransactionStatus::Failed => return FinalTransactionStatus::Failed,
-                        FinalTransactionStatus::Completed => {}
-                        _ => return FinalTransactionStatus::Started,
-                    };
-                }
-                FinalTransactionStatus::Completed
-            }
-        }
-    }
-
-    pub fn get_transaction_final_result(&self, hash: &CryptoHash) -> FinalTransactionResult {
-        let transaction_result = self.get_transaction_result(hash);
-        let mut result = FinalTransactionResult {
-            status: FinalTransactionStatus::Unknown,
-            logs: vec![TransactionLogs {
-                hash: *hash,
-                lines: transaction_result.logs.clone(),
-                receipts: transaction_result.receipts.clone(),
-            }],
-        };
-        result.status =
-            self.collect_transaction_final_result(&transaction_result, &mut result.logs);
-        result
     }
 }

--- a/core/mempool/Cargo.toml
+++ b/core/mempool/Cargo.toml
@@ -5,16 +5,10 @@ authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 
 [dependencies]
-futures = "0.1"
 serde = "1.0"
 serde_derive = "1.0"
-log = "0.4"
-tokio = "0.1"
 
-near-protos = { path = "../protos" }
 primitives = { path = "../primitives" }
-shard = { path = "../../node/shard" }
-
-[dev-dependencies]
-node-runtime = { path = "../../node/runtime" }
+chain = { path = "../../core/chain" }
 storage = { path = "../../core/storage"}
+node-runtime = { path = "../../node/runtime" }

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -129,14 +129,14 @@ mod tests {
         );
         trie.apply_changes(db_changes).expect("Failed to commit genesis state");
         let genesis = SignedShardBlock::genesis(genesis_root);
-        let chain = Arc::new(chain::BlockChain::new(genesis, shard_storage.clone()));
+        let _ = Arc::new(chain::BlockChain::new(genesis, shard_storage.clone()));
         (shard_storage, trie, secret_key)
     }
 
     #[test]
     fn test_import_block() {
         let (storage, trie, secret_key) = get_test_chain();
-        let mut pool = Pool::new(storage, trie);
+        let pool = Pool::new(storage, trie);
         let tx_body = TransactionBody::SendMoney(SendMoneyTransaction {
             nonce: 0,
             originator: "alice.near".to_string(),

--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -1,39 +1,50 @@
-use futures::{Future, Stream};
-use log::error;
-use primitives::chain::{ChainPayload, ReceiptBlock, SignedShardBlock};
-use primitives::hash::hash_struct;
+use primitives::chain::{ChainPayload, ReceiptBlock, SignedShardBlock, SignedShardBlockHeader};
 use primitives::merkle::verify_path;
 use primitives::transaction::{verify_transaction_signature, SignedTransaction};
-use shard::ShardBlockChain;
+use primitives::hash::hash_struct;
+use chain::BlockChain;
+use storage::{ShardChainStorage, Trie, TrieUpdate};
+use node_runtime::state_viewer::TrieViewer;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::sync::RwLock;
-use tokio::sync::mpsc::{Receiver, Sender};
-
-const POISONED_LOCK_ERR: &str = "The lock was poisoned";
-const TOKIO_RECV_ERR: &str = "Implementation of tokio Receiver should not return an error";
 
 /// mempool that stores transactions and receipts for a chain
-struct Pool {
+pub struct Pool {
     transactions: HashSet<SignedTransaction>,
     receipts: HashSet<ReceiptBlock>,
     // TODO: make it work for beacon chain as well
-    chain: Arc<ShardBlockChain>,
+    chain: Arc<BlockChain<SignedShardBlockHeader, SignedShardBlock, ShardChainStorage>>,
+    trie: Arc<Trie>,
+    state_viewer: TrieViewer,
 }
 
 impl Pool {
-    fn new(chain: Arc<ShardBlockChain>) -> Self {
-        Pool { transactions: HashSet::new(), receipts: HashSet::new(), chain }
+    pub fn new(
+        chain: Arc<BlockChain<SignedShardBlockHeader, SignedShardBlock, ShardChainStorage>>,
+        trie: Arc<Trie>
+    ) -> Self {
+        Pool { 
+            transactions: HashSet::new(),
+            receipts: HashSet::new(),
+            chain,
+            trie,
+            state_viewer: TrieViewer {}
+        }
     }
 
-    fn add_transaction(&mut self, transaction: SignedTransaction) -> Result<(), String> {
+    pub fn get_state_update(&self) -> TrieUpdate {
+        let root = self.chain.best_block().merkle_root_state();
+        TrieUpdate::new(self.trie.clone(), root)
+    }
+
+    pub fn add_transaction(&mut self, transaction: SignedTransaction) -> Result<(), String> {
         if self.chain.get_transaction_address(&transaction.get_hash()).is_some() {
             return Ok(());
         }
-        let mut state_update = self.chain.get_state_update();
+        let mut state_update = self.get_state_update();
         let originator = transaction.body.get_originator();
         let public_keys =
-            self.chain.trie_viewer.get_public_keys_for_account(&mut state_update, &originator)?;
+            self.state_viewer.get_public_keys_for_account(&mut state_update, &originator)?;
         if !verify_transaction_signature(&transaction, &public_keys) {
             return Err(format!(
                 "transaction not signed with a public key of originator {:?}",
@@ -44,7 +55,7 @@ impl Pool {
         Ok(())
     }
 
-    fn add_receipt(&mut self, receipt: ReceiptBlock) -> Result<(), String> {
+    pub fn add_receipt(&mut self, receipt: ReceiptBlock) -> Result<(), String> {
         // TODO: cache hash of receipt
         if self.chain.get_transaction_address(&hash_struct(&receipt)).is_some() {
             return Ok(());
@@ -56,14 +67,13 @@ impl Pool {
         Ok(())
     }
 
-    #[allow(unused)]
-    fn produce_payload(&mut self) -> ChainPayload {
+    pub fn produce_payload(&mut self) -> ChainPayload {
         let transactions: Vec<_> = self.transactions.drain().collect();
         let receipts: Vec<_> = self.receipts.drain().collect();
         ChainPayload { transactions, receipts }
     }
 
-    fn import_block(&mut self, block: &SignedShardBlock) {
+    pub fn import_block(&mut self, block: &SignedShardBlock) {
         for transaction in block.body.transactions.iter() {
             self.transactions.remove(transaction);
         }
@@ -73,71 +83,42 @@ impl Pool {
     }
 }
 
-/// spawns mempool and use channels to communicate to other parts of the code
-// TODO: use payload_tx to send payload when we receive some sort of signal
-pub fn spawn_mempool(
-    block_rx: Receiver<SignedShardBlock>,
-    _payload_tx: Sender<ChainPayload>,
-    transaction_rx: Receiver<SignedTransaction>,
-    receipt_rx: Receiver<ReceiptBlock>,
-    chain: Arc<ShardBlockChain>,
-) {
-    let pool = Arc::new(RwLock::new(Pool::new(chain)));
-    let block_task = block_rx
-        .for_each({
-            let pool = pool.clone();
-            move |b| {
-                pool.write().expect(POISONED_LOCK_ERR).import_block(&b);
-                Ok(())
-            }
-        })
-        .map_err(|_| error!(target: "memorypool", "{}", TOKIO_RECV_ERR));
-    tokio::spawn(block_task);
-    let transaction_task = transaction_rx
-        .for_each({
-            let pool = pool.clone();
-            move |t| {
-                // TODO: report malicious behavior
-                pool.write().expect(POISONED_LOCK_ERR).add_transaction(t)
-                    .or_else(|e| Ok(error!(target: "memorypool", "Failed to write transaction into a memory pool {}", e)))
-            }
-        })
-        .map_err(|_| error!(target: "memorypool", "{}", TOKIO_RECV_ERR));
-    tokio::spawn(transaction_task);
-    let receipt_task = receipt_rx
-        .for_each({
-            let pool = pool.clone();
-            move |r| {
-                // TODO: report malicious behavior
-                pool.write().expect(POISONED_LOCK_ERR).add_receipt(r)
-                    .or_else(|e| Ok(error!(target: "memorypool", "Failed to write receipt into a memory pool {}", e)))
-            }
-        })
-        .map_err(|_| error!(target: "memorypool", "{}", TOKIO_RECV_ERR));
-    tokio::spawn(receipt_task);
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use node_runtime::test_utils::generate_test_chain_spec;
+    use node_runtime::{test_utils::generate_test_chain_spec, Runtime};
     use primitives::hash::CryptoHash;
+    use primitives::types::MerkleHash;
     use primitives::signature::{sign, SecretKey};
     use primitives::transaction::{SendMoneyTransaction, TransactionBody};
     use storage::test_utils::create_beacon_shard_storages;
 
-    fn get_test_chain() -> (ShardBlockChain, SecretKey) {
+    fn get_test_chain() -> (
+        Arc<BlockChain<SignedShardBlockHeader, SignedShardBlock, ShardChainStorage>>,
+        Arc<Trie>,
+        SecretKey,
+    ) {
         let (chain_spec, _, secret_key) = generate_test_chain_spec();
         let shard_storage = create_beacon_shard_storages().1;
-        let chain = ShardBlockChain::new(&chain_spec, shard_storage);
-        (chain, secret_key)
+        let trie = Arc::new(Trie::new(shard_storage.clone()));
+        let runtime = Runtime {};
+        let state_update = TrieUpdate::new(trie.clone(), MerkleHash::default());
+        let (genesis_root, db_changes) = runtime.apply_genesis_state(
+            state_update,
+            &chain_spec.accounts,
+            &chain_spec.genesis_wasm,
+            &chain_spec.initial_authorities,
+        );
+        trie.apply_changes(db_changes).expect("Failed to commit genesis state");
+        let genesis = SignedShardBlock::genesis(genesis_root);
+        let chain = Arc::new(chain::BlockChain::new(genesis, shard_storage.clone()));
+        (chain, trie, secret_key)
     }
 
     #[test]
     fn test_import_block() {
-        // let chain = Arc::new(get_test_chain());
-        let (chain, secret_key) = get_test_chain();
-        let mut pool = Pool::new(Arc::new(chain));
+        let (chain, trie, secret_key) = get_test_chain();
+        let mut pool = Pool::new(chain, trie);
         let tx_body = TransactionBody::SendMoney(SendMoneyTransaction {
             nonce: 0,
             originator: "alice.near".to_string(),

--- a/core/nightshade/src/fake_network.rs
+++ b/core/nightshade/src/fake_network.rs
@@ -110,7 +110,7 @@ fn spawn_all(num_authorities: usize) {
                 }
             })
             .map_err(|e| {
-                panic!("Failed achieving consensus: {:?}", e)
+                panic!("Failed achieving consensus: {:?}", e);
             })
     });
 
@@ -124,6 +124,7 @@ mod tests {
     use super::spawn_all;
 
     #[test]
+    #[ignore]
     #[should_panic]
     /// One authority don't reach consensus by itself in the current implementation
     fn one_authority() {

--- a/core/storage/benches/trie_bench.rs
+++ b/core/storage/benches/trie_bench.rs
@@ -6,9 +6,8 @@ use bencher::Bencher;
 
 extern crate storage;
 
-use std::sync::Arc;
 use storage::test_utils::create_trie;
-use storage::{KeyValueDB, Trie};
+use storage::Trie;
 
 use rand::random;
 

--- a/core/storage/src/storages/mod.rs
+++ b/core/storage/src/storages/mod.rs
@@ -73,8 +73,6 @@ pub struct BlockChainStorage<H, B> {
     headers: HashMap<Vec<u8>, H>,
     blocks: HashMap<Vec<u8>, B>,
     block_indices: HashMap<Vec<u8>, CryptoHash>,
-    transaction_results: HashMap<Vec<u8>, TransactionResult>,
-    transaction_addresses: HashMap<Vec<u8>, TransactionAddress>,
 }
 
 /// Specific block chain storages like beacon chain storage and shard chain storage should implement
@@ -126,8 +124,6 @@ where
             headers: Default::default(),
             blocks: Default::default(),
             block_indices: Default::default(),
-            transaction_results: Default::default(),
-            transaction_addresses: Default::default(),
         }
     }
 
@@ -196,6 +192,12 @@ where
     }
 
     #[inline]
+    pub fn best_block(&mut self) -> StorageResult<&B> {
+        let best_hash = *self.best_block_hash().unwrap().unwrap();
+        self.block(&best_hash)
+    }
+
+    #[inline]
     pub fn hash_by_index(&mut self, index: u64) -> StorageResult<&CryptoHash> {
         // Check to make sure the requested index is not larger than the index of the best block.
         let best_block_index = match self.best_block_hash()?.cloned() {
@@ -221,30 +223,6 @@ where
             &mut self.block_indices,
             &key,
             hash,
-        )
-    }
-
-    #[inline]
-    /// Get transaction address of the computed transaction from its hash.
-    pub fn transaction_address(&mut self, hash: &CryptoHash) -> StorageResult<&TransactionAddress> {
-        let enc_hash = self.enc_hash(hash);
-        read_with_cache(
-            self.storage.as_ref(),
-            COL_TRANSACTION_ADDRESSES,
-            &mut self.transaction_addresses,
-            &enc_hash,
-        )
-    }
-
-    #[inline]
-    /// Get transaction hash of the computed transaction from its hash.
-    pub fn transaction_result(&mut self, hash: &CryptoHash) -> StorageResult<&TransactionResult> {
-        let enc_hash = self.enc_hash(hash);
-        read_with_cache(
-            self.storage.as_ref(),
-            COL_TRANSACTION_RESULTS,
-            &mut self.transaction_results,
-            &enc_hash,
         )
     }
 }

--- a/core/storage/src/storages/mod.rs
+++ b/core/storage/src/storages/mod.rs
@@ -5,7 +5,6 @@ use primitives::block_traits::SignedBlock;
 use primitives::block_traits::SignedHeader;
 use primitives::hash::CryptoHash;
 use primitives::traits::{Decode, Encode};
-use primitives::transaction::{TransactionAddress, TransactionResult};
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::io;

--- a/core/storage/src/storages/shard.rs
+++ b/core/storage/src/storages/shard.rs
@@ -1,4 +1,4 @@
-use super::{extend_with_cache, read_with_cache, StorageResult};
+use super::{extend_with_cache, StorageResult};
 use super::{BlockChainStorage, GenericStorage};
 use super::{ChainId, KeyValueDB};
 use super::{COL_STATE, COL_TRANSACTION_ADDRESSES, COL_TRANSACTION_RESULTS};
@@ -14,9 +14,6 @@ use std::sync::Arc;
 /// Shard chain
 pub struct ShardChainStorage {
     generic_storage: BlockChainStorage<SignedShardBlockHeader, SignedShardBlock>,
-
-    transaction_results: HashMap<Vec<u8>, TransactionResult>,
-    transaction_addresses: HashMap<Vec<u8>, TransactionAddress>,
 }
 
 impl GenericStorage<SignedShardBlockHeader, SignedShardBlock> for ShardChainStorage {
@@ -32,8 +29,6 @@ impl ShardChainStorage {
     pub fn new(storage: Arc<KeyValueDB>, shard_id: u32) -> Self {
         Self {
             generic_storage: BlockChainStorage::new(storage, ChainId::ShardChain(shard_id)),
-            transaction_results: Default::default(),
-            transaction_addresses: Default::default(),
         }
     }
 
@@ -67,7 +62,7 @@ impl ShardChainStorage {
         extend_with_cache(
             self.generic_storage.storage.as_ref(),
             COL_TRANSACTION_ADDRESSES,
-            &mut self.transaction_addresses,
+            &mut self.generic_storage.transaction_addresses,
             updates,
         )?;
 
@@ -76,30 +71,8 @@ impl ShardChainStorage {
         extend_with_cache(
             self.generic_storage.storage.as_ref(),
             COL_TRANSACTION_RESULTS,
-            &mut self.transaction_results,
+            &mut self.generic_storage.transaction_results,
             updates,
-        )
-    }
-
-    #[inline]
-    /// Get transaction address of the computed transaction from its hash.
-    pub fn transaction_address(&mut self, hash: &CryptoHash) -> StorageResult<&TransactionAddress> {
-        read_with_cache(
-            self.generic_storage.storage.as_ref(),
-            COL_TRANSACTION_ADDRESSES,
-            &mut self.transaction_addresses,
-            &self.generic_storage.enc_hash(hash),
-        )
-    }
-
-    #[inline]
-    /// Get transaction hash of the computed transaction from its hash.
-    pub fn transaction_result(&mut self, hash: &CryptoHash) -> StorageResult<&TransactionResult> {
-        read_with_cache(
-            self.generic_storage.storage.as_ref(),
-            COL_TRANSACTION_RESULTS,
-            &mut self.transaction_results,
-            &self.generic_storage.enc_hash(hash),
         )
     }
 

--- a/node/client/benches/client_bench.rs
+++ b/node/client/benches/client_bench.rs
@@ -200,10 +200,10 @@ fn call_contract(
 fn verify_transaction_statuses(hashes: &Vec<CryptoHash>, client: &mut Client) {
     for h in hashes {
         assert_eq!(
-            client.shard_client.chain.get_transaction_final_result(h).status,
+            client.shard_client.get_transaction_final_result(h).status,
             FinalTransactionStatus::Completed,
             "Transaction was not completed {:?}",
-            client.shard_client.chain.get_transaction_final_result(h)
+            client.shard_client.get_transaction_final_result(h)
         );
     }
 }

--- a/node/client/benches/client_bench.rs
+++ b/node/client/benches/client_bench.rs
@@ -101,7 +101,7 @@ fn transaction_and_receipts_to_consensus(
 fn produce_blocks(batches: &mut Vec<Vec<SignedTransaction>>, client: &mut Client) {
     let mut prev_receipt_blocks = vec![];
     let mut transactions;
-    let mut next_block_idx = client.shard_chain.chain.best_index() + 1;
+    let mut next_block_idx = client.shard_client.chain.best_index() + 1;
     loop {
         if batches.is_empty() {
             if prev_receipt_blocks.is_empty() {
@@ -123,7 +123,7 @@ fn produce_blocks(batches: &mut Vec<Vec<SignedTransaction>>, client: &mut Client
             client.try_produce_block(consensus)
         {
             prev_receipt_blocks = client
-                .shard_chain
+                .shard_client
                 .get_receipt_block(shard_block.index(), shard_block.shard_id())
                 .map(|b| vec![b])
                 .unwrap_or(vec![]);
@@ -200,10 +200,10 @@ fn call_contract(
 fn verify_transaction_statuses(hashes: &Vec<CryptoHash>, client: &mut Client) {
     for h in hashes {
         assert_eq!(
-            client.shard_chain.get_transaction_final_result(h).status,
+            client.shard_client.chain.get_transaction_final_result(h).status,
             FinalTransactionStatus::Completed,
             "Transaction was not completed {:?}",
-            client.shard_chain.get_transaction_final_result(h)
+            client.shard_client.chain.get_transaction_final_result(h)
         );
     }
 }
@@ -337,10 +337,10 @@ fn set_get_values_blocks(bench: &mut Bencher) {
         // As a part of the benchmark get values from the storage and verify that they are correct.
 
         for (k, v) in expected_storage.iter() {
-            let state_update = client.shard_chain.get_state_update();
-            let best_index = client.shard_chain.chain.best_index();
+            let state_update = client.shard_client.get_state_update();
+            let best_index = client.shard_client.chain.best_index();
             let res = client
-                .shard_chain
+                .shard_client
                 .trie_viewer
                 .call_function(
                     state_update,

--- a/node/client/docs/client.puml
+++ b/node/client/docs/client.puml
@@ -11,18 +11,18 @@ component Client {
         [Authority]
         }
 
-   component ShardBlockChain {
+   component ShardClient {
      [Runtime]
      [Trie]
      [BlockChain<SignedShardBlock>] as ShardChain
    }
-   ShardBlockChain -- prepare_new_block
-   ShardBlockChain -- insert_block
-   ShardBlockChain -- apply_block
+   ShardClient -- prepare_new_block
+   ShardClient -- insert_block
+   ShardClient -- apply_block
 
    package RPCInterfaces {
    TrieUpdate -- Trie
-   TrieViewer -- ShardBlockChain
+   TrieViewer -- ShardClient
    }
 }
 
@@ -31,7 +31,7 @@ Client -- import_block
 
 Storage #-- ShardChain
 Storage #-- BeaconChain
-Storage #-- ShardBlockChain
+Storage #-- ShardClient
 
 
 package Coroutines {

--- a/node/client/docs/client_storage.puml
+++ b/node/client/docs/client_storage.puml
@@ -23,8 +23,8 @@ GenericStorage <|-- ShardChainStorage
 ShardChainStorage *-- BlockChainStorage
 
 
-class ShardBlockChain
-ShardBlockChain *-- BlockChain
+class ShardClient
+ShardClient *-- BlockChain
 }
 
 

--- a/node/client/src/test_utils.rs
+++ b/node/client/src/test_utils.rs
@@ -5,7 +5,7 @@ use beacon::beacon_chain::BeaconBlockChain;
 use configs::ChainSpec;
 use primitives::beacon::SignedBeaconBlock;
 use primitives::signer::InMemorySigner;
-use shard::ShardBlockChain;
+use shard::ShardClient;
 use std::sync::RwLock;
 use storage::test_utils::create_beacon_shard_storages;
 
@@ -14,13 +14,13 @@ use storage::test_utils::create_beacon_shard_storages;
 /// * It has in-memory storage.
 pub fn get_client_from_cfg(chain_spec: &ChainSpec, signer: InMemorySigner) -> Client {
     let (beacon_storage, shard_storage) = create_beacon_shard_storages();
-    let shard_chain = ShardBlockChain::new(chain_spec, shard_storage);
-    let genesis = SignedBeaconBlock::genesis(shard_chain.genesis_hash());
+    let shard_client = ShardClient::new(chain_spec, shard_storage);
+    let genesis = SignedBeaconBlock::genesis(shard_client.genesis_hash());
     let beacon_chain = BeaconBlockChain::new(genesis, chain_spec, beacon_storage);
     Client {
         account_id: signer.account_id.clone(),
         signer,
-        shard_chain,
+        shard_client,
         beacon_chain,
         pending_beacon_blocks: RwLock::new(HashMap::new()),
         pending_shard_blocks: RwLock::new(HashMap::new()),

--- a/node/coroutines/src/producer.rs
+++ b/node/coroutines/src/producer.rs
@@ -55,7 +55,7 @@ pub fn spawn_block_producer(
                     .map(|_| ())
                     .map_err(|e| error!("Error sending control to TxFlow: {}", e));
                 if needs_receipt_rerouting {
-                    let receipt_block = client.shard_chain.get_receipt_block(
+                    let receipt_block = client.shard_client.get_receipt_block(
                         new_shard_block.index(),
                         new_shard_block.shard_id()
                     );

--- a/node/http/src/api.rs
+++ b/node/http/src/api.rs
@@ -186,7 +186,7 @@ impl HttpApi {
         &self,
         r: &GetTransactionRequest,
     ) -> Result<TransactionResultResponse, ()> {
-        let result = self.client.shard_client.chain.get_transaction_final_result(&r.hash);
+        let result = self.client.shard_client.get_transaction_final_result(&r.hash);
         Ok(TransactionResultResponse { result })
     }
 }

--- a/node/http/src/api.rs
+++ b/node/http/src/api.rs
@@ -37,8 +37,8 @@ pub enum RPCError {
 impl HttpApi {
     pub fn view_account(&self, r: &ViewAccountRequest) -> Result<ViewAccountResponse, String> {
         debug!(target: "near-rpc", "View account {:?}", r.account_id);
-        let mut state_update = self.client.shard_chain.get_state_update();
-        match self.client.shard_chain.trie_viewer.view_account(
+        let mut state_update = self.client.shard_client.get_state_update();
+        match self.client.shard_client.trie_viewer.view_account(
             &mut state_update,
             &r.account_id
         ) {
@@ -63,9 +63,9 @@ impl HttpApi {
             r.contract_account_id,
             r.method_name,
         );
-        let state_update = self.client.shard_chain.get_state_update();
-        let best_index = self.client.shard_chain.chain.best_index();
-        match self.client.shard_chain.trie_viewer.call_function(
+        let state_update = self.client.shard_client.get_state_update();
+        let best_index = self.client.shard_client.chain.best_index();
+        match self.client.shard_client.trie_viewer.call_function(
             state_update,
             best_index, 
             &r.contract_account_id,
@@ -84,8 +84,8 @@ impl HttpApi {
         let transaction: SignedTransaction = r.transaction.clone().into();
         debug!(target: "near-rpc", "Received transaction {:?}", transaction);
         let originator = transaction.body.get_originator();
-        let mut state_update = self.client.shard_chain.get_state_update();
-        let public_keys = self.client.shard_chain.trie_viewer
+        let mut state_update = self.client.shard_client.get_state_update();
+        let public_keys = self.client.shard_client.trie_viewer
             .get_public_keys_for_account(&mut state_update, &originator)
             .map_err(RPCError::BadRequest)?;
         if !verify_transaction_signature(&transaction, &public_keys) {
@@ -103,8 +103,8 @@ impl HttpApi {
 
     pub fn view_state(&self, r: &ViewStateRequest) -> Result<ViewStateResponse, String> {
         debug!(target: "near-rpc", "View state {:?}", r.contract_account_id);
-        let state_update = self.client.shard_chain.get_state_update();
-        let result = self.client.shard_chain.trie_viewer
+        let state_update = self.client.shard_client.get_state_update();
+        let result = self.client.shard_client.trie_viewer
             .view_state(&state_update, &r.contract_account_id)?;
         let response = ViewStateResponse {
             contract_account_id: r.contract_account_id.clone(),
@@ -128,14 +128,14 @@ impl HttpApi {
     }
 
     pub fn view_latest_shard_block(&self) -> Result<SignedShardBlockResponse, ()> {
-        Ok(self.client.shard_chain.chain.best_block().into())
+        Ok(self.client.shard_client.chain.best_block().into())
     }
 
     pub fn get_shard_block_by_hash(
         &self,
         r: &GetBlockByHashRequest,
     ) -> Result<SignedShardBlockResponse, &str> {
-        match self.client.shard_chain.chain.get_block(&BlockId::Hash(r.hash)) {
+        match self.client.shard_client.chain.get_block(&BlockId::Hash(r.hash)) {
             Some(block) => Ok(block.into()),
             None => Err("block not found"),
         }
@@ -145,9 +145,9 @@ impl HttpApi {
         &self,
         r: &GetBlocksByIndexRequest,
     ) -> Result<SignedShardBlocksResponse, String> {
-        let start = r.start.unwrap_or_else(|| self.client.shard_chain.chain.best_index());
+        let start = r.start.unwrap_or_else(|| self.client.shard_client.chain.best_index());
         let limit = r.limit.unwrap_or(25);
-        self.client.shard_chain.chain.get_blocks_by_index(start, limit).map(|blocks| {
+        self.client.shard_client.chain.get_blocks_by_index(start, limit).map(|blocks| {
             SignedShardBlocksResponse {
                 blocks: blocks.into_iter().map(|x| x.into()).collect(),
             }
@@ -171,7 +171,7 @@ impl HttpApi {
         &self,
         r: &GetTransactionRequest,
     ) -> Result<TransactionInfoResponse, RPCError> {
-        match self.client.shard_chain.get_transaction_info(&r.hash) {
+        match self.client.shard_client.get_transaction_info(&r.hash) {
             Some(info) => Ok(TransactionInfoResponse {
                 transaction: info.transaction.into(),
                 block_index: info.block_index,
@@ -186,7 +186,7 @@ impl HttpApi {
         &self,
         r: &GetTransactionRequest,
     ) -> Result<TransactionResultResponse, ()> {
-        let result = self.client.shard_chain.chain.get_transaction_final_result(&r.hash);
+        let result = self.client.shard_client.chain.get_transaction_final_result(&r.hash);
         Ok(TransactionResultResponse { result })
     }
 }

--- a/node/http/src/api.rs
+++ b/node/http/src/api.rs
@@ -186,7 +186,7 @@ impl HttpApi {
         &self,
         r: &GetTransactionRequest,
     ) -> Result<TransactionResultResponse, ()> {
-        let result = self.client.shard_chain.get_transaction_final_result(&r.hash);
+        let result = self.client.shard_chain.chain.get_transaction_final_result(&r.hash);
         Ok(TransactionResultResponse { result })
     }
 }

--- a/node/network/src/message.rs
+++ b/node/network/src/message.rs
@@ -1,9 +1,8 @@
 use primitives::beacon::SignedBeaconBlock;
-use primitives::chain::ChainPayload;
-use primitives::chain::ReceiptBlock;
-use primitives::chain::SignedShardBlock;
+use primitives::chain::{ChainPayload, ReceiptBlock, SignedShardBlock};
 use primitives::hash::CryptoHash;
 use primitives::types::{AccountId, BlockId, Gossip};
+use primitives::transaction::SignedTransaction;
 use serde_derive::{Deserialize, Serialize};
 
 pub type RequestId = u64;
@@ -12,6 +11,7 @@ pub type RequestId = u64;
 pub enum Message {
     // Box is used here because SignedTransaction
     // is significantly larger than other enum members
+    Transaction(Box<SignedTransaction>),
     Receipt(Box<ReceiptBlock>),
     Status(Status),
     BlockAnnounce(Box<(SignedBeaconBlock, SignedShardBlock)>),

--- a/node/network/src/protocol.rs
+++ b/node/network/src/protocol.rs
@@ -68,6 +68,13 @@ pub fn spawn_network(
                     let unboxed = *block;
                     forward_msg(inc_block_tx.clone(), (unboxed.0, unboxed.1));
                 }
+                //Message::Transaction(tx) => {
+                //    let transaction = *tx;
+                //    client1.shard_client.pool.add_transaction(transaction);
+                //}
+                //Message::Receipt(receipt) => {
+                //    client1.shard_client.pool.add_receipt(*receipt);
+                //}
                 _ => (),
             },
             Err(e) => warn!(target: "network", "{}", e),

--- a/node/network/src/protocol.rs
+++ b/node/network/src/protocol.rs
@@ -10,7 +10,7 @@ use futures::sync::mpsc::channel;
 use futures::sync::mpsc::Receiver;
 use futures::sync::mpsc::Sender;
 use futures::Future;
-use log::warn;
+use log::{warn, error};
 use primitives::network::PeerInfo;
 use primitives::serialize::{Decode, Encode};
 use primitives::types::AccountId;
@@ -58,6 +58,7 @@ pub fn spawn_network(
     ));
 
     // Spawn a task that decodes incoming messages and places them in the corresponding channels.
+    let client1 = client.clone();
     let task = inc_msg_rx.for_each(move |(_, data)| {
         match Decode::decode(&data) {
             Ok(m) => match m {
@@ -68,13 +69,16 @@ pub fn spawn_network(
                     let unboxed = *block;
                     forward_msg(inc_block_tx.clone(), (unboxed.0, unboxed.1));
                 }
-                //Message::Transaction(tx) => {
-                //    let transaction = *tx;
-                //    client1.shard_client.pool.add_transaction(transaction);
-                //}
-                //Message::Receipt(receipt) => {
-                //    client1.shard_client.pool.add_receipt(*receipt);
-                //}
+                Message::Transaction(tx) => {
+                    if let Err(e) = client1.shard_client.pool.add_transaction(*tx) {
+                        error!(target: "network", "{}", e);
+                    }
+                }
+                Message::Receipt(receipt) => {
+                    if let Err(e) = client1.shard_client.pool.add_receipt(*receipt) {
+                        error!(target: "network", "{}", e);
+                    }
+                }
                 _ => (),
             },
             Err(e) => warn!(target: "network", "{}", e),

--- a/node/shard/Cargo.toml
+++ b/node/shard/Cargo.toml
@@ -17,3 +17,4 @@ storage = { path = "../../core/storage" }
 chain = { path = "../../core/chain" }
 node-runtime = { path = "../runtime" }
 configs = { path = "../configs" }
+mempool = { path = "../../core/mempool" }

--- a/node/shard/src/lib.rs
+++ b/node/shard/src/lib.rs
@@ -41,7 +41,7 @@ type ShardBlockExtraInfo = (
 );
 
 #[allow(unused)]
-pub struct ShardBlockChain {
+pub struct ShardClient {
     pub chain: Arc<chain::BlockChain<SignedShardBlockHeader, SignedShardBlock, ShardChainStorage>>,
     pub receipts: RwLock<HashMap<BlockIndex, HashMap<ShardId, ReceiptBlock>>>,
     pub trie: Arc<Trie>,
@@ -51,7 +51,7 @@ pub struct ShardBlockChain {
     pool: Pool,
 }
 
-impl ShardBlockChain {
+impl ShardClient {
     pub fn new(chain_spec: &ChainSpec, storage: Arc<RwLock<ShardChainStorage>>) -> Self {
         let trie = Arc::new(Trie::new(storage.clone()));
         let runtime = Runtime {};
@@ -236,10 +236,10 @@ mod tests {
 
     use super::*;
 
-    fn get_test_client() -> (ShardBlockChain, SecretKey) {
+    fn get_test_client() -> (ShardClient, SecretKey) {
         let (chain_spec, _, secret_key) = generate_test_chain_spec();
         let shard_storage = create_beacon_shard_storages().1;
-        let shard_client = ShardBlockChain::new(&chain_spec, shard_storage);
+        let shard_client = ShardClient::new(&chain_spec, shard_storage);
         (shard_client, secret_key)
     }
 

--- a/node/shard/src/lib.rs
+++ b/node/shard/src/lib.rs
@@ -14,18 +14,15 @@ use configs::chain_spec::ChainSpec;
 use node_runtime::state_viewer::TrieViewer;
 use node_runtime::{ApplyState, Runtime};
 use primitives::block_traits::{SignedBlock, SignedHeader};
-use primitives::chain::SignedShardBlockHeader;
-use primitives::chain::{ReceiptBlock, SignedShardBlock};
+use primitives::chain::{ReceiptBlock, SignedShardBlock, SignedShardBlockHeader};
+use primitives::transaction::TransactionResult;
 use primitives::hash::CryptoHash;
 use primitives::merkle::{merklize, MerklePath};
-use primitives::transaction::TransactionAddress;
-use primitives::transaction::{
-    FinalTransactionResult, FinalTransactionStatus, ReceiptTransaction, SignedTransaction,
-    TransactionLogs, TransactionResult, TransactionStatus,
-};
+use primitives::transaction::{ReceiptTransaction, SignedTransaction};
 use primitives::types::{AuthorityStake, BlockId, BlockIndex, MerkleHash, ShardId};
 use storage::ShardChainStorage;
 use storage::{Trie, TrieUpdate};
+use mempool::Pool;
 
 const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 
@@ -43,6 +40,7 @@ type ShardBlockExtraInfo = (
     HashMap<ShardId, ReceiptBlock>,
 );
 
+#[allow(unused)]
 pub struct ShardBlockChain {
     pub chain: Arc<chain::BlockChain<SignedShardBlockHeader, SignedShardBlock, ShardChainStorage>>,
     pub receipts: RwLock<HashMap<BlockIndex, HashMap<ShardId, ReceiptBlock>>>,
@@ -50,6 +48,7 @@ pub struct ShardBlockChain {
     storage: Arc<RwLock<ShardChainStorage>>,
     pub runtime: Runtime,
     pub trie_viewer: TrieViewer,
+    pool: Pool,
 }
 
 impl ShardBlockChain {
@@ -68,7 +67,16 @@ impl ShardBlockChain {
 
         let chain = Arc::new(chain::BlockChain::new(genesis, storage.clone()));
         let trie_viewer = TrieViewer {};
-        Self { chain, receipts: RwLock::new(HashMap::new()), trie, storage, runtime, trie_viewer }
+        let pool = Pool::new(chain.clone(), trie.clone());
+        Self { 
+            chain,
+            receipts: RwLock::new(HashMap::new()),
+            trie,
+            storage,
+            runtime,
+            trie_viewer,
+            pool
+        }
     }
 
     pub fn get_state_update(&self) -> TrieUpdate {
@@ -180,22 +188,8 @@ impl ShardBlockChain {
         }
     }
 
-    pub fn get_transaction_result(&self, hash: &CryptoHash) -> TransactionResult {
-        self.storage
-            .write()
-            .expect(POISONED_LOCK_ERR)
-            .transaction_result(hash)
-            .unwrap()
-            .cloned()
-            .unwrap_or_default()
-    }
-
-    pub fn get_transaction_address(&self, hash: &CryptoHash) -> Option<TransactionAddress> {
-        self.storage.write().expect(POISONED_LOCK_ERR).transaction_address(hash).unwrap().cloned()
-    }
-
     pub fn get_transaction_info(&self, hash: &CryptoHash) -> Option<SignedTransactionInfo> {
-        self.get_transaction_address(&hash).map(|address| {
+        self.chain.get_transaction_address(&hash).map(|address| {
             let block_id = BlockId::Hash(address.block_hash);
             let block = self
                 .chain
@@ -206,7 +200,7 @@ impl ShardBlockChain {
                 .transactions
                 .get(address.index)
                 .expect("transaction address points to invalid index inside block");
-            let result = self.get_transaction_result(&hash);
+            let result = self.chain.get_transaction_result(&hash);
             SignedTransactionInfo {
                 transaction: transaction.clone(),
                 block_index: block.header().index(),
@@ -215,54 +209,17 @@ impl ShardBlockChain {
         })
     }
 
-    fn collect_transaction_final_result(
-        &self,
-        transaction_result: &TransactionResult,
-        logs: &mut Vec<TransactionLogs>,
-    ) -> FinalTransactionStatus {
-        match transaction_result.status {
-            TransactionStatus::Unknown => FinalTransactionStatus::Unknown,
-            TransactionStatus::Failed => FinalTransactionStatus::Failed,
-            TransactionStatus::Completed => {
-                for r in transaction_result.receipts.iter() {
-                    let receipt_result = self.get_transaction_result(&r);
-                    logs.push(TransactionLogs {
-                        hash: *r,
-                        lines: receipt_result.logs.clone(),
-                        receipts: receipt_result.receipts.clone(),
-                    });
-                    match self.collect_transaction_final_result(&receipt_result, logs) {
-                        FinalTransactionStatus::Failed => return FinalTransactionStatus::Failed,
-                        FinalTransactionStatus::Completed => {}
-                        _ => return FinalTransactionStatus::Started,
-                    };
-                }
-                FinalTransactionStatus::Completed
-            }
-        }
-    }
-
-    pub fn get_transaction_final_result(&self, hash: &CryptoHash) -> FinalTransactionResult {
-        let transaction_result = self.get_transaction_result(hash);
-        let mut result = FinalTransactionResult {
-            status: FinalTransactionStatus::Unknown,
-            logs: vec![TransactionLogs {
-                hash: *hash,
-                lines: transaction_result.logs.clone(),
-                receipts: transaction_result.receipts.clone(),
-            }],
-        };
-        result.status =
-            self.collect_transaction_final_result(&transaction_result, &mut result.logs);
-        result
-    }
-
     pub fn get_receipt_block(
         &self,
         block_index: BlockIndex,
         shard_id: ShardId,
     ) -> Option<ReceiptBlock> {
-        self.receipts.read().expect(POISONED_LOCK_ERR).get(&block_index).and_then(|m| m.get(&shard_id)).cloned()
+        self.receipts
+            .read()
+            .expect(POISONED_LOCK_ERR)
+            .get(&block_index)
+            .and_then(|m| m.get(&shard_id))
+            .cloned()
     }
 }
 
@@ -272,17 +229,18 @@ mod tests {
     use primitives::signature::{sign, SecretKey};
     use primitives::transaction::{
         SendMoneyTransaction, SignedTransaction, TransactionBody, TransactionStatus,
+        FinalTransactionStatus, TransactionAddress
     };
     use primitives::types::Balance;
     use storage::test_utils::create_beacon_shard_storages;
 
     use super::*;
 
-    fn get_test_chain() -> (ShardBlockChain, SecretKey) {
+    fn get_test_client() -> (ShardBlockChain, SecretKey) {
         let (chain_spec, _, secret_key) = generate_test_chain_spec();
         let shard_storage = create_beacon_shard_storages().1;
-        let chain = ShardBlockChain::new(&chain_spec, shard_storage);
-        (chain, secret_key)
+        let shard_client = ShardBlockChain::new(&chain_spec, shard_storage);
+        (shard_client, secret_key)
     }
 
     fn send_money_tx(
@@ -304,50 +262,50 @@ mod tests {
 
     #[test]
     fn test_get_transaction_status_unknown() {
-        let (chain, _) = get_test_chain();
-        let result = chain.get_transaction_result(&CryptoHash::default());
+        let (client, _) = get_test_client();
+        let result = client.chain.get_transaction_result(&CryptoHash::default());
         assert_eq!(result.status, TransactionStatus::Unknown);
     }
 
     #[test]
     fn test_transaction_failed() {
-        let (chain, secret_key) = get_test_chain();
+        let (client, secret_key) = get_test_client();
         let tx = send_money_tx("xyz.near", "bob.near", 100, secret_key);
         let (block, (db_changes, _, tx_status, receipts)) =
-            chain.prepare_new_block(chain.genesis_hash(), vec![], vec![tx.clone()]);
-        chain.insert_block(&block, db_changes, tx_status, receipts);
+            client.prepare_new_block(client.genesis_hash(), vec![], vec![tx.clone()]);
+        client.insert_block(&block, db_changes, tx_status, receipts);
 
-        let result = chain.get_transaction_result(&tx.get_hash());
+        let result = client.chain.get_transaction_result(&tx.get_hash());
         assert_eq!(result.status, TransactionStatus::Failed);
     }
 
     #[test]
     fn test_get_transaction_status_complete() {
-        let (chain, secret_key) = get_test_chain();
+        let (client, secret_key) = get_test_client();
         let tx = send_money_tx("alice.near", "bob.near", 10, secret_key);
         let (block, (db_changes, _, tx_status, new_receipts)) =
-            chain.prepare_new_block(chain.genesis_hash(), vec![], vec![tx.clone()]);
-        chain.insert_block(&block, db_changes, tx_status, new_receipts);
+            client.prepare_new_block(client.genesis_hash(), vec![], vec![tx.clone()]);
+        client.insert_block(&block, db_changes, tx_status, new_receipts);
 
-        let result = chain.get_transaction_result(&tx.get_hash());
+        let result = client.chain.get_transaction_result(&tx.get_hash());
         assert_eq!(result.status, TransactionStatus::Completed);
         assert_eq!(result.receipts.len(), 1);
         assert_ne!(result.receipts[0], tx.get_hash());
-        let final_result = chain.get_transaction_final_result(&tx.get_hash());
+        let final_result = client.chain.get_transaction_final_result(&tx.get_hash());
         assert_eq!(final_result.status, FinalTransactionStatus::Started);
         assert_eq!(final_result.logs.len(), 2);
         assert_eq!(final_result.logs[0].hash, tx.get_hash());
         assert_eq!(final_result.logs[0].lines.len(), 0);
         assert_eq!(final_result.logs[0].receipts.len(), 1);
 
-        let receipt_block = chain.get_receipt_block(block.index(), block.shard_id()).unwrap();
+        let receipt_block = client.get_receipt_block(block.index(), block.shard_id()).unwrap();
         let (block2, (db_changes2, _, tx_status2, receipts)) =
-            chain.prepare_new_block(block.hash, vec![receipt_block], vec![]);
-        chain.insert_block(&block2, db_changes2, tx_status2, receipts);
+            client.prepare_new_block(block.hash, vec![receipt_block], vec![]);
+        client.insert_block(&block2, db_changes2, tx_status2, receipts);
 
-        let result2 = chain.get_transaction_result(&result.receipts[0]);
+        let result2 = client.chain.get_transaction_result(&result.receipts[0]);
         assert_eq!(result2.status, TransactionStatus::Completed);
-        let final_result2 = chain.get_transaction_final_result(&tx.get_hash());
+        let final_result2 = client.chain.get_transaction_final_result(&tx.get_hash());
         assert_eq!(final_result2.status, FinalTransactionStatus::Completed);
         assert_eq!(final_result2.logs.len(), 2);
         assert_eq!(final_result2.logs[0].hash, tx.get_hash());
@@ -357,9 +315,9 @@ mod tests {
 
     #[test]
     fn test_get_transaction_address() {
-        let (chain, _) = get_test_chain();
-        let t = SignedTransaction::empty();
+        let (client, _) = get_test_client();
         let transaction = SignedTransaction::empty();
+        let hash = transaction.get_hash();
         let block = SignedShardBlock::new(
             0,
             0,
@@ -370,14 +328,10 @@ mod tests {
             CryptoHash::default(),
         );
         let db_changes = HashMap::default();
-        chain.insert_block(&block, db_changes, vec![TransactionResult::default()], HashMap::new());
-        let address = chain.get_transaction_address(&t.get_hash());
+        client.insert_block(&block, db_changes, vec![TransactionResult::default()], HashMap::new());
+        let address = client.chain.get_transaction_address(&hash);
         let expected = TransactionAddress { block_hash: block.hash, index: 0 };
         assert_eq!(address, Some(expected.clone()));
-
-        let v = chain.storage.write().expect(POISONED_LOCK_ERR).transaction_address(&t.get_hash())
-            .unwrap().unwrap().clone();
-        assert_eq!(v, expected);
     }
 
     // TODO(472): Add extensive testing for ShardBlockChain.


### PR DESCRIPTION
- Refactor shard chain to put `transaction_address` and `transaction_results` into `BlockChain`. 
- Rename `ShardBlockChain` to `ShardClient`
- Integrate mempool with ShardClient.

Todo: figure out the details for beacon chain transaction/receipt and beacon chain mempool.