### PR TITLE
Generating and executing transactions in bulk

### DIFF
--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod node;
-pub mod user;
+pub mod sampler;
 pub mod test_helpers;
+pub mod transactions_generator;
+pub mod user;

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -2,4 +2,5 @@ pub mod node;
 pub mod sampler;
 pub mod test_helpers;
 pub mod transactions_generator;
+pub mod transactions_executor;
 pub mod user;

--- a/test-utils/testlib/src/sampler.rs
+++ b/test-utils/testlib/src/sampler.rs
@@ -1,0 +1,280 @@
+//! Functions to sample a collection of objects. The functions that accept predicate optimize not
+//! for the runtime complexity but for how many times it runs the predicate. It is useful for
+//! predicates that do expensive invocations, e.g. querying a node.
+use rand::seq::SliceRandom;
+use rand::thread_rng;
+use std::collections::HashSet;
+
+const EMPTY_COLLECTION: &str = "Collection is expected to be non-empty";
+const COLLECTION_TOO_SMALL: &str = "Collection size is less than sample size";
+const COLLECTION_EXHAUSTED: &str =
+    "Not enough elements in the collection that satisfy the predicate";
+
+/// Get one item from the collection.
+pub fn sample_one<T>(collection: &[T]) -> &T {
+    collection.choose(&mut thread_rng()).expect(EMPTY_COLLECTION)
+}
+
+/// Get one item from the collection that satisfy the given predicate.
+pub fn sample_one_fn<T, F>(collection: &[T], f: F) -> &T
+where
+    F: Fn(&T) -> bool,
+{
+    let mut attempted_indices = HashSet::new();
+    let mut i;
+    let mut res;
+    loop {
+        i = rand::random::<usize>() % collection.len();
+        // Check if already attempted.
+        if attempted_indices.contains(&i) {
+            continue;
+        };
+
+        res = &collection[i];
+        if f(res) {
+            break;
+        } else {
+            attempted_indices.insert(i);
+            assert!(attempted_indices.len() < collection.len(), COLLECTION_EXHAUSTED);
+        }
+    }
+    res
+}
+
+/// Get several items from the collections.
+pub fn sample<T>(collection: &[T], sample_size: usize) -> Vec<&T> {
+    assert!(collection.len() >= sample_size, COLLECTION_TOO_SMALL);
+    collection.choose_multiple(&mut thread_rng(), sample_size).collect()
+}
+
+/// Get several items from the collection that satisfy the given predicate.
+pub fn sample_fn<T, F>(collection: &[T], sample_size: usize, f: F) -> Vec<&T>
+where
+    F: Fn(&T) -> bool,
+{
+    let mut attempted_indices = HashSet::new();
+    let mut i;
+    let mut res = vec![];
+    loop {
+        i = rand::random::<usize>() % collection.len();
+        // Check if already attempted.
+        if attempted_indices.contains(&i) {
+            continue;
+        };
+
+        let el = &collection[i];
+        if f(el) {
+            res.push(el);
+            if res.len() == sample_size {
+                break;
+            }
+        }
+        attempted_indices.insert(i);
+        assert!(attempted_indices.len() < collection.len(), COLLECTION_EXHAUSTED);
+    }
+    res
+}
+
+/// Binds a tuple to a vector.
+/// # Examples:
+///
+/// ```
+/// let v = vec![1,2,3];
+/// tuplet!((a,b,c) = v);
+/// assert_eq!(a, &1);
+/// assert_eq!(b, &2);
+/// assert_eq!(c, &3);
+/// ```
+macro_rules! tuplet {
+    { ($y:ident $(, $x:ident)*) = $v:expr } => {
+        let ($y, $($x),*) = tuplet!($v ; 1 ; ($($x),*) ; (&$v[0]) );
+    };
+    { $v:expr ; $j:expr ; ($y:ident $(, $x:ident)*) ; ($($a:expr),*) } => {
+        tuplet!( $v ; $j+1 ; ($($x),*) ; ($($a),*,&$v[$j]) )
+    };
+    { $v:expr ; $j:expr ; () ; $accu:expr } => {
+        $accu
+    }
+}
+
+/// Sample two elements from the slice.
+pub fn sample_two<T>(collection: &[T]) -> (&T, &T) {
+    tuplet!((a, b) = sample(collection, 2));
+    (a, b)
+}
+
+/// Sample two elements from the slice that satisfy the predicate.
+pub fn sample_two_fn<T, F>(collection: &[T], f: F) -> (&T, &T)
+where
+    F: Fn(&T) -> bool,
+{
+    tuplet!((a, b) = sample_fn(collection, 2, &f));
+    (a, b)
+}
+
+/// Sample three elements from the slice.
+pub fn sample_three<T>(collection: &[T]) -> (&T, &T, &T) {
+    tuplet!((a, b, c) = sample(collection, 3));
+    (a, b, c)
+}
+
+/// Sample three elements from the slice that satisfy the predicate.
+pub fn sample_three_fn<T, F>(collection: &[T], f: F) -> (&T, &T, &T)
+where
+    F: Fn(&T) -> bool,
+{
+    tuplet!((a, b, c) = sample_fn(collection, 3, &f));
+    (a, b, c)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::sampler::{
+        sample, sample_fn, sample_one, sample_one_fn, sample_three, sample_three_fn, sample_two,
+        sample_two_fn,
+    };
+
+    #[test]
+    fn test_sample_one() {
+        let c = vec![1];
+        assert_eq!(*sample_one(&c), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sample_one_panics() {
+        let c: Vec<usize> = vec![];
+        sample_one(&c);
+    }
+
+    #[test]
+    fn test_sample_one_many() {
+        for _ in 0..100 {
+            let len = rand::random::<usize>() % 10 + 1;
+            let c: Vec<usize> = (0..len).collect();
+            sample_one(&c);
+        }
+    }
+
+    #[test]
+    fn test_sample_one_fn() {
+        let c = vec![1, 2];
+        assert_eq!(*sample_one_fn(&c, |el| *el == 1), 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sample_one_fn_panics() {
+        let c = vec![1, 2];
+        sample_one_fn(&c, |_| false);
+    }
+
+    #[test]
+    fn test_sample_one_fn_many() {
+        for _ in 0..100 {
+            let len = rand::random::<usize>() % 10 + 1;
+            let c: Vec<usize> = (0..len).collect();
+            sample_one_fn(&c, |el| *el % 2 == 0);
+        }
+    }
+
+    #[test]
+    fn test_sample() {
+        let c = vec![1, 2, 3];
+        let mut res = sample(&c, 3);
+        res.sort();
+        assert_eq!(res, c.iter().collect::<Vec<_>>());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sample_panic1() {
+        let c = vec![1, 2, 3];
+        sample(&c, 4);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sample_panic2() {
+        let c: Vec<usize> = vec![];
+        sample(&c, 1);
+    }
+
+    #[test]
+    fn test_sample_many() {
+        for _ in 0..100 {
+            let len = rand::random::<usize>() % 10 + 1;
+            let c: Vec<usize> = (0..len).collect();
+            let mut res = sample(&c, len);
+            res.sort();
+            assert_eq!(res, c.iter().collect::<Vec<_>>());
+        }
+    }
+
+    #[test]
+    fn test_sample_fn() {
+        let c = vec![1, 2, 3];
+        let mut res = sample_fn(&c, 2, |e| *e > 1);
+        res.sort();
+        assert_eq!(res, c[1..].iter().collect::<Vec<_>>());
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sample_fn_panic1() {
+        let c = vec![1, 2, 3];
+        sample_fn(&c, 3, |e| *e > 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_sample_fn_panic2() {
+        let c: Vec<usize> = vec![];
+        sample_fn(&c, 1, |_| true);
+    }
+
+    #[test]
+    fn test_sample_fn_many() {
+        for _ in 0..100 {
+            let len = rand::random::<usize>() % 10 + 1;
+            let c: Vec<usize> = (0..len).collect();
+            sample_fn(&c, (len + 1) / 2, |e| (*e) % 2 == 0);
+        }
+    }
+
+    #[test]
+    fn test_sample_two() {
+        for _ in 0..100 {
+            let len = rand::random::<usize>() % 4 + 2;
+            let c: Vec<usize> = (0..len).collect();
+            sample_two(&c);
+        }
+    }
+
+    #[test]
+    fn test_sample_two_fn() {
+        for _ in 0..100 {
+            let len = rand::random::<usize>() % 4 + 3;
+            let c: Vec<usize> = (0..len).collect();
+            sample_two_fn(&c, |e| *e > 0);
+        }
+    }
+
+    #[test]
+    fn test_sample_three() {
+        for _ in 0..100 {
+            let len = rand::random::<usize>() % 4 + 3;
+            let c: Vec<usize> = (0..len).collect();
+            sample_three(&c);
+        }
+    }
+
+    #[test]
+    fn test_sample_three_fn() {
+        for _ in 0..100 {
+            let len = rand::random::<usize>() % 4 + 4;
+            let c: Vec<usize> = (0..len).collect();
+            sample_three_fn(&c, |e| *e > 0);
+        }
+    }
+}

--- a/test-utils/testlib/src/transactions_executor.rs
+++ b/test-utils/testlib/src/transactions_executor.rs
@@ -1,0 +1,143 @@
+//! Executes a single transaction or a list of transactions on a set of nodes.
+
+use crate::node::Node;
+use crate::sampler::sample_one;
+use crate::transactions_generator::{Generator, TransactionType};
+use futures::future::Future;
+use futures::stream::Stream;
+use futures::sync::mpsc::{channel, Sender};
+use primitives::transaction::SignedTransaction;
+use rand::distributions::{Distribution, Exp};
+use std::collections::vec_deque::VecDeque;
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+use tokio::timer::{Delay, Interval};
+
+pub struct Executor {
+    /// Nodes that can be used to generate nonces
+    pub nodes: Vec<Arc<RwLock<dyn Node>>>,
+}
+
+impl Executor {
+    /// Spawn executor in a separate thread. Submit transactions with random delay, following
+    /// exponential distribution, which is commonly used to imitate network lag.
+    /// Args:
+    /// * `nodes`: nodes to run on;
+    /// * `transaction_type`: type of transaction to send;
+    /// * `timeout`: if specified will terminate after the given time;
+    /// * `transactions_limit`: if specified will terminate after submitting the given number of
+    /// transactions;
+    /// * `tps`: transactions-per-second;
+    /// * `delay_mean`: mean latency;
+    pub fn spawn(
+        nodes: Vec<Arc<RwLock<dyn Node>>>,
+        transaction_type: TransactionType,
+        timeout: Option<Duration>,
+        transactions_limit: Option<usize>,
+        tps: u64,
+        delay_mean: Duration,
+    ) -> JoinHandle<()> {
+        let (tx_sender, tx_receiver) = channel(1000);
+        Self::spawn_producer(nodes.to_vec(), tx_sender, transaction_type);
+
+        // Schedule submission of transactions with random delays and given tps.
+        // We use tokio because it allows to spawn a large number of tasks that will be resolved
+        // some time in the future.
+        thread::spawn(move || {
+            let interval = Duration::from_nanos((Duration::from_secs(1).as_nanos() as u64) / tps);
+            let timeout = timeout.map(|t| Instant::now() + t);
+            let messages_sent = Arc::new(Mutex::new(0usize));
+            tokio::run(
+                Interval::new_interval(interval)
+                    .take_while(move |_| {
+                        let mut guard = messages_sent.lock().unwrap();
+                        *guard += 1;
+                        if let Some(t_limit) = transactions_limit {
+                            if t_limit <= *guard {
+                                // We hit transaction limit.
+                                return Ok(false);
+                            }
+                        }
+
+                        if let Some(t_limit) = timeout {
+                            if t_limit > Instant::now() {
+                                // We hit timeout.
+                                return Ok(false);
+                            }
+                        }
+                        Ok(true)
+                    })
+                    .map_err(|_| ()) // Timer errors are irrelevant.
+                    .zip(tx_receiver)
+                    .map(|(_, t)| t)
+                    .for_each(move |t| {
+                        let instant = Instant::now() + Self::sample_exp(delay_mean);
+                        let node = sample_one(&nodes).clone();
+                        tokio::spawn(
+                            Delay::new(instant)
+                                .map(move |_| {
+                                    let _ = node.write().unwrap().add_transaction(t);
+                                })
+                                .map_err(|_| ()),
+                        );
+                        Ok(())
+                    })
+                    .map(|_| ())
+                    .map_err(|_| ()),
+            );
+        })
+    }
+
+    /// Get random duration according to exponential distribution.
+    fn sample_exp(mean: Duration) -> Duration {
+        let lambda = 1.0f64 / (mean.as_micros() as f64);
+        let exp = Exp::new(lambda);
+        Duration::from_micros(exp.sample(&mut rand::thread_rng()) as u64)
+    }
+
+    /// Spawn task that produces transactions.
+    /// Args:
+    /// * `nodes`: nodes with accounts that generate transactions;
+    /// * `sender`: where to send the produced transactions;
+    /// * `transaction_type`: what kind of transactions to send.
+    fn spawn_producer(
+        nodes: Vec<Arc<RwLock<dyn Node>>>,
+        mut sender: Sender<SignedTransaction>,
+        transaction_type: TransactionType,
+    ) {
+        thread::spawn(move || {
+            let mut generator = Generator::new(nodes).iter(transaction_type);
+            let mut backlog = VecDeque::new();
+            loop {
+                if backlog.is_empty() {
+                    backlog.push_back(generator.next().unwrap());
+                }
+
+                match sender.try_send(backlog.front().cloned().unwrap()) {
+                    // The transaction was successfully processed. Pop it from the backlog.
+                    Ok(()) => {
+                        backlog.pop_front();
+                    }
+                    Err(err) => {
+                        if err.is_disconnected() {
+                            // The channel disconnected, we stop producing transactions.
+                            break;
+                        }
+                        if err.is_full() {
+                            // The channel is full, we wait a bit.
+                            thread::sleep(Duration::from_millis(50));
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    /// Submits transaction to a random node.
+    pub fn submit_transaction(&self, transaction: SignedTransaction) -> Result<(), String> {
+        let node = sample_one(&self.nodes);
+        node.write().unwrap().add_transaction(transaction)
+    }
+}

--- a/test-utils/testlib/src/transactions_generator.rs
+++ b/test-utils/testlib/src/transactions_generator.rs
@@ -1,24 +1,155 @@
 //! Set of methods that construct transactions of various kind.
 
-use std::sync::{Arc, RwLock};
-use primitives::types::AccountId;
 use crate::node::Node;
+use crate::sampler::{sample_one, sample_two};
+use primitives::crypto::signer::InMemorySigner;
+use primitives::transaction::{
+    DeployContractTransaction, FunctionCallTransaction, SignedTransaction, TransactionBody,
+};
+use primitives::types::AccountId;
 use std::collections::HashMap;
-use primitives::transaction::SignedTransaction;
-
-/// Tracks nonces for the accounts.
-type Nonces = RwLock<HashMap<AccountId, u64>>;
-/// Nodes that can be used to generate nonces
-type Nodes = Vec<Arc<RwLock<dyn Node>>>;
+use std::iter::repeat_with;
+use std::sync::{Arc, RwLock};
 
 /// Keeps the context that is needed to generate a random transaction.
-struct Generator {
-    pub nodes: Nodes,
-    pub nonces: Nonces,
+pub struct Generator {
+    /// Nodes that can be used to generate nonces
+    pub nodes: Vec<Arc<RwLock<dyn Node>>>,
+    /// Tracks nonces for the accounts.
+    nonces: RwLock<HashMap<AccountId, u64>>,
+}
+
+/// Type of transaction to generate.
+pub enum TransactionType {
+    Monetary,
+    SetGet,
+    HeavyStorage,
 }
 
 impl Generator {
+    pub fn new(nodes: Vec<Arc<RwLock<dyn Node>>>) -> Self {
+        Self { nodes, nonces: Default::default() }
+    }
+
+    /// Increments nonce and returns it.
+    fn nonce(&self, node: &Arc<RwLock<dyn Node>>) -> u64 {
+        *self
+            .nonces
+            .write()
+            .unwrap()
+            .entry(Self::account_id(node))
+            .and_modify(|e| *e += 1)
+            .or_insert(1)
+    }
+
+    /// Get account id of the given node.
+    fn account_id(node: &Arc<RwLock<dyn Node>>) -> AccountId {
+        node.read().unwrap().account_id().unwrap().clone()
+    }
+
+    /// Get in-memory-signer of the given node.
+    fn signer(node: &Arc<RwLock<dyn Node>>) -> Arc<InMemorySigner> {
+        node.read().unwrap().signer()
+    }
+
+    /// Create send money transaction.
     pub fn send_money(&mut self) -> SignedTransaction {
-        unimplemented!()
+        let (alice, bob) = sample_two(&self.nodes);
+        let nonce = self.nonce(alice);
+        TransactionBody::send_money(
+            nonce,
+            Self::account_id(alice).as_str(),
+            Self::account_id(bob).as_str(),
+            1,
+        )
+        .sign(&*Self::signer(alice))
+    }
+
+    /// Returns transactions that deploy test contract to an account of every node.
+    pub fn deploy_test_contract(&mut self) -> Vec<SignedTransaction> {
+        let wasm_binary: &[u8] = include_bytes!("../../../tests/hello.wasm");
+        let mut res = vec![];
+        for node in &self.nodes {
+            let t = DeployContractTransaction {
+                nonce: self.nonce(node),
+                contract_id: Self::account_id(node),
+                wasm_byte_array: wasm_binary.to_vec(),
+            };
+            res.push(TransactionBody::DeployContract(t).sign(&*Self::signer(node)));
+        }
+        res
+    }
+
+    /// Returns a transaction that calls `setKeyValue` on a random contract from a random account.
+    pub fn call_set(&mut self) -> SignedTransaction {
+        let node = sample_one(&self.nodes);
+        let key = rand::random::<usize>() % 1_000;
+        let value = rand::random::<usize>() % 1_000;
+        let t = FunctionCallTransaction {
+            nonce: self.nonce(node),
+            originator: Self::account_id(node),
+            contract_id: Self::account_id(node),
+            method_name: "setKeyValue".as_bytes().to_vec(),
+            args: format!("{{\"key\":\"{}\", \"value\":\"{}\"}}", key, value).as_bytes().to_vec(),
+            amount: 1,
+        };
+        TransactionBody::FunctionCall(t).sign(&*Self::signer(node))
+    }
+
+    /// Returns a transaction that calls `setKeyValue` on a random contract.
+    pub fn call_get(&mut self) -> SignedTransaction {
+        let node = sample_one(&self.nodes);
+        let key = rand::random::<usize>() % 1_000;
+        let t = FunctionCallTransaction {
+            nonce: self.nonce(node),
+            originator: Self::account_id(node),
+            contract_id: Self::account_id(node),
+            method_name: "getValueByKey".as_bytes().to_vec(),
+            args: format!("{{\"key\":\"{}\"}}", key).as_bytes().to_vec(),
+            amount: 1,
+        };
+        TransactionBody::FunctionCall(t).sign(&*Self::signer(node))
+    }
+
+    /// Returns a transaction that calls `heavy_storage_blocks` on a random contract.
+    pub fn call_benchmark_storage(&mut self) -> SignedTransaction {
+        let node = sample_one(&self.nodes);
+        let t = FunctionCallTransaction {
+            nonce: self.nonce(node),
+            originator: Self::account_id(node),
+            contract_id: Self::account_id(node),
+            method_name: "heavy_storage_blocks".as_bytes().to_vec(),
+            args: "{\"n\":1000}".as_bytes().to_vec(),
+            amount: 1,
+        };
+        TransactionBody::FunctionCall(t).sign(&*Self::signer(node))
+    }
+
+    /// Endlessly generates transactions of the given type.
+    pub fn iter(
+        mut self,
+        transaction_type: TransactionType,
+    ) -> impl Iterator<Item = SignedTransaction> {
+        // Create transactions that do initialization for other transactions to be successful.
+        let initialization_transactions = match &transaction_type {
+            TransactionType::SetGet | TransactionType::HeavyStorage => self.deploy_test_contract(),
+            _ => vec![],
+        };
+        // Create transactions that constitute the main load.
+        let transactions = repeat_with(move || {
+            match transaction_type {
+                TransactionType::HeavyStorage => self.call_benchmark_storage(),
+                TransactionType::Monetary => self.send_money(),
+                TransactionType::SetGet => {
+                    // Randomly execute set and get operators.
+                    if rand::random::<bool>() {
+                        self.call_set()
+                    } else {
+                        self.call_get()
+                    }
+                }
+            }
+        });
+        initialization_transactions.into_iter().chain(transactions)
     }
 }

--- a/test-utils/testlib/src/transactions_generator.rs
+++ b/test-utils/testlib/src/transactions_generator.rs
@@ -1,0 +1,24 @@
+//! Set of methods that construct transactions of various kind.
+
+use std::sync::{Arc, RwLock};
+use primitives::types::AccountId;
+use crate::node::Node;
+use std::collections::HashMap;
+use primitives::transaction::SignedTransaction;
+
+/// Tracks nonces for the accounts.
+type Nonces = RwLock<HashMap<AccountId, u64>>;
+/// Nodes that can be used to generate nonces
+type Nodes = Vec<Arc<RwLock<dyn Node>>>;
+
+/// Keeps the context that is needed to generate a random transaction.
+struct Generator {
+    pub nodes: Nodes,
+    pub nonces: Nonces,
+}
+
+impl Generator {
+    pub fn send_money(&mut self) -> SignedTransaction {
+        unimplemented!()
+    }
+}


### PR DESCRIPTION
Adds the following features:
* Transactions generator -- can generate one transaction or an endless stream of transactions. With correct nonce;
* Transactions executor -- executes one transaction or a stream of transactions against a set of nodes. Can limit transactions by number and time. Can imitate network lag to produce load spikes;
* Sampler -- a set of functions to sample nodes that optimizes not for the runtime, but the number of expensive invocations to nodes.