### PR TITLE
Fix PoA chainspec being incorrectly overridden

### DIFF
--- a/node/configs/src/authority.rs
+++ b/node/configs/src/authority.rs
@@ -3,7 +3,7 @@ use primitives::signature::PublicKey;
 use primitives::traits::Base58Encoded;
 use primitives::types::AuthorityStake;
 
-use crate::chain_spec::{ChainSpec, AuthorityRotation};
+use crate::chain_spec::{AuthorityRotation, ChainSpec};
 
 /// Configure the authority rotation.
 #[derive(Clone)]

--- a/node/configs/src/chain_spec.rs
+++ b/node/configs/src/chain_spec.rs
@@ -51,8 +51,8 @@ impl ChainSpec {
     }
 
     /// Read ChainSpec from a file or use the default value.
-    pub fn from_file_or_default(path: &Option<PathBuf>) -> Self {
-        path.as_ref().map(|p| Self::from_file(p)).unwrap_or_default()
+    pub fn from_file_or_default(path: &Option<PathBuf>, default: Self) -> Self {
+        path.as_ref().map(|p| Self::from_file(p)).unwrap_or(default)
     }
 
     /// Writes ChainSpec to the file.

--- a/node/configs/src/client.rs
+++ b/node/configs/src/client.rs
@@ -70,13 +70,13 @@ pub fn get_args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
     ]
 }
 
-pub fn from_matches(matches: &ArgMatches) -> ClientConfig {
+pub fn from_matches(matches: &ArgMatches, default_chain_spec: ChainSpec) -> ClientConfig {
     let base_path = matches.value_of("base_path").map(PathBuf::from).unwrap();
     let account_id = matches.value_of("account_id").map(String::from).unwrap();
     let public_key = matches.value_of("public_key").map(String::from);
     let log_level = matches.value_of("log_level").map(log::LevelFilter::from_str).unwrap().unwrap();
 
     let chain_spec_path = matches.value_of("chain_spec_file").map(PathBuf::from);
-    let chain_spec = ChainSpec::from_file_or_default(&chain_spec_path);
+    let chain_spec = ChainSpec::from_file_or_default(&chain_spec_path, default_chain_spec);
     ClientConfig { base_path, account_id, public_key, chain_spec, log_level }
 }

--- a/node/configs/src/lib.rs
+++ b/node/configs/src/lib.rs
@@ -24,9 +24,11 @@ pub fn get_alphanet_configs() -> (ClientConfig, NetworkConfig, RPCConfig) {
         .args(&network::get_args())
         .args(&rpc::get_args())
         .get_matches();
-    let mut client_cfg = client::from_matches(&matches);
-    client_cfg.chain_spec = ChainSpec::default_poa();
-    (client_cfg, network::from_matches(&matches), rpc::from_matches(&matches))
+    (
+        client::from_matches(&matches, ChainSpec::default_poa()),
+        network::from_matches(&matches),
+        rpc::from_matches(&matches),
+    )
 }
 
 pub fn get_devnet_configs() -> (ClientConfig, DevNetConfig, RPCConfig) {
@@ -35,5 +37,9 @@ pub fn get_devnet_configs() -> (ClientConfig, DevNetConfig, RPCConfig) {
         .args(&devnet::get_args())
         .args(&rpc::get_args())
         .get_matches();
-    (client::from_matches(&matches), devnet::from_matches(&matches), rpc::from_matches(&matches))
+    (
+        client::from_matches(&matches, ChainSpec::default()),
+        devnet::from_matches(&matches),
+        rpc::from_matches(&matches),
+    )
 }

--- a/node/configs/src/network.rs
+++ b/node/configs/src/network.rs
@@ -1,12 +1,12 @@
+use rand;
 use std::mem;
 use std::net::SocketAddr;
 use std::time::Duration;
-use rand;
 
 use clap::{Arg, ArgMatches};
 
-use primitives::{hash::hash, types::PeerId};
 use primitives::network::PeerAddr;
+use primitives::{hash::hash, types::PeerId};
 
 const DEFAULT_RECONNECT_DELAY_MS: &str = "50";
 const DEFAULT_GOSSIP_INTERVAL_MS: &str = "50";
@@ -105,17 +105,16 @@ pub fn get_peer_id_from_seed(seed: Option<u32>) -> PeerId {
 }
 
 pub fn from_matches(matches: &ArgMatches) -> NetworkConfig {
-    let listen_addr =
-        matches.value_of("addr").map(|value| value.parse::<SocketAddr>().expect("Cannot parse address"));
+    let listen_addr = matches
+        .value_of("addr")
+        .map(|value| value.parse::<SocketAddr>().expect("Cannot parse address"));
     let test_network_key_seed =
         matches.value_of("test_network_key_seed").map(|x| x.parse::<u32>().unwrap());
 
     let parsed_boot_nodes =
         matches.values_of("boot_nodes").unwrap_or_else(clap::Values::default).map(String::from);
     let boot_nodes: Vec<_> = parsed_boot_nodes
-        .map(|addr_id| {
-            PeerAddr::parse(&addr_id).expect("Cannot parse address")
-        })
+        .map(|addr_id| PeerAddr::parse(&addr_id).expect("Cannot parse address"))
         .clone()
         .collect();
 


### PR DESCRIPTION
#807 Introduced a bug that incorrectly overrides the chainspec. `test_4_20_kill1` caught it (yay @mikhailOK ) and started failing, but I incorrectly attributed it to the flakiness (see #801 , cc @azban ) because the same integration test sometimes fails randomly due to flakiness, see failure before #807 was merged: https://gitlab.com/nearprotocol/nearcore/-/jobs/187118763 It is my fault, though, for not double checking.