### PR TITLE
docker: fix typo in run alphanet script on chain spec generation path

### DIFF
--- a/docker/scripts/run_alphanet
+++ b/docker/scripts/run_alphanet
@@ -8,7 +8,7 @@ mkdir -p ${BASE_PATH}
 if [[ -z ${CHAIN_SPEC_PATH} ]]
 then
 generate-test-spec -n ${TOTAL_NODES} -c ${BASE_PATH}/chain_spec.json
-CHAIN_SPEC_PATH="${BASE_PATH}/chain-spec.json"
+CHAIN_SPEC_PATH="${BASE_PATH}/chain_spec.json"
 fi
 
 if [[ -z ${KEYGEN_SEED} ]]

--- a/node/configs/src/chain_spec.rs
+++ b/node/configs/src/chain_spec.rs
@@ -88,6 +88,9 @@ impl ChainSpec {
 
         let mut signers = vec![];
         let mut accounts = vec![];
+        let alice_signer = InMemorySigner::from_seed("alice.near", "alice.near");
+        let signer = InMemorySigner::from_seed("alice.near", "alice.near");
+        accounts.push(("alice.near".to_string(), signer.public_key().to_readable(), 1_000_000 as u64, 10));
         let mut initial_authorities = vec![];
         for i in 0..num_signers {
             let account_id = match id_type {

--- a/ops/deploy_alphanet.sh
+++ b/ops/deploy_alphanet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-IMAGE=${1:-nearprotocol/alphanet:0.1.2}
+IMAGE=${1:-nearprotocol/alphanet:0.1.3}
 PREFIX=${2:-alphanet}
 STUDIO_IMAGE=${3:-nearprotocol/studio:0.1.6}
 ZONE=${4:-us-west2-a}

--- a/ops/deploy_alphanet.sh
+++ b/ops/deploy_alphanet.sh
@@ -9,9 +9,16 @@ REGION=${5:-us-west2}
 
 echo "Starting 4 nodes prefixed ${PREFIX} of ${IMAGE} on GCloud ${ZONE} zone..."
 
+set +e
+gcloud compute firewall-rules describe alphanet-instance > /dev/null 2>&1
+INSTANCE_FIRE_WALL_EXISTS=$?
+set -e
+
+if [[ ! ${INSTANCE_FIRE_WALL_EXISTS} -eq 0 ]]; then
 gcloud compute firewall-rules create alphanet-instance \
     --allow tcp:3000,tcp:3030 \
     --target-tags=alphanet-instance
+fi
 
 gcloud compute disks create --size 200GB --zone ${ZONE} \
     ${PREFIX}-persistent-0 \
@@ -71,9 +78,16 @@ gcloud beta compute instances create-with-container ${PREFIX}-3 \
     --container-mount-disk=mount-path="/srv/near" \
     --boot-disk-size 200GB
 
+set +e
+gcloud compute firewall-rules describe alphanet-studio > /dev/null 2>&1
+STUDIO_FIRE_WALL_EXISTS=$?
+set -e
+
+if [[ ! ${STUDIO_FIRE_WALL_EXISTS} -eq 0 ]]; then
 gcloud compute firewall-rules create alphanet-studio \
     --allow tcp:80 \
     --target-tags=alphanet-studio
+fi
 
 gcloud compute disks create --size 200GB --zone ${ZONE} \
     ${PREFIX}-studio-persistent

--- a/ops/local_alphanet.sh
+++ b/ops/local_alphanet.sh
@@ -28,7 +28,7 @@ sudo docker run -d --name alphanet-3 --add-host=alphanet-0:172.17.0.2 \
     -e "TOTAL_NODES=4" \
     ${IMAGE}
 
-sudo docker run -d --name studio -p 80:80 --add-host=alphanet-0:127.17.0.2 \
+sudo docker run -d --name studio -p 80:80 --add-host=alphanet-0:172.17.0.2 \
     -e "DEVNET_HOST=http://172.17.0.2" \
     ${STUDIO_IMAGE}
 

--- a/ops/local_alphanet.sh
+++ b/ops/local_alphanet.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 
-IMAGE=${1:-nearprotocol/alphanet:0.1.2}
-STUDIO_IMAGE=${2:-nearprotocol/studio:0.1.6}
+IMAGE=${1:-nearprotocol/alphanet:0.1.3}
+STUDIO_IMAGE=${2:-nearprotocol/studio:0.1.7}
 
 sudo docker run -d --name alphanet-0 -p 3000:3000 -p 3030:3030 \
     -e "BOOT_NODE_IP=127.0.0.1" \

--- a/ops/reset_alphanet.sh
+++ b/ops/reset_alphanet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-IMAGE=${1:-nearprotocol/alphanet:0.1.2}
+IMAGE=${1:-nearprotocol/alphanet:0.1.3}
 PREFIX=${2:-alphanet}
 ZONE=${3:-us-west2-a}
 REGION=${4:-us-west2}

--- a/ops/update_alphanet.sh
+++ b/ops/update_alphanet.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-IMAGE=${1:-nearprotocol/alphanet:0.1.1}
+IMAGE=${1:-nearprotocol/alphanet:0.1.3}
 PREFIX=${2:-alphanet}
 ZONE=${3:-us-west2-a}
 

--- a/ops/update_studio.sh
+++ b/ops/update_studio.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-STUDIO_IMAGE=${3:-nearprotocol/studio:0.1.6}
+STUDIO_IMAGE=${3:-nearprotocol/studio:0.1.7}
 PREFIX=${2:-alphanet}
 ZONE=${3:-us-west2-a}
 


### PR DESCRIPTION
need to rebuild docker image, push new version, and update ops scripts