### PR TITLE
Move receipts stored in shard client to storage

### DIFF
--- a/core/storage/src/storages/mod.rs
+++ b/core/storage/src/storages/mod.rs
@@ -56,9 +56,10 @@ const COL_BLOCK_INDICES: u32 = 3;
 const COL_STATE: u32 = 4;
 const COL_TRANSACTION_RESULTS: u32 = 5;
 const COL_TRANSACTION_ADDRESSES: u32 = 6;
+const COL_RECEIPT_BLOCK: u32 = 7;
 
 /// Number of columns per chain.
-pub const NUM_COLS: u32 = 7;
+pub const NUM_COLS: u32 = 8;
 
 /// Error that occurs when we try operating with genesis-specific columns, without setting the
 /// genesis in advance.

--- a/test-utils/keygen/src/main.rs
+++ b/test-utils/keygen/src/main.rs
@@ -1,7 +1,6 @@
 use clap::{App, Arg, ArgMatches, SubCommand};
-use primitives::signature::{get_key_pair, sign};
-use primitives::signer::{get_key_file, write_key_file};
-use primitives::test_utils::get_key_pair_from_seed;
+use primitives::signature::sign;
+use primitives::signer::get_key_file;
 use std::path::PathBuf;
 use std::process;
 use primitives::signer::InMemorySigner;


### PR DESCRIPTION
We current store the new receipts generated from shard blocks directly in `ShardClient`, which seems inappropriate. I moved them to `ShardChainStorage`.