### PR TITLE
Subtract storage cost from the account's balance

### DIFF
--- a/nearmint/tests/test.rs
+++ b/nearmint/tests/test.rs
@@ -102,35 +102,39 @@ mod test {
     };
     use testlib::test_helpers::heavy_test;
 
-    #[test]
+    //    #[test]
     fn test_send_tx() {
         heavy_test(|| {
             let storage_path = "tmp/test_send_tx";
             let _test_node = start_nearmint(storage_path);
             let signer = InMemorySigner::from_seed("alice.near", "alice.near");
+            let money_to_send = 1_000_000;
             let tx: near_protos::signed_transaction::SignedTransaction =
-                TransactionBody::send_money(1, "alice.near", "bob.near", 10).sign(&signer).into();
+                TransactionBody::send_money(1, "alice.near", "bob.near", money_to_send)
+                    .sign(&signer)
+                    .into();
             submit_tx(tx);
 
             let alice_account = view_account_request("alice.near").unwrap();
-            assert_eq!(alice_account.amount, TESTING_INIT_BALANCE - 10);
+            assert!(alice_account.amount < TESTING_INIT_BALANCE - money_to_send);
             let bob_account = view_account_request("bob.near").unwrap();
-            assert_eq!(bob_account.amount, TESTING_INIT_BALANCE + 10);
+            assert_eq!(bob_account.amount, TESTING_INIT_BALANCE + money_to_send);
         });
     }
 
-    #[test]
+    //    #[test]
     fn test_create_account() {
         heavy_test(|| {
             let storage_path = "tmp/test_create_account";
             let _test_node = start_nearmint(storage_path);
             let signer = InMemorySigner::from_seed("alice.near", "alice.near");
+            let money_to_send = 1_000_000;
             let tx: near_protos::signed_transaction::SignedTransaction =
                 TransactionBody::CreateAccount(CreateAccountTransaction {
                     nonce: 1,
                     originator: "alice.near".to_string(),
                     new_account_id: "test.near".to_string(),
-                    amount: 10,
+                    amount: money_to_send,
                     public_key: signer.public_key.0[..].to_vec(),
                 })
                 .sign(&signer)
@@ -138,9 +142,9 @@ mod test {
             submit_tx(tx);
 
             let alice_account = view_account_request("alice.near").unwrap();
-            assert_eq!(alice_account.amount, TESTING_INIT_BALANCE - 10);
+            assert!(alice_account.amount < TESTING_INIT_BALANCE - money_to_send);
             let eve_account = view_account_request("test.near").unwrap();
-            assert_eq!(eve_account.amount, 10);
+            assert_eq!(eve_account.amount, money_to_send);
         });
     }
 
@@ -150,12 +154,13 @@ mod test {
             let storage_path = "tmp/test_create_account";
             let _test_node = start_nearmint(storage_path);
             let signer = InMemorySigner::from_seed("alice.near", "alice.near");
+            let money_to_send = 1_000_000;
             let tx: near_protos::signed_transaction::SignedTransaction =
                 TransactionBody::CreateAccount(CreateAccountTransaction {
                     nonce: 1,
                     originator: "alice.near".to_string(),
                     new_account_id: "test.near".to_string(),
-                    amount: 10,
+                    amount: money_to_send,
                     public_key: signer.public_key.0[..].to_vec(),
                 })
                 .sign(&signer)
@@ -173,7 +178,8 @@ mod test {
                 .into();
             submit_tx(tx);
             let eve_account = view_account_request("test.near").unwrap();
-            assert_eq!(eve_account.amount, 10);
+            assert!(eve_account.amount > 0);
+            assert!(eve_account.amount < money_to_send);
             assert_eq!(eve_account.code_hash, hash(wasm_binary));
         });
     }

--- a/nearmint/tests/test.rs
+++ b/nearmint/tests/test.rs
@@ -102,7 +102,7 @@ mod test {
     };
     use testlib::test_helpers::heavy_test;
 
-    //    #[test]
+    #[test]
     fn test_send_tx() {
         heavy_test(|| {
             let storage_path = "tmp/test_send_tx";
@@ -122,7 +122,7 @@ mod test {
         });
     }
 
-    //    #[test]
+    #[test]
     fn test_create_account() {
         heavy_test(|| {
             let storage_path = "tmp/test_create_account";

--- a/runtime/primitives/src/account.rs
+++ b/runtime/primitives/src/account.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use crate::crypto::signature::PublicKey;
 use crate::hash::CryptoHash;
 use crate::logging;
-use crate::types::{AccountId, Balance, Nonce, StorageUsage};
+use crate::types::{AccountId, Balance, BlockIndex, Nonce, StorageUsage};
 
 use near_protos::access_key as access_key_proto;
 
@@ -22,11 +22,21 @@ pub struct Account {
     pub code_hash: CryptoHash,
     /// Storage used by the given account.
     pub storage_usage: StorageUsage,
+    /// Last block index at which the storage was paid for.
+    pub storage_paid_at: BlockIndex,
 }
 
 impl Account {
     pub fn new(public_keys: Vec<PublicKey>, amount: Balance, code_hash: CryptoHash) -> Self {
-        Account { public_keys, nonce: 0, amount, staked: 0, code_hash, storage_usage: 0 }
+        Account {
+            public_keys,
+            nonce: 0,
+            amount,
+            staked: 0,
+            code_hash,
+            storage_usage: 0,
+            storage_paid_at: 0,
+        }
     }
 }
 

--- a/runtime/runtime/src/chain_spec.rs
+++ b/runtime/runtime/src/chain_spec.rs
@@ -35,7 +35,7 @@ pub struct ChainSpec {
 }
 
 /// Initial balance used in tests.
-pub const TESTING_INIT_BALANCE: Balance = 1_000_000_000_000;
+pub const TESTING_INIT_BALANCE: Balance = 1_000_000_000_000_000;
 /// Initial transactions stake used in tests.
 pub const TESTING_INIT_TX_STAKE: Balance = 1_000;
 /// Stake used by authorities to validate used in tests.

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -37,7 +37,6 @@ use crate::ethereum::EthashProvider;
 use crate::ext::RuntimeExt;
 use crate::system::{system_account, system_create_account, SYSTEM_METHOD_CREATE_ACCOUNT};
 use crate::tx_stakes::{TxStakeConfig, TxTotalStake};
-use std::cmp::max;
 use std::sync::{Arc, Mutex};
 use storage::{get, set, TrieUpdate};
 use verifier::{TransactionVerifier, VerificationData};

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -179,10 +179,8 @@ impl Runtime {
         let meta_storage = key_for_account(account_id).len() as StorageUsage
             + account.encode().unwrap().len() as StorageUsage;
         let total_storage = account.storage_usage + meta_storage;
-        account.amount = max(
-            0,
-            account.amount - (block_index - account.storage_paid_at) * total_storage * STORAGE_COST,
-        );
+        let charge = (block_index - account.storage_paid_at) * total_storage * STORAGE_COST;
+        account.amount = if charge <= account.amount { account.amount - charge } else { 0 };
         account.storage_paid_at = block_index;
     }
 

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -269,8 +269,7 @@ mod tests {
     fn test_view_state() {
         let (_, trie, root) = get_runtime_and_trie();
         let mut state_update = TrieUpdate::new(trie.clone(), root);
-        state_update
-            .set(account_suffix(&alice_account(), b"test123"), DBValue::from_slice(b"123"));
+        state_update.set(account_suffix(&alice_account(), b"test123"), DBValue::from_slice(b"123"));
         let (new_root, db_changes) = state_update.finalize();
         trie.apply_changes(db_changes).unwrap();
 

--- a/scripts/start_nearmint.sh
+++ b/scripts/start_nearmint.sh
@@ -3,4 +3,4 @@ set -ex
 
 cargo run --package keystore keygen --tendermint --test-seed "alice.near" -p ~/.tendermint/config/
 cargo build --package nearmint --release
-./target/release/nearmint --devnet & tendermint node --rpc.laddr "tcp://0.0.0.0:3030"
+./target/release/nearmint --devnet & tendermint node --rpc.laddr "tcp://0.0.0.0:3030" --consensus.create_empty_blocks=false


### PR DESCRIPTION
Limitations:
* Currently we subtract storage cost from the account balance only when the transaction is sent from that account. We don't debit all accounts on each block automatically, because that would be too much of the computation.
* We do not debit AccessKeys, because they are not fully implemented yet. Specifically, their balance is not used;
* The `storage_usage` field of the account does not include the storage that it takes to store the account itself, because we would have to update it too frequently -- every time we change the nonce, public keys, etc of the account because the resulting serialized size is not easily computable.
* The callbacks do not pay for storage because they are temporary.