### PR TITLE
removing deprecated links on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ finally makes using a blockchain protocol easy for both developers and consumers
 
 [Check out quick start documentation](https://docs.nearprotocol.com/quick-start), specifically:
   - [Working with Smart Contracts in NEAR Studio](https://docs.nearprotocol.com/working-smart-contracts)
-  - [Running local DevNet](https://docs.nearprotocol.com/development-environment/advanced)
-  - [Join TestNet](https://docs.nearprotocol.com/development-environment/run-your-own-testnet)
   
 Develop and deploy contracts without any setup required using [NEAR Studio](https://studio.nearprotocol.com):
 


### PR DESCRIPTION
removing links for running local devnet and joining testnet as links have been deprecated