### PR TITLE
Add uncompressed encoding for BLS signatures

### DIFF
--- a/core/nightshade/src/nightshade.rs
+++ b/core/nightshade/src/nightshade.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use primitives::aggregate_signature::{
     AggregatePublicKey, BlsAggregateSignature, BlsPublicKey, BlsSignature,
+    uncompressed_bs58_signature_serializer,
 };
 use primitives::hash::CryptoHash;
 use primitives::serialize::Encode;
@@ -165,7 +166,7 @@ pub struct State {
     /// Proof for `secondary_bare_state`.
     pub secondary_proof: Option<Proof>,
     /// Signature of the authority emitting this state
-    #[serde(with = "bs58_serializer")]
+    #[serde(with = "uncompressed_bs58_signature_serializer")]
     pub signature: BlsSignature,
 }
 

--- a/core/primitives/benches/bls.rs
+++ b/core/primitives/benches/bls.rs
@@ -91,7 +91,7 @@ fn bls_decompress_signature(bench: &mut Bencher) {
     let compressed = signature.compress();
 
     bench.iter(|| {
-        compressed.decompress().unwrap();
+        compressed.decode().unwrap();
     });
 }
 
@@ -104,15 +104,15 @@ fn bls_decompress_pubkey_unchecked(bench: &mut Bencher) {
     });
 }
 
-fn bls_decompress_signature_unchecked(bench: &mut Bencher) {
+fn bls_decode_uncompressed_signature(bench: &mut Bencher) {
     let key = BlsSecretKey::generate();
     let message = "Hello, world!";
     let signature = key.sign(message.as_bytes());
-    let compressed = signature.compress();
+    let encoded = signature.encode_uncompressed();
 
     bench.iter(|| {
-        compressed.decompress_unchecked();
-    });
+        encoded.decode().ok();
+    })
 }
 
 benchmark_group!(
@@ -125,7 +125,7 @@ benchmark_group!(
     bls_aggregate_pubkey_slow,
     bls_decompress_signature,
     bls_decompress_pubkey,
-    bls_decompress_signature_unchecked,
     bls_decompress_pubkey_unchecked,
+    bls_decode_uncompressed_signature,
 );
 benchmark_main!(benches);


### PR DESCRIPTION
Uncompressed signature decompresses in about 3us compared to 750us for compressed signature.