### PR TITLE
Trie changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 name = "cached"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be#7e472eddef68607e344d5a106a0e6705d92e55be"
 dependencies = [
  "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2434,7 +2434,7 @@ dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cached 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)",
  "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2978,7 +2978,7 @@ version = "0.0.2"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "cached 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "primitives 0.1.0",
@@ -3247,7 +3247,7 @@ dependencies = [
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
 "checksum bzip2 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42b7c3cbf0fa9c1b82308d57191728ca0256cb821220f4e2fd410a72ade26e3b"
 "checksum bzip2-sys 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6584aa36f5ad4c9247f5323b0a42f37802b37a836f0ad87084d7a33961abe25f"
-"checksum cached 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f13d7a614340cc6be5df8a69063c421716c10c0c9e79f85d0a446ae40f078b44"
+"checksum cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)" = "<none>"
 "checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.36 (registry+https://github.com/rust-lang/crates.io-index)" = "a0c56216487bb80eec9c4516337b2588a4f2a2290d72a1416d930e4dcdb0c90d"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -78,7 +78,7 @@ impl<'a> RuntimeExt<'a> {
     /// write callbacks to stateUpdate
     pub fn flush_callbacks(&mut self) {
         for (id, callback) in self.callbacks.drain() {
-            set(self.trie_update, &key_for_callback(&id), &callback);
+            set(self.trie_update, key_for_callback(&id), &callback);
         }
     }
 }
@@ -86,7 +86,7 @@ impl<'a> RuntimeExt<'a> {
 impl<'a> External for RuntimeExt<'a> {
     fn storage_set(&mut self, key: &[u8], value: &[u8]) -> ExtResult<Option<Vec<u8>>> {
         let storage_key = self.create_storage_key(key);
-        Ok(self.trie_update.set(&storage_key, &DBValue::from_slice(value)))
+        Ok(self.trie_update.set(storage_key, DBValue::from_slice(value)))
     }
 
     fn storage_get(&self, key: &[u8]) -> ExtResult<Option<Vec<u8>>> {

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -270,7 +270,7 @@ mod tests {
         let (_, trie, root) = get_runtime_and_trie();
         let mut state_update = TrieUpdate::new(trie.clone(), root);
         state_update
-            .set(&account_suffix(&alice_account(), b"test123"), &DBValue::from_slice(b"123"));
+            .set(account_suffix(&alice_account(), b"test123"), DBValue::from_slice(b"123"));
         let (new_root, db_changes) = state_update.finalize();
         trie.apply_changes(db_changes).unwrap();
 

--- a/runtime/runtime/tests/test_evil_contracts.rs
+++ b/runtime/runtime/tests/test_evil_contracts.rs
@@ -1,0 +1,63 @@
+use primitives::transaction::{
+    CreateAccountTransaction, DeployContractTransaction, TransactionBody,
+};
+use testlib::node::{Node, RuntimeNode};
+
+fn setup_test_contract(wasm_binary: &[u8]) -> RuntimeNode {
+    let node = RuntimeNode::new(&"alice.near".to_string());
+    let account_id = node.account_id().unwrap();
+    let transaction = TransactionBody::CreateAccount(CreateAccountTransaction {
+        nonce: node.get_account_nonce(account_id).unwrap_or_default() + 1,
+        originator: account_id.clone(),
+        new_account_id: "test_contract".to_string(),
+        public_key: node.signer().public_key.0[..].to_vec(),
+        amount: 0,
+    })
+    .sign(&*node.signer());
+    let user = node.user();
+    user.add_transaction(transaction).unwrap();
+
+    let transaction = TransactionBody::DeployContract(DeployContractTransaction {
+        nonce: node.get_account_nonce(account_id).unwrap_or_default() + 1,
+        contract_id: "test_contract".to_string(),
+        wasm_byte_array: wasm_binary.to_vec(),
+    })
+    .sign(&*node.signer());
+    user.add_transaction(transaction).unwrap();
+    node
+}
+
+#[test]
+fn test_evil_deep_trie() {
+    let node = setup_test_contract(include_bytes!("../../../tests/hello.wasm"));
+    (0..50).for_each(|i| {
+        println!("insertStrings #{}", i);
+        let input_data = format!("{{\"from\": {}, \"to\": {}}}", i * 10, (i + 1) * 10);
+        node.call_function(
+            "test_contract",
+            "insertStrings",
+            input_data.as_bytes().to_vec(),
+            0,
+        );
+    });
+    (0..50).rev().for_each(|i| {
+        println!("deleteStrings #{}", i);
+        let input_data = format!("{{\"from\": {}, \"to\": {}}}", i * 10, (i + 1) * 10);
+        node.call_function(
+            "test_contract",
+            "deleteStrings",
+            input_data.as_bytes().to_vec(),
+            0,
+        );
+    });
+}
+
+#[test]
+fn test_evil_deep_recursion() {
+    let node = setup_test_contract(include_bytes!("../../../tests/hello.wasm"));
+    [100, 1000, 10000, 100000, 1000000].iter().for_each(|n| {
+        println!("{}", n);
+        let input_data = format!("{{\"n\": {}}}", n);
+        node.call_function("test_contract", "recurse", input_data.as_bytes().to_vec(), 0);
+    });
+}

--- a/runtime/storage/Cargo.toml
+++ b/runtime/storage/Cargo.toml
@@ -16,7 +16,7 @@ parity-rocksdb = "0.5"
 parking_lot = "0.7.1"
 serde = "1.0"
 serde_derive = "1.0"
-cached = "0.8"
+cached = { git = "https://github.com/nearprotocol/cached", rev = "7e472eddef68607e344d5a106a0e6705d92e55be" }
 
 primitives = { path = "../primitives" }
 

--- a/runtime/storage/src/lib.rs
+++ b/runtime/storage/src/lib.rs
@@ -4,9 +4,9 @@ extern crate elastic_array;
 extern crate hex_literal;
 #[macro_use]
 extern crate log;
+extern crate primitives;
 #[cfg(test)]
 extern crate rand;
-extern crate primitives;
 
 use std::sync::Arc;
 use std::sync::RwLock;
@@ -32,13 +32,11 @@ pub fn get<T: DeserializeOwned>(state_update: &TrieUpdate, key: &[u8]) -> Option
     state_update.get(key).and_then(|data| Decode::decode(&data).ok())
 }
 
-pub fn set<T: Serialize>(state_update: &mut TrieUpdate, key: &[u8], value: &T) {
-    value.encode().ok().map(|data| state_update.set(key, &DBValue::from_slice(&data))).or_else(
-        || {
-            debug!("set value failed");
-            None
-        },
-    );
+pub fn set<T: Serialize>(state_update: &mut TrieUpdate, key: Vec<u8>, value: &T) {
+    value.encode().ok().map(|data| state_update.set(key, DBValue::from_vec(data))).or_else(|| {
+        debug!("set value failed");
+        None
+    });
 }
 
 /// Initializes beacon and shard chain storages from the given path.

--- a/runtime/storage/src/lib.rs
+++ b/runtime/storage/src/lib.rs
@@ -4,6 +4,8 @@ extern crate elastic_array;
 extern crate hex_literal;
 #[macro_use]
 extern crate log;
+#[cfg(test)]
+extern crate rand;
 extern crate primitives;
 
 use std::sync::Arc;

--- a/runtime/storage/src/storages/mod.rs
+++ b/runtime/storage/src/storages/mod.rs
@@ -107,7 +107,7 @@ where
     /// Encodes a slice of bytes into a vector by adding a prefix that corresponds to the chain id.
     pub fn enc_slice(&self, slice: &[u8]) -> Vec<u8> {
         let id: u32 = self.chain_id.clone().into();
-        let mut res = vec![];
+        let mut res = Vec::with_capacity(4 + slice.len());
         res.extend_from_slice(chain_id_to_bytes(&id));
         res.extend_from_slice(slice);
         res
@@ -311,7 +311,7 @@ fn write_with_cache<T: Clone + Encode>(
 ) -> io::Result<()> {
     let data = Encode::encode(&value)?;
     let mut db_transaction = storage.transaction();
-    db_transaction.put(Some(col), key, &data);
+    db_transaction.put_vec(Some(col), key, data);
     storage.write(db_transaction)?;
     // If it has reached here then it is safe to put in cache.
     cache.cache_set(key.to_vec(), value);
@@ -325,11 +325,11 @@ fn extend_with_cache<T: Clone + Encode>(
     values: HashMap<Vec<u8>, T>,
 ) -> io::Result<()> {
     let mut db_transaction = storage.transaction();
-    let mut cache_to_extend = vec![];
+    let mut cache_to_extend = Vec::with_capacity(values.len());
     for (key, value) in values {
         let data = Encode::encode(&value)?;
-        cache_to_extend.push((key.clone(), value));
-        db_transaction.put(Some(col), &key, &data);
+        db_transaction.put_vec(Some(col), &key, data);
+        cache_to_extend.push((key, value));
     }
     storage.write(db_transaction)?;
     // If it has reached here then it is safe to put in cache.

--- a/runtime/storage/src/storages/shard.rs
+++ b/runtime/storage/src/storages/shard.rs
@@ -144,20 +144,20 @@ impl ShardChainStorage {
     pub fn get_state(&self, hash: &CryptoHash) -> StorageResult<Vec<u8>> {
         self.generic_storage
             .storage
-            .get(Some(COL_STATE), &self.generic_storage.enc_slice(hash.as_ref()))
+            .get(Some(COL_STATE), &self.generic_storage.enc_hash(hash))
             .map(|a| a.map(|b| b.to_vec()))
     }
 
     /// Saves state updates in the db.
     pub fn apply_state_updates(
         &self,
-        changes: &HashMap<Vec<u8>, Option<Vec<u8>>>,
+        changes: HashMap<Vec<u8>, Option<Vec<u8>>>,
     ) -> std::io::Result<()> {
         let mut db_transaction = self.generic_storage.storage.transaction();
         let col = Some(COL_STATE);
-        for (key, value) in changes {
+        for (key, value) in changes.into_iter() {
             match value {
-                Some(arr) => db_transaction.put(col, &self.generic_storage.enc_slice(&key), &arr),
+                Some(arr) => db_transaction.put_vec(col, &self.generic_storage.enc_slice(&key), arr),
                 None => db_transaction.delete(col, &self.generic_storage.enc_slice(&key)),
             }
         }

--- a/runtime/storage/src/trie/mod.rs
+++ b/runtime/storage/src/trie/mod.rs
@@ -4,7 +4,6 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use cached::{Cached, SizedCache};
 pub use kvdb::DBValue;
 use primitives::hash::{hash, CryptoHash};
-use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt;

--- a/runtime/storage/src/trie/mod.rs
+++ b/runtime/storage/src/trie/mod.rs
@@ -83,7 +83,7 @@ impl TrieNode {
                             child.print(f, memory, spaces)?;
                         }
                     }
-                    writeln!(f, "")?;
+                    writeln!(f)?;
                 }
                 spaces.remove(spaces.len() - 1);
                 write!(f, "{}}}", spaces)?;
@@ -101,7 +101,7 @@ impl TrieNode {
                         child.print(f, memory, spaces)?;
                     }
                 }
-                writeln!(f, "")?;
+                writeln!(f)?;
                 spaces.remove(spaces.len() - 1);
             }
         }
@@ -899,11 +899,12 @@ impl Trie {
             buffer.clear();
             last_hash = key;
         }
-        let (insertions, deletions) = Trie::to_insertions_and_deletions(memory.refcount_changes);
+        let (insertions, deletions) =
+            Trie::convert_to_insertions_and_deletions(memory.refcount_changes);
         TrieChanges { new_root: last_hash, insertions, deletions }
     }
 
-    fn to_insertions_and_deletions(
+    fn convert_to_insertions_and_deletions(
         changes: HashMap<CryptoHash, (Option<Vec<u8>>, i32)>,
     ) -> ((Vec<(CryptoHash, Vec<u8>, u32)>, Vec<(CryptoHash, u32)>)) {
         let mut deletions = Vec::new();

--- a/runtime/storage/src/trie/mod.rs
+++ b/runtime/storage/src/trie/mod.rs
@@ -1,34 +1,39 @@
 use self::nibble_slice::NibbleSlice;
 use crate::storages::shard::ShardChainStorage;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use cached::{Cached, SizedCache};
 pub use kvdb::DBValue;
 use primitives::hash::{hash, CryptoHash};
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::fmt;
 use std::io::{Cursor, Read, Write};
-use std::sync::Arc;
 use std::sync::RwLock;
+use std::sync::{Arc, Mutex};
 
 mod nibble_slice;
 pub mod update;
 
 const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 
+#[derive(Clone, Hash, Debug, Copy)]
+struct StorageHandle(usize);
+
 #[derive(Clone, Hash, Debug)]
 enum NodeHandle {
-    InMemory(Box<TrieNode>),
+    InMemory(StorageHandle),
     Hash(CryptoHash),
 }
 
 #[derive(Clone, Hash, Debug)]
-#[allow(clippy::large_enum_variant)]
 enum TrieNode {
     /// Null trie node. Could be an empty root or an empty branch entry.
     Empty,
     /// Key and value of the leaf node.
     Leaf(Vec<u8>, Vec<u8>),
     /// Branch of 16 possible children and value if key ends here.
-    Branch([Option<NodeHandle>; 16], Option<Vec<u8>>),
+    Branch(Box<[Option<NodeHandle>; 16]>, Option<Vec<u8>>),
     /// Key and child of extension.
     Extension(Vec<u8>, NodeHandle),
 }
@@ -38,7 +43,7 @@ impl TrieNode {
         match rc_node {
             RawTrieNode::Leaf(key, value) => TrieNode::Leaf(key, value),
             RawTrieNode::Branch(children, value) => {
-                let mut new_children: [Option<NodeHandle>; 16] = Default::default();
+                let mut new_children: Box<[Option<NodeHandle>; 16]> = Default::default();
                 for i in 0..children.len() {
                     new_children[i] = children[i].map(NodeHandle::Hash);
                 }
@@ -46,6 +51,69 @@ impl TrieNode {
             }
             RawTrieNode::Extension(key, child) => TrieNode::Extension(key, NodeHandle::Hash(child)),
         }
+    }
+
+    fn print(&self, f: &mut fmt::Write, memory: &NodesStorage, spaces: &mut String) -> fmt::Result {
+        match self {
+            TrieNode::Empty => {
+                write!(f, "{}Empty", spaces)?;
+            }
+            TrieNode::Leaf(key, _value) => {
+                let slice = NibbleSlice::from_encoded(key);
+                write!(f, "{}Leaf({:?}, val)", spaces, slice.0)?;
+            }
+            TrieNode::Branch(children, value) => {
+                writeln!(
+                    f,
+                    "{}Branch({}){{",
+                    spaces,
+                    if value.is_some() { "Some" } else { "None" }
+                )?;
+                spaces.push_str(" ");
+                for (idx, child) in
+                    children.iter().enumerate().filter(|(_idx, child)| child.is_some())
+                {
+                    let child = child.as_ref().unwrap();
+                    write!(f, "{}{:01x}->", spaces, idx)?;
+                    match child {
+                        NodeHandle::Hash(hash) => {
+                            write!(f, "{}", hash)?;
+                        }
+                        NodeHandle::InMemory(handle) => {
+                            let child = memory.node_ref(*handle);
+                            child.print(f, memory, spaces)?;
+                        }
+                    }
+                    writeln!(f, "")?;
+                }
+                spaces.remove(spaces.len() - 1);
+                write!(f, "{}}}", spaces)?;
+            }
+            TrieNode::Extension(key, child) => {
+                let slice = NibbleSlice::from_encoded(key);
+                writeln!(f, "{}Extension({:?})", spaces, slice)?;
+                spaces.push_str(" ");
+                match child {
+                    NodeHandle::Hash(hash) => {
+                        write!(f, "{}{}", spaces, hash)?;
+                    }
+                    NodeHandle::InMemory(handle) => {
+                        let child = memory.node_ref(*handle);
+                        child.print(f, memory, spaces)?;
+                    }
+                }
+                writeln!(f, "")?;
+                spaces.remove(spaces.len() - 1);
+            }
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    fn deep_to_string(&self, memory: &NodesStorage) -> String {
+        let mut buf = String::new();
+        self.print(&mut buf, memory, &mut "".to_string()).expect("printing failed");
+        buf
     }
 }
 
@@ -55,6 +123,47 @@ enum RawTrieNode {
     Leaf(Vec<u8>, Vec<u8>),
     Branch([Option<CryptoHash>; 16], Option<Vec<u8>>),
     Extension(Vec<u8>, CryptoHash),
+}
+
+struct NodesStorage {
+    nodes: Vec<Option<TrieNode>>,
+    moved_from_db: HashMap<CryptoHash, u32>,
+}
+
+const INVALID_STORAGE_HANDLE: &str = "invalid storage handle";
+
+/// Local mutable storage that owns node objects.
+///
+impl NodesStorage {
+    fn new() -> NodesStorage {
+        NodesStorage { nodes: Vec::new(), moved_from_db: HashMap::new() }
+    }
+
+    fn destroy(&mut self, handle: StorageHandle) -> TrieNode {
+        self.nodes
+            .get_mut(handle.0)
+            .expect(INVALID_STORAGE_HANDLE)
+            .take()
+            .expect(INVALID_STORAGE_HANDLE)
+    }
+
+    fn node_ref(&self, handle: StorageHandle) -> &TrieNode {
+        self.nodes
+            .get(handle.0)
+            .expect(INVALID_STORAGE_HANDLE)
+            .as_ref()
+            .expect(INVALID_STORAGE_HANDLE)
+    }
+
+    fn store(&mut self, node: TrieNode) -> StorageHandle {
+        self.nodes.push(Some(node));
+        StorageHandle(self.nodes.len() - 1)
+    }
+
+    fn store_at(&mut self, handle: StorageHandle, node: TrieNode) {
+        debug_assert!(self.nodes.get(handle.0).expect(INVALID_STORAGE_HANDLE).is_none());
+        self.nodes[handle.0] = Some(node);
+    }
 }
 
 const LEAF_NODE: u8 = 0;
@@ -185,24 +294,36 @@ impl RcTrieNode {
     }
 }
 
-pub struct Trie {
+pub struct TrieCachingStorage {
     storage: Arc<RwLock<ShardChainStorage>>,
-    null_node: CryptoHash,
+    cache: Arc<Mutex<SizedCache<CryptoHash, Option<Vec<u8>>>>>,
 }
 
-pub type DBChanges = HashMap<Vec<u8>, Option<Vec<u8>>>;
-
-impl Trie {
-    pub fn new(storage: Arc<RwLock<ShardChainStorage>>) -> Self {
-        Trie { storage, null_node: Trie::empty_root() }
+impl TrieCachingStorage {
+    fn new(storage: Arc<RwLock<ShardChainStorage>>) -> TrieCachingStorage {
+        // TODO defend from huge values in cache
+        TrieCachingStorage { storage, cache: Arc::new(Mutex::new(SizedCache::with_size(10000))) }
     }
 
-    pub fn empty_root() -> CryptoHash {
-        CryptoHash::default()
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Option<(Vec<u8>)> {
+        let mut _guard = self.cache.lock().expect(POISONED_LOCK_ERR);
+        if let Some(val) = (*_guard).cache_get(hash) {
+            val.clone()
+        } else {
+            let result = if let Ok(Some(bytes)) =
+                self.storage.read().expect(POISONED_LOCK_ERR).get_state(hash)
+            {
+                Some(bytes)
+            } else {
+                None
+            };
+            (*_guard).cache_set(*hash, result.clone());
+            result
+        }
     }
 
     fn retrieve_raw_node(&self, hash: &CryptoHash) -> Option<(Vec<u8>, u32)> {
-        if let Ok(Some(bytes)) = self.storage.read().expect(POISONED_LOCK_ERR).get_state(hash) {
+        if let Some(bytes) = self.retrieve_raw_bytes(hash) {
             match RcTrieNode::decode_raw(&bytes) {
                 Ok((bytes, rc)) => Some((bytes, rc)),
                 Err(_) => None,
@@ -213,10 +334,10 @@ impl Trie {
     }
 
     fn retrieve_node(&self, hash: &CryptoHash) -> Result<TrieNode, String> {
-        if *hash == self.null_node {
+        if *hash == Trie::empty_root() {
             return Ok(TrieNode::Empty);
         }
-        if let Ok(Some(bytes)) = self.storage.read().expect(POISONED_LOCK_ERR).get_state(hash) {
+        if let Some(bytes) = self.retrieve_raw_bytes(hash) {
             match RcTrieNode::decode(&bytes) {
                 Ok((value, _)) => Ok(TrieNode::new(value)),
                 Err(_) => Err(format!("Failed to decode node {}", hash)),
@@ -225,16 +346,85 @@ impl Trie {
             Err(format!("Node {} not found in storage", hash))
         }
     }
+}
+
+pub struct Trie {
+    storage: TrieCachingStorage,
+}
+
+///
+/// TrieChanges stores delta for refcount.
+/// Multiple versions of the state work the following way:
+///         __changes1___state1
+/// state0 /
+///        \__changes2___state2
+///
+/// To store state1, state2 and state3, apply insertions from changes1 and changes2
+///
+/// Then, to discard state2, apply insertions from changes2 as deletions
+///
+/// Then, to discard state0, apply deletions from changes1
+///
+///
+/// create a fork -> apply insertions
+/// resolve a fork -> apply opposite of insertions
+/// discard old parent which has no forks from it -> apply deletions
+///
+///
+/// DBChanges are the changes from current state refcount to refcount + delta.
+pub struct TrieChanges {
+    new_root: CryptoHash,
+    insertions: Vec<(CryptoHash, Vec<u8>, u32)>, // key, value, rc
+    deletions: Vec<(CryptoHash, u32)>,           // key, rc
+}
+
+pub type DBChanges = HashMap<Vec<u8>, Option<Vec<u8>>>;
+
+enum FlattenNodesCrumb {
+    Entering,
+    AtChild(Box<[Option<CryptoHash>; 16]>, usize),
+    Exiting,
+}
+
+impl Trie {
+    pub fn new(storage: Arc<RwLock<ShardChainStorage>>) -> Self {
+        Trie { storage: TrieCachingStorage::new(storage) }
+    }
+
+    pub fn empty_root() -> CryptoHash {
+        CryptoHash::default()
+    }
+
+    fn move_node_to_mutable(
+        &self,
+        memory: &mut NodesStorage,
+        hash: &CryptoHash,
+    ) -> Result<StorageHandle, String> {
+        if *hash == Trie::empty_root() {
+            Ok(memory.store(TrieNode::Empty))
+        } else {
+            let result = memory.store(self.retrieve_node(hash)?);
+            *memory.moved_from_db.entry(*hash).or_default() += 1;
+            Ok(result)
+        }
+    }
+
+    fn retrieve_node(&self, hash: &CryptoHash) -> Result<TrieNode, String> {
+        if *hash == Trie::empty_root() {
+            return Ok(TrieNode::Empty);
+        }
+        self.storage.retrieve_node(hash)
+    }
 
     fn lookup(&self, root: &CryptoHash, mut key: NibbleSlice) -> Result<Option<Vec<u8>>, String> {
         let mut hash = *root;
 
         loop {
-            if hash == self.null_node {
+            if hash == Trie::empty_root() {
                 return Ok(None);
             }
-            let node = match self.storage.read().expect(POISONED_LOCK_ERR).get_state(&hash) {
-                Ok(Some(bytes)) => RcTrieNode::decode(&bytes)
+            let node = match self.storage.retrieve_raw_bytes(&hash) {
+                Some(bytes) => RcTrieNode::decode(&bytes)
                     .map(|trie_node| trie_node.0)
                     .map_err(|_| "Failed to decode node".to_string())?,
                 _ => return Err(format!("Node {} not found in storage", hash)),
@@ -285,122 +475,157 @@ impl Trie {
         }
     }
 
+    /// Allowed to mutate nodes in NodesStorage.
+    /// Insert while holding StorageHandles to NodesStorage is unsafe
     fn insert(
         &self,
-        node: TrieNode,
+        memory: &mut NodesStorage,
+        node: StorageHandle,
         partial: NibbleSlice,
         value: Vec<u8>,
-    ) -> Result<TrieNode, String> {
-        match node {
-            TrieNode::Empty => {
-                let leaf_node = TrieNode::Leaf(partial.encoded(true).into_vec(), value);
-                Ok(leaf_node)
-            }
-            TrieNode::Branch(mut children, existing_value) => {
-                // If the key ends here, store the value in branch's value.
-                if partial.is_empty() {
-                    Ok(TrieNode::Branch(children, Some(value)))
-                } else {
-                    let idx = partial.at(0) as usize;
-                    let partial = partial.mid(1);
-                    let child = children[idx].take();
-                    let new_hash = match child {
-                        Some(NodeHandle::Hash(hash)) => {
-                            self.insert(self.retrieve_node(&hash)?, partial, value)?
-                        }
-                        Some(NodeHandle::InMemory(node)) => self.insert(*node, partial, value)?,
-                        _ => TrieNode::Leaf(partial.encoded(true).into_vec(), value),
-                    };
-                    children[idx] = Some(NodeHandle::InMemory(Box::new(new_hash)));
-                    Ok(TrieNode::Branch(children, existing_value))
+    ) -> Result<StorageHandle, String> {
+        let root_handle = node;
+        let mut handle = node;
+        let mut value = Some(value);
+        let mut partial = partial;
+
+        loop {
+            match memory.destroy(handle) {
+                TrieNode::Empty => {
+                    let leaf_node =
+                        TrieNode::Leaf(partial.encoded(true).into_vec(), value.take().unwrap());
+                    memory.store_at(handle, leaf_node);
+                    break;
                 }
-            }
-            TrieNode::Leaf(key, existing_value) => {
-                let existing_key = NibbleSlice::from_encoded(&key).0;
-                let common_prefix = partial.common_prefix(&existing_key);
-                if common_prefix == existing_key.len() && common_prefix == partial.len() {
-                    // Equivalent leaf.
-                    Ok(TrieNode::Leaf(key.clone(), value))
-                } else if common_prefix == 0 {
-                    let mut children = Default::default();
-                    let branch_node = if existing_key.is_empty() {
-                        TrieNode::Branch(children, Some(existing_value))
+                TrieNode::Branch(mut children, existing_value) => {
+                    // If the key ends here, store the value in branch's value.
+                    if partial.is_empty() {
+                        memory.store_at(
+                            handle,
+                            TrieNode::Branch(children, Some(value.take().unwrap())),
+                        );
+                        break;
                     } else {
-                        let idx = existing_key.at(0) as usize;
-                        let new_leaf = TrieNode::Leaf(
-                            existing_key.mid(1).encoded(true).into_vec(),
+                        let idx = partial.at(0) as usize;
+                        let child = children[idx].take();
+                        let child = match child {
+                            Some(NodeHandle::Hash(hash)) => {
+                                self.move_node_to_mutable(memory, &hash)?
+                            }
+                            Some(NodeHandle::InMemory(handle)) => handle,
+                            None => memory.store(TrieNode::Empty),
+                        };
+                        children[idx] = Some(NodeHandle::InMemory(child));
+                        memory.store_at(handle, TrieNode::Branch(children, existing_value));
+                        handle = child;
+                        partial = partial.mid(1);
+                        continue;
+                    }
+                }
+                TrieNode::Leaf(key, existing_value) => {
+                    let existing_key = NibbleSlice::from_encoded(&key).0;
+                    let common_prefix = partial.common_prefix(&existing_key);
+                    if common_prefix == existing_key.len() && common_prefix == partial.len() {
+                        // Equivalent leaf.
+                        memory.store_at(handle, TrieNode::Leaf(key.clone(), value.take().unwrap()));
+                        break;
+                    } else if common_prefix == 0 {
+                        let mut children = Default::default();
+                        let branch_node = if existing_key.is_empty() {
+                            TrieNode::Branch(children, Some(existing_value))
+                        } else {
+                            let idx = existing_key.at(0) as usize;
+                            let new_leaf = TrieNode::Leaf(
+                                existing_key.mid(1).encoded(true).into_vec(),
+                                existing_value,
+                            );
+                            children[idx] = Some(NodeHandle::InMemory(memory.store(new_leaf)));
+                            TrieNode::Branch(children, None)
+                        };
+                        memory.store_at(handle, branch_node);
+                        continue;
+                    } else if common_prefix == existing_key.len() {
+                        let child = memory
+                            .store(TrieNode::Branch(Default::default(), Some(existing_value)));
+                        memory.store_at(
+                            handle,
+                            TrieNode::Extension(
+                                existing_key.encoded(false).into_vec(),
+                                NodeHandle::InMemory(child),
+                            ),
+                        );
+                        handle = child;
+                        partial = partial.mid(common_prefix);
+                        continue;
+                    } else {
+                        // Partially shared prefix: convert to leaf and call recursively to add a branch.
+                        let child = memory.store(TrieNode::Leaf(
+                            existing_key.mid(common_prefix).encoded(true).into_vec(),
                             existing_value,
+                        ));
+                        memory.store_at(
+                            handle,
+                            TrieNode::Extension(
+                                partial.encoded_leftmost(common_prefix, false).into_vec(),
+                                NodeHandle::InMemory(child),
+                            ),
                         );
-                        children[idx] = Some(NodeHandle::InMemory(Box::new(new_leaf)));
-                        TrieNode::Branch(children, None)
-                    };
-                    self.insert(branch_node, partial, value)
-                } else if common_prefix == existing_key.len() {
-                    let branch_node = TrieNode::Branch(Default::default(), Some(existing_value));
-                    let child = self.insert(branch_node, partial.mid(common_prefix), value)?;
-                    Ok(TrieNode::Extension(
-                        existing_key.encoded(false).into_vec(),
-                        NodeHandle::InMemory(Box::new(child)),
-                    ))
-                } else {
-                    // Partially shared prefix: convert to leaf and call recursively to add a branch.
-                    let low = TrieNode::Leaf(
-                        existing_key.mid(common_prefix).encoded(true).into_vec(),
-                        existing_value,
-                    );
-                    let child = self.insert(low, partial.mid(common_prefix), value)?;
-                    Ok(TrieNode::Extension(
-                        partial.encoded_leftmost(common_prefix, false).into_vec(),
-                        NodeHandle::InMemory(Box::new(child)),
-                    ))
+                        handle = child;
+                        partial = partial.mid(common_prefix);
+                        continue;
+                    }
                 }
-            }
-            TrieNode::Extension(key, child) => {
-                let existing_key = NibbleSlice::from_encoded(&key).0;
-                let common_prefix = partial.common_prefix(&existing_key);
-                if common_prefix == 0 {
-                    let idx = existing_key.at(0) as usize;
-                    let mut children: [Option<NodeHandle>; 16] = Default::default();
-                    children[idx] = if existing_key.len() == 1 {
-                        Some(child)
-                    } else {
-                        let ext_node = TrieNode::Extension(
-                            existing_key.mid(1).encoded(false).into_vec(),
-                            child,
+                TrieNode::Extension(key, child) => {
+                    let existing_key = NibbleSlice::from_encoded(&key).0;
+                    let common_prefix = partial.common_prefix(&existing_key);
+                    if common_prefix == 0 {
+                        let idx = existing_key.at(0) as usize;
+                        let mut children: Box<[Option<NodeHandle>; 16]> = Default::default();
+                        children[idx] = if existing_key.len() == 1 {
+                            Some(child)
+                        } else {
+                            let ext_node = TrieNode::Extension(
+                                existing_key.mid(1).encoded(false).into_vec(),
+                                child,
+                            );
+                            Some(NodeHandle::InMemory(memory.store(ext_node)))
+                        };
+                        let branch_node = TrieNode::Branch(children, None);
+                        memory.store_at(handle, branch_node);
+                        continue;
+                    } else if common_prefix == existing_key.len() {
+                        let child = match child {
+                            NodeHandle::Hash(hash) => self.move_node_to_mutable(memory, &hash)?,
+                            NodeHandle::InMemory(handle) => handle,
+                        };
+                        memory.store_at(
+                            handle,
+                            TrieNode::Extension(key, NodeHandle::InMemory(child)),
                         );
-                        Some(NodeHandle::InMemory(Box::new(ext_node)))
-                    };
-                    let branch_node = TrieNode::Branch(children, None);
-                    self.insert(branch_node, partial, value)
-                } else if common_prefix == existing_key.len() {
-                    let child_node = match child {
-                        NodeHandle::Hash(hash) => self.retrieve_node(&hash)?,
-                        NodeHandle::InMemory(node) => *node,
-                    };
-                    let new_child = NodeHandle::InMemory(Box::new(self.insert(
-                        child_node,
-                        partial.mid(common_prefix),
-                        value,
-                    )?));
-                    Ok(TrieNode::Extension(key.clone(), new_child))
-                } else {
-                    // Partially shared prefix: covert to shorter extension and recursively add a branch.
-                    let low = TrieNode::Extension(
-                        existing_key.mid(common_prefix).encoded(false).into_vec(),
-                        child,
-                    );
-                    let new_child = NodeHandle::InMemory(Box::new(self.insert(
-                        low,
-                        partial.mid(common_prefix),
-                        value,
-                    )?));
-                    Ok(TrieNode::Extension(
-                        existing_key.encoded_leftmost(common_prefix, false).into_vec(),
-                        new_child,
-                    ))
+                        handle = child;
+                        partial = partial.mid(common_prefix);
+                        continue;
+                    } else {
+                        // Partially shared prefix: covert to shorter extension and recursively add a branch.
+                        let child = memory.store(TrieNode::Extension(
+                            existing_key.mid(common_prefix).encoded(false).into_vec(),
+                            child,
+                        ));
+                        memory.store_at(
+                            handle,
+                            TrieNode::Extension(
+                                existing_key.encoded_leftmost(common_prefix, false).into_vec(),
+                                NodeHandle::InMemory(child),
+                            ),
+                        );
+                        handle = child;
+                        partial = partial.mid(common_prefix);
+                        continue;
+                    }
                 }
             }
         }
+        Ok(root_handle)
     }
 
     /// Deletes a node from the trie which has key = `partial` given root node.
@@ -408,203 +633,334 @@ impl Trie {
     /// While deleting keeps track of all the removed / updated nodes in `death_row`.
     fn delete(
         &self,
-        node: TrieNode,
-        hash: Option<CryptoHash>,
+        memory: &mut NodesStorage,
+        node: StorageHandle,
         partial: NibbleSlice,
-        death_row: &mut HashMap<CryptoHash, u32>,
-    ) -> Result<(Option<TrieNode>, bool), String> {
-        match node {
-            TrieNode::Empty => Ok((Some(node), false)),
-            TrieNode::Leaf(key, value) => {
-                if NibbleSlice::from_encoded(&key).0 == partial {
-                    if let Some(hash) = hash {
-                        *death_row.entry(hash).or_insert(0) += 1
-                    }
-                    Ok((None, true))
-                } else {
-                    Ok((Some(TrieNode::Leaf(key, value)), false))
+    ) -> Result<(StorageHandle, bool), String> {
+        let mut handle = node;
+        let mut partial = partial;
+        let root_node = handle;
+        let mut path: Vec<StorageHandle> = Vec::new();
+        let deleted: bool;
+        loop {
+            path.push(handle);
+            match memory.destroy(handle) {
+                TrieNode::Empty => {
+                    memory.store_at(handle, TrieNode::Empty);
+                    deleted = false;
+                    break;
                 }
-            }
-            TrieNode::Branch(mut children, value) => {
-                if partial.is_empty() {
-                    if let Some(hash) = hash {
-                        *death_row.entry(hash).or_insert(0) += 1;
-                    }
-                    if children.iter().filter(|&x| x.is_some()).count() == 0 {
-                        Ok((None, true))
+                TrieNode::Leaf(key, value) => {
+                    if NibbleSlice::from_encoded(&key).0 == partial {
+                        memory.store_at(handle, TrieNode::Empty);
+                        deleted = true;
+                        break;
                     } else {
-                        Ok((Some(TrieNode::Branch(children, None)), value.is_none()))
+                        memory.store_at(handle, TrieNode::Leaf(key, value));
+                        deleted = false;
+                        break;
                     }
-                } else {
-                    let idx = partial.at(0) as usize;
-                    if let Some(node_or_hash) = children[idx].take() {
-                        let (new_node, changed) = match node_or_hash {
-                            NodeHandle::Hash(hash) => self.delete(
-                                self.retrieve_node(&hash)?,
-                                Some(hash),
-                                partial.mid(1),
-                                death_row,
-                            )?,
-                            NodeHandle::InMemory(node) => {
-                                self.delete(*node, None, partial.mid(1), death_row)?
-                            }
-                        };
-                        children[idx] = match new_node {
-                            Some(node) => Some(NodeHandle::InMemory(Box::new(node))),
-                            None => None,
-                        };
-                        if let Some(hash) = hash {
-                            if changed {
-                                *death_row.entry(hash).or_insert(0) += 1;
-                            }
-                        }
-                        if children.iter().filter(|x| x.is_some()).count() == 0 {
-                            match value {
-                                Some(value) => Ok((
-                                    Some(TrieNode::Leaf(
-                                        NibbleSlice::new(&[]).encoded(true).into_vec(),
-                                        value,
-                                    )),
-                                    true,
-                                )),
-                                None => Ok((None, true)),
-                            }
+                }
+                TrieNode::Branch(mut children, value) => {
+                    if partial.is_empty() {
+                        if children.iter().filter(|&x| x.is_some()).count() == 0 {
+                            memory.store_at(handle, TrieNode::Empty);
+                            deleted = value.is_some();
+                            break;
                         } else {
-                            Ok((Some(TrieNode::Branch(children, value)), changed))
+                            memory.store_at(handle, TrieNode::Branch(children, None));
+                            deleted = value.is_some();
+                            break;
                         }
                     } else {
-                        Ok((Some(TrieNode::Branch(children, value)), false))
+                        let idx = partial.at(0) as usize;
+                        if let Some(node_or_hash) = children[idx].take() {
+                            let node = match node_or_hash {
+                                NodeHandle::Hash(hash) => {
+                                    self.move_node_to_mutable(memory, &hash)?
+                                }
+                                NodeHandle::InMemory(node) => node,
+                            };
+                            children[idx] = Some(NodeHandle::InMemory(node));
+                            memory.store_at(handle, TrieNode::Branch(children, value));
+                            handle = node;
+                            partial = partial.mid(1);
+                            continue;
+                        } else {
+                            memory.store_at(handle, TrieNode::Branch(children, value));
+                            deleted = false;
+                            break;
+                        }
                     }
                 }
-            }
-            TrieNode::Extension(key, child) => {
-                let (common_prefix, existing_len) = {
-                    let existing_key = NibbleSlice::from_encoded(&key).0;
-                    (existing_key.common_prefix(&partial), existing_key.len())
-                };
-                if common_prefix == existing_len {
-                    let (result, changed) = match child {
-                        NodeHandle::Hash(hash) => self.delete(
-                            self.retrieve_node(&hash)?,
-                            Some(hash),
-                            partial.mid(existing_len),
-                            death_row,
-                        )?,
-                        NodeHandle::InMemory(node) => {
-                            self.delete(*node, None, partial.mid(existing_len), death_row)?
-                        }
+                TrieNode::Extension(key, child) => {
+                    let (common_prefix, existing_len) = {
+                        let existing_key = NibbleSlice::from_encoded(&key).0;
+                        (existing_key.common_prefix(&partial), existing_key.len())
                     };
-                    if let Some(hash) = hash {
-                        if changed {
-                            *death_row.entry(hash).or_insert(0) += 1
-                        }
+                    if common_prefix == existing_len {
+                        let node = match child {
+                            NodeHandle::Hash(hash) => self.move_node_to_mutable(memory, &hash)?,
+                            NodeHandle::InMemory(node) => node,
+                        };
+                        memory
+                            .store_at(handle, TrieNode::Extension(key, NodeHandle::InMemory(node)));
+                        partial = partial.mid(existing_len);
+                        handle = node;
+                        continue;
+                    } else {
+                        memory.store_at(handle, TrieNode::Extension(key, child));
+                        deleted = false;
+                        break;
                     }
-                    match result {
-                        Some(node) => Ok((
-                            Some(TrieNode::Extension(key, NodeHandle::InMemory(Box::new(node)))),
-                            changed,
-                        )),
-                        None => Ok((None, true)),
-                    }
-                } else {
-                    Ok((Some(TrieNode::Extension(key, child)), false))
                 }
             }
         }
+        self.fix_nodes(memory, path)?;
+        Ok((root_node, deleted))
     }
 
-    fn flatten_nodes(
-        &self,
-        node: TrieNode,
-        nodes: &mut HashMap<CryptoHash, (Vec<u8>, u32)>,
-    ) -> CryptoHash {
-        let rc_node = match node {
-            TrieNode::Empty => return self.null_node,
-            TrieNode::Branch(mut children, value) => {
-                let mut new_children: [Option<CryptoHash>; 16] = Default::default();
-                for i in 0..children.len() {
-                    new_children[i] = match children[i].take() {
-                        Some(NodeHandle::InMemory(child_node)) => {
-                            Some(self.flatten_nodes(*child_node, nodes))
+    fn fix_nodes(&self, memory: &mut NodesStorage, path: Vec<StorageHandle>) -> Result<(), String> {
+        for handle in path.into_iter().rev() {
+            match memory.destroy(handle) {
+                TrieNode::Empty => {
+                    memory.store_at(handle, TrieNode::Empty);
+                }
+                TrieNode::Leaf(key, value) => {
+                    memory.store_at(handle, TrieNode::Leaf(key, value));
+                }
+                TrieNode::Branch(mut children, value) => {
+                    children.iter_mut().for_each(|child| {
+                        if let Some(NodeHandle::InMemory(h)) = child {
+                            if let TrieNode::Empty = memory.node_ref(*h) {
+                                *child = None
+                            }
                         }
-                        Some(NodeHandle::Hash(hash)) => Some(hash),
-                        _ => None,
+                    });
+                    let num_children = children.iter().filter(|&x| x.is_some()).count();
+                    if num_children == 0 {
+                        if let Some(value) = value {
+                            let empty = NibbleSlice::new(&[]).encoded(true).into_vec();
+                            memory.store_at(handle, TrieNode::Leaf(empty, value));
+                        } else {
+                            memory.store_at(handle, TrieNode::Empty);
+                        }
+                    } else if num_children == 1 && value.is_none() {
+                        // Branch with one child becomes extension
+                        // Extension followed by leaf becomes leaf
+                        // Extension followed by extension becomes extension
+                        let idx =
+                            children.iter().enumerate().find(|(_i, x)| x.is_some()).unwrap().0;
+                        let key = NibbleSlice::new(&[(idx << 4) as u8])
+                            .encoded_leftmost(1, false)
+                            .into_vec();
+                        self.fix_extension_node(
+                            memory,
+                            handle,
+                            key,
+                            children[idx].take().unwrap(),
+                        )?;
+                    } else {
+                        memory.store_at(handle, TrieNode::Branch(children, value));
                     }
                 }
-                RawTrieNode::Branch(new_children, value)
+                TrieNode::Extension(key, child) => {
+                    self.fix_extension_node(memory, handle, key, child)?;
+                }
             }
-            TrieNode::Extension(key, child) => {
-                let child = match child {
-                    NodeHandle::InMemory(child) => self.flatten_nodes(*child, nodes),
-                    NodeHandle::Hash(hash) => hash,
-                };
-                RawTrieNode::Extension(key, child)
-            }
-            TrieNode::Leaf(key, value) => RawTrieNode::Leaf(key, value),
-        };
-        let data = rc_node.encode().expect("Failed to serialize");
-        let key = hash(&data);
-        if let Some(value) = nodes.get_mut(&key) {
-            value.1 += 1;
-        } else {
-            let node_rc = if let Some((_, rc)) = self.retrieve_raw_node(&key) { rc } else { 0 };
-            nodes.insert(key, (data, node_rc + 1));
         }
-        key
+        Ok(())
+    }
+
+    fn fix_extension_node(
+        &self,
+        memory: &mut NodesStorage,
+        handle: StorageHandle,
+        key: Vec<u8>,
+        child: NodeHandle,
+    ) -> Result<(), String> {
+        let child = match child {
+            NodeHandle::Hash(hash) => self.move_node_to_mutable(memory, &hash)?,
+            NodeHandle::InMemory(h) => h,
+        };
+        match memory.destroy(child) {
+            TrieNode::Empty => {
+                memory.store_at(handle, TrieNode::Empty);
+            }
+            TrieNode::Leaf(child_key, value) => {
+                let key = NibbleSlice::from_encoded(&key)
+                    .0
+                    .merge_encoded(&NibbleSlice::from_encoded(&child_key).0, true)
+                    .into_vec();
+                memory.store_at(handle, TrieNode::Leaf(key, value));
+            }
+            TrieNode::Branch(children, value) => {
+                memory.store_at(child, TrieNode::Branch(children, value));
+                memory.store_at(handle, TrieNode::Extension(key, NodeHandle::InMemory(child)));
+            }
+            TrieNode::Extension(child_key, child_child) => {
+                let key = NibbleSlice::from_encoded(&key)
+                    .0
+                    .merge_encoded(&NibbleSlice::from_encoded(&child_key).0, false)
+                    .into_vec();
+                memory.store_at(handle, TrieNode::Extension(key, child_child));
+            }
+        }
+        Ok(())
+    }
+
+    fn flatten_nodes(memory: NodesStorage, node: StorageHandle) -> TrieChanges {
+        let mut stack: Vec<(StorageHandle, FlattenNodesCrumb)> = Vec::new();
+        stack.push((node, FlattenNodesCrumb::Entering));
+        let mut last_hash = CryptoHash::default();
+        let mut nodes: HashMap<CryptoHash, (Vec<u8>, u32)> = HashMap::new();
+        while !stack.is_empty() {
+            let (node, position) = stack.pop().unwrap();
+            let rc_node = match memory.node_ref(node) {
+                TrieNode::Empty => {
+                    last_hash = Trie::empty_root();
+                    continue;
+                }
+                TrieNode::Branch(children, value) => match position {
+                    FlattenNodesCrumb::Entering => {
+                        let new_children: [Option<CryptoHash>; 16] = Default::default();
+                        stack.push((node, FlattenNodesCrumb::AtChild(Box::new(new_children), 0)));
+                        continue;
+                    }
+                    FlattenNodesCrumb::AtChild(mut new_children, mut i) => {
+                        if i > 0 && children[i - 1].is_some() {
+                            new_children[i - 1] = Some(last_hash);
+                        }
+                        while i < 16 {
+                            match children[i].as_ref() {
+                                Some(NodeHandle::InMemory(_)) => {
+                                    break;
+                                }
+                                Some(NodeHandle::Hash(hash)) => {
+                                    new_children[i] = Some(*hash);
+                                }
+                                None => {}
+                            }
+                            i += 1;
+                        }
+                        if i < 16 {
+                            match children[i].as_ref() {
+                                Some(NodeHandle::InMemory(child_node)) => {
+                                    stack.push((
+                                        node,
+                                        FlattenNodesCrumb::AtChild(new_children, i + 1),
+                                    ));
+                                    stack.push((*child_node, FlattenNodesCrumb::Entering));
+                                    continue;
+                                }
+                                _ => unreachable!(),
+                            }
+                        }
+                        RawTrieNode::Branch(*new_children, value.clone())
+                    }
+                    FlattenNodesCrumb::Exiting => unreachable!(),
+                },
+                TrieNode::Extension(key, child) => match position {
+                    FlattenNodesCrumb::Entering => match child {
+                        NodeHandle::InMemory(child) => {
+                            stack.push((node, FlattenNodesCrumb::Exiting));
+                            stack.push((*child, FlattenNodesCrumb::Entering));
+                            continue;
+                        }
+                        NodeHandle::Hash(hash) => RawTrieNode::Extension(key.clone(), *hash),
+                    },
+                    FlattenNodesCrumb::Exiting => RawTrieNode::Extension(key.clone(), last_hash),
+                    _ => unreachable!(),
+                },
+                TrieNode::Leaf(key, value) => RawTrieNode::Leaf(key.clone(), value.clone()),
+            };
+            let data = rc_node.encode().expect("Failed to serialize");
+            let key = hash(&data);
+
+            nodes.entry(key).or_insert_with(|| (data, 0)).1 += 1;
+            last_hash = key;
+        }
+        let (insertions, deletions) = Trie::cancel_out_changes(nodes, memory.moved_from_db);
+        TrieChanges { new_root: last_hash, insertions, deletions }
+    }
+
+    fn cancel_out_changes(
+        insertions: HashMap<CryptoHash, (Vec<u8>, u32)>,
+        deletions: HashMap<CryptoHash, u32>,
+    ) -> ((Vec<(CryptoHash, Vec<u8>, u32)>, Vec<(CryptoHash, u32)>)) {
+        let mut deletions = deletions;
+        let mut node_insertions = Vec::new();
+        for (key, (value, mut rc)) in insertions.into_iter() {
+            if let Entry::Occupied(mut entry) = deletions.entry(key) {
+                let death_rc = entry.get_mut();
+                if rc >= *death_rc {
+                    rc -= *death_rc;
+                    entry.remove();
+                } else {
+                    *death_rc -= rc;
+                    rc = 0;
+                }
+            }
+            if rc > 0 {
+                node_insertions.push((key, value, rc));
+            }
+        }
+        let mut node_deletions: Vec<_> = deletions.into_iter().collect();
+        // Sort so that trie changes have unique representation
+        node_insertions.sort();
+        node_deletions.sort();
+        (node_insertions, node_deletions)
     }
 
     pub fn update<I>(&self, root: &CryptoHash, changes: I) -> (DBChanges, CryptoHash)
     where
         I: Iterator<Item = (Vec<u8>, Option<Vec<u8>>)>,
     {
-        let mut death_row: HashMap<CryptoHash, u32> = HashMap::default();
-        let mut last_root = Some(*root);
-        let mut root_node = self.retrieve_node(root).expect("Root not found");
+        let mut memory = NodesStorage::new();
+        let mut root_node = self.move_node_to_mutable(&mut memory, root).expect("Root not found");
         for (key, value) in changes {
             let key = NibbleSlice::new(&key);
             match value {
                 Some(arr) => {
-                    root_node = self.insert(root_node, key, arr).expect("Failed to insert");
-                    last_root = None;
+                    root_node =
+                        self.insert(&mut memory, root_node, key, arr).expect("Failed to insert");
                 }
                 None => {
                     root_node = match self
-                        .delete(root_node, last_root, key, &mut death_row)
+                        .delete(&mut memory, root_node, key)
                         .expect("Failed to remove element")
                     {
-                        (Some(value), _) => value,
-                        (None, _) => TrieNode::Empty,
+                        (value, _) => value,
                     };
-                    last_root = None;
                 }
             }
         }
-        let mut db_changes = HashMap::default();
+        //        println!("root node is {}", memory.node_ref(root_node).deep_to_string(&memory));
+        let trie_changes = Trie::flatten_nodes(memory, root_node);
 
-        let mut nodes = HashMap::default();
-        let new_root = self.flatten_nodes(root_node, &mut nodes);
-        for (key, (value, mut rc)) in nodes.drain() {
-            if let Some(death_rc) = death_row.get(&key) {
-                rc -= death_rc;
-                death_row.remove(&key);
-            }
-            if rc > 0 {
-                let bytes = RcTrieNode::encode(&value, rc).expect("Failed to serialize");
+        self.convert_to_db_changes(trie_changes)
+    }
+
+    pub fn convert_to_db_changes(&self, changes: TrieChanges) -> (DBChanges, CryptoHash) {
+        let mut db_changes = HashMap::default();
+        let TrieChanges { new_root, insertions, deletions } = changes;
+        for (key, value, rc) in insertions.into_iter() {
+            let storage_rc =
+                self.storage.retrieve_raw_node(&key).map_or_else(|| 0, |(_val, rc)| rc);
+            let bytes = RcTrieNode::encode(&value, storage_rc + rc).expect("Failed to serialize");
+            db_changes.insert(key.as_ref().to_vec(), Some(bytes));
+        }
+        for (key, rc) in deletions.into_iter() {
+            let (value, storage_rc) =
+                self.storage.retrieve_raw_node(&key).expect("Node to delete does not exist");
+            assert!(rc <= storage_rc);
+            if rc < storage_rc {
+                let bytes =
+                    RcTrieNode::encode(&value, storage_rc - rc).expect("Failed to serialize");
                 db_changes.insert(key.as_ref().to_vec(), Some(bytes));
             } else {
                 db_changes.insert(key.as_ref().to_vec(), None);
             }
-        }
-        for (hash, death_rc) in death_row {
-            if let Some((bytes, rc)) = self.retrieve_raw_node(&hash) {
-                if rc - death_rc > 0 {
-                    let bytes =
-                        RcTrieNode::encode(&bytes, rc - death_rc).expect("Failed to serialize");
-                    db_changes.insert(hash.as_ref().to_vec(), Some(bytes));
-                    continue;
-                }
-            }
-            db_changes.insert(hash.as_ref().to_vec(), None);
         }
         (db_changes, new_root)
     }
@@ -615,7 +971,8 @@ impl Trie {
 
     #[inline]
     pub fn apply_changes(&self, changes: DBChanges) -> std::io::Result<()> {
-        self.storage.read().expect(POISONED_LOCK_ERR).apply_state_updates(&changes)
+        self.storage.cache.lock().expect(POISONED_LOCK_ERR).cache_clear();
+        self.storage.storage.read().expect(POISONED_LOCK_ERR).apply_state_updates(&changes)
     }
 }
 
@@ -682,7 +1039,7 @@ impl<'a> TrieIterator<'a> {
         loop {
             let node = match hash {
                 NodeHandle::Hash(hash) => self.trie.retrieve_node(&hash)?,
-                NodeHandle::InMemory(node) => *node,
+                NodeHandle::InMemory(_node) => unreachable!(),
             };
             let copy_node = node.clone();
             match node {
@@ -797,7 +1154,7 @@ impl<'a> Iterator for TrieIterator<'a> {
                     (CrumbStatus::At, TrieNode::Extension(_, child)) => {
                         let next_node = match child {
                             NodeHandle::Hash(hash) => self.trie.retrieve_node(hash).map(Box::new),
-                            NodeHandle::InMemory(node) => Ok(node.clone()),
+                            NodeHandle::InMemory(_node) => unreachable!(),
                         };
                         IterStep::Descend(next_node)
                     }
@@ -815,7 +1172,7 @@ impl<'a> Iterator for TrieIterator<'a> {
                             Some(NodeHandle::Hash(hash)) => {
                                 self.trie.retrieve_node(&hash).map(Box::new)
                             }
-                            Some(NodeHandle::InMemory(node)) => Ok(node.clone()),
+                            Some(NodeHandle::InMemory(_node)) => unreachable!(),
                             _ => panic!("Wrapped with is_some()"),
                         };
                         IterStep::Descend(next_node)
@@ -845,6 +1202,8 @@ impl<'a> Iterator for TrieIterator<'a> {
 mod tests {
     use super::*;
     use crate::test_utils::create_trie;
+    use rand::seq::SliceRandom;
+    use rand::{rngs::ThreadRng, Rng};
 
     type TrieChanges = Vec<(Vec<u8>, Option<Vec<u8>>)>;
 
@@ -867,6 +1226,7 @@ mod tests {
         for (key, _) in delete_changes {
             assert_eq!(trie.get(&root, &key), None);
         }
+        println!("nice trie has no keys");
         root
     }
 
@@ -999,7 +1359,7 @@ mod tests {
     }
 
     #[test]
-    fn test_trie_remove_non_existant_key() {
+    fn test_trie_remove_non_existent_key() {
         let trie = create_trie();
         let mut initial = vec![
             (vec![99, 44, 100, 58, 58, 49], Some(vec![1])),
@@ -1039,6 +1399,80 @@ mod tests {
         trie.apply_changes(db_changes).unwrap();
         for r in trie.iter(&root).unwrap() {
             r.unwrap();
+        }
+    }
+
+    fn gen_changes(rng: &mut ThreadRng) -> Vec<(Vec<u8>, Option<Vec<u8>>)> {
+        let alphabet = &b"abcdefgh"[0..rng.gen_range(2, 8)];
+        let max_length = rng.gen_range(2, 8);
+
+        let mut state: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
+        let mut result = Vec::new();
+        let delete_probability = rng.gen_range(0.1, 0.5);
+        let size = rng.gen_range(1, 20);
+        for _ in 0..size {
+            let key_length = rng.gen_range(1, max_length);
+            let key: Vec<u8> =
+                (0..key_length).map(|_| alphabet.choose(rng).unwrap().clone()).collect();
+
+            let delete = rng.gen_range(0.0, 1.0) < delete_probability;
+            if delete {
+                let mut keys: Vec<_> = state.keys().cloned().collect();
+                keys.push(key);
+                let key = keys.choose(rng).unwrap().clone();
+                state.remove(&key);
+                result.push((key.clone(), None));
+            } else {
+                let value_length = rng.gen_range(1, max_length);
+                let value: Vec<u8> =
+                    (0..value_length).map(|_| alphabet.choose(rng).unwrap().clone()).collect();
+                result.push((key.clone(), Some(value.clone())));
+                state.insert(key, value);
+            }
+        }
+        result
+    }
+
+    fn simplify_changes(
+        changes: &Vec<(Vec<u8>, Option<Vec<u8>>)>,
+    ) -> Vec<(Vec<u8>, Option<Vec<u8>>)> {
+        let mut state: HashMap<Vec<u8>, Vec<u8>> = HashMap::new();
+        for (key, value) in changes.iter() {
+            if let Some(value) = value {
+                state.insert(key.clone(), value.clone());
+            } else {
+                state.remove(key);
+            }
+        }
+        let mut result: Vec<_> = state.into_iter().map(|(k, v)| (k, Some(v))).collect();
+        result.sort();
+        result
+    }
+
+    #[test]
+    fn test_trie_unique() {
+        let mut rng = rand::thread_rng();
+        for _ in 0..1000 {
+            let trie = create_trie();
+            let trie_changes = gen_changes(&mut rng);
+            let simplified_changes = simplify_changes(&trie_changes);
+
+            let (db_changes1, root1) =
+                trie.update(&Trie::empty_root(), trie_changes.iter().cloned());
+            let (db_changes2, root2) =
+                trie.update(&Trie::empty_root(), simplified_changes.iter().cloned());
+            if root1 != root2 {
+                eprintln!("{:?}", trie_changes);
+                eprintln!("{:?}", simplified_changes);
+                eprintln!("root1: {}", root1);
+                eprintln!("root2: {}", root2);
+                panic!("MISMATCH!");
+            }
+            let mut db_changes1: Vec<_> = db_changes1.into_iter().collect();
+            db_changes1.sort();
+            let mut db_changes2: Vec<_> = db_changes2.into_iter().collect();
+            db_changes2.sort();
+            assert_eq!(db_changes1, db_changes2);
         }
     }
 }

--- a/runtime/storage/src/trie/nibble_slice.rs
+++ b/runtime/storage/src/trie/nibble_slice.rs
@@ -46,8 +46,6 @@ use std::fmt;
 pub struct NibbleSlice<'a> {
     data: &'a [u8],
     offset: usize,
-    data_encode_suffix: &'a [u8],
-    offset_encode_suffix: usize,
 }
 
 /// Iterator type for a nibble slice.
@@ -76,7 +74,7 @@ impl<'a> NibbleSlice<'a> {
 
     /// Create a new nibble slice with the given byte-slice with a nibble offset.
     pub fn new_offset(data: &'a [u8], offset: usize) -> Self {
-        NibbleSlice { data, offset, data_encode_suffix: &b""[..], offset_encode_suffix: 0 }
+        NibbleSlice { data, offset }
     }
 
     /// Get an iterator for the series of nibbles.
@@ -97,39 +95,22 @@ impl<'a> NibbleSlice<'a> {
     /// Get the length (in nibbles, naturally) of this slice.
     #[inline]
     pub fn len(&self) -> usize {
-        (self.data.len() + self.data_encode_suffix.len()) * 2
-            - self.offset
-            - self.offset_encode_suffix
+        self.data.len() * 2 - self.offset
     }
 
     /// Get the nibble at position `i`.
     #[inline(always)]
     pub fn at(&self, i: usize) -> u8 {
-        let l = self.data.len() * 2 - self.offset;
-        if i < l {
-            if (self.offset + i) & 1 == 1 {
-                self.data[(self.offset + i) / 2] & 15u8
-            } else {
-                self.data[(self.offset + i) / 2] >> 4
-            }
+        if (self.offset + i) & 1 == 1 {
+            self.data[(self.offset + i) / 2] & 15u8
         } else {
-            let i = i - l;
-            if (self.offset_encode_suffix + i) & 1 == 1 {
-                self.data_encode_suffix[(self.offset_encode_suffix + i) / 2] & 15u8
-            } else {
-                self.data_encode_suffix[(self.offset_encode_suffix + i) / 2] >> 4
-            }
+            self.data[(self.offset + i) / 2] >> 4
         }
     }
 
     /// Return object which represents a view on to this slice (further) offset by `i` nibbles.
     pub fn mid(&self, i: usize) -> NibbleSlice<'a> {
-        NibbleSlice {
-            data: self.data,
-            offset: self.offset + i,
-            data_encode_suffix: &b""[..],
-            offset_encode_suffix: 0,
-        }
+        NibbleSlice { data: self.data, offset: self.offset + i }
     }
 
     /// Do we start with the same nibbles as the whole of `them`?

--- a/runtime/storage/src/trie/update.rs
+++ b/runtime/storage/src/trie/update.rs
@@ -25,7 +25,7 @@ impl TrieUpdate {
         } else if let Some(value) = self.committed.get(key) {
             Some(DBValue::from_slice(value.as_ref()?))
         } else {
-            self.trie.get(&self.root, key).map(|x| DBValue::from_vec(x))
+            self.trie.get(&self.root, key).map(DBValue::from_vec)
         }
     }
     pub fn set(&mut self, key: Vec<u8>, value: DBValue) -> Option<Vec<u8>> {

--- a/runtime/wasm/Cargo.toml
+++ b/runtime/wasm/Cargo.toml
@@ -11,7 +11,7 @@ parity-wasm = "0.31"
 wasmer-runtime = "0.3.0"
 byteorder = "1.2"
 log = "0.4"
-cached = "0.8.0"
+cached = { git = "https://github.com/nearprotocol/cached", rev = "7e472eddef68607e344d5a106a0e6705d92e55be" }
 serde = "1.0"
 serde_derive = "1.0"
 

--- a/test-utils/testlib/src/standard_test_cases.rs
+++ b/test-utils/testlib/src/standard_test_cases.rs
@@ -340,7 +340,7 @@ pub fn test_callback(node: RuntimeNode) {
     let callback_id = [0; 32].to_vec();
 
     let mut state_update = node.client.read().unwrap().get_state_update();
-    set(&mut state_update, &key_for_callback(&callback_id), &callback);
+    set(&mut state_update, key_for_callback(&callback_id), &callback);
     let (root, transaction) = state_update.finalize();
     {
         let mut client = node.client.write().unwrap();
@@ -386,7 +386,7 @@ pub fn test_callback_failure(node: RuntimeNode) {
     callback.results.resize(1, None);
     let callback_id = [0; 32].to_vec();
     let mut state_update = node.client.read().unwrap().get_state_update();
-    set(&mut state_update, &key_for_callback(&callback_id.clone()), &callback);
+    set(&mut state_update, key_for_callback(&callback_id.clone()), &callback);
     let (root, transaction) = state_update.finalize();
     {
         let mut client = node.client.write().unwrap();

--- a/tests/hello/assembly/main.ts
+++ b/tests/hello/assembly/main.ts
@@ -104,6 +104,39 @@ export function testSetRemove(value: string): void {
   assert(storage.getItem("test") == null, "Item must be empty");
 }
 
+function buildString(n: i32): string {
+  assert(n >= 0);
+  let result = "";
+  for (let i = 20; i >= 0; --i) {
+    result = result + result;
+    if ((n >> i) & 1) {
+      result += "a";
+    }
+  }
+  return result;
+}
+
+export function insertStrings(from: i32, to: i32): void {
+  let str = buildString(to);
+  for (let i = from; i < to; i++) {
+    storage.setItem(str.substr(to - i) + "b", "x");
+  }
+}
+
+export function deleteStrings(from: i32, to: i32): void {
+  let str = buildString(to);
+  for (let i = to - 1; i >= from; i--) {
+    storage.removeItem(str.substr(to - i) + "b");
+  }
+}
+
+export function recurse(n: i32): i32 {
+  if (n <= 0) {
+    return n;
+  }
+  return recurse(n - 1) + 1;
+}
+
 // For testing promises
 
 export function callPromise(args: PromiseArgs): void {


### PR DESCRIPTION
- change structure, make an storage object for temporary mutable trie nodes
- normalize nodes after delete, a test for unique representation
- non-recursive trie methods, an evil contract test
- correctly compute refcounts
- TrieChanges to support storing multiple versions in the future
- Cache for storage, will be more useful later, also fix cached crate

Performance got better but still a lot of time is spent allocating.