### PR TITLE
Limiting block size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,6 +301,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "shard 0.0.1",
  "storage 0.0.1",
+ "testlib 0.1.0",
 ]
 
 [[package]]
@@ -2155,6 +2156,7 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage 0.0.1",
+ "testlib 0.1.0",
 ]
 
 [[package]]

--- a/node/alphanet/src/lib.rs
+++ b/node/alphanet/src/lib.rs
@@ -147,9 +147,8 @@ mod tests {
     use primitives::chain::ChainPayload;
     use primitives::test_utils::TestSignedBlock;
     use primitives::transaction::TransactionBody;
-    use testlib::node::{
-        configure_chain_spec, Node, NodeConfig, TEST_BLOCK_FETCH_LIMIT,
-    };
+    use testlib::node::TEST_BLOCK_MAX_SIZE;
+    use testlib::node::{configure_chain_spec, Node, NodeConfig, TEST_BLOCK_FETCH_LIMIT};
     use testlib::test_helpers::wait;
 
     /// Creates two nodes, one boot node and secondary node booting from it.
@@ -168,6 +167,7 @@ mod tests {
             vec![],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
 
@@ -179,6 +179,7 @@ mod tests {
             vec![alice.boot_addr()],
             chain_spec,
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let mut alice = Node::new(alice);
@@ -232,6 +233,7 @@ mod tests {
             vec![],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let bob = NodeConfig::for_test(
@@ -242,6 +244,7 @@ mod tests {
             vec![alice.boot_addr()],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let charlie = NodeConfig::for_test_passive(
@@ -252,6 +255,7 @@ mod tests {
             vec![bob.boot_addr()],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
 
@@ -306,6 +310,7 @@ mod tests {
             vec![],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let bob = NodeConfig::for_test(
@@ -316,6 +321,7 @@ mod tests {
             vec![alice.boot_addr()],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let mut alice = Node::new(alice);
@@ -362,6 +368,7 @@ mod tests {
             vec![],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let bob = NodeConfig::for_test(
@@ -372,6 +379,7 @@ mod tests {
             vec![alice.boot_addr()],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let charlie = NodeConfig::for_test(
@@ -382,6 +390,7 @@ mod tests {
             vec![bob.boot_addr()],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let dan = NodeConfig::for_test(
@@ -392,6 +401,7 @@ mod tests {
             vec![charlie.boot_addr()],
             chain_spec,
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let mut alice = Node::new(alice);
@@ -424,6 +434,7 @@ mod tests {
             vec![],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let bob = NodeConfig::for_test(
@@ -434,6 +445,7 @@ mod tests {
             vec![alice.boot_addr()],
             chain_spec.clone(),
             TEST_BLOCK_FETCH_LIMIT,
+            TEST_BLOCK_MAX_SIZE,
             vec![],
         );
         let mut alice = Node::new(alice);

--- a/node/client/Cargo.toml
+++ b/node/client/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1.0"
 bencher = "0.1.5"
 rand = "0.6"
 rand_xorshift = "0.1"
+testlib = { path = "../../test-utils/testlib" }
 
 [[bench]]
 name = "client_bench"

--- a/node/client/src/test_utils.rs
+++ b/node/client/src/test_utils.rs
@@ -12,9 +12,14 @@ use storage::test_utils::create_beacon_shard_storages;
 use crate::Client;
 
 /// Creates a test client, that uses in memory storage.
-pub fn get_client_from_cfg(chain_spec: &ChainSpec, signer: Arc<InMemorySigner>) -> Client<InMemorySigner> {
+pub fn get_client_from_cfg(
+    chain_spec: &ChainSpec,
+    signer: Arc<InMemorySigner>,
+    max_block_size: u32,
+) -> Client<InMemorySigner> {
     let (beacon_storage, shard_storage) = create_beacon_shard_storages();
-    let shard_client = ShardClient::new(Some(signer.clone()), chain_spec, shard_storage);
+    let shard_client =
+        ShardClient::new(Some(signer.clone()), chain_spec, shard_storage, max_block_size);
     let genesis = SignedBeaconBlock::genesis(shard_client.genesis_hash());
     let beacon_client = BeaconClient::new(genesis, chain_spec, beacon_storage);
     Client {

--- a/node/configs/src/chain_spec.rs
+++ b/node/configs/src/chain_spec.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use serde_json;
 
-use primitives::crypto::signer::{BLSSigner, InMemorySigner, EDSigner};
+use primitives::crypto::signer::{BLSSigner, EDSigner, InMemorySigner};
 use primitives::types::{AccountId, Balance, ReadableBlsPublicKey, ReadablePublicKey};
 use std::cmp::max;
 use std::io::Write;
@@ -78,6 +78,7 @@ impl ChainSpec {
     /// Returns:
     /// * generated `ChainSpec`;
     /// * signers that can be used for assertions and mocking in tests.
+    #[allow(clippy::needless_range_loop)]
     pub fn testing_spec(
         id_type: DefaultIdType,
         num_accounts: usize,

--- a/node/configs/src/client.rs
+++ b/node/configs/src/client.rs
@@ -9,6 +9,7 @@ use primitives::types::AccountId;
 const DEFAULT_BASE_PATH: &str = ".";
 const DEFAULT_LOG_LEVEL: &str = "Info";
 const MAX_NUM_BLOCKS_REQUEST: u64 = 100;
+const MAX_BLOCK_SIZE: u32 = 1000;
 
 #[derive(Clone)]
 pub struct ClientConfig {
@@ -18,6 +19,8 @@ pub struct ClientConfig {
     pub chain_spec: ChainSpec,
     /// Maximum number of blocks to be fetched in one request.
     pub block_fetch_limit: u64,
+    /// Maximum block size
+    pub block_size_limit: u32,
     pub log_level: log::LevelFilter,
 }
 
@@ -29,6 +32,7 @@ impl ClientConfig {
             public_key: None,
             chain_spec: ChainSpec::default_devnet(),
             block_fetch_limit: MAX_NUM_BLOCKS_REQUEST,
+            block_size_limit: MAX_BLOCK_SIZE,
             log_level: log::LevelFilter::Info,
         }
     }
@@ -68,6 +72,12 @@ pub fn get_args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .help("Sets maximum number of blocks that should be fetched in one request.")
             .takes_value(true)
             .default_value("100"),
+        Arg::with_name("block_size_limit")
+            .long("block-size-limit")
+            .value_name("BLOCK_SIZE_LIMIT")
+            .help("Sets maximum block size")
+            .takes_value(true)
+            .default_value("1000"),
         Arg::with_name("log_level")
             .short("l")
             .long("log-level")
@@ -85,9 +95,19 @@ pub fn from_matches(matches: &ArgMatches, default_chain_spec: ChainSpec) -> Clie
     let public_key = matches.value_of("public_key").map(String::from);
     let block_fetch_limit =
         matches.value_of("block_fetch_limit").and_then(|s| s.parse::<u64>().ok()).unwrap();
+    let block_size_limit =
+        matches.value_of("block_size_limit").and_then(|s| s.parse::<u32>().ok()).unwrap();
     let log_level = matches.value_of("log_level").map(log::LevelFilter::from_str).unwrap().unwrap();
 
     let chain_spec_path = matches.value_of("chain_spec_file").map(PathBuf::from);
     let chain_spec = ChainSpec::from_file_or_default(&chain_spec_path, default_chain_spec);
-    ClientConfig { base_path, account_id, public_key, block_fetch_limit, chain_spec, log_level }
+    ClientConfig {
+        base_path,
+        account_id,
+        public_key,
+        block_fetch_limit,
+        block_size_limit,
+        chain_spec,
+        log_level,
+    }
 }

--- a/node/configs/src/client.rs
+++ b/node/configs/src/client.rs
@@ -9,7 +9,7 @@ use primitives::types::AccountId;
 const DEFAULT_BASE_PATH: &str = ".";
 const DEFAULT_LOG_LEVEL: &str = "Info";
 const MAX_NUM_BLOCKS_REQUEST: u64 = 100;
-const MAX_BLOCK_SIZE: u32 = 1000;
+const MAX_BLOCK_SIZE: u32 = 10000;
 
 #[derive(Clone)]
 pub struct ClientConfig {
@@ -77,7 +77,7 @@ pub fn get_args<'a, 'b>() -> Vec<Arg<'a, 'b>> {
             .value_name("BLOCK_SIZE_LIMIT")
             .help("Sets maximum block size")
             .takes_value(true)
-            .default_value("1000"),
+            .default_value("10000"),
         Arg::with_name("log_level")
             .short("l")
             .long("log-level")

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -729,9 +729,7 @@ impl Runtime {
                 for receipt in receipts {
                     result.receipts.push(receipt.nonce);
                     let shard_id = receipt.shard_id();
-                    new_receipts.entry(shard_id)
-                        .or_insert( vec![])
-                        .push(receipt);
+                    new_receipts.entry(shard_id).or_insert_with(|| vec![]).push(receipt);
                 }
                 state_update.commit();
                 result.status = TransactionStatus::Completed;

--- a/node/runtime/src/test_utils.rs
+++ b/node/runtime/src/test_utils.rs
@@ -74,7 +74,7 @@ pub fn encode_int(val: i32) -> [u8; 4] {
 }
 
 pub fn to_receipt_block(receipts: Vec<ReceiptTransaction>) -> ReceiptBlock {
-    let (receipt_merkle_root, path) = merklize(&vec![&receipts]);
+    let (receipt_merkle_root, path) = merklize(&[&receipts]);
     let header = SignedShardBlockHeader {
         body: ShardBlockHeader {
             parent_hash: CryptoHash::default(),

--- a/node/shard/Cargo.toml
+++ b/node/shard/Cargo.toml
@@ -19,3 +19,6 @@ node-runtime = { path = "../runtime" }
 configs = { path = "../configs" }
 mempool = { path = "../../core/mempool" }
 
+[dev-dependencies]
+testlib = { path = "../../test-utils/testlib"}
+

--- a/node/shard/src/lib.rs
+++ b/node/shard/src/lib.rs
@@ -87,7 +87,9 @@ impl ShardClient {
         let chain = Arc::new(chain::BlockChain::new(genesis, storage.clone()));
         let trie_viewer = TrieViewer {};
         let pool = match signer {
-            Some(signer) => Some(Arc::new(RwLock::new( Pool::new(signer, storage.clone(), trie.clone())))),
+            Some(signer) => {
+                Some(Arc::new(RwLock::new(Pool::new(signer, storage.clone(), trie.clone()))))
+            }
             None => None,
         };
         Self { chain, trie, storage, runtime, trie_viewer, pool }
@@ -268,7 +270,7 @@ impl ShardClient {
                 .unwrap()
                 .map(|b| b.receipts[address.index].clone())?;
             let result = self.get_transaction_result(&hash);
-            Some(ReceiptInfo { receipt: receipt, block_index, result })
+            Some(ReceiptInfo { receipt, block_index, result })
         })
     }
 
@@ -380,7 +382,8 @@ mod tests {
                 .unwrap();
             let mut nonce = self.get_account_nonce(sender.to_string()).unwrap_or_else(|| 0) + 1;
             for _ in 0..num_blocks {
-                let tx = TransactionBody::send_money(nonce, sender, receiver, 1).sign(&*sender_signer);
+                let tx =
+                    TransactionBody::send_money(nonce, sender, receiver, 1).sign(&*sender_signer);
                 let (block, block_extra) =
                     self.prepare_new_block(prev_hash, vec![], vec![tx.clone()]);
                 prev_hash = block.hash;

--- a/test-utils/testlib/src/node/mod.rs
+++ b/test-utils/testlib/src/node/mod.rs
@@ -31,6 +31,7 @@ pub use shard_client_node::ShardClientNode;
 
 const TMP_DIR: &str = "../../tmp/testnet";
 pub const TEST_BLOCK_FETCH_LIMIT: u64 = 5;
+pub const TEST_BLOCK_MAX_SIZE: u32 = 1000;
 
 pub fn configure_chain_spec() -> ChainSpec {
     ChainSpec::default_poa()
@@ -165,6 +166,7 @@ impl NodeConfig {
         boot_nodes: Vec<PeerAddr>,
         chain_spec: ChainSpec,
         block_fetch_limit: u64,
+        block_size_limit: u32,
         proxy_handlers: Vec<Arc<ProxyHandler>>,
     ) -> Self {
         let addr = format!("0.0.0.0:{}", test_port + peer_id);
@@ -177,6 +179,7 @@ impl NodeConfig {
             boot_nodes,
             chain_spec,
             block_fetch_limit,
+            block_size_limit,
             proxy_handlers,
         )
     }
@@ -191,6 +194,7 @@ impl NodeConfig {
         boot_nodes: Vec<PeerAddr>,
         chain_spec: ChainSpec,
         block_fetch_limit: u64,
+        block_size_limit: u32,
         proxy_handlers: Vec<Arc<ProxyHandler>>,
     ) -> Self {
         Self::new(
@@ -202,6 +206,7 @@ impl NodeConfig {
             boot_nodes,
             chain_spec,
             block_fetch_limit,
+            block_size_limit,
             proxy_handlers,
         )
     }
@@ -216,6 +221,7 @@ impl NodeConfig {
         boot_nodes: Vec<PeerAddr>,
         chain_spec: ChainSpec,
         block_fetch_limit: u64,
+        block_size_limit: u32,
         proxy_handlers: Vec<Arc<ProxyHandler>>,
     ) -> Self {
         let node_info = PeerInfo {
@@ -240,6 +246,7 @@ impl NodeConfig {
             account_id: account_id.map(String::from),
             public_key: None,
             block_fetch_limit,
+            block_size_limit,
             chain_spec,
             log_level: log::LevelFilter::Info,
         };
@@ -273,6 +280,7 @@ pub fn create_nodes(
     test_prefix: &str,
     test_port: u16,
     block_fetch_limit: u64,
+    block_size_limit: u32,
     proxy_handlers: Vec<Arc<ProxyHandler>>,
 ) -> (u64, Vec<String>, Vec<NodeConfig>) {
     let (chain_spec, _) = ChainSpec::testing_spec(
@@ -295,6 +303,7 @@ pub fn create_nodes(
             boot_nodes,
             chain_spec.clone(),
             block_fetch_limit,
+            block_size_limit,
             proxy_handlers.clone(),
         );
         boot_nodes = vec![node.boot_addr()];

--- a/test-utils/testlib/src/node/shard_client_node.rs
+++ b/test-utils/testlib/src/node/shard_client_node.rs
@@ -1,4 +1,4 @@
-use crate::node::{Node, ProcessNode, ThreadNode};
+use crate::node::{Node, ProcessNode, ThreadNode, TEST_BLOCK_MAX_SIZE};
 use crate::user::{ShardClientUser, User};
 use configs::ClientConfig;
 use primitives::crypto::signer::InMemorySigner;
@@ -19,7 +19,8 @@ impl ShardClientNode {
         let (_, shard_storage) = create_beacon_shard_storages();
 
         let chain_spec = &config.chain_spec;
-        let shard_client = ShardClient::new(Some(signer.clone()), chain_spec, shard_storage);
+        let shard_client =
+            ShardClient::new(Some(signer.clone()), chain_spec, shard_storage, TEST_BLOCK_MAX_SIZE);
         ShardClientNode { client: Arc::new(shard_client), signer }
     }
 }

--- a/tests/test_alphanet.rs
+++ b/tests/test_alphanet.rs
@@ -5,15 +5,23 @@ use std::time::Duration;
 use network::proxy::benchmark::BenchmarkHandler;
 use network::proxy::ProxyHandler;
 use primitives::transaction::TransactionBody;
-use testlib::node::{create_nodes, sample_two_nodes, Node, TEST_BLOCK_FETCH_LIMIT};
-use testlib::test_helpers::{wait, heavy_test};
+use testlib::node::{
+    create_nodes, sample_two_nodes, Node, TEST_BLOCK_FETCH_LIMIT, TEST_BLOCK_MAX_SIZE,
+};
+use testlib::test_helpers::{heavy_test, wait};
 
 fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port: u16) {
     // Add proxy handlers to the pipeline.
     let proxy_handlers: Vec<Arc<ProxyHandler>> = vec![Arc::new(BenchmarkHandler::new())];
 
-    let (init_balance, account_names, mut nodes) =
-        create_nodes(num_nodes, test_prefix, test_port, TEST_BLOCK_FETCH_LIMIT, proxy_handlers);
+    let (init_balance, account_names, mut nodes) = create_nodes(
+        num_nodes,
+        test_prefix,
+        test_port,
+        TEST_BLOCK_FETCH_LIMIT,
+        TEST_BLOCK_MAX_SIZE,
+        proxy_handlers,
+    );
 
     let nodes: Vec<_> = nodes.drain(..).map(|cfg| Node::new_sharable(cfg)).collect();
     for i in 0..num_nodes {

--- a/tests/test_alphanet_command_line.rs
+++ b/tests/test_alphanet_command_line.rs
@@ -8,7 +8,8 @@ use primitives::transaction::TransactionBody;
 use primitives::types::AccountId;
 use std::sync::{Arc, RwLock};
 use testlib::node::{
-    create_nodes, sample_queryable_node, sample_two_nodes, Node, NodeConfig, TEST_BLOCK_FETCH_LIMIT,
+    create_nodes, sample_queryable_node, sample_two_nodes, Node, NodeConfig,
+    TEST_BLOCK_FETCH_LIMIT, TEST_BLOCK_MAX_SIZE,
 };
 use testlib::test_helpers::{heavy_test, wait, wait_for_catchup};
 
@@ -49,8 +50,14 @@ fn test_kill_1(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port
     // Start all nodes, crash node#2, proceed, restart node #2 but crash node #3
     let crash1 = 2;
     let crash2 = 3;
-    let (init_balance, account_names, nodes) =
-        create_nodes(num_nodes, test_prefix, test_port, TEST_BLOCK_FETCH_LIMIT, proxy_handlers);
+    let (init_balance, account_names, nodes) = create_nodes(
+        num_nodes,
+        test_prefix,
+        test_port,
+        TEST_BLOCK_FETCH_LIMIT,
+        TEST_BLOCK_MAX_SIZE,
+        proxy_handlers,
+    );
     // Convert some of the thread nodes into processes.
     let nodes: Vec<_> = nodes
         .into_iter()
@@ -116,8 +123,14 @@ fn test_kill_2(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port
     warmup();
     // Start all nodes, crash nodes 2 and 3, restart node 2, proceed, restart node 3
     let (crash1, crash2) = (2, 3);
-    let (init_balance, account_names, nodes) =
-        create_nodes(num_nodes, test_prefix, test_port, TEST_BLOCK_FETCH_LIMIT, vec![]);
+    let (init_balance, account_names, nodes) = create_nodes(
+        num_nodes,
+        test_prefix,
+        test_port,
+        TEST_BLOCK_FETCH_LIMIT,
+        TEST_BLOCK_MAX_SIZE,
+        vec![],
+    );
 
     // Convert some of the thread nodes into processes.
     let nodes: Vec<_> = nodes
@@ -134,7 +147,8 @@ fn test_kill_2(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port
             }
         })
         .collect();
-    let nodes: Vec<Arc<RwLock<Node>>> = nodes.into_iter().map(|cfg| Node::new_sharable(cfg)).collect();
+    let nodes: Vec<Arc<RwLock<Node>>> =
+        nodes.into_iter().map(|cfg| Node::new_sharable(cfg)).collect();
 
     for i in 0..num_nodes {
         nodes[i].write().unwrap().start();

--- a/tests/test_alphanet_tps_regression.rs
+++ b/tests/test_alphanet_tps_regression.rs
@@ -90,7 +90,7 @@ fn run_multiple_nodes(
         test_prefix,
         test_port,
         TEST_BLOCK_FETCH_LIMIT,
-        TEST_BLOCK_MAX_SIZE,
+        TEST_BLOCK_MAX_SIZE * 10,
         proxy_handlers,
     );
     for n in &mut nodes {

--- a/tests/test_alphanet_tps_regression.rs
+++ b/tests/test_alphanet_tps_regression.rs
@@ -12,7 +12,10 @@ use primitives::transaction::TransactionBody;
 use std::io::stdout;
 use std::io::Write;
 use std::sync::{Arc, RwLock};
-use testlib::node::{create_nodes, sample_queryable_node, sample_two_nodes, Node, TEST_BLOCK_FETCH_LIMIT, NodeConfig};
+use testlib::node::{
+    create_nodes, sample_queryable_node, sample_two_nodes, Node, NodeConfig,
+    TEST_BLOCK_FETCH_LIMIT, TEST_BLOCK_MAX_SIZE,
+};
 use testlib::test_helpers::heavy_test;
 
 /// Creates and sends a random transaction.
@@ -82,15 +85,22 @@ fn run_multiple_nodes(
     // Add proxy handlers to the pipeline.
     let proxy_handlers: Vec<Arc<ProxyHandler>> = vec![Arc::new(BenchmarkHandler::new())];
 
-    let (_, _, mut nodes) =
-        create_nodes(num_nodes, test_prefix, test_port, TEST_BLOCK_FETCH_LIMIT, proxy_handlers);
+    let (_, _, mut nodes) = create_nodes(
+        num_nodes,
+        test_prefix,
+        test_port,
+        TEST_BLOCK_FETCH_LIMIT,
+        TEST_BLOCK_MAX_SIZE,
+        proxy_handlers,
+    );
     for n in &mut nodes {
         if let NodeConfig::Thread(cfg) = n {
             cfg.client_cfg.log_level = log::LevelFilter::Off;
         }
     }
 
-    let nodes: Vec<Arc<RwLock<dyn Node>>> = nodes.drain(..).map(|cfg| Node::new_sharable(cfg)).collect();
+    let nodes: Vec<Arc<RwLock<dyn Node>>> =
+        nodes.drain(..).map(|cfg| Node::new_sharable(cfg)).collect();
     for i in 0..num_nodes {
         nodes[i].write().unwrap().start();
     }

--- a/tests/tests_custom_handler.rs
+++ b/tests/tests_custom_handler.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use network::proxy::predicate::FnProxyHandler;
 use network::proxy::ProxyHandler;
 use primitives::transaction::TransactionBody;
-use testlib::node::{create_nodes, sample_two_nodes, Node, TEST_BLOCK_FETCH_LIMIT};
+use testlib::node::{
+    create_nodes, sample_two_nodes, Node, TEST_BLOCK_FETCH_LIMIT, TEST_BLOCK_MAX_SIZE,
+};
 use testlib::test_helpers::wait;
 
 fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, test_port: u16) {
@@ -23,8 +25,14 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, te
 
     let proxy_handlers: Vec<Arc<ProxyHandler>> = vec![fn_proxy_handler];
 
-    let (init_balance, account_names, mut nodes) =
-        create_nodes(num_nodes, test_prefix, test_port, TEST_BLOCK_FETCH_LIMIT, proxy_handlers);
+    let (init_balance, account_names, mut nodes) = create_nodes(
+        num_nodes,
+        test_prefix,
+        test_port,
+        TEST_BLOCK_FETCH_LIMIT,
+        TEST_BLOCK_MAX_SIZE,
+        proxy_handlers,
+    );
 
     let nodes: Vec<_> = nodes.drain(..).map(|cfg| Node::new_sharable(cfg)).collect();
     for i in 0..num_nodes {
@@ -41,7 +49,8 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, te
     for _ in 0..num_trials {
         let (i, j) = sample_two_nodes(num_nodes);
         let (k, r) = sample_two_nodes(num_nodes);
-        let nonce = nodes[i].read().unwrap().get_account_nonce(&account_names[i]).unwrap_or_default() + 1;
+        let nonce =
+            nodes[i].read().unwrap().get_account_nonce(&account_names[i]).unwrap_or_default() + 1;
         let transaction = TransactionBody::send_money(
             nonce,
             account_names[i].as_str(),
@@ -54,7 +63,10 @@ fn run_multiple_nodes(num_nodes: usize, num_trials: usize, test_prefix: &str, te
         expected_balances[j] += 1;
 
         wait(
-            || expected_balances[j] == nodes[r].read().unwrap().view_balance(&account_names[j]).unwrap(),
+            || {
+                expected_balances[j]
+                    == nodes[r].read().unwrap().view_balance(&account_names[j]).unwrap()
+            },
             1000,
             trial_duration,
         );


### PR DESCRIPTION
Limiting block size by limiting the size of transactions only. It is hard to limit the size of receipts because they come in blocks and if we try to limit the size of receipt blocks when producing them, we cannot send all receipts in one shard block, which is also suboptimal. So we decide to limit only transaction size for now.