### PR TITLE
Create Transaction Verifier and switch runtime/api to use it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1613,6 +1613,7 @@ dependencies = [
  "serde_derive 1.0.90 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "shard 0.0.1",
+ "verifier 0.1.0",
 ]
 
 [[package]]
@@ -1632,6 +1633,7 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "storage 0.0.1",
  "testlib 0.1.0",
+ "verifier 0.1.0",
  "wasm 0.0.2",
 ]
 
@@ -3067,6 +3069,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "verifier"
+version = "0.1.0"
+dependencies = [
+ "primitives 0.1.0",
+ "storage 0.0.1",
+]
 
 [[package]]
 name = "version_check"

--- a/chain/http/Cargo.toml
+++ b/chain/http/Cargo.toml
@@ -19,5 +19,6 @@ chain = { path = "../../chain/chain" }
 client = { path = "../../chain/client" }
 node-runtime = { path = "../../runtime/runtime" }
 primitives = { path = "../../runtime/primitives" }
+verifier = { path = "../../runtime/verifier" }
 near-protos = { path = "../../runtime/protos", features = ["with-serde"] }
 shard = { path = "../../chain/shard" }

--- a/nearmint/src/main.rs
+++ b/nearmint/src/main.rs
@@ -16,11 +16,11 @@ use node_runtime::adapter::{query_client, RuntimeAdapter};
 use node_runtime::chain_spec::ChainSpec;
 use node_runtime::state_viewer::{AccountViewCallResult, TrieViewer};
 use node_runtime::{ApplyState, Runtime};
+use primitives::crypto::signature::PublicKey;
+use primitives::crypto::signer::InMemorySigner;
 use primitives::traits::ToBytes;
 use primitives::transaction::{SignedTransaction, TransactionStatus};
 use primitives::types::{AccountId, AuthorityStake, MerkleHash};
-use primitives::crypto::signature::PublicKey;
-use primitives::crypto::signer::InMemorySigner;
 use protobuf::parse_from_bytes;
 use storage::{create_storage, GenericStorage, ShardChainStorage, Trie, TrieUpdate};
 
@@ -123,8 +123,8 @@ fn convert_tx(data: &[u8]) -> Result<SignedTransaction, String> {
 
 impl RuntimeAdapter for NearMint {
     fn view_account(&self, account_id: &AccountId) -> Result<AccountViewCallResult, String> {
-        let mut state_update = TrieUpdate::new(self.trie.clone(), self.root);
-        self.trie_viewer.view_account(&mut state_update, account_id)
+        let state_update = TrieUpdate::new(self.trie.clone(), self.root);
+        self.trie_viewer.view_account(&state_update, account_id)
     }
 
     fn call_function(

--- a/runtime/primitives/src/account.rs
+++ b/runtime/primitives/src/account.rs
@@ -19,8 +19,8 @@ impl Account {
     }
 }
 
-/// Limited Access key for some account. It implies to properties: account_id of the owner and
-/// public_key for this access key.
+/// Limited Access key to use owner's account with the given public_key.
+/// Access Key is stored using `account_id` of the owner and the `public_key` for this access key.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct AccessKey {
     /// Balance amount on this Access Key. Can be used to pay for the transactions.

--- a/runtime/primitives/src/account.rs
+++ b/runtime/primitives/src/account.rs
@@ -19,8 +19,8 @@ impl Account {
     }
 }
 
-/// Limited Access key to use owner's account with the given public_key.
-/// Access Key is stored using `account_id` of the owner and the `public_key` for this access key.
+/// Limited Access key to use owner's account with the fixed public_key.
+/// Access Key is stored under the key of owner's `account_id` and the `public_key`.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct AccessKey {
     /// Balance amount on this Access Key. Can be used to pay for the transactions.

--- a/runtime/primitives/src/account.rs
+++ b/runtime/primitives/src/account.rs
@@ -1,6 +1,6 @@
 use crate::crypto::signature::PublicKey;
 use crate::hash::CryptoHash;
-use crate::types::{Balance, Nonce};
+use crate::types::{AccountId, Balance, Nonce};
 
 /// Per account information stored in the state.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
@@ -17,4 +17,19 @@ impl Account {
     pub fn new(public_keys: Vec<PublicKey>, amount: Balance, code_hash: CryptoHash) -> Self {
         Account { public_keys, nonce: 0, amount, staked: 0, code_hash }
     }
+}
+
+/// Limited Access key for some account. It implies to properties: account_id of the owner and
+/// public_key for this access key.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
+pub struct AccessKey {
+    /// Balance amount on this Access Key. Can be used to pay for the transactions.
+    pub amount: Balance,
+    /// Owner of the balance of this Access Key. None means the account owner.
+    pub balance_owner: Option<AccountId>,
+    /// Contract ID that can be called with this Access Key. None means the account owner.
+    /// Access key only allows to call given contract_id.
+    pub contract_id: Option<AccountId>,
+    /// The only method name that can be called with this Access Key. None means any method name.
+    pub method_name: Option<Vec<u8>>,
 }

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -17,6 +17,7 @@ rand_xorshift = "0.1"
 
 primitives = { path = "../../runtime/primitives" }
 storage = { path = "../../runtime/storage" }
+verifier = { path = "../../runtime/verifier" }
 wasm = { path = "../../runtime/wasm" }
 
 [features]

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -169,14 +169,9 @@ impl Runtime {
             let verifier = TransactionVerifier::new(state_update);
             verifier.verify_transaction(transaction)?
         };
-        // Update nonce regardless of whether the transaction succeeds. This is done
-        // before verifying signatures because signatures are verified already in mempool.
-        // However, it is possible, although rare, that the key is swapped out before this
-        // transaction is applied. We do not treat this case specially now.
         originator.nonce = transaction.body.get_nonce();
         set(state_update, &key_for_account(&originator_id), &originator);
         state_update.commit();
-        // Checked in the transaction verifier
         let contract_id = transaction.body.get_contract_id();
         let mana = transaction.body.get_mana();
         let accounting_info = self

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -18,17 +18,17 @@ use primitives::chain::ReceiptBlock;
 use primitives::crypto::signature::PublicKey;
 use primitives::hash::CryptoHash;
 use primitives::transaction::{
-    verify_transaction_signature, AsyncCall, Callback, CallbackInfo, CallbackResult,
-    FunctionCallTransaction, LogEntry, ReceiptBody, ReceiptTransaction, SignedTransaction,
-    TransactionBody, TransactionResult, TransactionStatus,
+    AsyncCall, Callback, CallbackInfo, CallbackResult, FunctionCallTransaction, LogEntry,
+    ReceiptBody, ReceiptTransaction, SignedTransaction, TransactionBody, TransactionResult,
+    TransactionStatus,
 };
 use primitives::types::{
     AccountId, AccountingInfo, AuthorityStake, Balance, BlockIndex, Mana, ManaAccounting,
     MerkleHash, PromiseId, ReadableBlsPublicKey, ReadablePublicKey, ShardId,
 };
 use primitives::utils::{
-    account_to_shard_id, create_nonce_with_nonce, is_valid_account_id, key_for_account,
-    key_for_callback, key_for_code, key_for_tx_stake,
+    account_to_shard_id, create_nonce_with_nonce, key_for_account, key_for_callback, key_for_code,
+    key_for_tx_stake,
 };
 use wasm::executor;
 use wasm::types::{ContractCode, ReturnData, RuntimeContext};
@@ -37,6 +37,7 @@ use crate::ext::RuntimeExt;
 use crate::system::{system_account, system_create_account, SYSTEM_METHOD_CREATE_ACCOUNT};
 use crate::tx_stakes::{TxStakeConfig, TxTotalStake};
 use storage::{get, set, TrieUpdate};
+use verifier::{TransactionVerifier, VerificationData};
 
 pub mod adapter;
 pub mod chain_spec;
@@ -164,100 +165,63 @@ impl Runtime {
         transaction: &SignedTransaction,
         authority_proposals: &mut Vec<AuthorityStake>,
     ) -> Result<Vec<ReceiptTransaction>, String> {
-        let sender_account_id = transaction.body.get_originator();
-        let sender: Option<Account> = get(state_update, &key_for_account(&sender_account_id));
-        match sender {
-            Some(mut sender) => {
-                if transaction.body.get_nonce() <= sender.nonce {
-                    // in this case, no need to update sender's nonce
-                    return Err(format!(
-                        "Transaction nonce {} must be larger than sender nonce {}",
-                        transaction.body.get_nonce(),
-                        sender.nonce,
-                    ));
-                }
-                // Update nonce regardless of whether the transaction succeeds. This is done
-                // before verifying signatures because signatures are verified already in mempool.
-                // However, it is possible, although rare, that the key is swapped out before this
-                // transaction is applied. We do not treat this case specially now.
-                sender.nonce = transaction.body.get_nonce();
-                set(state_update, &key_for_account(&sender_account_id), &sender);
-                state_update.commit();
-
-                if !verify_transaction_signature(&transaction, &sender.public_keys) {
-                    return Err(format!(
-                        "transaction not signed with a public key of originator {:?}",
-                        transaction.body.get_originator()
-                    ));
-                }
-
-                let contract_id = transaction.body.get_contract_id();
-                if let Some(ref contract_id) = contract_id {
-                    if !is_valid_account_id(&contract_id) {
-                        return Err(format!(
-                            "Invalid contract_id / receiver {} according to requirements",
-                            contract_id
-                        ));
-                    }
-                }
-                let mana = transaction.body.get_mana();
-                let accounting_info = self
-                    .try_charge_mana(
-                        state_update,
-                        block_index,
-                        &sender_account_id,
-                        &contract_id,
-                        mana,
-                    )
-                    .ok_or_else(|| {
-                        format!("sender {} does not have enough mana {}", sender_account_id, mana)
-                    })?;
-                match transaction.body {
-                    TransactionBody::SendMoney(ref t) => system::send_money(
-                        state_update,
-                        &t,
-                        transaction.get_hash(),
-                        &mut sender,
-                        accounting_info,
-                    ),
-                    TransactionBody::Stake(ref t) => system::staking(
-                        state_update,
-                        &t,
-                        &sender_account_id,
-                        &mut sender,
-                        authority_proposals,
-                    ),
-                    TransactionBody::FunctionCall(ref t) => self.call_function(
-                        state_update,
-                        &t,
-                        transaction.get_hash(),
-                        &mut sender,
-                        accounting_info,
-                        mana,
-                    ),
-                    TransactionBody::DeployContract(ref t) => system::deploy(
-                        state_update,
-                        &t.contract_id,
-                        &t.wasm_byte_array,
-                        &mut sender,
-                    ),
-                    TransactionBody::CreateAccount(ref t) => system::create_account(
-                        state_update,
-                        t,
-                        transaction.get_hash(),
-                        &mut sender,
-                        accounting_info,
-                    ),
-                    TransactionBody::SwapKey(ref t) => {
-                        system::swap_key(state_update, t, &mut sender)
-                    }
-                    TransactionBody::AddKey(ref t) => system::add_key(state_update, t, &mut sender),
-                    TransactionBody::DeleteKey(ref t) => {
-                        system::delete_key(state_update, t, &mut sender)
-                    }
-                }
+        let VerificationData { originator_id, mut originator, .. } = {
+            let verifier = TransactionVerifier::new(state_update);
+            verifier.verify_transaction(transaction)?
+        };
+        // Update nonce regardless of whether the transaction succeeds. This is done
+        // before verifying signatures because signatures are verified already in mempool.
+        // However, it is possible, although rare, that the key is swapped out before this
+        // transaction is applied. We do not treat this case specially now.
+        originator.nonce = transaction.body.get_nonce();
+        set(state_update, &key_for_account(&originator_id), &originator);
+        state_update.commit();
+        // Checked in the transaction verifier
+        let contract_id = transaction.body.get_contract_id();
+        let mana = transaction.body.get_mana();
+        let accounting_info = self
+            .try_charge_mana(state_update, block_index, &originator_id, &contract_id, mana)
+            .ok_or_else(|| {
+                format!("sender {} does not have enough mana {}", originator_id, mana)
+            })?;
+        match transaction.body {
+            TransactionBody::SendMoney(ref t) => system::send_money(
+                state_update,
+                &t,
+                transaction.get_hash(),
+                &mut originator,
+                accounting_info,
+            ),
+            TransactionBody::Stake(ref t) => system::staking(
+                state_update,
+                &t,
+                &originator_id,
+                &mut originator,
+                authority_proposals,
+            ),
+            TransactionBody::FunctionCall(ref t) => self.call_function(
+                state_update,
+                &t,
+                transaction.get_hash(),
+                &mut originator,
+                accounting_info,
+                mana,
+            ),
+            TransactionBody::DeployContract(ref t) => {
+                system::deploy(state_update, &t.contract_id, &t.wasm_byte_array, &mut originator)
             }
-            _ => Err(format!("sender {} does not exist", sender_account_id)),
+            TransactionBody::CreateAccount(ref t) => system::create_account(
+                state_update,
+                t,
+                transaction.get_hash(),
+                &mut originator,
+                accounting_info,
+            ),
+            TransactionBody::SwapKey(ref t) => system::swap_key(state_update, t, &mut originator),
+            TransactionBody::AddKey(ref t) => system::add_key(state_update, t, &mut originator),
+            TransactionBody::DeleteKey(ref t) => {
+                system::delete_key(state_update, t, &mut originator)
+            }
         }
     }
 
@@ -820,7 +784,7 @@ impl Runtime {
         for (account_id, _, _, amount) in initial_authorities {
             let account_id_bytes = key_for_account(account_id);
             let mut account: Account =
-                get(&mut state_update, &account_id_bytes).expect("account must exist");
+                get(&state_update, &account_id_bytes).expect("account must exist");
             account.staked = *amount;
             set(&mut state_update, &account_id_bytes, &account);
         }
@@ -846,7 +810,7 @@ mod tests {
         let test_account = Account::new(vec![], 10, hash(&[]));
         let account_id = bob_account();
         set(&mut state_update, &key_for_account(&account_id), &test_account);
-        let get_res = get(&mut state_update, &key_for_account(&account_id)).unwrap();
+        let get_res = get(&state_update, &key_for_account(&account_id)).unwrap();
         assert_eq!(test_account, get_res);
     }
 
@@ -860,8 +824,8 @@ mod tests {
         set(&mut state_update, &key_for_account(&account_id), &test_account);
         let (new_root, transaction) = state_update.finalize();
         trie.apply_changes(transaction).unwrap();
-        let mut new_state_update = TrieUpdate::new(trie.clone(), new_root);
-        let get_res = get(&mut new_state_update, &key_for_account(&account_id)).unwrap();
+        let new_state_update = TrieUpdate::new(trie.clone(), new_root);
+        let get_res = get(&new_state_update, &key_for_account(&account_id)).unwrap();
         assert_eq!(test_account, get_res);
     }
 }

--- a/runtime/storage/src/lib.rs
+++ b/runtime/storage/src/lib.rs
@@ -14,19 +14,19 @@ use kvdb_rocksdb::{Database, DatabaseConfig};
 
 use serde::{de::DeserializeOwned, Serialize};
 
-pub use crate::storages::{BlockChainStorage, GenericStorage};
 pub use crate::storages::beacon::BeaconChainStorage;
-use crate::storages::NUM_COLS;
 pub use crate::storages::shard::ShardChainStorage;
-pub use crate::trie::{DBChanges, Trie};
+use crate::storages::NUM_COLS;
+pub use crate::storages::{BlockChainStorage, GenericStorage};
 pub use crate::trie::update::{TrieUpdate, TrieUpdateIterator};
+pub use crate::trie::{DBChanges, Trie};
 use primitives::serialize::{Decode, Encode};
 
 pub mod storages;
 pub mod test_utils;
 pub mod trie;
 
-pub fn get<T: DeserializeOwned>(state_update: &mut TrieUpdate, key: &[u8]) -> Option<T> {
+pub fn get<T: DeserializeOwned>(state_update: &TrieUpdate, key: &[u8]) -> Option<T> {
     state_update.get(key).and_then(|data| Decode::decode(&data).ok())
 }
 

--- a/runtime/verifier/Cargo.toml
+++ b/runtime/verifier/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "verifier"
+version = "0.1.0"
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2018"
+
+[dependencies]
+
+primitives = { path = "../primitives" }
+storage = { path = "../storage"}

--- a/runtime/verifier/src/lib.rs
+++ b/runtime/verifier/src/lib.rs
@@ -1,0 +1,131 @@
+use primitives::account::{AccessKey, Account};
+use primitives::crypto::signature::{verify, PublicKey};
+use primitives::logging;
+use primitives::transaction::{SignedTransaction, TransactionBody};
+use primitives::types::AccountId;
+use primitives::utils::{is_valid_account_id, key_for_access_key, key_for_account};
+use storage::{get, TrieUpdate};
+
+pub struct VerificationData {
+    pub originator_id: AccountId,
+    pub originator: Account,
+    pub public_key: PublicKey,
+    pub access_key: Option<AccessKey>,
+}
+
+pub struct TransactionVerifier<'a> {
+    state_update: &'a TrieUpdate,
+}
+
+impl<'a> TransactionVerifier<'a> {
+    pub fn new(state_update: &'a TrieUpdate) -> Self {
+        TransactionVerifier { state_update }
+    }
+
+    pub fn verify_transaction(
+        &self,
+        transaction: &SignedTransaction,
+    ) -> Result<VerificationData, String> {
+        let originator_id = transaction.body.get_originator();
+        let originator: Option<Account> = get(self.state_update, &key_for_account(&originator_id));
+        match originator {
+            Some(originator) => {
+                if transaction.body.get_nonce() <= originator.nonce {
+                    return Err(format!(
+                        "Transaction nonce {} must be larger than originator's nonce {}",
+                        transaction.body.get_nonce(),
+                        originator.nonce,
+                    ));
+                }
+
+                let contract_id = transaction.body.get_contract_id();
+                if let Some(ref contract_id) = contract_id {
+                    if !is_valid_account_id(&contract_id) {
+                        return Err(format!(
+                            "Invalid contract_id / receiver {} according to requirements",
+                            contract_id
+                        ));
+                    }
+                }
+
+                let hash = transaction.get_hash();
+                let hash = hash.as_ref();
+                let public_key = originator
+                    .public_keys
+                    .iter()
+                    .find(|key| verify(&hash, &transaction.signature, &key))
+                    .cloned();
+
+                if let Some(public_key) = public_key {
+                    if let Some(ref tx_public_key) = transaction.public_key {
+                        if &public_key != tx_public_key {
+                            return Err(
+                                "Transaction is signed with different public key than given"
+                                    .to_string(),
+                            );
+                        }
+                    }
+                    Ok(VerificationData { originator_id, originator, public_key, access_key: None })
+                } else {
+                    if let Some(ref public_key) = transaction.public_key {
+                        let access_key: Option<AccessKey> = get(
+                            self.state_update,
+                            &key_for_access_key(&originator_id, &public_key),
+                        );
+                        if let Some(access_key) = access_key {
+                            if let TransactionBody::FunctionCall(ref function_call) =
+                                transaction.body
+                            {
+                                let access_contract_id =
+                                    access_key.contract_id.as_ref().unwrap_or(&originator_id);
+
+                                if &function_call.contract_id != access_contract_id {
+                                    return Err(format!(
+                                        "Access key contract ID {:?} doesn't match TX contract account ID {:?}",
+                                        access_contract_id,
+                                        function_call.contract_id,
+                                    ));
+                                }
+                                if function_call.amount > access_key.amount {
+                                    return Err(format!(
+                                        "Transaction amount {} is larger than the access key amount {}",
+                                        function_call.amount,
+                                        access_key.amount,
+                                    ));
+                                }
+                                if let Some(ref access_method_name) = access_key.method_name {
+                                    if &function_call.method_name != access_method_name {
+                                        return Err(format!(
+                                            "Transaction method name {:?} doesn't match the access key method name {:?}",
+                                            logging::pretty_utf8(&function_call.method_name),
+                                            logging::pretty_utf8(access_method_name),
+                                        ));
+                                    }
+                                }
+                                Ok(VerificationData {
+                                    originator_id,
+                                    originator,
+                                    public_key: *public_key,
+                                    access_key: Some(access_key),
+                                })
+                            } else {
+                                Err("Access key can only be used with the FunctionCall transactions".to_string())
+                            }
+                        } else {
+                            Err(format!(
+                                "Transaction is not signed with a public key of the originator {:?}",
+                                originator_id,
+                            ))
+                        }
+                    } else {
+                        Err(format!(
+                            "Transaction is not signed with a public key of the originator {:?}",
+                            originator_id,
+                        ))
+                    }
+                }
+            }
+            _ => Err(format!("Originator {:?} does not exist", originator_id)),
+        }
+    }
+}

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -1,5 +1,5 @@
-use crate::user::{User, POISONED_LOCK_ERR};
 use crate::runtime_utils::to_receipt_block;
+use crate::user::{User, POISONED_LOCK_ERR};
 use node_http::types::{GetBlocksByIndexRequest, SignedShardBlocksResponse};
 use node_runtime::state_viewer::{AccountViewCallResult, TrieViewer, ViewStateResult};
 use node_runtime::{ApplyState, Runtime};
@@ -7,7 +7,7 @@ use primitives::chain::ReceiptBlock;
 use primitives::hash::CryptoHash;
 use primitives::transaction::{
     FinalTransactionResult, FinalTransactionStatus, ReceiptTransaction, SignedTransaction,
-    TransactionLogs, TransactionResult, TransactionStatus
+    TransactionLogs, TransactionResult, TransactionStatus,
 };
 use primitives::types::{AccountId, MerkleHash, Nonce};
 use shard::ReceiptInfo;
@@ -131,8 +131,8 @@ impl RuntimeUser {
 
 impl User for RuntimeUser {
     fn view_account(&self, account_id: &AccountId) -> Result<AccountViewCallResult, String> {
-        let mut state_update = self.client.read().expect(POISONED_LOCK_ERR).get_state_update();
-        self.trie_viewer.view_account(&mut state_update, account_id)
+        let state_update = self.client.read().expect(POISONED_LOCK_ERR).get_state_update();
+        self.trie_viewer.view_account(&state_update, account_id)
     }
 
     fn view_state(&self, account_id: &AccountId) -> Result<ViewStateResult, String> {

--- a/test-utils/testlib/src/user/shard_client_user.rs
+++ b/test-utils/testlib/src/user/shard_client_user.rs
@@ -1,5 +1,5 @@
-use crate::user::{User, POISONED_LOCK_ERR};
 use crate::runtime_utils::to_receipt_block;
+use crate::user::{User, POISONED_LOCK_ERR};
 use node_http::types::{GetBlocksByIndexRequest, SignedShardBlocksResponse};
 use node_runtime::state_viewer::{AccountViewCallResult, ViewStateResult};
 use primitives::block_traits::SignedBlock;
@@ -70,8 +70,8 @@ impl ShardClientUser {
 
 impl User for ShardClientUser {
     fn view_account(&self, account_id: &AccountId) -> Result<AccountViewCallResult, String> {
-        let mut state_update = self.client.get_state_update();
-        self.client.trie_viewer.view_account(&mut state_update, account_id)
+        let state_update = self.client.get_state_update();
+        self.client.trie_viewer.view_account(&state_update, account_id)
     }
 
     fn view_state(&self, account_id: &AccountId) -> Result<ViewStateResult, String> {

--- a/test-utils/testlib/src/user/thread_user.rs
+++ b/test-utils/testlib/src/user/thread_user.rs
@@ -1,5 +1,5 @@
-use crate::user::{User, POISONED_LOCK_ERR};
 use crate::runtime_utils::to_receipt_block;
+use crate::user::{User, POISONED_LOCK_ERR};
 use client::Client;
 use node_http::types::{GetBlocksByIndexRequest, SignedShardBlocksResponse};
 use node_runtime::state_viewer::{AccountViewCallResult, ViewStateResult};
@@ -24,8 +24,8 @@ impl ThreadUser {
 
 impl User for ThreadUser {
     fn view_account(&self, account_id: &AccountId) -> Result<AccountViewCallResult, String> {
-        let mut state_update = self.client.shard_client.get_state_update();
-        self.client.shard_client.trie_viewer.view_account(&mut state_update, account_id)
+        let state_update = self.client.shard_client.get_state_update();
+        self.client.shard_client.trie_viewer.view_account(&state_update, account_id)
     }
 
     fn view_state(&self, account_id: &AccountId) -> Result<ViewStateResult, String> {


### PR DESCRIPTION
Adding TX Verifier that mimics current Runtime checks.
It also verifies AccessKeys, but they are not tested and you can't add one yet.
Remove `&mut` from `get` resulted in a lot of files touched.
Also rust_fmt modified some style in the touched files 
For #687 