### PR TITLE
Order transactions in mempool by account and nonce

### DIFF
--- a/core/mempool/src/lib.rs
+++ b/core/mempool/src/lib.rs
@@ -47,8 +47,8 @@ impl Pool {
     pub fn new(signer: Arc<BlockSigner>, storage: Arc<RwLock<ShardChainStorage>>, trie: Arc<Trie>) -> Self {
         Pool {
             signer,
-            transactions: RwLock::new(HashMap::new()),
-            receipts: RwLock::new(HashSet::new()),
+            transactions: Default::default(),
+            receipts: Default::default(),
             storage,
             trie,
             state_viewer: TrieViewer {},

--- a/core/storage/src/storages/mod.rs
+++ b/core/storage/src/storages/mod.rs
@@ -57,16 +57,17 @@ const COL_STATE: u32 = 4;
 const COL_TRANSACTION_RESULTS: u32 = 5;
 const COL_TRANSACTION_ADDRESSES: u32 = 6;
 const COL_RECEIPT_BLOCK: u32 = 7;
+const COL_TX_NONCE: u32 = 8;
 
 // Columns used by the beacon chain only.
-const COL_PROPOSAL: u32 = 8;
-const COL_PARTICIPATION: u32 = 9;
-const COL_PROCESSED_BLOCKS: u32 = 10;
-const COL_THRESHOLD: u32 = 11;
-const COL_ACCEPTED_AUTHORITY: u32 = 12;
+const COL_PROPOSAL: u32 = 9;
+const COL_PARTICIPATION: u32 = 10;
+const COL_PROCESSED_BLOCKS: u32 = 11;
+const COL_THRESHOLD: u32 = 12;
+const COL_ACCEPTED_AUTHORITY: u32 = 13;
 
 /// Number of columns per chain.
-pub const NUM_COLS: u32 = 13;
+pub const NUM_COLS: u32 = 14;
 
 /// Error that occurs when we try operating with genesis-specific columns, without setting the
 /// genesis in advance.

--- a/core/storage/src/storages/shard.rs
+++ b/core/storage/src/storages/shard.rs
@@ -21,7 +21,7 @@ pub struct ShardChainStorage {
     transaction_results: HashMap<Vec<u8>, TransactionResult>,
     transaction_addresses: HashMap<Vec<u8>, TransactionAddress>,
     receipts: HashMap<Vec<u8>, HashMap<ShardId, ReceiptBlock>>,
-    // records the largest transaction nonce per account
+    // Records the largest transaction nonce per account
     tx_nonce: HashMap<Vec<u8>, u64>,
 }
 

--- a/core/storage/src/storages/shard.rs
+++ b/core/storage/src/storages/shard.rs
@@ -1,9 +1,9 @@
-use super::{extend_with_cache, read_with_cache, StorageResult};
+use super::{extend_with_cache, read_with_cache, write_with_cache, StorageResult};
 use super::{BlockChainStorage, GenericStorage};
 use super::{ChainId, KeyValueDB};
 use super::{
     COL_STATE, COL_TRANSACTION_ADDRESSES, COL_TRANSACTION_RESULTS,
-    COL_RECEIPT_BLOCK
+    COL_RECEIPT_BLOCK, COL_TX_NONCE,
 };
 use primitives::chain::{
     SignedShardBlock, SignedShardBlockHeader, ReceiptBlock
@@ -21,6 +21,8 @@ pub struct ShardChainStorage {
     transaction_results: HashMap<Vec<u8>, TransactionResult>,
     transaction_addresses: HashMap<Vec<u8>, TransactionAddress>,
     receipts: HashMap<Vec<u8>, HashMap<ShardId, ReceiptBlock>>,
+    // records the largest transaction nonce in a given block
+    tx_nonce: HashMap<Vec<u8>, u64>,
 }
 
 impl GenericStorage<SignedShardBlockHeader, SignedShardBlock> for ShardChainStorage {
@@ -39,6 +41,7 @@ impl ShardChainStorage {
             transaction_results: Default::default(),
             transaction_addresses: Default::default(),
             receipts: Default::default(),
+            tx_nonce: Default::default(),
         }
     }
 
@@ -161,6 +164,25 @@ impl ShardChainStorage {
             COL_RECEIPT_BLOCK,
             &mut self.receipts,
             value,
+        )
+    }
+
+    pub fn tx_nonce(&mut self, index: BlockIndex) -> StorageResult<&u64> {
+        read_with_cache(
+            self.generic_storage.storage.as_ref(),
+            COL_TX_NONCE,
+            &mut self.tx_nonce,
+            &self.generic_storage.enc_index(index)
+        )
+    }
+
+    pub fn insert_tx_nonce(&mut self, index: BlockIndex, nonce: u64) -> io::Result<()> {
+        write_with_cache(
+            self.generic_storage.storage.as_ref(),
+            COL_TX_NONCE,
+            &mut self.tx_nonce,
+            &self.generic_storage.enc_index(index),
+            nonce
         )
     }
 }

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -202,13 +202,13 @@ impl Client {
         // Get previous receipts:
         let receipt_block = self.shard_client.get_receipt_block(last_shard_block.index(), last_shard_block.shard_id());
         let receipt_blocks = receipt_block.map(|b| vec![b]).unwrap_or_else(|| vec![]);
-        let (mut shard_block, (transaction, authority_proposals, tx_results, new_receipts)) = self
+        let (mut shard_block, shard_block_extra) = self
             .shard_client
             .prepare_new_block(last_block.body.header.shard_block_hash, receipt_blocks, payload.transactions);
         let mut block = SignedBeaconBlock::new(
             last_block.body.header.index + 1,
             last_block.block_hash(),
-            authority_proposals,
+            shard_block_extra.authority_proposals,
             shard_block.block_hash(),
         );
         // TODO(645): Remove this and fill in correctly when collecting final BLS.
@@ -241,18 +241,24 @@ impl Client {
             let block_receipts = get_all_receipts(shard_block.body.receipts.iter());
             let mut tx_with_results: Vec<String> = block_receipts
                 .iter()
-                .zip(&tx_results[..block_receipts.len()])
+                .zip(&shard_block_extra.tx_results[..block_receipts.len()])
                 .map(|(receipt, result)| format!("{:#?} -> {:#?}", receipt, result))
                 .collect();
             tx_with_results.extend(shard_block.body.transactions
                 .iter()
-                .zip(&tx_results[block_receipts.len()..])
+                .zip(&shard_block_extra.tx_results[block_receipts.len()..])
                 .map(|(tx, result)| format!("{:#?} -> {:#?}", tx, result))
             );
             debug!(target: "client", "Input Transactions: [{}]", tx_with_results.join("\n"));
-            debug!(target: "client", "Output Transactions: {:#?}", get_all_receipts(new_receipts.values()));
+            debug!(target: "client", "Output Transactions: {:#?}", get_all_receipts(shard_block_extra.new_receipts.values()));
         }
-        self.shard_client.insert_block(&shard_block.clone(), transaction, tx_results, new_receipts);
+        self.shard_client.insert_block(
+            &shard_block.clone(),
+            shard_block_extra.db_changes,
+            shard_block_extra.tx_results,
+            shard_block_extra.largest_tx_nonce,
+            shard_block_extra.new_receipts
+        );
         self.beacon_chain.chain.insert_block(block.clone());
         io::stdout().flush().expect("Could not flush stdout");
         // Just produced blocks should be the best in the blockchain.

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -10,7 +10,7 @@ extern crate serde_derive;
 extern crate storage;
 extern crate wasm;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, hash_map::Entry};
 
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -111,7 +111,7 @@ pub struct ApplyResult {
     pub authority_proposals: Vec<AuthorityStake>,
     pub new_receipts: HashMap<ShardId, Vec<ReceiptTransaction>>,
     pub tx_result: Vec<TransactionResult>,
-    pub largest_tx_nonce: u64,
+    pub largest_tx_nonce: HashMap<AccountId, u64>,
 }
 
 fn get<T: DeserializeOwned>(state_update: &mut TrieUpdate, key: &[u8]) -> Option<T> {
@@ -864,7 +864,7 @@ impl Runtime {
         let shard_id = apply_state.shard_id;
         let block_index = apply_state.block_index;
         let mut tx_result = vec![];
-        let mut largest_tx_nonce = 0;
+        let mut largest_tx_nonce = HashMap::new();
         for receipt in prev_receipts.iter().flat_map(|b| &b.receipts) {
             tx_result.push(Self::process_receipt(
                 self,
@@ -876,10 +876,20 @@ impl Runtime {
             ));
         }
         for transaction in transactions {
+            let sender = transaction.body.get_originator();
             let nonce = transaction.body.get_nonce();
-            if nonce > largest_tx_nonce {
-                largest_tx_nonce = nonce;
-            }
+            match largest_tx_nonce.entry(sender) {
+                Entry::Occupied(mut e) => {
+                    let largest_nonce = e.get_mut();
+                    if *largest_nonce < nonce {
+                        *largest_nonce = nonce;
+                    }
+                }
+                Entry::Vacant(e) => {
+                    e.insert(nonce);
+                }
+            };
+
             tx_result.push(Self::process_transaction(
                 self,
                 &mut state_update,

--- a/node/runtime/src/test_utils.rs
+++ b/node/runtime/src/test_utils.rs
@@ -56,7 +56,7 @@ pub fn generate_test_chain_spec() -> (ChainSpec, Vec<Arc<InMemorySigner>>) {
         beacon_chain_epoch_length: 2,
         beacon_chain_num_seats_per_slot: 1,
         boot_nodes: vec![],
-    }, vec![Arc::new(alice_signer)])
+    }, vec![Arc::new(alice_signer), Arc::new(bob_signer)])
 }
 
 pub fn get_runtime_and_trie_from_chain_spec(chain_spec: &ChainSpec) -> (Runtime, Arc<Trie>, MerkleHash) {

--- a/node/shard/Cargo.toml
+++ b/node/shard/Cargo.toml
@@ -18,3 +18,4 @@ chain = { path = "../../core/chain" }
 node-runtime = { path = "../runtime" }
 configs = { path = "../configs" }
 mempool = { path = "../../core/mempool" }
+

--- a/node/shard/src/lib.rs
+++ b/node/shard/src/lib.rs
@@ -24,8 +24,7 @@ use primitives::transaction::{
     TransactionAddress, TransactionLogs, TransactionResult, TransactionStatus
 };
 use primitives::types::{AuthorityStake, BlockId, BlockIndex, MerkleHash, ShardId};
-use storage::{Trie, TrieUpdate};
-use storage::ShardChainStorage;
+use storage::{Trie, TrieUpdate, GenericStorage, ShardChainStorage};
 
 const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 
@@ -36,12 +35,13 @@ pub struct SignedTransactionInfo {
     pub result: TransactionResult,
 }
 
-type ShardBlockExtraInfo = (
-    storage::DBChanges,
-    Vec<AuthorityStake>,
-    Vec<TransactionResult>,
-    HashMap<ShardId, ReceiptBlock>,
-);
+pub struct ShardBlockExtraInfo {
+    pub db_changes: storage::DBChanges,
+    pub authority_proposals: Vec<AuthorityStake>,
+    pub tx_results: Vec<TransactionResult>,
+    pub largest_tx_nonce: u64,
+    pub new_receipts: HashMap<ShardId, ReceiptBlock>,
+} 
 
 pub fn get_all_receipts<'a, I>(receipt_blocks_iter: I) -> Vec<&'a ReceiptTransaction>
 where
@@ -101,24 +101,19 @@ impl ShardClient {
         &self,
         block: &SignedShardBlock,
         db_transaction: storage::DBChanges,
-        tx_result: Vec<TransactionResult>,
+        tx_results: Vec<TransactionResult>,
+        largest_tx_nonce: u64,
         new_receipts: HashMap<ShardId, ReceiptBlock>,
     ) {
         self.trie.apply_changes(db_transaction).ok();
         self.chain.insert_block(block.clone());
         self.pool.import_block(&block);
-        self.storage
-            .write()
-            .expect(POISONED_LOCK_ERR)
-            .extend_transaction_results_addresses(block, tx_result)
-            .unwrap();
-        
         let index = block.index();
-        self.storage
-            .write()
-            .expect(POISONED_LOCK_ERR)
-            .extend_receipts(index, new_receipts)
-            .unwrap();
+        
+        let mut guard = self.storage.write().expect(POISONED_LOCK_ERR);
+        guard.extend_transaction_results_addresses(block, tx_results).unwrap();
+        guard.extend_receipts(index, new_receipts).unwrap();
+        guard.insert_tx_nonce(index, largest_tx_nonce).unwrap();
     }
 
     fn compute_receipt_blocks(
@@ -174,19 +169,20 @@ impl ShardClient {
             receipt_merkle_paths,
             &shard_block,
         );
-        let shard_block_extra = (
-            apply_result.db_changes,
-            apply_result.authority_proposals,
-            apply_result.tx_result,
-            receipt_map,
-        );
+        let shard_block_extra = ShardBlockExtraInfo {
+            db_changes: apply_result.db_changes,
+            authority_proposals: apply_result.authority_proposals,
+            tx_results: apply_result.tx_result,
+            largest_tx_nonce: apply_result.largest_tx_nonce,
+            new_receipts: receipt_map,
+        };
         (shard_block, shard_block_extra)
     }
 
     pub fn apply_block(&self, block: SignedShardBlock) -> bool {
         let state_merkle_root = block.body.header.merkle_root_state;
         let receipt_merkle_root = block.body.header.receipt_merkle_root;
-        let (shard_block, (db_changes, _, tx_result, receipt_map)) = self.prepare_new_block(
+        let (shard_block, shard_block_extra) = self.prepare_new_block(
             block.body.header.parent_hash,
             block.body.receipts,
             block.body.transactions,
@@ -194,7 +190,13 @@ impl ShardClient {
         if shard_block.body.header.merkle_root_state == state_merkle_root
             && shard_block.body.header.receipt_merkle_root == receipt_merkle_root
         {
-            self.insert_block(&shard_block, db_changes, tx_result, receipt_map);
+            self.insert_block(
+                &shard_block,
+                shard_block_extra.db_changes,
+                shard_block_extra.tx_results,
+                shard_block_extra.largest_tx_nonce,
+                shard_block_extra.new_receipts
+            );
             true
         } else {
             error!("Received Invalid block. It's a scam");
@@ -296,6 +298,21 @@ impl ShardClient {
             .unwrap()
             .cloned()
     }
+
+    /// get the largest transaction nonce from last block
+    pub fn get_last_block_nonce(&self) -> u64 {
+        let mut guard = self.storage.write().expect(POISONED_LOCK_ERR);
+        let last_index = guard
+            .blockchain_storage_mut()
+            .best_block()
+            .unwrap()
+            .unwrap()
+            .index();
+        if last_index == 0 {
+            return 0;
+        }
+        *guard.tx_nonce(last_index).unwrap().unwrap()
+    }
 }
 
 #[cfg(test)]
@@ -307,6 +324,8 @@ mod tests {
         TransactionBody, TransactionStatus
     };
     use storage::test_utils::create_beacon_shard_storages;
+    use rand::thread_rng;
+    use rand::prelude::SliceRandom;
 
     use super::*;
 
@@ -315,6 +334,29 @@ mod tests {
         let shard_storage = create_beacon_shard_storages().1;
         let shard_client = ShardClient::new(signers[0].clone(), &chain_spec, shard_storage);
         (shard_client, signers)
+    }
+
+    impl ShardClient {
+        // add a number of test blocks
+        fn add_blocks(&mut self, signer: Arc<InMemorySigner>, num_blocks: u32) -> (u64, CryptoHash) {
+            let mut prev_hash = self.genesis_hash();
+            let mut nonce = 1;
+            for _ in 0..num_blocks {
+                let tx = TransactionBody::send_money(nonce, "alice.near", "bob.near", 1).sign(signer.clone());
+                let (block, block_extra) =
+                    self.prepare_new_block(prev_hash, vec![], vec![tx.clone()]);
+                prev_hash = block.hash;
+                nonce += 1;
+                self.insert_block(
+                    &block,
+                    block_extra.db_changes,
+                    block_extra.tx_results,
+                    block_extra.largest_tx_nonce,
+                    block_extra.new_receipts
+                );
+            }
+            (nonce, prev_hash)
+        }
     }
 
     #[test]
@@ -328,9 +370,15 @@ mod tests {
     fn test_transaction_failed() {
         let (client, signers) = get_test_client();
         let tx = TransactionBody::send_money(1, "xyz.near", "bob.near", 100).sign(signers[0].clone());
-        let (block, (db_changes, _, tx_status, receipts)) =
+        let (block, block_extra) =
             client.prepare_new_block(client.genesis_hash(), vec![], vec![tx.clone()]);
-        client.insert_block(&block, db_changes, tx_status, receipts);
+        client.insert_block(
+            &block,
+            block_extra.db_changes,
+            block_extra.tx_results,
+            block_extra.largest_tx_nonce,
+            block_extra.new_receipts
+        );
 
         let result = client.get_transaction_result(&tx.get_hash());
         assert_eq!(result.status, TransactionStatus::Failed);
@@ -340,9 +388,15 @@ mod tests {
     fn test_get_transaction_status_complete() {
         let (client, signers) = get_test_client();
         let tx = TransactionBody::send_money(1, "alice.near", "bob.near", 10).sign(signers[0].clone());
-        let (block, (db_changes, _, tx_status, new_receipts)) =
+        let (block, block_extra) =
             client.prepare_new_block(client.genesis_hash(), vec![], vec![tx.clone()]);
-        client.insert_block(&block, db_changes, tx_status, new_receipts);
+        client.insert_block(
+            &block,
+            block_extra.db_changes,
+            block_extra.tx_results,
+            block_extra.largest_tx_nonce,
+            block_extra.new_receipts
+        );
 
         let result = client.get_transaction_result(&tx.get_hash());
         assert_eq!(result.status, TransactionStatus::Completed);
@@ -356,9 +410,15 @@ mod tests {
         assert_eq!(final_result.logs[0].receipts.len(), 1);
 
         let receipt_block = client.get_receipt_block(block.index(), block.shard_id()).unwrap();
-        let (block2, (db_changes2, _, tx_status2, receipts)) =
+        let (block2, block_extra2) =
             client.prepare_new_block(block.hash, vec![receipt_block], vec![]);
-        client.insert_block(&block2, db_changes2, tx_status2, receipts);
+        client.insert_block(
+            &block2,
+            block_extra2.db_changes,
+            block_extra2.tx_results,
+            block_extra2.largest_tx_nonce,
+            block_extra2.new_receipts
+        );
 
         let result2 = client.get_transaction_result(&result.receipts[0]);
         assert_eq!(result2.status, TransactionStatus::Completed);
@@ -385,11 +445,54 @@ mod tests {
             CryptoHash::default(),
         );
         let db_changes = HashMap::default();
-        client.insert_block(&block, db_changes, vec![TransactionResult::default()], HashMap::new());
+        client.insert_block(&block, db_changes, vec![TransactionResult::default()], 0, HashMap::new());
         let address = client.get_transaction_address(&hash);
         let expected = TransactionAddress { block_hash: block.hash, index: 0 };
         assert_eq!(address, Some(expected.clone()));
     }
 
     // TODO(472): Add extensive testing for ShardBlockChain.
+
+    #[test]
+    fn test_tx_nonce() {
+        let (mut client, signers) = get_test_client();
+        let (nonce, _) = client.add_blocks(signers[0].clone(), 5);
+        let tx_nonce = client.storage
+            .write()
+            .expect(POISONED_LOCK_ERR)
+            .tx_nonce(5)
+            .unwrap()
+            .unwrap()
+            .clone();
+        assert_eq!(nonce - 1, tx_nonce);
+    }
+
+    #[test]
+    fn test_mempool_invalid_tx() {
+        let (mut client, signers) = get_test_client();
+        client.add_blocks(signers[0].clone(), 5);
+        let tx = TransactionBody::send_money(
+            2, "alice.near", "bob.near", 1
+        ).sign(signers[0].clone());
+        client.pool.add_transaction(tx).unwrap();
+        assert!(client.pool.is_empty());
+    }
+
+    #[test]
+    fn test_mempool_order_tx() {
+        let (client, signers) = get_test_client();
+        let mut transactions: Vec<_> = (0..10).map(|i| {
+            TransactionBody::send_money(i + 1, "alice.near", "bob.near", 1)
+            .sign(signers[0].clone())
+        }).collect();
+        let mut rng = thread_rng();
+        transactions.shuffle(&mut rng);
+        for tx in transactions {
+            client.pool.add_transaction(tx).unwrap();
+        }
+        let snapshot_hash = client.pool.snapshot_payload();
+        let payload = client.pool.pop_payload_snapshot(&snapshot_hash).unwrap();
+        let nonces: Vec<u64> = payload.transactions.iter().map(|tx| tx.body.get_nonce()).collect();
+        assert_eq!(nonces, (1..11).collect::<Vec<u64>>())
+    }
 }

--- a/tests/test_alphanet.rs
+++ b/tests/test_alphanet.rs
@@ -63,7 +63,15 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize) {
                 )
                 .unwrap();
         }
-        nonces[i] = max(nonces[i] + 1, nodes[i].client.shard_client.get_last_block_nonce() + 1);
+        nonces[i] = max(
+            nonces[i] + 1,
+            nodes[i]
+                .client
+                .shard_client
+                .get_last_block_nonce(account_names[i].clone())
+                .unwrap_or_else(|| 0) 
+                + 1
+        );
         expected_balances[i] -= 1;
         expected_balances[j] += 1;
 

--- a/tests/test_alphanet.rs
+++ b/tests/test_alphanet.rs
@@ -2,6 +2,7 @@ use alphanet::testing_utils::Node;
 use primitives::transaction::TransactionBody;
 use alphanet::testing_utils::wait;
 use alphanet::testing_utils::generate_test_chain_spec;
+use std::cmp::max;
 
 fn run_multiple_nodes(num_nodes: usize, num_trials: usize) {
     let init_balance = 1_000_000_000;
@@ -62,7 +63,7 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize) {
                 )
                 .unwrap();
         }
-        nonces[i] += 1;
+        nonces[i] = max(nonces[i] + 1, nodes[i].client.shard_client.get_last_block_nonce() + 1);
         expected_balances[i] -= 1;
         expected_balances[j] += 1;
 


### PR DESCRIPTION
Group transactions in mempool by account and order each group by nonce so that runtime does not reject some transactions. Also persist information about transaction nonces across blocks to not accept old transactions.