### PR TITLE
Update nearlib and tests to use result JSON directly instead of a "result" key

### DIFF
--- a/core/wasm/runtest/src/lib.rs
+++ b/core/wasm/runtest/src/lib.rs
@@ -336,7 +336,7 @@ mod tests {
         println!("Gas used for simple call {}", outcome.gas_used);
 
         match outcome.return_data {
-            Ok(ReturnData::Value(output_data)) => assert_eq!(&output_data, b"{\"result\":\"hello Alice\"}"),
+            Ok(ReturnData::Value(output_data)) => assert_eq!(&output_data, b"\"hello Alice\""),
             _ => assert!(false, "Expected returned value"),
         };
     }

--- a/nearlib/near.js
+++ b/nearlib/near.js
@@ -67,7 +67,7 @@ class Near {
             console.log(`[${contractAccountId}]: ${line}`);
         });
         const json = JSON.parse(Buffer.from(response.result).toString());
-        return json.result;
+        return json;
     }
 
     /**

--- a/nearlib/package.json
+++ b/nearlib/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nearlib",
   "description": "Javascript library to interact with near blockchain",
-  "version": "0.3.5",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "git@:nearprotocol/nearcore.git"

--- a/pynear/setup.py
+++ b/pynear/setup.py
@@ -8,7 +8,7 @@ tests_require = [
 
 setup(
     name='near.pynear',
-    version='0.1.0',
+    version='0.1.1',
     packages=find_packages('src'),
     package_dir={'': 'src'},
     install_requires=[

--- a/pynear/src/near/pynear/lib.py
+++ b/pynear/src/near/pynear/lib.py
@@ -282,11 +282,7 @@ class NearLib(object):
             'method_name': function_name,
             'args': args,
         }
-        result = self._call_rpc('call_view_function', params)
-        try:
-            return json.loads(bytearray(result['result']).decode('utf-8'))
-        except json.JSONDecodeError:
-            return result
+        return self._call_rpc('call_view_function', params)
 
     def check_health(self):
         url = "{}healthz".format(self._server_url)

--- a/pynear/src/near/pynear/lib.py
+++ b/pynear/src/near/pynear/lib.py
@@ -282,7 +282,11 @@ class NearLib(object):
             'method_name': function_name,
             'args': args,
         }
-        return self._call_rpc('call_view_function', params)
+        result = self._call_rpc('call_view_function', params)
+        try:
+            return json.loads(bytearray(result['result']).decode('utf-8'))
+        except json.JSONDecodeError:
+            return result
 
     def check_health(self):
         url = "{}healthz".format(self._server_url)

--- a/pynear/tests/integration/test_cli.py
+++ b/pynear/tests/integration/test_cli.py
@@ -103,7 +103,7 @@ def test_set_get_values(
             .format(contract_name)
         out = CliHelpers(port).run_command(command_)
         data = json.loads(out)
-        assert data['result'] == value
+        assert data == value
 
     _wait_for_state_change()
 

--- a/tests/hello/assembly/main.ts
+++ b/tests/hello/assembly/main.ts
@@ -3,7 +3,7 @@ export { memory };
 
 import { context, storage, ContractPromise, ContractPromiseResult, near } from "./near";
 
-import { PromiseArgs, InputPromiseArgs, MyCallbackResult, MyContractPromiseResult, ResultWrappedMyCallbackResult } from "./model.near";
+import { PromiseArgs, InputPromiseArgs, MyCallbackResult, MyContractPromiseResult } from "./model.near";
 
 export function hello(name: string): string {
 
@@ -122,7 +122,7 @@ export function callbackWithName(args: PromiseArgs): MyCallbackResult {
     allRes[i] = new MyContractPromiseResult();
     allRes[i].ok = contractResults[i].success;
     if (allRes[i].ok && contractResults[i].buffer != null && contractResults[i].buffer.length > 0) {
-      allRes[i].r = ResultWrappedMyCallbackResult.decode(contractResults[i].buffer).result;
+      allRes[i].r = MyCallbackResult.decode(contractResults[i].buffer);
     }
   } 
   let result: MyCallbackResult = {

--- a/tests/hello/assembly/model.ts
+++ b/tests/hello/assembly/model.ts
@@ -21,7 +21,3 @@ export class MyCallbackResult {
     rs: MyContractPromiseResult[];
     n: string;
 }
-
-export class ResultWrappedMyCallbackResult {
-  result: MyCallbackResult;
-}

--- a/tests/hello/package.json
+++ b/tests/hello/package.json
@@ -2,14 +2,13 @@
     "name": "hello-wasm",
     "version": "0.0.1",
     "dependencies": {
-        "assemblyscript": "github:nearprotocol/assemblyscript.git#wasm-new-read-api",
         "assemblyscript-json": "github:nearprotocol/assemblyscript-json",
-        "near-runtime-ts": "github:nearprotocol/near-runtime-ts#wasm-new-read-api"
+        "near-runtime-ts": "github:nearprotocol/near-runtime-ts"
     },
     "scripts": {
         "build": "near build --out_file hello.wasm && cp ./out/hello.wasm .."
     },
     "devDependencies": {
-        "near-shell": "github:nearprotocol/near-shell.git#wasm-new-read-api"
+        "near-shell": "github:nearprotocol/near-shell.git#remove-result"
     }
 }


### PR DESCRIPTION
Bump nearlib to 0.4.0 to work with new AS compiler that removes wrapped object with `"result"` key from returned result. See https://github.com/nearprotocol/assemblyscript/pull/26

Update tests to work with new result format.
 