### PR TITLE
Fix alphanet with >4 nodes

### DIFF
--- a/node/client/src/lib.rs
+++ b/node/client/src/lib.rs
@@ -104,6 +104,7 @@ fn configure_logging(log_level: log::LevelFilter) {
     if let Ok(lvl) = env::var("RUST_LOG") {
         builder.parse_filters(&lvl);
     }
+    builder.default_format_timestamp_nanos(true);
     if let Err(e) = builder.try_init() {
         warn!(target: "client", "Failed to reinitialize the log level {}", e);
     }

--- a/node/tokio-utils/src/lib.rs
+++ b/node/tokio-utils/src/lib.rs
@@ -1,6 +1,6 @@
 use futures::future::IntoFuture;
 use futures::stream::Stream;
-use log::error;
+use log::{debug, error};
 use std::thread::JoinHandle;
 use std::{panic, thread};
 use tokio::prelude::Future;
@@ -65,8 +65,10 @@ impl Drop for ShutdownableThread {
     fn drop(&mut self) {
         // Ignore the panic from child thread
         if let Some(InitializedState { thread, shutdown_tx }) = self.state.take() {
+            debug!("Trying to kill thread...");
             let _ = shutdown_tx.send(()).map_err(|_| error!("Error sending shutdown signal"));
             let _ = thread.join().map_err(|_| error!("Error joining child thread"));
+            debug!("Killed thread");
         }
     }
 }

--- a/tests/test_alphanet.rs
+++ b/tests/test_alphanet.rs
@@ -55,9 +55,7 @@ fn test_4_10_multiple_nodes() {
     heavy_test(|| run_multiple_nodes(4, 10, "4_10", 3200));
 }
 
-// TODO: #817
 #[test]
-#[ignore]
 fn test_7_10_multiple_nodes() {
     heavy_test(|| run_multiple_nodes(7, 10, "7_10", 3300));
 }


### PR DESCRIPTION
Issue #817

The bug was that the main loop of ClientTask processes one event from
each channel at a time, and for the channel that receives partial BLS
signatures it meant that it drained it slower than it produced new
requests.

The workaround for now is to request signatures with a higher interval
(50 ms -> 500 ms).

Some additional changes:
- change log format to output nanoseconds
- cache your own BLS signature and don't recompute on each request
- make the requester of BLS signatures request from all authorities
instead of up to his own index