### PR TITLE
Add monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ tmp/
 
 # OS X
 .DS_Store
+
+# Logs
+*.log

--- a/node/network/src/lib.rs
+++ b/node/network/src/lib.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate futures;
 
 pub use crate::protocol::spawn_network;

--- a/tests/test_alphanet.rs
+++ b/tests/test_alphanet.rs
@@ -3,9 +3,9 @@ use testlib::alphanet_utils::wait;
 use testlib::alphanet_utils::Node;
 use primitives::transaction::TransactionBody;
 
-use network::proxy::debug::DebugHandler;
 use std::sync::Arc;
 use network::proxy::ProxyHandler;
+use network::proxy::benchmark::BenchmarkHandler;
 
 fn sample_two_nodes(num_nodes: usize) -> (usize, usize) {
     let i = rand::random::<usize>() % num_nodes;
@@ -29,7 +29,9 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, te
     let mut boot_nodes = vec![];
 
     // Add proxy handlers to the pipeline.
-    let proxy_handlers: Vec<Arc<ProxyHandler>> = vec![];
+    let proxy_handlers: Vec<Arc<ProxyHandler>> = vec![
+        Arc::new(BenchmarkHandler::new())
+    ];
 
     // Launch nodes in a chain, such that X+1 node boots from X node.
     for i in 0..num_nodes {


### PR DESCRIPTION
**DONT MERGE**

This branch will be merged with #735 after merging issues are resolved there. Right now some monitoring is performed on the network on test `test_4_10_multiple_nodes`, each message type is counted and logged in a file. To see results:

> `git checkout network-proxy-monitor`

Run `test_4_10_multiple_nodes`. This should create the file `monitor.log` in the root of the project.
> `cargo test --package nearcore --test test_alphanet test_4_10_multiple_nodes -- --exact`

Run in a separate terminal, from the root of the project, while the test is running
> `watch -n 1 tail -n 12 monitor.log`

(Or simply open `monitor.log`)

You should see something like this:
```
Instant { tv_sec: 13328, tv_nsec: 67098609 }
"Gossip": 1755
"Connected": 0
"Transaction": 0
"Receipt": 0
"BlockAnnounce": 350
"BlockFetchRequest": 1
"BlockResponse": 1
"PayloadGossip": 1280
"PayloadRequest": 0
"PayloadSnapshotRequest": 1
"PayloadResponse": 1
```