### PR TITLE
Arbitrary genesis state in chain_spec

### DIFF
--- a/nearmint/src/lib.rs
+++ b/nearmint/src/lib.rs
@@ -67,12 +67,17 @@ impl NearMint {
 
         // Compute genesis from current spec.
         let state_update = TrieUpdate::new(trie.clone(), MerkleHash::default());
-        let (genesis_root, db_changes) = runtime.apply_genesis_state(
-            state_update,
-            &chain_spec.accounts,
-            &chain_spec.genesis_wasm,
-            &chain_spec.initial_authorities,
-        );
+        let (genesis_root, db_changes) =
+            if let Some(ref hardcoded_genesis) = chain_spec.genesis_state {
+                runtime.apply_hardcoded_genesis(state_update, hardcoded_genesis.clone())
+            } else {
+                runtime.apply_genesis_state(
+                    state_update,
+                    &chain_spec.accounts,
+                    &chain_spec.genesis_wasm,
+                    &chain_spec.initial_authorities,
+                )
+            };
 
         storage
             .write()

--- a/runtime/runtime/src/chain_spec.rs
+++ b/runtime/runtime/src/chain_spec.rs
@@ -32,6 +32,9 @@ pub struct ChainSpec {
 
     /// Define authority rotation strategy.
     pub authority_rotation: AuthorityRotation,
+
+    /// Start from a specific state
+    pub genesis_state: Option<Vec<(Vec<u8>, Vec<u8>)>>,
 }
 
 /// Initial balance used in tests.
@@ -129,6 +132,7 @@ impl ChainSpec {
             genesis_wasm: include_bytes!("../../../runtime/wasm/runtest/res/wasm_with_mem.wasm")
                 .to_vec(),
             authority_rotation,
+            genesis_state: None,
         };
         (spec, signers)
     }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -36,6 +36,7 @@ use crate::economics_config::EconomicsConfig;
 use crate::ethereum::EthashProvider;
 use crate::ext::RuntimeExt;
 use crate::system::{system_account, system_create_account, SYSTEM_METHOD_CREATE_ACCOUNT};
+use kvdb::DBValue;
 use std::sync::{Arc, Mutex};
 use storage::{get, set, TrieUpdate};
 use verifier::{TransactionVerifier, VerificationData};
@@ -760,6 +761,17 @@ impl Runtime {
                 get(&state_update, &account_id_bytes).expect("account must exist");
             account.staked = *amount;
             set(&mut state_update, account_id_bytes, &account);
+        }
+        state_update.finalize()
+    }
+
+    pub fn apply_hardcoded_genesis(
+        &self,
+        mut state_update: TrieUpdate,
+        state: Vec<(Vec<u8>, Vec<u8>)>,
+    ) -> (MerkleHash, storage::DBChanges) {
+        for (key, value) in state {
+            state_update.set(key, DBValue::from_vec(value));
         }
         state_update.finalize()
     }

--- a/test-utils/state-viewer/README.md
+++ b/test-utils/state-viewer/README.md
@@ -1,0 +1,13 @@
+# State viewer
+
+Simple tool to view the current state
+
+## Example usage
+
+View the current state in a human-readable format:
+
+    cargo run --package state-viewer -- -d <BASE_DIR> -c <CHAIN_SPEC_FILE>
+
+Dump the current state into a chain spec that starts with it as genesis:
+
+    cargo run --package state-viewer -- -d <BASE_DIR> -c <CHAIN_SPEC_FILE> --dump-genesis-file <OUT_FILE>


### PR DESCRIPTION
- ChainSpec has an optional list of key-value pairs, if it's set then it
is used as genesis state and genesis_wasm/accounts are ignored
- state-viewer can dump the state into a chain spec file