### PR TITLE
Block production should be able to unlock pending blocks

### DIFF
--- a/node/alphanet/src/lib.rs
+++ b/node/alphanet/src/lib.rs
@@ -227,7 +227,7 @@ mod tests {
         let (mut beacon_block, mut shard_block) =
             match alice.client.try_produce_block(1, ChainPayload::default()) {
                 BlockProductionResult::Success(beacon_block, shard_block) => {
-                    (beacon_block, shard_block)
+                    (*beacon_block, *shard_block)
                 }
                 _ => panic!("Should produce block"),
             };
@@ -291,7 +291,7 @@ mod tests {
         let (mut beacon_block, mut shard_block) =
             match alice.client.try_produce_block(1, ChainPayload::default()) {
                 BlockProductionResult::Success(beacon_block, shard_block) => {
-                    (beacon_block, shard_block)
+                    (*beacon_block, *shard_block)
                 }
                 _ => panic!("Should produce block"),
             };

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -37,10 +37,9 @@ const BEACON_SHARD_BLOCK_MATCH: &str =
     "Expected to have shard block present when processing beacon block";
 
 /// Result of client trying to produce a block from a given consensus.
-#[allow(clippy::large_enum_variant)] // This enum is no different from `Option`.
 pub enum BlockProductionResult {
     /// The blocks were successfully produced.
-    Success(SignedBeaconBlock, SignedShardBlock),
+    Success(Box<SignedBeaconBlock>, Box<SignedShardBlock>),
     /// The consensus was achieved after the block with the given index was already imported.
     /// The beacon and the shard chains are currently at index `current_index`.
     LateConsensus { current_index: BlockIndex },
@@ -283,7 +282,7 @@ impl Client {
         self.update_authority(&block.header());
         // Try apply pending blocks that were unlocked by this block, if any.
         self.try_apply_pending_blocks();
-        BlockProductionResult::Success(block, shard_block)
+        BlockProductionResult::Success(Box::new(block), Box::new(shard_block))
     }
 
     fn blocks_to_process(&self) -> (Vec<SignedBeaconBlock>, HashSet<SignedBeaconBlock>) {
@@ -574,7 +573,7 @@ mod tests {
     impl BlockProductionResult {
         pub fn unwrap(self) -> (SignedBeaconBlock, SignedShardBlock) {
             match self {
-                BlockProductionResult::Success(bb, sb) => (bb, sb),
+                BlockProductionResult::Success(bb, sb) => (*bb, *sb),
                 _ => panic!("Expected to produce a block"),
             }
         }

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -7,36 +7,37 @@ extern crate parking_lot;
 extern crate primitives;
 extern crate serde;
 
-use std::{cmp, env, fs};
 use std::collections::{HashMap, HashSet};
 use std::io;
 use std::io::prelude::*;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
+use std::{cmp, env, fs};
 
 use env_logger::Builder;
 use log::Level::Debug;
 
 use beacon::beacon_chain::BeaconClient;
 use configs::ClientConfig;
+use primitives::aggregate_signature::BlsPublicKey;
 use primitives::beacon::{SignedBeaconBlock, SignedBeaconBlockHeader};
 use primitives::block_traits::SignedBlock;
 use primitives::chain::{ChainPayload, SignedShardBlock};
+use primitives::hash::hash_struct;
 use primitives::hash::CryptoHash;
 use primitives::signer::InMemorySigner;
 use primitives::types::{AccountId, AuthorityId, AuthorityStake, BlockId, BlockIndex};
 use shard::{get_all_receipts, ShardClient};
 use storage::create_storage;
-use primitives::hash::hash_struct;
-use primitives::aggregate_signature::BlsPublicKey;
 
 pub mod test_utils;
 
 const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
-const BEACON_SHARD_BLOCK_MATCH: &str = "Expected to have shard block present when processing beacon block";
+const BEACON_SHARD_BLOCK_MATCH: &str =
+    "Expected to have shard block present when processing beacon block";
 
 /// Result of client trying to produce a block from a given consensus.
-#[allow(clippy::large_enum_variant)]  // This enum is no different from `Option`.
+#[allow(clippy::large_enum_variant)] // This enum is no different from `Option`.
 pub enum BlockProductionResult {
     /// The blocks were successfully produced.
     Success(SignedBeaconBlock, SignedShardBlock),
@@ -67,7 +68,7 @@ pub struct Client {
     pub signer: Arc<InMemorySigner>,
 
     pub shard_client: ShardClient,
-    pub beacon_chain: BeaconClient,
+    pub beacon_client: BeaconClient,
 
     // TODO: The following logic might need to be hidden somewhere.
     /// Stores blocks that cannot be added yet.
@@ -144,7 +145,7 @@ impl Client {
             account_id: config.account_id.clone(),
             signer,
             shard_client,
-            beacon_chain,
+            beacon_client: beacon_chain,
             pending_beacon_blocks: RwLock::new(HashSet::new()),
             pending_shard_blocks: RwLock::new(HashSet::new()),
         }
@@ -167,13 +168,13 @@ impl Client {
         // 1 to 1.
         let mut guard = self.pending_beacon_blocks.write().expect(POISONED_LOCK_ERR);
         // Prune outdated pending blocks.
-        let best_index = self.beacon_chain.chain.best_index();
+        let best_index = self.beacon_client.chain.best_index();
         guard.retain(|v| v.index() > best_index);
         if guard.is_empty() {
             // There are no pending blocks.
             vec![]
         } else {
-            let best_index = self.beacon_chain.chain.best_index();
+            let best_index = self.beacon_client.chain.best_index();
             guard
                 .iter()
                 .filter_map(|b| if b.index() > best_index { Some(b.index()) } else { None })
@@ -182,18 +183,22 @@ impl Client {
     }
 
     // Block producer code.
-    pub fn try_produce_block(&self, block_index: BlockIndex, payload: ChainPayload) -> BlockProductionResult {
-        let current_index = self.beacon_chain.chain.best_block().index();
+    pub fn try_produce_block(
+        &self,
+        block_index: BlockIndex,
+        payload: ChainPayload,
+    ) -> BlockProductionResult {
+        let current_index = self.beacon_client.chain.best_block().index();
         if block_index < current_index + 1 {
             // The consensus is too late, the block was already imported.
             return BlockProductionResult::LateConsensus { current_index };
         }
 
-        let last_block = self.beacon_chain.chain.best_block();
+        let last_block = self.beacon_client.chain.best_block();
         let last_shard_block = self.shard_client.chain.best_block();
         let next_index = current_index + 1;
         let authorities = self
-            .beacon_chain
+            .beacon_client
             .authority
             .read()
             .expect(POISONED_LOCK_ERR)
@@ -201,13 +206,17 @@ impl Client {
             .expect("Authorities should be present for given block to produce it");
         let mut receipts = payload.receipts;
         // Get previous receipts from the same shard:
-        let receipt_block = self.shard_client.get_receipt_block(last_shard_block.index(), last_shard_block.shard_id());
+        let receipt_block = self
+            .shard_client
+            .get_receipt_block(last_shard_block.index(), last_shard_block.shard_id());
         if let Some(receipt) = receipt_block {
             receipts.push(receipt);
         }
-        let (mut shard_block, shard_block_extra) = self
-            .shard_client
-            .prepare_new_block(last_block.body.header.shard_block_hash, receipts, payload.transactions);
+        let (mut shard_block, shard_block_extra) = self.shard_client.prepare_new_block(
+            last_block.body.header.shard_block_hash,
+            receipts,
+            payload.transactions,
+        );
         let mut block = SignedBeaconBlock::new(
             last_block.body.header.index + 1,
             last_block.block_hash(),
@@ -227,7 +236,7 @@ impl Client {
         }
 
         assert!(
-            !self.beacon_chain.chain.is_known(&block.hash),
+            !self.beacon_client.chain.is_known(&block.hash),
             "The block was already imported, before we managed to produce it.\
              This should never happen, because block production is atomic."
         );
@@ -247,10 +256,13 @@ impl Client {
                 .zip(&shard_block_extra.tx_results[..block_receipts.len()])
                 .map(|(receipt, result)| format!("{:#?} -> {:#?}", receipt, result))
                 .collect();
-            tx_with_results.extend(shard_block.body.transactions
-                .iter()
-                .zip(&shard_block_extra.tx_results[block_receipts.len()..])
-                .map(|(tx, result)| format!("{:#?} -> {:#?}", tx, result))
+            tx_with_results.extend(
+                shard_block
+                    .body
+                    .transactions
+                    .iter()
+                    .zip(&shard_block_extra.tx_results[block_receipts.len()..])
+                    .map(|(tx, result)| format!("{:#?} -> {:#?}", tx, result)),
             );
             debug!(target: "client", "Input Transactions: [{}]", tx_with_results.join("\n"));
             debug!(target: "client", "Output Transactions: {:#?}", get_all_receipts(shard_block_extra.new_receipts.values()));
@@ -260,25 +272,25 @@ impl Client {
             shard_block_extra.db_changes,
             shard_block_extra.tx_results,
             shard_block_extra.largest_tx_nonce,
-            shard_block_extra.new_receipts
+            shard_block_extra.new_receipts,
         );
-        self.beacon_chain.chain.insert_block(block.clone());
+        self.beacon_client.chain.insert_block(block.clone());
         io::stdout().flush().expect("Could not flush stdout");
         // Just produced blocks should be the best in the blockchain.
         assert_eq!(self.shard_client.chain.best_block().hash, shard_block.hash);
-        assert_eq!(self.beacon_chain.chain.best_block().hash, block.hash);
+        assert_eq!(self.beacon_client.chain.best_block().hash, block.hash);
         // Update the authority.
         self.update_authority(&block.header());
+        // Try apply pending blocks that were unlocked by this block, if any.
+        self.try_apply_pending_blocks();
         BlockProductionResult::Success(block, shard_block)
     }
 
-    fn blocks_to_process(
-        &self,
-    ) -> (Vec<SignedBeaconBlock>, HashSet<SignedBeaconBlock>) {
+    fn blocks_to_process(&self) -> (Vec<SignedBeaconBlock>, HashSet<SignedBeaconBlock>) {
         let mut part_add = vec![];
         let mut part_pending = HashSet::new();
         for other in self.pending_beacon_blocks.write().expect(POISONED_LOCK_ERR).drain() {
-            if self.beacon_chain.chain.is_known(&other.body.header.parent_hash)
+            if self.beacon_client.chain.is_known(&other.body.header.parent_hash)
                 && (self.shard_client.chain.is_known(&other.body.header.shard_block_hash)
                     || self
                         .pending_shard_blocks
@@ -295,10 +307,13 @@ impl Client {
     }
 
     /// Checks that the cached hash matches the content of the block
-    pub fn verify_block_hash(beacon_block: &SignedBeaconBlock, shard_block: &SignedShardBlock) -> bool {
-        shard_block.hash == hash_struct(&shard_block.body.header) &&
-            beacon_block.hash == hash_struct(&beacon_block.body.header) &&
-            beacon_block.body.header.shard_block_hash == shard_block.hash
+    pub fn verify_block_hash(
+        beacon_block: &SignedBeaconBlock,
+        shard_block: &SignedShardBlock,
+    ) -> bool {
+        shard_block.hash == hash_struct(&shard_block.body.header)
+            && beacon_block.hash == hash_struct(&beacon_block.body.header)
+            && beacon_block.body.header.shard_block_hash == shard_block.hash
     }
 
     /// Gets BLS keys for validating GroupSignature at block_index
@@ -322,7 +337,7 @@ impl Client {
               beacon_block.body.header.index,
               self.account_id,
               beacon_block.hash, shard_block.hash);
-        if self.beacon_chain.chain.is_known(&hash) {
+        if self.beacon_client.chain.is_known(&hash) {
             return BlockImportingResult::AlreadyImported;
         }
         if !Client::verify_block_hash(&beacon_block, &shard_block) {
@@ -330,8 +345,9 @@ impl Client {
         }
         // TODO get_authority_keys panics if block index is too high
         let bls_keys = self.get_authority_keys(beacon_block.index());
-        if !beacon_block.signature.verify(&bls_keys, beacon_block.hash.as_ref()) ||
-            !shard_block.signature.verify(&bls_keys, shard_block.hash.as_ref()) {
+        if !beacon_block.signature.verify(&bls_keys, beacon_block.hash.as_ref())
+            || !shard_block.signature.verify(&bls_keys, shard_block.hash.as_ref())
+        {
             error!(target: "client", "Importing a block with an incorrect signature ({:?}, {:?}); signers: ({:?},{:?})",
                    shard_block.block_hash(), beacon_block.block_hash(),
                    beacon_block.signature.authority_count(),
@@ -349,15 +365,26 @@ impl Client {
             };
         }
 
-        self.pending_shard_blocks
-            .write()
-            .expect(POISONED_LOCK_ERR)
-            .insert(shard_block);
+        self.pending_shard_blocks.write().expect(POISONED_LOCK_ERR).insert(shard_block);
         self.pending_beacon_blocks.write().expect(POISONED_LOCK_ERR).insert(beacon_block);
-        let best_block_hash = self.beacon_chain.chain.best_hash();
+        let best_block_hash = self.beacon_client.chain.best_hash();
 
+        let new_best_block = self.beacon_client.chain.best_block();
+        self.try_apply_pending_blocks();
+
+        if new_best_block.block_hash() == best_block_hash {
+            BlockImportingResult::MissingParent {
+                orphan_hash: hash,
+                missing_indices: self.get_missing_indices(),
+            }
+        } else {
+            BlockImportingResult::Success { new_index: new_best_block.index() }
+        }
+    }
+
+    /// Examines pending blocks and tries to apply those blocks for which we already know parents.
+    fn try_apply_pending_blocks(&self) {
         let mut blocks_to_add: Vec<SignedBeaconBlock> = vec![];
-        let mut bad_block: bool = false;
         // Loop until we run out of blocks to add.
         loop {
             // Only keep those blocks in `pending_blocks` that are still pending.
@@ -371,7 +398,7 @@ impl Client {
                 Some(b) => b,
                 None => break,
             };
-            if self.beacon_chain.chain.is_known(&next_beacon_block.block_hash()) {
+            if self.beacon_client.chain.is_known(&next_beacon_block.block_hash()) {
                 continue;
             }
 
@@ -382,32 +409,17 @@ impl Client {
                 .take(&next_beacon_block.body.header.shard_block_hash)
                 .expect(BEACON_SHARD_BLOCK_MATCH);
 
-
             if self.shard_client.apply_block(next_shard_block) {
-                self.beacon_chain.chain.insert_block(next_beacon_block.clone());
+                self.beacon_client.chain.insert_block(next_beacon_block.clone());
                 // Update the authority.
                 self.update_authority(&next_beacon_block.header());
-            } else {
-                bad_block |= hash == next_beacon_block.block_hash();
             }
-        }
-        let new_best_block = self.beacon_chain.chain.best_block();
-
-        if bad_block {
-            BlockImportingResult::InvalidBlock
-        } else if new_best_block.block_hash() == best_block_hash {
-            BlockImportingResult::MissingParent {
-                orphan_hash: hash,
-                missing_indices: self.get_missing_indices(),
-            }
-        } else {
-            BlockImportingResult::Success { new_index: new_best_block.index() }
         }
     }
 
     // Authority-related code. Consider hiding it inside the shard chain.
     fn update_authority(&self, beacon_header: &SignedBeaconBlockHeader) {
-        self.beacon_chain
+        self.beacon_client
             .authority
             .write()
             .expect(POISONED_LOCK_ERR)
@@ -421,7 +433,7 @@ impl Client {
         block_index: u64,
     ) -> (Option<AuthorityId>, HashMap<AuthorityId, AuthorityStake>) {
         let next_authorities = self
-            .beacon_chain
+            .beacon_client
             .authority
             .read()
             .expect(POISONED_LOCK_ERR)
@@ -443,42 +455,61 @@ impl Client {
     }
 
     pub fn get_recent_uid_to_authority_map(&self) -> HashMap<AuthorityId, AuthorityStake> {
-        let index = self.beacon_chain.chain.best_block().index() + 1;
+        let index = self.beacon_client.chain.best_block().index() + 1;
         self.get_uid_to_authority_map(index).1
     }
 
     /// Fetch "coupled" blocks by hash.
-    pub fn fetch_blocks(&self, hashes: Vec<CryptoHash>) -> Result<Vec<(SignedBeaconBlock, SignedShardBlock)>, String> {
+    pub fn fetch_blocks(
+        &self,
+        hashes: Vec<CryptoHash>,
+    ) -> Result<Vec<(SignedBeaconBlock, SignedShardBlock)>, String> {
         let mut result = vec![];
         for hash in hashes.iter() {
-            match self.beacon_chain.chain.get_block(&BlockId::Hash(*hash)) {
+            match self.beacon_client.chain.get_block(&BlockId::Hash(*hash)) {
                 Some(beacon_block) => {
-                    let shard_block = self.shard_client.chain.get_block(&BlockId::Hash(beacon_block.body.header.shard_block_hash)).expect(BEACON_SHARD_BLOCK_MATCH);
+                    let shard_block = self
+                        .shard_client
+                        .chain
+                        .get_block(&BlockId::Hash(beacon_block.body.header.shard_block_hash))
+                        .expect(BEACON_SHARD_BLOCK_MATCH);
                     result.push((beacon_block, shard_block));
-                },
-                None => return Err(format!("Missing {:?} in beacon chain", hash))
+                }
+                None => return Err(format!("Missing {:?} in beacon chain", hash)),
             }
         }
         Ok(result)
     }
 
     /// Fetch "coupled" blocks by index range.
-    pub fn fetch_blocks_range(&self, from_index: u64, til_index: u64) -> Result<Vec<(SignedBeaconBlock, SignedShardBlock)>, String> {
+    pub fn fetch_blocks_range(
+        &self,
+        from_index: u64,
+        til_index: u64,
+    ) -> Result<Vec<(SignedBeaconBlock, SignedShardBlock)>, String> {
         let mut result = vec![];
         for i in from_index..=til_index {
-            match self.beacon_chain.chain.get_block(&BlockId::Number(i)) {
+            match self.beacon_client.chain.get_block(&BlockId::Number(i)) {
                 Some(beacon_block) => {
-                    let shard_block = self.shard_client.chain.get_block(&BlockId::Hash(beacon_block.body.header.shard_block_hash)).expect(BEACON_SHARD_BLOCK_MATCH);
+                    let shard_block = self
+                        .shard_client
+                        .chain
+                        .get_block(&BlockId::Hash(beacon_block.body.header.shard_block_hash))
+                        .expect(BEACON_SHARD_BLOCK_MATCH);
                     result.push((beacon_block, shard_block));
-                },
-                None => return Err(format!("Missing index={:?} in beacon chain", i))
+                }
+                None => return Err(format!("Missing index={:?} in beacon chain", i)),
             }
         }
         Ok(result)
     }
 
     /// Fetch transaction / receipts by hash from mempool.
-    pub fn fetch_payload(&self, _transaction_hashes: Vec<CryptoHash>, _receipt_hashes: Vec<CryptoHash>) -> Result<ChainPayload, String> {
+    pub fn fetch_payload(
+        &self,
+        _transaction_hashes: Vec<CryptoHash>,
+        _receipt_hashes: Vec<CryptoHash>,
+    ) -> Result<ChainPayload, String> {
         Ok(ChainPayload::new(vec![], vec![]))
     }
 }
@@ -492,14 +523,28 @@ mod tests {
     use crate::test_utils::get_client_from_cfg;
 
     use super::*;
+    use configs::ChainSpec;
+    use primitives::signer::BlockSigner;
+    use primitives::signer::TransactionSigner;
 
-    fn make_coupled_blocks(prev_beacon_block: &SignedBeaconBlock, prev_shard_block: &SignedShardBlock, count: u32, signers: &Vec<Arc<InMemorySigner>>) -> Vec<(SignedBeaconBlock, SignedShardBlock)> {
-        let (mut beacon_block, mut shard_block) = (prev_beacon_block.clone(), prev_shard_block.clone());
+    fn make_coupled_blocks(
+        prev_beacon_block: &SignedBeaconBlock,
+        prev_shard_block: &SignedShardBlock,
+        count: u32,
+        signers: &Vec<Arc<InMemorySigner>>,
+    ) -> Vec<(SignedBeaconBlock, SignedShardBlock)> {
+        let (mut beacon_block, mut shard_block) =
+            (prev_beacon_block.clone(), prev_shard_block.clone());
         let mut result = vec![];
         for _ in 0..count {
             let mut new_shard_block = SignedShardBlock::empty(&shard_block);
             new_shard_block.sign_all(signers);
-            let mut new_beacon_block = SignedBeaconBlock::new(beacon_block.index() + 1, beacon_block.hash, vec![], new_shard_block.hash);
+            let mut new_beacon_block = SignedBeaconBlock::new(
+                beacon_block.index() + 1,
+                beacon_block.hash,
+                vec![],
+                new_shard_block.hash,
+            );
             new_beacon_block.sign_all(signers);
             println!("sigs: {:?}", new_beacon_block.signature.authority_mask);
             beacon_block = new_beacon_block.clone();
@@ -515,10 +560,90 @@ mod tests {
         let client = get_client_from_cfg(&chain_spec, signers[0].clone());
 
         let blocks = make_coupled_blocks(
-            &client.beacon_chain.chain.best_block(), &client.shard_client.chain.best_block(), 10, &signers);
+            &client.beacon_client.chain.best_block(),
+            &client.shard_client.chain.best_block(),
+            10,
+            &signers,
+        );
         for i in (0..10).rev() {
             client.try_import_blocks(blocks[i].0.clone(), blocks[i].1.clone());
         }
-        assert_eq!(client.beacon_chain.chain.best_index(), 10);
+        assert_eq!(client.beacon_client.chain.best_index(), 10);
+    }
+
+    impl BlockProductionResult {
+        pub fn unwrap(self) -> (SignedBeaconBlock, SignedShardBlock) {
+            match self {
+                BlockProductionResult::Success(bb, sb) => (bb, sb),
+                _ => panic!("Expected to produce a block"),
+            }
+        }
+    }
+
+    impl BlockImportingResult {
+        pub fn unwrap(self) -> BlockIndex {
+            match self {
+                BlockImportingResult::Success { new_index } => new_index,
+                _ => panic!("Expected to import a block"),
+            }
+        }
+    }
+
+    #[test]
+    /// Tests the following scenario. A node is working on block X, suddenly it receives blocks
+    /// X + 1, X + 2, ... etc which it cannot incorporate into the blockchain because it lacks
+    fn test_catchup_through_production() {
+        // Set-up genesis and chain spec.
+        let genesis_wasm =
+            include_bytes!("../../../core/wasm/runtest/res/wasm_with_mem.wasm").to_vec();
+        let alice_signer = InMemorySigner::from_seed("alice.near", "alice.near");
+        let bob_signer = InMemorySigner::from_seed("bob.near", "bob.near");
+        let chain_spec = ChainSpec {
+            accounts: vec![
+                ("alice.near".to_string(), alice_signer.public_key().to_readable(), 100, 10),
+                ("bob.near".to_string(), bob_signer.public_key().to_readable(), 100, 10),
+            ],
+            initial_authorities: vec![
+                (
+                    "alice.near".to_string(),
+                    alice_signer.public_key().to_readable(),
+                    alice_signer.bls_public_key().to_readable(),
+                    50,
+                ),
+                (
+                    "bob.near".to_string(),
+                    bob_signer.public_key().to_readable(),
+                    bob_signer.bls_public_key().to_readable(),
+                    50,
+                ),
+            ],
+            genesis_wasm,
+            beacon_chain_epoch_length: 2,
+            beacon_chain_num_seats_per_slot: 1,
+            boot_nodes: vec![],
+        };
+
+        // Start both clients.
+        let alice_client = get_client_from_cfg(&chain_spec, Arc::new(alice_signer));
+        let bob_client = get_client_from_cfg(&chain_spec, Arc::new(bob_signer));
+
+        // First produce several blocks by Alice and Bob.
+        for i in 1..=5 {
+            alice_client.try_produce_block(i, ChainPayload::new(vec![], vec![])).unwrap();
+            bob_client.try_produce_block(i, ChainPayload::new(vec![], vec![])).unwrap();
+        }
+
+        // Then Bob produces several blocks and Alice tries to import them except the first one.
+        bob_client.try_produce_block(6, ChainPayload::new(vec![], vec![])).unwrap();
+        for i in 7..=10 {
+            let (bb, sb) =
+                bob_client.try_produce_block(i, ChainPayload::new(vec![], vec![])).unwrap();
+            alice_client.try_import_blocks(bb, sb);
+        }
+
+        // Lastly, alice produces the missing block and is expected to progess to block 10.
+        alice_client.try_produce_block(6, ChainPayload::new(vec![], vec![])).unwrap();
+        assert_eq!(alice_client.beacon_client.chain.best_index(), 10);
+        assert_eq!(alice_client.shard_client.chain.best_index(), 10);
     }
 }

--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -369,8 +369,8 @@ impl Client {
         self.pending_beacon_blocks.write().expect(POISONED_LOCK_ERR).insert(beacon_block);
         let best_block_hash = self.beacon_client.chain.best_hash();
 
-        let new_best_block = self.beacon_client.chain.best_block();
         self.try_apply_pending_blocks();
+        let new_best_block = self.beacon_client.chain.best_block();
 
         if new_best_block.block_hash() == best_block_hash {
             BlockImportingResult::MissingParent {

--- a/node/client/src/test_utils.rs
+++ b/node/client/src/test_utils.rs
@@ -23,7 +23,7 @@ pub fn get_client_from_cfg(chain_spec: &ChainSpec, signer: Arc<InMemorySigner>) 
         account_id: signer.account_id.clone(),
         signer,
         shard_client,
-        beacon_chain,
+        beacon_client: beacon_chain,
         pending_beacon_blocks: RwLock::new(HashSet::new()),
         pending_shard_blocks: RwLock::new(HashSet::new()),
     }

--- a/node/consensus/src/passthrough.rs
+++ b/node/consensus/src/passthrough.rs
@@ -17,13 +17,13 @@ pub fn spawn_consensus(
     control_rx: Receiver<Control>,
     block_period: Duration,
 ) {
-    let initial_beacon_block_index = client.beacon_chain.chain.best_index();
+    let initial_beacon_block_index = client.beacon_client.chain.best_index();
     let task = Interval::new_interval(block_period)
         .fold(
             (control_rx, initial_beacon_block_index),
             move |(control_rx, mut beacon_block_index), _| {
                 // First check previous block was produced.
-                if client.beacon_chain.chain.best_index() >= beacon_block_index {
+                if client.beacon_client.chain.best_index() >= beacon_block_index {
                     let hash = client.shard_client.pool.snapshot_payload();
                     let last_shard_block = client.shard_client.chain.best_block();
                     let receipt_block = client.shard_client.get_receipt_block(last_shard_block.index(), last_shard_block.shard_id());

--- a/node/coroutines/src/client_task.rs
+++ b/node/coroutines/src/client_task.rs
@@ -77,13 +77,13 @@ impl Stream for ClientTask {
         loop {
             match self.consensus_rx.poll() {
                 Ok(Async::Ready(Some(c))) => {
-                    if c.index == self.client.beacon_chain.chain.best_index() + 1 {
+                    if c.index == self.client.beacon_client.chain.best_index() + 1 {
                         if let ind @ Some(_) = self.try_produce_block(c) {
                             new_block_index = ind;
                         }
                     } else {
                         info!(target: "client", "Ignoring consensus for {} because current block index is {}",
-                              c.index, self.client.beacon_chain.chain.best_index());
+                              c.index, self.client.beacon_client.chain.best_index());
                     }
                     continue;
                 }
@@ -286,7 +286,7 @@ impl ClientTask {
             self.client.try_produce_block(consensus_block_header.index, payload)
         {
             self.announce_block(produced_beacon_block, produced_shard_block);
-            let new_best_block = self.client.beacon_chain.chain.best_block();
+            let new_best_block = self.client.beacon_client.chain.best_block();
             Some(new_best_block.index())
         } else {
             None
@@ -327,16 +327,16 @@ impl ClientTask {
 
     fn process_peer_state(&mut self, peer_id: PeerId, chain_state: ChainState) {
         self.assumed_peer_last_index.insert(peer_id, chain_state.last_index);
-        if chain_state.last_index > self.client.beacon_chain.chain.best_index() {
+        if chain_state.last_index > self.client.beacon_client.chain.best_index() {
             // TODO: we should keep track of already fetching stuff.
             info!(target: "client", "Missing blocks {}..{} (from {}) for {}",
-                  self.client.beacon_chain.chain.best_index(),
+                  self.client.beacon_client.chain.best_index(),
                   chain_state.last_index, peer_id,
                   self.client.account_id);
             tokio::spawn(
                 self.out_block_fetch_tx
                     .clone()
-                    .send((peer_id, self.client.beacon_chain.chain.best_index() + 1, chain_state.last_index))
+                    .send((peer_id, self.client.beacon_client.chain.best_index() + 1, chain_state.last_index))
                     .map(|_| ())
                     .map_err(|e| error!(target: "client", "Error sending request to fetch blocks from peer: {}", e))
             );
@@ -418,7 +418,7 @@ impl ClientTask {
 
     /// Resets MemPool and returns NS control for next block.
     fn restart_pool_nightshade(&self, block_index: BlockIndex) -> Control {
-        let index = self.client.beacon_chain.chain.best_index() + 1;
+        let index = self.client.beacon_client.chain.best_index() + 1;
         let (owner_uid, uid_to_authority_map) =
             self.client.get_uid_to_authority_map(index);
 
@@ -470,7 +470,7 @@ impl ClientTask {
 
     /// Spawn a kick-off task.
     fn spawn_kickoff(&self) {
-        let next_index = self.client.beacon_chain.chain.best_block().index() + 1;
+        let next_index = self.client.beacon_client.chain.best_block().index() + 1;
         let control = self.restart_pool_nightshade(next_index);
 
         // Send mempool control.

--- a/node/coroutines/src/client_task.rs
+++ b/node/coroutines/src/client_task.rs
@@ -285,7 +285,7 @@ impl ClientTask {
         if let BlockProductionResult::Success(produced_beacon_block, produced_shard_block) =
             self.client.try_produce_block(consensus_block_header.index, payload)
         {
-            self.announce_block(produced_beacon_block, produced_shard_block);
+            self.announce_block(*produced_beacon_block, *produced_shard_block);
             let new_best_block = self.client.beacon_client.chain.best_block();
             Some(new_best_block.index())
         } else {

--- a/node/http/src/api.rs
+++ b/node/http/src/api.rs
@@ -115,14 +115,14 @@ impl HttpApi {
     }
 
     pub fn view_latest_beacon_block(&self) -> Result<SignedBeaconBlockResponse, ()> {
-        Ok(self.client.beacon_chain.chain.best_block().into())
+        Ok(self.client.beacon_client.chain.best_block().into())
     }
 
     pub fn get_beacon_block_by_hash(
         &self,
         r: &GetBlockByHashRequest,
     ) -> Result<SignedBeaconBlockResponse, &str> {
-        match self.client.beacon_chain.chain.get_block(&BlockId::Hash(r.hash)) {
+        match self.client.beacon_client.chain.get_block(&BlockId::Hash(r.hash)) {
             Some(block) => Ok(block.into()),
             None => Err("block not found"),
         }
@@ -159,9 +159,9 @@ impl HttpApi {
         &self,
         r: &GetBlocksByIndexRequest,
     ) -> Result<SignedBeaconBlocksResponse, String> {
-        let start = r.start.unwrap_or_else(|| self.client.beacon_chain.chain.best_index());
+        let start = r.start.unwrap_or_else(|| self.client.beacon_client.chain.best_index());
         let limit = r.limit.unwrap_or(25);
-        self.client.beacon_chain.chain.get_blocks_by_index(start, limit).map(|blocks| {
+        self.client.beacon_client.chain.get_blocks_by_index(start, limit).map(|blocks| {
             SignedBeaconBlocksResponse {
                 blocks: blocks.into_iter().map(std::convert::Into::into).collect(),
             }

--- a/node/network/src/protocol.rs
+++ b/node/network/src/protocol.rs
@@ -38,8 +38,8 @@ impl ChainStateRetriever for ClientChainStateRetriever {
     #[inline]
     fn get_chain_state(&self) -> ChainState {
         ChainState {
-            genesis_hash: self.client.beacon_chain.chain.genesis_hash(),
-            last_index: self.client.beacon_chain.chain.best_block().index(),
+            genesis_hash: self.client.beacon_client.chain.genesis_hash(),
+            last_index: self.client.beacon_client.chain.best_block().index(),
         }
     }
 }
@@ -130,7 +130,7 @@ impl Protocol {
     }
 
     fn on_new_peer(&self, peer_id: PeerId, connected_info: ConnectedInfo) {
-        if connected_info.chain_state.genesis_hash != self.client.beacon_chain.chain.genesis_hash()
+        if connected_info.chain_state.genesis_hash != self.client.beacon_client.chain.genesis_hash()
         {
             self.peer_manager.ban_peer(&peer_id);
         }

--- a/node/shard/src/lib.rs
+++ b/node/shard/src/lib.rs
@@ -201,7 +201,7 @@ impl ShardClient {
             );
             true
         } else {
-            error!("Received Invalid block. It's a scam");
+            error!("Received Invalid block.");
             false
         }
     }


### PR DESCRIPTION
If we produce block X but there are blocks X+1, ... X+Y that we have already received through the announcements, then we should be able to progress to block X+Y.