### PR TITLE
Test that hangs despite panics

### DIFF
--- a/node/coroutines/src/client_task.rs
+++ b/node/coroutines/src/client_task.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use futures::future::Future;
 use futures::sink::Sink;
@@ -66,7 +66,7 @@ pub struct ClientTask {
     /// Channel into which we gossip payloads.
     out_payload_gossip_tx: Sender<PayloadGossip>,
     /// Interval at which we gossip payloads.
-    payload_gossip_interval: Interval,
+    payload_gossip_interval: tokio::timer::Interval,
 
     /// Last block index per peer. Might not be the real block index the peer is it, in the cases:
     /// The value is underestimated if when the remote node managed to progress several blocks
@@ -196,6 +196,8 @@ impl Stream for ClientTask {
 
             match self.payload_gossip_interval.poll() {
                 Ok(Async::Ready(Some(_))) => {
+                    warn!(target: "client", "INTERVAL TRIGGERED");
+
                     self.gossip_payload();
                     continue;
                 }

--- a/node/tokio-utils/src/lib.rs
+++ b/node/tokio-utils/src/lib.rs
@@ -65,8 +65,11 @@ impl Drop for ShutdownableThread {
     fn drop(&mut self) {
         // Ignore the panic from child thread
         if let Some(InitializedState { thread, shutdown_tx }) = self.state.take() {
+            println!("BEFORE SHUTDOWN");
             let _ = shutdown_tx.send(()).map_err(|_| error!("Error sending shutdown signal"));
+            println!("AFTER SHUTDOWN");
             let _ = thread.join().map_err(|_| error!("Error joining child thread"));
+            println!("AFTER JOIN");
         }
     }
 }
@@ -78,7 +81,7 @@ pub fn spawn<F>(f: F)
 where
     F: Future<Item = (), Error = ()> + Send + 'static,
 {
-    panic::set_hook(Box::new(|_info| {}));
+//    panic::set_hook(Box::new(|_info| {}));
     tokio::spawn(f);
-    let _ = panic::take_hook();
+//    let _ = panic::take_hook();
 }

--- a/test-utils/testlib/src/alphanet_utils.rs
+++ b/test-utils/testlib/src/alphanet_utils.rs
@@ -66,7 +66,9 @@ impl NodeConfig {
     }
 }
 
-pub trait Node {
+pub trait Node: Send + Sync {
+    fn account_id(&self) -> AccountId;
+
     fn config(&self) -> &NodeConfig;
 
     fn node_type(&self) -> NodeType;
@@ -123,6 +125,10 @@ pub struct ProcessNode {
 }
 
 impl Node for ProcessNode {
+    fn account_id(&self) -> AccountId {
+        self.config.client_cfg.account_id.clone()
+    }
+
     fn config(&self) -> &NodeConfig {
         &self.config
     }
@@ -180,6 +186,10 @@ impl Node for ProcessNode {
 }
 
 impl Node for ThreadNode {
+    fn account_id(&self) -> AccountId {
+        self.config.client_cfg.account_id.clone()
+    }
+
     fn config(&self) -> &NodeConfig {
         &self.config
     }

--- a/test-utils/testlib/src/alphanet_utils.rs
+++ b/test-utils/testlib/src/alphanet_utils.rs
@@ -24,6 +24,7 @@ use primitives::types::{AccountId, Balance};
 use tokio_utils::ShutdownableThread;
 
 use crate::node_user::{NodeUser, RpcNodeUser, ThreadNodeUser};
+use std::sync::RwLock;
 
 const TMP_DIR: &str = "../../tmp/testnet";
 
@@ -102,10 +103,10 @@ pub trait Node {
 }
 
 impl Node {
-    pub fn new(config: NodeConfig) -> Box<dyn Node> {
+    pub fn new(config: NodeConfig) -> Arc<RwLock<dyn Node>> {
         match config.node_type {
-            NodeType::ThreadNode => Box::new(ThreadNode::new(config)),
-            NodeType::ProcessNode => Box::new(ProcessNode::new(config)),
+            NodeType::ThreadNode => Arc::new(RwLock::new(ThreadNode::new(config))),
+            NodeType::ProcessNode => Arc::new(RwLock::new(ProcessNode::new(config))),
         }
     }
 }
@@ -510,10 +511,10 @@ pub fn sample_two_nodes(num_nodes: usize) -> (usize, usize) {
 }
 
 /// Sample a node for sending a transaction/checking balance
-pub fn sample_queryable_node(nodes: &Vec<Box<Node>>) -> usize {
+pub fn sample_queryable_node(nodes: &Vec<Arc<RwLock<Node>>>) -> usize {
     let num_nodes = nodes.len();
     let mut k = rand::random::<usize>() % num_nodes;
-    while !nodes[k].is_running() {
+    while !nodes[k].read().unwrap().is_running() {
         k = rand::random::<usize>() % num_nodes;
     }
     k
@@ -524,13 +525,13 @@ pub fn sample_queryable_node(nodes: &Vec<Box<Node>>) -> usize {
 /// Wait until a certain node is caught up and participating in a consensus. Check first-layer BLS signatures;
 /// Wait until all nodes are more-or-less caught up. Check that the max_block_index - min_block_index < threshold;
 ///
-pub fn wait_for_catchup(nodes: &Vec<Box<Node>>) {
+pub fn wait_for_catchup(nodes: &Vec<Arc<RwLock<Node>>>) {
     wait(
         || {
             let tips: Vec<_> = nodes
                 .iter()
-                .filter(|node| node.is_running())
-                .map(|node| node.user().get_best_block_index())
+                .filter(|node| node.read().unwrap().is_running())
+                .map(|node| node.read().unwrap().user().get_best_block_index())
                 .collect();
             tips.iter().min() == tips.iter().max()
         },

--- a/tests/test_alphanet.rs
+++ b/tests/test_alphanet.rs
@@ -19,9 +19,9 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, te
 
     let (init_balance, account_names, mut nodes) = create_nodes(num_nodes, test_prefix, test_port, proxy_handlers);
 
-    let mut nodes: Vec<Box<Node>> = nodes.drain(..).map(|cfg| Node::new(cfg)).collect();
+    let nodes: Vec<_> = nodes.drain(..).map(|cfg| Node::new(cfg)).collect();
     for i in 0..num_nodes {
-        nodes[i].start();
+        nodes[i].write().unwrap().start();
     }
 
     // Execute N trials. In each trial we submit a transaction to a random node i, that sends
@@ -33,20 +33,20 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, te
         println!("TRIAL #{}", trial);
         let (i, j) = sample_two_nodes(num_nodes);
         let (k, r) = sample_two_nodes(num_nodes);
-        let nonce = nodes[i].get_account_nonce(&account_names[i]).unwrap_or_default() + 1;
+        let nonce = nodes[i].read().unwrap().get_account_nonce(&account_names[i]).unwrap_or_default() + 1;
         let transaction = TransactionBody::send_money(
             nonce,
             account_names[i].as_str(),
             account_names[j].as_str(),
             1,
         )
-            .sign(nodes[i].signer());
-        nodes[k].add_transaction(transaction).unwrap();
+            .sign(nodes[i].read().unwrap().signer());
+        nodes[k].read().unwrap().add_transaction(transaction).unwrap();
         expected_balances[i] -= 1;
         expected_balances[j] += 1;
 
         wait(
-            || expected_balances[j] == nodes[r].view_balance(&account_names[j]).unwrap(),
+            || expected_balances[j] == nodes[r].read().unwrap().view_balance(&account_names[j]).unwrap(),
             1000,
             trial_duration,
         );

--- a/tests/test_alphanet_command_line.rs
+++ b/tests/test_alphanet_command_line.rs
@@ -13,6 +13,7 @@ use std::sync::Arc;
 use network::proxy::ProxyHandler;
 use network::proxy::benchmark::BenchmarkHandler;
 use testlib::test_locks::heavy_test;
+use std::sync::RwLock;
 
 fn warmup() {
     Command::new("cargo").args(&["build"]).spawn().expect("warmup failed").wait().unwrap();
@@ -23,7 +24,7 @@ fn warmup() {
 // to ensure they are not run in parallel.
 
 fn send_transaction(
-    nodes: &Vec<Box<Node>>,
+    nodes: &Vec<Arc<RwLock<Node>>>,
     account_names: &Vec<AccountId>,
     nonces: &Vec<u64>,
     from: usize,
@@ -31,6 +32,8 @@ fn send_transaction(
 ) {
     let k = sample_queryable_node(nodes);
     nodes[k]
+        .read()
+        .unwrap()
         .add_transaction(
             TransactionBody::send_money(
                 nonces[from],
@@ -38,7 +41,7 @@ fn send_transaction(
                 account_names[to].as_str(),
                 1,
             )
-                .sign(nodes[from].signer()),
+                .sign(nodes[from].read().unwrap().signer()),
         )
         .unwrap();
 }
@@ -56,10 +59,10 @@ fn test_kill_1(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port
         nodes[i].node_type = if rand::random::<bool>() { NodeType::ProcessNode } else { NodeType::ThreadNode };
     }
 
-    let mut nodes: Vec<Box<Node>> = nodes.drain(..).map(|cfg| Node::new(cfg)).collect();
+    let nodes: Vec<_> = nodes.drain(..).map(|cfg| Node::new(cfg)).collect();
 
     for i in 0..num_nodes {
-        nodes[i].start();
+        nodes[i].write().unwrap().start();
     }
 
     let mut expected_balances = vec![init_balance; num_nodes];
@@ -69,19 +72,19 @@ fn test_kill_1(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port
         println!("TRIAL #{}", trial);
         if trial % 10 == 3 {
             println!("Killing node {}", crash1);
-            nodes[crash1].kill();
+            nodes[crash1].write().unwrap().kill();
             thread::sleep(Duration::from_secs(2));
         }
         if trial % 10 == 6 {
             println!("Restarting node {}", crash1);
-            nodes[crash1].start();
+            nodes[crash1].write().unwrap().start();
             wait_for_catchup(&nodes);
             println!("Killing node {}", crash2);
-            nodes[crash2].kill();
+            nodes[crash2].write().unwrap().kill();
         }
         if trial % 10 == 9 {
             println!("Restarting node {}", crash2);
-            nodes[crash2].start();
+            nodes[crash2].write().unwrap().start();
         }
 
         let (i, j) = sample_two_nodes(num_nodes);
@@ -92,7 +95,7 @@ fn test_kill_1(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port
         let t = sample_queryable_node(&nodes);
         wait(
             || {
-                let amt = nodes[t].view_balance(&account_names[j]).unwrap();
+                let amt = nodes[t].read().unwrap().view_balance(&account_names[j]).unwrap();
                 expected_balances[j] == amt
             },
             1000,
@@ -110,10 +113,10 @@ fn test_kill_2(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port
         nodes[i].node_type = if rand::random::<bool>() { NodeType::ProcessNode } else { NodeType::ThreadNode };
     }
 
-    let mut nodes: Vec<Box<Node>> = nodes.drain(..).map(|cfg| Node::new(cfg)).collect();
+    let nodes: Vec<_> = nodes.drain(..).map(|cfg| Node::new(cfg)).collect();
 
     for i in 0..num_nodes {
-        nodes[i].start();
+        nodes[i].write().unwrap().start();
     }
 
     let mut expected_balances = vec![init_balance; num_nodes];
@@ -126,22 +129,22 @@ fn test_kill_2(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port
             // Here we kill two nodes, make sure transactions stop going through,
             // then restart one of the nodes
             println!("Killing nodes {}, {}", crash1, crash2);
-            nodes[crash1].kill();
-            nodes[crash2].kill();
+            nodes[crash1].write().unwrap().kill();
+            nodes[crash2].write().unwrap().kill();
 
             send_transaction(&nodes, &account_names, &nonces, i, j);
             thread::sleep(Duration::from_secs(2));
             let t = sample_queryable_node(&nodes);
-            assert_eq!(nodes[t].view_balance(&account_names[j]).unwrap(), expected_balances[j]);
+            assert_eq!(nodes[t].read().unwrap().view_balance(&account_names[j]).unwrap(), expected_balances[j]);
 
             println!("Restarting node {}", crash1);
-            nodes[crash1].start();
+            nodes[crash1].write().unwrap().start();
         } else {
             send_transaction(&nodes, &account_names, &nonces, i, j);
             if trial % 5 == 4 {
                 // Restart the second of the nodes killed earlier
                 println!("Restarting node {}", crash2);
-                nodes[crash2].start();
+                nodes[crash2].write().unwrap().start();
             }
         }
         nonces[i] += 1;
@@ -150,7 +153,7 @@ fn test_kill_2(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port
         let t = sample_queryable_node(&nodes);
         wait(
             || {
-                let amt = nodes[t].view_balance(&account_names[j]).unwrap();
+                let amt = nodes[t].read().unwrap().view_balance(&account_names[j]).unwrap();
                 expected_balances[j] == amt
             },
             1000,

--- a/tests/test_alphanet_highload.rs
+++ b/tests/test_alphanet_highload.rs
@@ -1,0 +1,101 @@
+use std::thread;
+use std::time::Duration;
+
+use network::proxy::benchmark::BenchmarkHandler;
+use network::proxy::ProxyHandler;
+use primitives::hash::CryptoHash;
+use primitives::transaction::TransactionBody;
+use serde_json::map::Entry;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::sync::RwLock;
+use testlib::alphanet_utils::{create_nodes, sample_queryable_node, sample_two_nodes, wait, Node};
+use testlib::test_locks::heavy_test;
+use std::time::Instant;
+
+/// Create and submit some transaction, returning its hash. Nonces are kept in a separate collection.
+fn submit_transaction(
+    nodes: &Vec<Arc<RwLock<dyn Node>>>,
+    nonces: &mut HashMap<usize, u64>,
+) -> CryptoHash {
+    let (money_sender, money_receiver) = sample_two_nodes(nodes.len());
+    let tx_sender = sample_queryable_node(nodes);
+    // Get and increase nonce.
+    let nonce = *nonces.entry(money_sender).and_modify(|e| *e += 1).or_insert(1);
+
+    let money_sender = &nodes[money_sender];
+    let money_receiver = &nodes[money_receiver];
+    let tx_sender = &nodes[tx_sender];
+    let money_to_send = 1;
+
+    let transaction = TransactionBody::send_money(
+        nonce,
+        money_sender.read().unwrap().account_id().as_str(),
+        money_receiver.read().unwrap().account_id().as_str(),
+        money_to_send,
+    )
+    .sign(money_sender.read().unwrap().signer());
+    let hash = transaction.get_hash();
+    tx_sender.read().unwrap().add_transaction(transaction).unwrap();
+    hash
+}
+
+/// Launch several nodes, then start submitting transactions with high frequency. Measure the
+/// throughput by checking the published blocks. Does not differentiate failing and passing
+/// transactions. Can be used to determine top tps.
+fn run_multiple_nodes(
+    num_nodes: usize,
+    running_time: Duration,
+    tps: usize,
+    test_prefix: &str,
+    test_port: u16,
+) {
+    // Add proxy handlers to the pipeline.
+    let proxy_handlers = vec![];
+
+    let (init_balance, account_names, mut nodes) =
+        create_nodes(num_nodes, test_prefix, test_port, proxy_handlers);
+
+    let nodes: Vec<_> = nodes.drain(..).map(Node::new).collect();
+    for node in &nodes {
+        node.write().unwrap().start();
+    }
+
+    // Transactions that were submitted but were not accepted yet into the block.
+    let pending_transactions = Arc::new(RwLock::new(HashSet::new()));
+
+    // Send transactions in a loop.
+    let tx_sender_handle = {
+        let transaction_delay = Duration::from_millis((Duration::from_secs(1).as_millis() / (tps as u128)) as u64);
+        let end = Instant::now() + running_time;
+        let pending_transactions = pending_transactions.clone();
+        let nodes = nodes.clone();
+        thread::spawn(move || {
+            let mut nonces = HashMap::new();
+
+            while Instant::now() <= end {
+                let tx_hash = submit_transaction(&nodes, &mut nonces);
+                pending_transactions.write().unwrap().insert(tx_hash);
+                thread::sleep(transaction_delay);
+            }
+        })
+    };
+
+    // Monitor when the most recent block changes and update the pending transactions.
+    // Also record finalized transactions.
+//    let finalized_transactions = Arc::new(RwLock::new(HashSet::new()));
+    let tx_monitor_handle = {
+        let end = Instant::now() + running_time;
+        thread::spawn(move || {
+
+        })
+    };
+
+    tx_sender_handle.join().unwrap();
+    tx_monitor_handle.join().unwrap();
+}
+
+#[test]
+fn test_4_10_multiple_nodes() {
+    heavy_test(|| run_multiple_nodes(4, Duration::from_secs(60), 1000, "4_10", 3300));
+}

--- a/tests/tests_custom_handler.rs
+++ b/tests/tests_custom_handler.rs
@@ -27,9 +27,9 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, te
 
     let (init_balance, account_names, mut nodes) = create_nodes(num_nodes, test_prefix, test_port, proxy_handlers);
 
-    let mut nodes: Vec<Box<Node>> = nodes.drain(..).map(|cfg| Node::new(cfg)).collect();
+    let nodes: Vec<_> = nodes.drain(..).map(|cfg| Node::new(cfg)).collect();
     for i in 0..num_nodes {
-        nodes[i].start();
+        nodes[i].write().unwrap().start();
     }
 
     thread::sleep(Duration::from_millis(1000));
@@ -42,20 +42,20 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, te
     for _ in 0..num_trials {
         let (i, j) = sample_two_nodes(num_nodes);
         let (k, r) = sample_two_nodes(num_nodes);
-        let nonce = nodes[i].get_account_nonce(&account_names[i]).unwrap_or_default() + 1;
+        let nonce = nodes[i].read().unwrap().get_account_nonce(&account_names[i]).unwrap_or_default() + 1;
         let transaction = TransactionBody::send_money(
             nonce,
             account_names[i].as_str(),
             account_names[j].as_str(),
             1,
         )
-            .sign(nodes[i].signer());
-        nodes[k].add_transaction(transaction).unwrap();
+            .sign(nodes[i].read().unwrap().signer());
+        nodes[k].read().unwrap().add_transaction(transaction).unwrap();
         expected_balances[i] -= 1;
         expected_balances[j] += 1;
 
         wait(
-            || expected_balances[j] == nodes[r].view_balance(&account_names[j]).unwrap(),
+            || expected_balances[j] == nodes[r].read().unwrap().view_balance(&account_names[j]).unwrap(),
             1000,
             trial_duration,
         );


### PR DESCRIPTION
To reproduce run test `test_4_10_multiple_nodes` from `test_alphanet_highload.rs`. Observe that panics are getting printed but the test does not shutdown. Observe that `set_hook` is commented out.