### PR TITLE
Change tie breaker for winning proposal.

### DIFF
--- a/core/nightshade/src/nightshade.rs
+++ b/core/nightshade/src/nightshade.rs
@@ -606,12 +606,12 @@ mod tests {
     #[test]
     fn test_nightshade_basics() {
         let mut ns = create_nightshades(2);
-        let state0 = ns[0].state();
-        assert_eq!(state0.endorses().author, 0);
-        let state1 = ns[1].state().clone();
-        assert_eq!(ns[0].update_state(1, state1).is_ok(), true);
-        let state0 = ns[0].state();
-        assert_eq!(state0.endorses().author, 1);
+        let state1 = ns[1].state();
+        assert_eq!(state1.endorses().author, 1);
+        let state0 = ns[0].state().clone();
+        assert_eq!(ns[1].update_state(0, state0).is_ok(), true);
+        let state1 = ns[1].state();
+        assert_eq!(state1.endorses().author, 0);
     }
 
     #[test]

--- a/core/nightshade/src/nightshade.rs
+++ b/core/nightshade/src/nightshade.rs
@@ -29,10 +29,10 @@ fn empty_cryptohash() -> CryptoHash {
 /// and penalize such behavior.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct BlockProposal {
-    /// Authority proposing the block.
-    pub author: AuthorityId,
     /// Hash of the payload contained in the block.
     pub hash: CryptoHash,
+    /// Authority proposing the block.
+    pub author: AuthorityId,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]


### PR DESCRIPTION
The best proposal now is the block with higher hash, instead of authority with a higher ID. Block proposal uses lexicographical order, and field hash is now before field author.

This doesn't work long term because authorities might try to produce blocks with higher hashes and effectively pass its proposal (this is something we don't want). Workaround: randomly rotate validators, and use authority Id as tie-breaker before.