### PR TITLE
Store the hash of contract code

### DIFF
--- a/core/wasm/runtest/src/lib.rs
+++ b/core/wasm/runtest/src/lib.rs
@@ -105,7 +105,7 @@ mod tests {
     use primitives::hash::hash;
     use std::fs;
     use wasm::executor::{self, ExecutionOutcome};
-    use wasm::types::{Config, Error, ReturnData, RuntimeContext};
+    use wasm::types::{Config, ContractCode, Error, ReturnData, RuntimeContext};
 
     use super::*;
     use std::path::PathBuf;
@@ -118,12 +118,13 @@ mod tests {
         filename: &str,
     ) -> Result<ExecutionOutcome, Error> {
         let wasm_binary = fs::read(filename).expect("Unable to read file");
+        let code = ContractCode::new(wasm_binary);
 
         let mut ext = MyExt::default();
         let config = Config::default();
 
         executor::execute(
-            &wasm_binary,
+            &code,
             &method_name,
             &input_data,
             &result_data,

--- a/core/wasm/src/cache.rs
+++ b/core/wasm/src/cache.rs
@@ -2,7 +2,7 @@ use cached::SizedCache;
 use wasmer_runtime;
 
 use crate::prepare;
-use crate::types::{Config, Error};
+use crate::types::{Config, ContractCode, Error};
 use primitives::hash::hash;
 use primitives::serialize::Encode;
 
@@ -14,12 +14,12 @@ cached_key! {
     MODULES: SizedCache<String, Result<wasmer_runtime::Module, Error>> = SizedCache::with_size(CACHE_SIZE);
     Key = {
         format!("{}:{}",
-            hash(code),
+            code.get_hash(),
             hash(&config.encode().expect("encoding of config shouldn't fail")),
         )
     };
 
-    fn compile_cached_module(code: &[u8], config: &Config) -> Result<wasmer_runtime::Module, Error> = {
+    fn compile_cached_module(code: &ContractCode, config: &Config) -> Result<wasmer_runtime::Module, Error> = {
         let prepared_code = prepare::prepare_contract(code, config).map_err(Error::Prepare)?;
 
         wasmer_runtime::compile(&prepared_code)

--- a/core/wasm/src/executor.rs
+++ b/core/wasm/src/executor.rs
@@ -4,7 +4,7 @@ use std::ffi::c_void;
 use std::fmt;
 
 use crate::runtime::{self, Runtime};
-use crate::types::{RuntimeContext, Config, ReturnData, Error};
+use crate::types::{RuntimeContext, Config, ReturnData, Error, ContractCode};
 use primitives::types::{Balance, Mana, Gas};
 use primitives::logging;
 use crate::cache;
@@ -40,14 +40,14 @@ impl fmt::Debug for ExecutionOutcome {
     }
 }
 
-pub fn execute<'a>(
-    code: &'a [u8],
-    method_name: &'a [u8],
-    input_data: &'a [u8],
-    result_data: &'a [Option<Vec<u8>>],
-    ext: &'a mut External,
-    config: &'a Config,
-    context: &'a RuntimeContext,
+pub fn execute(
+    code: &ContractCode,
+    method_name: &[u8],
+    input_data: &[u8],
+    result_data: &[Option<Vec<u8>>],
+    ext: &mut External,
+    config: &Config,
+    context: &RuntimeContext,
 ) -> Result<ExecutionOutcome, Error> {
     if method_name.is_empty() {
         return Err(Error::EmptyMethodName);

--- a/core/wasm/src/types.rs
+++ b/core/wasm/src/types.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use primitives::hash::{CryptoHash, hash};
 use primitives::types::{PromiseId, AccountId, Balance, Mana, BlockIndex};
 use primitives::logging;
 use wasmer_runtime::error as WasmerError;
@@ -303,5 +304,26 @@ impl RuntimeContext {
             block_index,
             random_seed,
         }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct ContractCode {
+    code: Vec<u8>,
+    hash: CryptoHash,
+}
+
+impl ContractCode {
+    pub fn new(code: Vec<u8>) -> ContractCode {
+        let hash = hash(&code);
+        ContractCode { code, hash }
+    }
+
+    pub fn get_hash(&self) -> CryptoHash {
+        self.hash
+    }
+
+    pub fn get_code(&self) -> &Vec<u8> {
+        &self.code
     }
 }

--- a/node/runtime/benches/bench.rs
+++ b/node/runtime/benches/bench.rs
@@ -4,6 +4,7 @@ extern crate bencher;
 use bencher::Bencher;
 
 use node_runtime::test_utils::{get_runtime_and_trie, User, setup_test_contract};
+use wasm::types::ContractCode;
 
 fn runtime_send_money(bench: &mut Bencher) {
     let (runtime, trie, root) = get_runtime_and_trie();
@@ -16,7 +17,8 @@ fn runtime_send_money(bench: &mut Bencher) {
 
 fn runtime_wasm_bad_code(bench: &mut Bencher) {
     let code = include_bytes!("../../../tests/hello.wasm");
-    let code = wasm::prepare::prepare_contract(code, &wasm::types::Config::default()).unwrap();
+    let code = ContractCode::new(code.to_vec());
+    let code = wasm::prepare::prepare_contract(&code, &wasm::types::Config::default()).unwrap();
     let (mut user, mut root) = setup_test_contract(&code);
     bench.iter(|| {
         let (new_root, _) = user.call_function(

--- a/node/runtime/src/state_viewer.rs
+++ b/node/runtime/src/state_viewer.rs
@@ -9,7 +9,7 @@ use primitives::types::{AccountId, AccountingInfo, Balance, Nonce};
 use primitives::utils::{is_valid_account_id, key_for_account, key_for_code};
 use storage::{get, TrieUpdate};
 use wasm::executor;
-use wasm::types::{ReturnData, RuntimeContext};
+use wasm::types::{ContractCode, ReturnData, RuntimeContext};
 
 use super::ext::ACCOUNT_DATA_SEPARATOR;
 use super::RuntimeExt;
@@ -96,7 +96,7 @@ impl TrieViewer {
             return Err(format!("Contract ID '{}' is not valid", contract_id));
         }
         let root = state_update.get_root();
-        let code: Vec<u8> =
+        let code: ContractCode =
             get(&mut state_update, &key_for_code(contract_id)).ok_or_else(|| {
                 format!("account {} does not have contract code", contract_id.clone())
             })?;

--- a/node/runtime/src/system.rs
+++ b/node/runtime/src/system.rs
@@ -15,6 +15,7 @@ use std::convert::TryFrom;
 use storage::{set, TrieUpdate};
 
 use crate::TxTotalStake;
+use wasm::types::ContractCode;
 
 /// const does not allow function call, so have to resort to this
 pub fn system_account() -> AccountId {
@@ -154,8 +155,9 @@ pub fn deploy(
     code: &[u8],
     sender: &mut Account,
 ) -> Result<Vec<ReceiptTransaction>, String> {
+    let code = ContractCode::new(code.to_vec());
     // Signature should be already checked at this point
-    sender.code_hash = hash(code);
+    sender.code_hash = code.get_hash();
     set(state_update, &key_for_code(&sender_id), &code);
     set(state_update, &key_for_account(&sender_id), &sender);
     Ok(vec![])


### PR DESCRIPTION
#886 
before:
```
test runtime_send_money                     ... bench:     170,030 ns/iter (+/- 12,920)
test runtime_wasm_bad_code                  ... bench:   1,040,480 ns/iter (+/- 147,577)
test runtime_wasm_benchmark_10_reads_legacy ... bench:     883,079 ns/iter (+/- 115,454)
test runtime_wasm_benchmark_storage_100     ... bench:   1,778,676 ns/iter (+/- 235,356)
test runtime_wasm_benchmark_storage_1000    ... bench:  12,418,531 ns/iter (+/- 1,074,537)
test runtime_wasm_benchmark_sum_1000        ... bench:     762,753 ns/iter (+/- 341,578)
test runtime_wasm_benchmark_sum_1000000     ... bench:  13,355,861 ns/iter (+/- 861,692)
test runtime_wasm_set_value                 ... bench:     750,164 ns/iter (+/- 100,792)
```
after:
```
test runtime_send_money                     ... bench:     164,393 ns/iter (+/- 9,350)
test runtime_wasm_bad_code                  ... bench:     462,570 ns/iter (+/- 94,355)
test runtime_wasm_benchmark_10_reads_legacy ... bench:     635,209 ns/iter (+/- 54,746)
test runtime_wasm_benchmark_storage_100     ... bench:   1,489,376 ns/iter (+/- 151,567)
test runtime_wasm_benchmark_storage_1000    ... bench:  11,913,450 ns/iter (+/- 1,179,097)
test runtime_wasm_benchmark_sum_1000        ... bench:     512,183 ns/iter (+/- 91,926)
test runtime_wasm_benchmark_sum_1000000     ... bench:  12,842,724 ns/iter (+/- 1,465,584)
test runtime_wasm_set_value                 ... bench:     503,174 ns/iter (+/- 44,961)
```