### PR TITLE
Fix missing_indices

### DIFF
--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -175,10 +175,14 @@ impl Client {
             // There are no pending blocks.
             vec![]
         } else {
-            let best_index = self.beacon_client.chain.best_index();
-            guard
+            let blocks_present: HashSet<BlockIndex> = guard
                 .iter()
                 .filter_map(|b| if b.index() > best_index { Some(b.index()) } else { None })
+                .collect();
+            blocks_present
+                .iter()
+                .map(|i| i - 1)
+                .filter(|i| !blocks_present.contains(i))
                 .collect()
         }
     }


### PR DESCRIPTION
Make get_missing_indices return missing indices rather than indices that
are present in pending_blocks.
This bug is what caused non-deterministic failures in the alphanet test.
The bug reproduces on losing some block announcement messages or
a race condition during node startup: simple test with a node starting
late won't catch it because of on_new_peer logic for fetching blocks.