### PR TITLE
Include originator_id and public_key into receipts and callbacks

### DIFF
--- a/core/primitives/src/crypto/signature.rs
+++ b/core/primitives/src/crypto/signature.rs
@@ -57,6 +57,11 @@ impl PublicKey {
     pub fn to_readable(&self) -> ReadablePublicKey {
         ReadablePublicKey(self.to_string())
     }
+    pub fn empty() -> Self {
+        let array = [0; sodiumoxide::crypto::sign::ed25519::PUBLICKEYBYTES];
+        let public_key = sodiumoxide::crypto::sign::ed25519::PublicKey(array);
+        PublicKey(public_key)
+    }
 }
 
 impl Hash for PublicKey {

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -617,6 +617,10 @@ pub struct AsyncCall {
     pub args: Vec<u8>,
     pub callback: Option<CallbackInfo>,
     pub refund_account: AccountId,
+    /// Account ID of the account who signed the initial transaction.
+    pub originator_id: AccountId,
+    /// The public key used to sign the initial transaction.
+    pub public_key: PublicKey,
 }
 
 impl TryFrom<receipt_proto::AsyncCall> for AsyncCall {
@@ -629,6 +633,8 @@ impl TryFrom<receipt_proto::AsyncCall> for AsyncCall {
             args: proto.args,
             callback: proto.callback.into_option().map(std::convert::Into::into),
             refund_account: proto.refund_account,
+            originator_id: proto.originator_id,
+            public_key: PublicKey::try_from(&proto.public_key as &[u8])?,
         })
     }
 }
@@ -641,6 +647,8 @@ impl From<AsyncCall> for receipt_proto::AsyncCall {
             args: call.args,
             callback: SingularPtrField::from_option(call.callback.map(std::convert::Into::into)),
             refund_account: call.refund_account,
+            originator_id: call.originator_id,
+            public_key: call.public_key.as_ref().to_vec(),
             ..Default::default()
         }
     }
@@ -652,8 +660,18 @@ impl AsyncCall {
         args: Vec<u8>,
         amount: Balance,
         refund_account: AccountId,
+        originator_id: AccountId,
+        public_key: PublicKey,
     ) -> Self {
-        AsyncCall { amount, method_name, args, callback: None, refund_account }
+        AsyncCall {
+            amount,
+            method_name,
+            args,
+            callback: None,
+            refund_account,
+            originator_id,
+            public_key,
+        }
     }
 }
 
@@ -665,6 +683,8 @@ impl fmt::Debug for AsyncCall {
             .field("args", &format_args!("{}", logging::pretty_utf8(&self.args)))
             .field("callback", &self.callback)
             .field("refund_account", &self.refund_account)
+            .field("originator_id", &self.originator_id)
+            .field("public_key", &self.public_key)
             .finish()
     }
 }
@@ -678,6 +698,10 @@ pub struct Callback {
     pub callback: Option<CallbackInfo>,
     pub result_counter: usize,
     pub refund_account: AccountId,
+    /// Account ID of the account who signed the initial transaction.
+    pub originator_id: AccountId,
+    /// The public key used to sign the initial transaction.
+    pub public_key: PublicKey,
 }
 
 impl Callback {
@@ -686,6 +710,8 @@ impl Callback {
         args: Vec<u8>,
         amount: Balance,
         refund_account: AccountId,
+        originator_id: AccountId,
+        public_key: PublicKey,
     ) -> Self {
         Callback {
             method_name,
@@ -695,6 +721,8 @@ impl Callback {
             callback: None,
             result_counter: 0,
             refund_account,
+            originator_id,
+            public_key,
         }
     }
 }
@@ -709,6 +737,8 @@ impl fmt::Debug for Callback {
             .field("callback", &self.callback)
             .field("result_counter", &format_args!("{}", &self.result_counter))
             .field("refund_account", &self.refund_account)
+            .field("originator_id", &self.originator_id)
+            .field("public_key", &self.public_key)
             .finish()
     }
 }

--- a/core/protos/protos/receipt.proto
+++ b/core/protos/protos/receipt.proto
@@ -15,6 +15,11 @@ message AsyncCall {
     bytes args = 4;
     CallbackInfo callback = 5;
     string refund_account = 7;
+    // Account ID of the account who signed the initial transaction.
+    string originator_id = 8;
+    // The public key used to sign the initial transaction.
+    bytes public_key = 9;
+
 
     // Removed fields.
     reserved 2, 6;

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -105,15 +105,20 @@ impl TrieViewer {
         }
         let root = state_update.get_root();
         let code = Runtime::get_code(&state_update, contract_id)?;
+        // TODO(#1015): Add ability to pass public key and originator_id
+        let originator_id = contract_id;
+        let public_key = PublicKey::empty();
         let wasm_res = match get::<Account>(&state_update, &key_for_account(contract_id)) {
             Some(account) => {
                 let empty_hash = CryptoHash::default();
                 let mut runtime_ext = RuntimeExt::new(
                     &mut state_update,
                     contract_id,
-                    contract_id,
+                    originator_id,
                     &empty_hash,
                     self.ethash_provider.clone(),
+                    originator_id,
+                    &public_key,
                 );
                 executor::execute(
                     &code,
@@ -125,13 +130,14 @@ impl TrieViewer {
                     &RuntimeContext::new(
                         account.amount,
                         0,
-                        contract_id,
+                        originator_id,
                         contract_id,
                         0,
                         block_index,
                         root.as_ref().into(),
                         true,
-                        None,
+                        originator_id,
+                        &public_key,
                     ),
                 )
             }

--- a/runtime/runtime/src/system.rs
+++ b/runtime/runtime/src/system.rs
@@ -10,8 +10,7 @@ use near_primitives::transaction::{
 };
 use near_primitives::types::{AccountId, Balance, ValidatorStake};
 use near_primitives::utils::{
-    create_nonce_with_nonce, is_valid_account_id, key_for_access_key, key_for_account,
-    key_for_code,
+    create_nonce_with_nonce, is_valid_account_id, key_for_access_key, key_for_account, key_for_code,
 };
 use near_store::{get, set, TrieUpdate};
 use wasm::types::ContractCode;
@@ -27,6 +26,7 @@ pub fn send_money(
     hash: CryptoHash,
     sender: &mut Account,
     refund_account_id: &AccountId,
+    public_key: PublicKey,
 ) -> Result<Vec<ReceiptTransaction>, String> {
     if transaction.amount == 0 {
         return Err("Sending 0 tokens".to_string());
@@ -44,6 +44,8 @@ pub fn send_money(
                 vec![],
                 transaction.amount,
                 refund_account_id.clone(),
+                transaction.originator.clone(),
+                public_key,
             )),
         );
         Ok(vec![receipt])
@@ -115,6 +117,7 @@ pub fn create_account(
     hash: CryptoHash,
     sender: &mut Account,
     refund_account_id: &AccountId,
+    public_key: PublicKey,
 ) -> Result<Vec<ReceiptTransaction>, String> {
     if !is_valid_account_id(&body.new_account_id) {
         return Err(format!("Account name {} {}", body.new_account_id, INVALID_ACCOUNT_ID));
@@ -132,6 +135,8 @@ pub fn create_account(
                 body.public_key.clone(),
                 body.amount,
                 refund_account_id.clone(),
+                body.originator.clone(),
+                public_key,
             )),
         );
         Ok(vec![receipt])

--- a/runtime/wasm/runtest/src/lib.rs
+++ b/runtime/wasm/runtest/src/lib.rs
@@ -124,6 +124,7 @@ mod tests {
     use wasm::types::{Config, ContractCode, Error, ReturnData, RuntimeContext, RuntimeError};
 
     use super::*;
+    use near_primitives::crypto::signature::PublicKey;
 
     fn infinite_initializer_contract() -> Vec<u8> {
         wabt::wat2wasm(
@@ -200,11 +201,7 @@ mod tests {
         LittleEndian::read_u128(val)
     }
 
-    fn runtime_context(
-        balance: u128,
-        amount: u128,
-        storage_usage: StorageUsage,
-    ) -> RuntimeContext {
+    fn runtime_context(balance: u128, amount: u128, storage_usage: StorageUsage) -> RuntimeContext {
         RuntimeContext::new(
             balance.into(),
             amount.into(),
@@ -214,7 +211,8 @@ mod tests {
             123,
             b"yolo".to_vec(),
             false,
-            None,
+            &"alice.near".to_string(),
+            &PublicKey::empty(),
         )
     }
 
@@ -324,8 +322,8 @@ mod tests {
     fn test_frozen_balance() {
         let input_data = [0u8; 0];
 
-        let outcome =
-            run(b"test_frozen_balance", &input_data, &[], &runtime_context(10, 100, 0)).expect("ok");
+        let outcome = run(b"test_frozen_balance", &input_data, &[], &runtime_context(10, 100, 0))
+            .expect("ok");
 
         // The frozen balance is not used for the runtime deductions.
         println!("{:?}", outcome);

--- a/runtime/wasm/src/types.rs
+++ b/runtime/wasm/src/types.rs
@@ -303,7 +303,7 @@ impl Default for Config {
 }
 
 /// Context for the WASM contract execution.
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub struct RuntimeContext {
     /// Initial balance is the balance of the account before the
     /// received_amount is added.
@@ -322,10 +322,11 @@ pub struct RuntimeContext {
     pub random_seed: Vec<u8>,
     /// Whether the execution should not charge any costs.
     pub free_of_charge: bool,
-    /// In case this is a function call on by the account owner on their account, we provide
-    /// public key to identify which access key or the public key was used to sign this transaction.
-    /// It's useful to create contract based accounts.
-    public_key: Option<PublicKey>,
+    /// TODO(#1017): Rename to originator_id
+    /// Account ID of the account who signed the initial transaction.
+    pub tx_originator_id: AccountId,
+    /// The public key used to sign the initial transaction.
+    pub public_key: PublicKey,
 }
 
 impl RuntimeContext {
@@ -338,7 +339,8 @@ impl RuntimeContext {
         block_index: BlockIndex,
         random_seed: Vec<u8>,
         free_of_charge: bool,
-        public_key: Option<PublicKey>,
+        originator_id: &AccountId,
+        public_key: &PublicKey,
     ) -> RuntimeContext {
         RuntimeContext {
             initial_balance,
@@ -349,7 +351,8 @@ impl RuntimeContext {
             block_index,
             random_seed,
             free_of_charge,
-            public_key,
+            tx_originator_id: originator_id.clone(),
+            public_key: public_key.clone(),
         }
     }
 }

--- a/test-utils/testlib/src/standard_test_cases.rs
+++ b/test-utils/testlib/src/standard_test_cases.rs
@@ -230,6 +230,8 @@ pub fn test_async_call_with_no_callback(node: impl Node) {
             vec![],
             FUNCTION_CALL_AMOUNT,
             account_id.clone(),
+            account_id.clone(),
+            node.signer().public_key().clone(),
         )),
     };
 
@@ -258,11 +260,19 @@ pub fn test_async_call_with_callback(node: impl Node) {
         args,
         FUNCTION_CALL_AMOUNT,
         refund_account.clone(),
+        account_id.clone(),
+        node.signer().public_key().clone(),
     );
     callback.results.resize(1, None);
     let callback_id = [0; 32].to_vec();
-    let mut async_call =
-        AsyncCall::new(b"run_test".to_vec(), vec![], FUNCTION_CALL_AMOUNT, refund_account.clone());
+    let mut async_call = AsyncCall::new(
+        b"run_test".to_vec(),
+        vec![],
+        FUNCTION_CALL_AMOUNT,
+        refund_account.clone(),
+        account_id.clone(),
+        node.signer().public_key().clone(),
+    );
     let callback_info = CallbackInfo::new(callback_id.clone(), 0, account_id.clone());
     async_call.callback = Some(callback_info.clone());
     let receipt = ReceiptTransaction::new(
@@ -309,6 +319,8 @@ pub fn test_async_call_with_logs(node: impl Node) {
             vec![],
             FUNCTION_CALL_AMOUNT,
             account_id.clone(),
+            account_id.clone(),
+            node.signer().public_key().clone(),
         )),
     };
 
@@ -333,10 +345,24 @@ pub fn test_deposit_with_callback(node: impl Node) {
     let account_id = &node.account_id().unwrap();
     let args = (7..9).flat_map(|x| encode_int(x).to_vec()).collect();
     let refund_account = account_id;
-    let mut callback = Callback::new(b"sum_with_input".to_vec(), args, 0, refund_account.clone());
+    let mut callback = Callback::new(
+        b"sum_with_input".to_vec(),
+        args,
+        0,
+        refund_account.clone(),
+        account_id.clone(),
+        node.signer().public_key().clone(),
+    );
     callback.results.resize(1, None);
     let callback_id = [0; 32].to_vec();
-    let mut async_call = AsyncCall::new(vec![], vec![], 0, refund_account.clone());
+    let mut async_call = AsyncCall::new(
+        vec![],
+        vec![],
+        0,
+        refund_account.clone(),
+        account_id.clone(),
+        node.signer().public_key().clone(),
+    );
     let callback_info = CallbackInfo::new(callback_id.clone(), 0, account_id.clone());
     async_call.callback = Some(callback_info.clone());
     let receipt = ReceiptTransaction::new(
@@ -370,6 +396,8 @@ pub fn test_callback(node: RuntimeNode) {
         vec![],
         FUNCTION_CALL_AMOUNT,
         refund_account.clone(),
+        account_id.clone(),
+        node.signer().public_key().clone(),
     );
     callback.results.resize(1, None);
     let callback_id = [0; 32].to_vec();
@@ -418,6 +446,8 @@ pub fn test_callback_failure(node: RuntimeNode) {
         vec![],
         0,
         refund_account.clone(),
+        account_id.clone(),
+        node.signer().public_key().clone(),
     );
     callback.results.resize(1, None);
     let callback_id = [0; 32].to_vec();


### PR DESCRIPTION
Currently `originator_id` and `public_key` from the `RuntimeContext` is not exposed yet to WASM runtime.

