### PR TITLE
Remove hardcoded block index

### DIFF
--- a/node/coroutines/src/client_task.rs
+++ b/node/coroutines/src/client_task.rs
@@ -345,11 +345,9 @@ impl ClientTask {
 
     /// Resets MemPool and returns NS control for next block.
     fn restart_pool_nightshade(&self, block_index: BlockIndex) -> Control {
-        // TODO: Get authorities for the correct block index. For now these are the same authorities
-        // that built the first block. In other words use `block_index` instead of `mock_block_index`.
-        let mock_block_index = 2;
+        let index = self.client.beacon_chain.chain.best_index() + 1;
         let (owner_uid, uid_to_authority_map) =
-            self.client.get_uid_to_authority_map(mock_block_index);
+            self.client.get_uid_to_authority_map(index);
 
         if owner_uid.is_none() {
             self.client.shard_client.pool.reset(None, None);

--- a/node/network/src/protocol.rs
+++ b/node/network/src/protocol.rs
@@ -157,9 +157,9 @@ impl Protocol {
     }
 
     fn get_authority_id_from_peer_id(&self, peer_id: &PeerId) -> Option<AuthorityId> {
-        if let Some(peer_info) = self.peer_manager.get_peer_info(peer_id) {
-            if let Some(account_id) = peer_info.account_id {
-                let (_, auth_map) = self.client.get_uid_to_authority_map(1);
+        self.peer_manager.get_peer_info(peer_id).and_then(|peer_info| {
+            peer_info.account_id.and_then(|account_id| {
+                let auth_map = self.client.get_recent_uid_to_authority_map();
                 auth_map.iter().find_map(|(authority_id, authority_stake)| {
                     if authority_stake.account_id == account_id {
                         Some(*authority_id as AuthorityId)
@@ -167,19 +167,12 @@ impl Protocol {
                         None
                     }
                 })
-            } else {
-                None
-            }
-        } else {
-            None
-        }
+            })
+        })
     }
 
     fn get_authority_channel(&self, authority_id: AuthorityId) -> Option<Sender<PeerMessage>> {
-        // TODO: Currently it gets the same authority map for all block indices.
-        // Update authority map, once block production and block importing is in place.
-        //        let auth_map = self.client.get_recent_uid_to_authority_map();
-        let (_, auth_map) = self.client.get_uid_to_authority_map(1);
+        let auth_map = self.client.get_recent_uid_to_authority_map();
         auth_map
             .get(&authority_id)
             .map(|auth| auth.account_id.clone())


### PR DESCRIPTION
Remove hardcoded block index in `network/protocol` and `client_task` to use most recent authority map.