### PR TITLE
Change query response to be just plain json instead of base58 encoded

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use near_primitives::crypto::signature::{PublicKey, Signature};
 use near_primitives::crypto::signer::{EDSigner, InMemorySigner};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::ABCIQueryResponse;
+use near_primitives::rpc::{AccountViewCallResult, QueryResponse};
 use near_primitives::test_utils::get_public_key_from_seed;
 use near_primitives::transaction::{
     ReceiptTransaction, SignedTransaction, TransactionResult, TransactionStatus,
@@ -14,7 +14,6 @@ use near_primitives::transaction::{
 use near_primitives::types::{AccountId, BlockIndex, MerkleHash, ShardId};
 use near_store::test_utils::create_test_store;
 use near_store::{Store, StoreUpdate, Trie, TrieChanges, WrappedTrieChanges};
-use node_runtime::state_viewer::AccountViewCallResult;
 
 use crate::error::{Error, ErrorKind};
 use crate::types::{BlockHeader, ReceiptResult, RuntimeAdapter, Weight};
@@ -161,19 +160,16 @@ impl RuntimeAdapter for KeyValueRuntime {
         _height: BlockIndex,
         path: &str,
         _data: &[u8],
-    ) -> Result<ABCIQueryResponse, Box<dyn std::error::Error>> {
+    ) -> Result<QueryResponse, Box<dyn std::error::Error>> {
         let path = path.split("/").collect::<Vec<_>>();
-        Ok(ABCIQueryResponse::account(
-            path[1],
-            AccountViewCallResult {
-                account_id: path[1].to_string(),
-                nonce: 0,
-                amount: 1000,
-                stake: 0,
-                public_keys: vec![],
-                code_hash: CryptoHash::default(),
-            },
-        ))
+        Ok(QueryResponse::ViewAccount(AccountViewCallResult {
+            account_id: path[1].to_string(),
+            nonce: 0,
+            amount: 1000,
+            stake: 0,
+            public_keys: vec![],
+            code_hash: CryptoHash::default(),
+        }))
     }
 }
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -11,7 +11,7 @@ use protobuf::{Message as ProtoMessage, RepeatedField, SingularPtrField};
 use near_primitives::crypto::signature::{verify, PublicKey, Signature, DEFAULT_SIGNATURE};
 use near_primitives::crypto::signer::EDSigner;
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::rpc::ABCIQueryResponse;
+use near_primitives::rpc::QueryResponse;
 use near_primitives::transaction::{ReceiptTransaction, SignedTransaction, TransactionResult};
 use near_primitives::types::{AccountId, BlockIndex, MerkleHash, ShardId, ValidatorStake};
 use near_primitives::utils::proto_to_type;
@@ -396,7 +396,7 @@ pub trait RuntimeAdapter: Send + Sync {
         height: BlockIndex,
         path: &str,
         data: &[u8],
-    ) -> Result<ABCIQueryResponse, Box<dyn std::error::Error>>;
+    ) -> Result<QueryResponse, Box<dyn std::error::Error>>;
 }
 
 /// The weight is defined as the number of unique validators approving this fork.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -409,7 +409,8 @@ impl ClientActor {
         }
 
         // If we are not producing empty blocks, skip this and call handle scheduling for the next block.
-        if !self.config.produce_empty_blocks && self.tx_pool.len() == 0 && !has_receipts {
+        // Also produce at least one block per epoch (produce a block even if empty if the last height was more than an epoch ago).
+        if !self.config.produce_empty_blocks && self.tx_pool.len() == 0 && !has_receipts && next_height - last_height < self.config.epoch_length {
             self.handle_scheduling_block_production(ctx, head.height, next_height);
             return Ok(());
         }

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -81,8 +81,10 @@ pub fn setup_no_network(
         validators,
         account_id,
         skip_sync_wait,
-        Box::new(|_, _, _| NetworkResponses::NoResponse),
-    )
+        Box::new(|req, _, _| match req {
+            NetworkRequests::FetchInfo => NetworkResponses::Info { num_active_peers: 0, peer_max_count: 0, most_weight_peers: vec![] },
+            _ => NetworkResponses::NoResponse
+        }))
 }
 
 impl BlockProducer {

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -9,7 +9,7 @@ use near_chain::Block;
 use near_network::types::FullPeerInfo;
 use near_primitives::crypto::signer::{AccountSigner, EDSigner, InMemorySigner};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::ABCIQueryResponse;
+use near_primitives::rpc::QueryResponse;
 use near_primitives::serialize::base_format;
 use near_primitives::transaction::{FinalTransactionResult, TransactionResult};
 use near_primitives::types::{AccountId, BlockIndex, MerkleHash};
@@ -204,7 +204,7 @@ pub struct Query {
 }
 
 impl Message for Query {
-    type Result = Result<ABCIQueryResponse, String>;
+    type Result = Result<QueryResponse, String>;
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -91,6 +91,8 @@ pub struct ClientConfig {
     pub log_summary_period: Duration,
     /// Produce empty blocks, use `false` for testing.
     pub produce_empty_blocks: bool,
+    /// Epoch length.
+    pub epoch_length: BlockIndex,
 }
 
 impl ClientConfig {
@@ -110,6 +112,7 @@ impl ClientConfig {
             fetch_info_period: Duration::from_millis(100),
             log_summary_period: Duration::from_secs(10),
             produce_empty_blocks: true,
+            epoch_length: 10,
         }
     }
 }
@@ -131,6 +134,7 @@ impl ClientConfig {
             fetch_info_period: Duration::from_millis(100),
             log_summary_period: Duration::from_secs(10),
             produce_empty_blocks: true,
+            epoch_length: 10,
         }
     }
 }

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 
 use near_chain::{Block, Chain, ErrorKind, RuntimeAdapter};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::ABCIQueryResponse;
+use near_primitives::rpc::QueryResponse;
 use near_primitives::transaction::{
     FinalTransactionResult, FinalTransactionStatus, TransactionLogs, TransactionResult,
     TransactionStatus,
@@ -85,7 +85,7 @@ impl Actor for ViewClientActor {
 
 /// Handles runtime query.
 impl Handler<Query> for ViewClientActor {
-    type Result = Result<ABCIQueryResponse, String>;
+    type Result = Result<QueryResponse, String>;
 
     fn handle(&mut self, msg: Query, _: &mut Context<Self>) -> Self::Result {
         let head = self.chain.head().map_err(|err| err.to_string())?;

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -4,6 +4,7 @@ use futures::future::Future;
 
 use near_client::test_utils::setup_no_network;
 use near_client::Query;
+use near_primitives::rpc::QueryResponse;
 use near_primitives::test_utils::init_test_logger;
 
 /// Query account from view client
@@ -15,7 +16,10 @@ fn query_client() {
         actix::spawn(
             view_client.send(Query { path: "account/test".to_string(), data: vec![] }).then(
                 |res| {
-                    assert_eq!(res.unwrap().unwrap().log, "exists");
+                    match res {
+                        Ok(Ok(QueryResponse::ViewAccount(_))) => (),
+                        _ => panic!("Invalid response"),
+                    }
                     System::current().stop();
                     future::result(Ok(()))
                 },

--- a/chain/jsonrpc/src/client.rs
+++ b/chain/jsonrpc/src/client.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 
 use near_chain::Block;
 use near_client::StatusResponse;
-use near_primitives::rpc::ABCIQueryResponse;
+use near_primitives::rpc::QueryResponse;
 use near_primitives::transaction::{FinalTransactionResult, TransactionResult};
 use near_primitives::types::BlockIndex;
 
@@ -164,7 +164,7 @@ macro_rules! jsonrpc_client {
 jsonrpc_client!(pub struct JsonRpcClient {
     pub fn broadcast_tx_async(&mut self, tx: String) -> RpcRequest<String>;
     pub fn broadcast_tx_commit(&mut self, tx: String) -> RpcRequest<FinalTransactionResult>;
-    pub fn query(&mut self, path: String, data: String) -> RpcRequest<ABCIQueryResponse>;
+    pub fn query(&mut self, path: String, data: String) -> RpcRequest<QueryResponse>;
     pub fn status(&mut self) -> RpcRequest<StatusResponse>;
     pub fn health(&mut self) -> RpcRequest<()>;
     pub fn tx(&mut self, hash: String) -> RpcRequest<FinalTransactionResult>;

--- a/core/primitives/src/account.rs
+++ b/core/primitives/src/account.rs
@@ -10,6 +10,7 @@ use near_protos::access_key as access_key_proto;
 use crate::crypto::signature::PublicKey;
 use crate::hash::CryptoHash;
 use crate::logging;
+use crate::serialize::u128_hex_format;
 use crate::types::{AccountId, Balance, BlockIndex, Nonce, StorageUsage};
 
 /// Per account information stored in the state.
@@ -61,6 +62,7 @@ impl Account {
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
 pub struct AccessKey {
     /// Balance amount on this Access Key. Can be used to pay for the transactions.
+    #[serde(with = "u128_hex_format")]
     pub amount: Balance,
     /// Owner of the balance of this Access Key. None means the account owner.
     pub balance_owner: Option<AccountId>,

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -177,6 +177,7 @@ impl NearConfig {
                 fetch_info_period: Duration::from_millis(100),
                 log_summary_period: Duration::from_secs(10),
                 produce_empty_blocks: config.consensus.produce_empty_blocks,
+                epoch_length: genesis_config.epoch_length,
             },
             network_config: NetworkConfig {
                 public_key: network_key_pair.public_key,

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -12,7 +12,7 @@ use near_chain::{
 use near_primitives::account::AccessKey;
 use near_primitives::crypto::signature::{PublicKey, Signature};
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::rpc::ABCIQueryResponse;
+use near_primitives::rpc::{AccountViewCallResult, QueryResponse, ViewStateResult};
 use near_primitives::transaction::{ReceiptTransaction, SignedTransaction, TransactionResult};
 use near_primitives::types::{AccountId, BlockIndex, Epoch, MerkleHash, ShardId, ValidatorStake};
 use near_primitives::utils::prefix_for_access_key;
@@ -20,7 +20,7 @@ use near_store::{get, Store, StoreUpdate, Trie, TrieUpdate, WrappedTrieChanges};
 use near_verifier::TransactionVerifier;
 use node_runtime::adapter::query_client;
 use node_runtime::ethereum::EthashProvider;
-use node_runtime::state_viewer::{AccountViewCallResult, TrieViewer, ViewStateResult};
+use node_runtime::state_viewer::TrieViewer;
 use node_runtime::{ApplyState, Runtime, ETHASH_CACHE_PATH};
 
 use crate::config::GenesisConfig;
@@ -290,7 +290,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         height: BlockIndex,
         path: &str,
         data: &[u8],
-    ) -> Result<ABCIQueryResponse, Box<dyn std::error::Error>> {
+    ) -> Result<QueryResponse, Box<dyn std::error::Error>> {
         query_client(self, state_root, height, path, data)
     }
 }

--- a/runtime/runtime/src/adapter.rs
+++ b/runtime/runtime/src/adapter.rs
@@ -1,10 +1,10 @@
 use near_primitives::account::AccessKey;
 use near_primitives::crypto::signature::PublicKey;
-use near_primitives::rpc::ABCIQueryResponse;
+use near_primitives::rpc::{
+    AccountViewCallResult, CallResult, QueryError, QueryResponse, ViewStateResult,
+};
 use near_primitives::serialize::BaseDecode;
 use near_primitives::types::{AccountId, BlockIndex, MerkleHash};
-
-use crate::state_viewer::{AccountViewCallResult, ViewStateResult};
 
 /// Adapter for querying runtime.
 pub trait RuntimeAdapter {
@@ -52,14 +52,14 @@ pub fn query_client(
     height: BlockIndex,
     path: &str,
     data: &[u8],
-) -> Result<ABCIQueryResponse, Box<dyn std::error::Error>> {
+) -> Result<QueryResponse, Box<dyn std::error::Error>> {
     let path_parts: Vec<&str> = path.split('/').collect();
     if path_parts.is_empty() {
         return Err("Path must contain at least single token".into());
     }
     match path_parts[0] {
         "account" => match adapter.view_account(state_root, &AccountId::from(path_parts[1])) {
-            Ok(r) => Ok(ABCIQueryResponse::account(path, r)),
+            Ok(r) => Ok(QueryResponse::ViewAccount(r)),
             Err(e) => Err(e),
         },
         "call" => {
@@ -72,22 +72,21 @@ pub fn query_client(
                 &data,
                 &mut logs,
             ) {
-                Ok(result) => Ok(ABCIQueryResponse::result(path, result, logs)),
-                Err(err) => Ok(ABCIQueryResponse::result_err(path, err.to_string(), logs)),
+                Ok(result) => Ok(QueryResponse::CallResult(CallResult { result, logs })),
+                Err(err) => Ok(QueryResponse::Error(QueryError { error: err.to_string(), logs })),
             }
         }
-        "contract" => match adapter
-            .view_state(state_root, &AccountId::from(path_parts[1]))
-            .and_then(|r| serde_json::to_string(&r).map_err(|err| err.into()))
-        {
-            Ok(result) => Ok(ABCIQueryResponse::result(path, result.as_bytes().to_vec(), vec![])),
-            Err(err) => Ok(ABCIQueryResponse::result_err(path, err.to_string(), vec![])),
+        "contract" => match adapter.view_state(state_root, &AccountId::from(path_parts[1])) {
+            Ok(result) => Ok(QueryResponse::ViewState(result)),
+            Err(err) => {
+                Ok(QueryResponse::Error(QueryError { error: err.to_string(), logs: vec![] }))
+            }
         },
         "access_key" => {
             let result = if path_parts.len() == 2 {
                 adapter
                     .view_access_keys(state_root, &AccountId::from(path_parts[1]))
-                    .and_then(|r| serde_json::to_string(&r).map_err(|err| err.into()))
+                    .map(|r| QueryResponse::AccessKeyList(r))
             } else {
                 adapter
                     .view_access_key(
@@ -95,13 +94,13 @@ pub fn query_client(
                         &AccountId::from(path_parts[1]),
                         &PublicKey::from_base(path_parts[2])?,
                     )
-                    .and_then(|r| serde_json::to_string(&r).map_err(|err| err.into()))
+                    .map(|r| QueryResponse::AccessKey(r))
             };
             match result {
-                Ok(result) => {
-                    Ok(ABCIQueryResponse::result(path, result.as_bytes().to_vec(), vec![]))
+                Ok(result) => Ok(result),
+                Err(err) => {
+                    Ok(QueryResponse::Error(QueryError { error: err.to_string(), logs: vec![] }))
                 }
-                Err(err) => Ok(ABCIQueryResponse::result_err(path, err.to_string(), vec![])),
             }
         }
         _ => Err(format!("Unknown path {}", path).into()),

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -6,8 +6,8 @@ use std::time::Instant;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::crypto::signature::PublicKey;
 use near_primitives::hash::CryptoHash;
-use near_primitives::serialize::{base_format, u128_hex_format};
-use near_primitives::types::{AccountId, Balance, Nonce};
+use near_primitives::rpc::{AccountViewCallResult, ViewStateResult};
+use near_primitives::types::AccountId;
 use near_primitives::utils::{is_valid_account_id, key_for_access_key, key_for_account};
 use near_store::{get, TrieUpdate};
 use wasm::executor;
@@ -19,26 +19,8 @@ use crate::Runtime;
 use super::ext::ACCOUNT_DATA_SEPARATOR;
 use super::RuntimeExt;
 
-#[derive(Serialize, Deserialize)]
-pub struct ViewStateResult {
-    pub values: HashMap<Vec<u8>, Vec<u8>>,
-}
-
 pub struct TrieViewer {
     ethash_provider: Arc<Mutex<EthashProvider>>,
-}
-
-#[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
-pub struct AccountViewCallResult {
-    pub account_id: AccountId,
-    pub nonce: Nonce,
-    #[serde(with = "u128_hex_format")]
-    pub amount: Balance,
-    #[serde(with = "u128_hex_format")]
-    pub stake: Balance,
-    pub public_keys: Vec<PublicKey>,
-    #[serde(with = "base_format")]
-    pub code_hash: CryptoHash,
 }
 
 impl TrieViewer {

--- a/scripts/start_near.sh
+++ b/scripts/start_near.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -ex
 
-cargo run --release -p near -- init --test-seed alice.near --account-id test.near
-cargo run --release -p near -- --verbose run --produce-empty-blocks=false
+cargo run -p near -- init --test-seed alice.near --account-id test.near
+cargo run -p near -- --verbose run --produce-empty-blocks=false

--- a/test-utils/loadtester/src/remote_node.rs
+++ b/test-utils/loadtester/src/remote_node.rs
@@ -9,10 +9,10 @@ use reqwest::r#async::Client as AsyncClient;
 use reqwest::Client as SyncClient;
 
 use near_primitives::crypto::signer::InMemorySigner;
+use near_primitives::rpc::AccountViewCallResult;
 use near_primitives::serialize::from_base;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, Nonce};
-use node_runtime::state_viewer::AccountViewCallResult;
 
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// Maximum number of blocks that can be fetched through a single RPC request.
@@ -148,9 +148,8 @@ impl RemoteNode {
             .form(&[("path", format!("\"account/{}\"", account_id))])
             .send()?
             .json()?;
-        let bytes = from_base(
-            response["result"]["response"]["value"].as_str().ok_or(VALUE_NOT_STR_ERR)?,
-        )?;
+        let bytes =
+            from_base(response["result"]["response"]["value"].as_str().ok_or(VALUE_NOT_STR_ERR)?)?;
         let s = std::str::from_utf8(&bytes)?;
         Ok(serde_json::from_str(s)?)
     }

--- a/test-utils/testlib/src/node/mod.rs
+++ b/test-utils/testlib/src/node/mod.rs
@@ -10,7 +10,7 @@ use near_primitives::crypto::signer::{EDSigner, InMemorySigner};
 use near_primitives::serialize::to_base;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, Balance};
-use node_runtime::state_viewer::AccountViewCallResult;
+use near_primitives::rpc::AccountViewCallResult;
 
 pub use crate::node::process_node::ProcessNode;
 pub use crate::node::runtime_node::RuntimeNode;

--- a/test-utils/testlib/src/standard_test_cases.rs
+++ b/test-utils/testlib/src/standard_test_cases.rs
@@ -2,6 +2,7 @@ use near::config::{TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use near_primitives::account::AccessKey;
 use near_primitives::crypto::signer::InMemorySigner;
 use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::rpc::AccountViewCallResult;
 use near_primitives::serialize::Decode;
 use near_primitives::transaction::{
     AddKeyTransaction, AsyncCall, Callback, CallbackInfo, CallbackResult, CreateAccountTransaction,
@@ -12,7 +13,6 @@ use near_primitives::transaction::{
 use near_primitives::types::Balance;
 use near_primitives::utils::key_for_callback;
 use near_store::set;
-use node_runtime::state_viewer::AccountViewCallResult;
 
 use crate::node::{Node, RuntimeNode};
 use crate::runtime_utils::{bob_account, default_code_hash, encode_int, eve_account};

--- a/test-utils/testlib/src/user/mod.rs
+++ b/test-utils/testlib/src/user/mod.rs
@@ -5,11 +5,11 @@ use near_primitives::account::AccessKey;
 use near_primitives::crypto::signature::PublicKey;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::ReceiptInfo;
+use near_primitives::rpc::{AccountViewCallResult, ViewStateResult};
 use near_primitives::transaction::{
     FinalTransactionResult, ReceiptTransaction, SignedTransaction, TransactionResult,
 };
 use near_primitives::types::{AccountId, Balance, MerkleHash};
-use node_runtime::state_viewer::{AccountViewCallResult, ViewStateResult};
 
 pub use crate::user::runtime_user::RuntimeUser;
 

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -2,14 +2,15 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, RwLock};
 
-use lazy_static::lazy_static;
 use tempdir::TempDir;
 
+use lazy_static::lazy_static;
 use near_chain::Block;
 use near_primitives::account::AccessKey;
 use near_primitives::crypto::signature::PublicKey;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::ReceiptInfo;
+use near_primitives::rpc::{AccountViewCallResult, ViewStateResult};
 use near_primitives::transaction::{
     FinalTransactionResult, FinalTransactionStatus, ReceiptTransaction, SignedTransaction,
     TransactionLogs, TransactionResult, TransactionStatus,
@@ -17,7 +18,7 @@ use near_primitives::transaction::{
 use near_primitives::types::{AccountId, MerkleHash};
 use near_store::{Trie, TrieUpdate};
 use node_runtime::ethereum::EthashProvider;
-use node_runtime::state_viewer::{AccountViewCallResult, TrieViewer, ViewStateResult};
+use node_runtime::state_viewer::TrieViewer;
 use node_runtime::{ApplyState, Runtime};
 
 use crate::user::{User, POISONED_LOCK_ERR};
@@ -161,7 +162,10 @@ impl User for RuntimeUser {
         Ok(())
     }
 
-    fn commit_transaction(&self, transaction: SignedTransaction) -> Result<FinalTransactionResult, String> {
+    fn commit_transaction(
+        &self,
+        transaction: SignedTransaction,
+    ) -> Result<FinalTransactionResult, String> {
         let apply_state = ApplyState {
             root: self.client.read().expect(POISONED_LOCK_ERR).state_root,
             shard_id: 0,


### PR DESCRIPTION
I think from this moment, we should not change the Query API, but instead add new options to the enum, pretty much allowing for versions of return values.
The only question is if we want to have some version number as part of response JSON for example or something else explicit.