### PR TITLE
Add a nightly rust-toolchain file

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This will automatically download nightly rust when a user runs cargo build --all
in the nearcode directory as opposed to failing with the following error:

```
error: failed to parse manifest at `/home/user/code/nearcore/Cargo.toml`

Caused by:
  the cargo feature `profile-overrides` requires a nightly version of Cargo, but this is the `stable` channel
See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more
  information about Rust release channels.
```