### PR TITLE
Change of stake

### DIFF
--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -435,3 +435,240 @@ impl node_runtime::adapter::RuntimeAdapter for NightshadeRuntime {
         self.trie_viewer.view_state(&state_update, account_id)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::config::{TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
+    use crate::runtime::POISONED_LOCK_ERR;
+    use crate::validator_manager::{ValidatorAssignment, ValidatorStakeChange};
+    use crate::{get_store_path, GenesisConfig, NightshadeRuntime};
+    use near_chain::RuntimeAdapter;
+    use near_client::BlockProducer;
+    use near_primitives::crypto::signer::InMemorySigner;
+    use near_primitives::hash::{hash, CryptoHash};
+    use near_primitives::rpc::AccountViewCallResult;
+    use near_primitives::serialize::BaseEncode;
+    use near_primitives::test_utils::get_key_pair_from_seed;
+    use near_primitives::transaction::{
+        CreateAccountTransaction, ReceiptTransaction, SignedTransaction, StakeTransaction,
+        TransactionBody,
+    };
+    use near_primitives::types::{Balance, BlockIndex, Nonce, ValidatorStake};
+    use near_store::create_store;
+    use node_runtime::adapter::RuntimeAdapter as ViewRuntimeAdapter;
+    use tempdir::TempDir;
+
+    fn stake(nonce: Nonce, sender: &BlockProducer, amount: Balance) -> SignedTransaction {
+        TransactionBody::Stake(StakeTransaction {
+            nonce,
+            originator: sender.account_id.clone(),
+            amount,
+            public_key: sender.signer.public_key().to_base(),
+        })
+        .sign(&*sender.signer.clone())
+    }
+
+    fn change_stake(
+        account_id: &str,
+        new_stake: Balance,
+        return_stake: Balance,
+    ) -> ValidatorStakeChange {
+        ValidatorStakeChange { account_id: account_id.to_string(), new_stake, return_stake }
+    }
+
+    fn assignment(
+        mut accounts: Vec<(&str, Balance)>,
+        block_producers: Vec<u64>,
+        chunk_producers: Vec<Vec<(usize, u64)>>,
+        fishermen: Vec<(usize, u64)>,
+        expected_epoch_start: BlockIndex,
+        stake_change: Vec<ValidatorStakeChange>,
+    ) -> ValidatorAssignment {
+        ValidatorAssignment {
+            validators: accounts
+                .drain(..)
+                .map(|(account_id, amount)| ValidatorStake {
+                    account_id: account_id.to_string(),
+                    public_key: get_key_pair_from_seed(account_id).0,
+                    amount,
+                })
+                .collect(),
+            block_producers,
+            chunk_producers,
+            fishermen,
+            expected_epoch_start,
+            stake_change,
+        }
+    }
+
+    impl NightshadeRuntime {
+        fn update(
+            &self,
+            state_root: &CryptoHash,
+            block_index: BlockIndex,
+            prev_block_hash: &CryptoHash,
+            receipts: &Vec<Vec<ReceiptTransaction>>,
+            transactions: &Vec<SignedTransaction>,
+        ) -> (CryptoHash, Vec<ValidatorStake>, Vec<Vec<ReceiptTransaction>>) {
+            let mut root = *state_root;
+            let (wrapped_trie_changes, new_root, _tx_results, receipt_results, stakes) = self
+                .apply_transactions(0, &root, block_index, &prev_block_hash, receipts, transactions)
+                .unwrap();
+            let mut store_update = self.store.store_update();
+            wrapped_trie_changes.insertions_into(&mut store_update).unwrap();
+            store_update.commit().unwrap();
+            root = new_root;
+            let new_receipts = receipt_results.into_iter().map(|(_, v)| v).collect();
+            (root, stakes, new_receipts)
+        }
+    }
+
+    #[test]
+    fn test_validator_rotation() {
+        let dir = TempDir::new("validator_rotation").unwrap();
+        let store = create_store(&get_store_path(dir.path()));
+        let num_nodes = 2;
+        let validators = (0..num_nodes).map(|i| format!("test{}", i + 1)).collect::<Vec<_>>();
+        let mut genesis_config =
+            GenesisConfig::test(validators.iter().map(|v| v.as_str()).collect());
+        genesis_config.epoch_length = 2;
+        let nightshade = NightshadeRuntime::new(dir.path(), store, genesis_config);
+        let (store_update, state_roots) = nightshade.genesis_state();
+        store_update.commit().unwrap();
+        let mut state_root = state_roots[0];
+        let block_producers: Vec<_> =
+            validators.iter().map(|id| InMemorySigner::from_seed(id, id).into()).collect();
+        let staking_transaction = stake(1, &block_producers[0], TESTING_INIT_STAKE * 2);
+        let (new_root, validator_stakes, _) = nightshade.update(
+            &state_root,
+            0,
+            &CryptoHash::default(),
+            &vec![],
+            &vec![staking_transaction],
+        );
+        state_root = new_root;
+        assert_eq!(
+            validator_stakes,
+            vec![ValidatorStake::new(
+                block_producers[0].account_id.clone(),
+                block_producers[0].signer.public_key(),
+                TESTING_INIT_STAKE * 2
+            )]
+        );
+        let account = nightshade.view_account(state_root, &block_producers[0].account_id).unwrap();
+        assert_eq!(
+            account,
+            AccountViewCallResult {
+                account_id: block_producers[0].account_id.clone(),
+                nonce: 1,
+                amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
+                stake: TESTING_INIT_STAKE * 2,
+                public_keys: vec![block_producers[0].signer.public_key()],
+                code_hash: account.code_hash
+            }
+        );
+        let (h0, h1, h2, h3, h4, h5, h6) =
+            (hash(&[0]), hash(&[1]), hash(&[2]), hash(&[3]), hash(&[4]), hash(&[5]), hash(&[6]));
+        nightshade
+            .add_validator_proposals(CryptoHash::default(), h0, 0, validator_stakes, vec![])
+            .unwrap();
+
+        let new_account = format!("test{}", num_nodes + 1);
+        let new_validator: BlockProducer =
+            InMemorySigner::from_seed(&new_account, &new_account).into();
+        let create_account_transaction = TransactionBody::CreateAccount(CreateAccountTransaction {
+            nonce: 2,
+            originator: block_producers[0].account_id.clone(),
+            new_account_id: new_account,
+            amount: TESTING_INIT_STAKE * 3,
+            public_key: new_validator.signer.public_key().0[..].to_vec(),
+        })
+        .sign(&*block_producers[0].signer.clone());
+        let staking_transaction = stake(1, &new_validator, TESTING_INIT_STAKE * 2);
+
+        let (new_root, _, receipts) =
+            nightshade.update(&state_root, 1, &h0, &vec![], &vec![create_account_transaction]);
+        state_root = new_root;
+        nightshade.add_validator_proposals(h0, h1, 1, vec![], vec![]).unwrap();
+
+        state_root = nightshade.update(&state_root, 2, &h1, &receipts, &vec![]).0;
+        nightshade.add_validator_proposals(h1, h2, 2, vec![], vec![]).unwrap();
+        let (new_root, validator_stakes, _) =
+            nightshade.update(&state_root, 3, &h2, &vec![], &vec![staking_transaction]);
+        state_root = new_root;
+        assert_eq!(
+            validator_stakes,
+            vec![ValidatorStake::new(
+                new_validator.account_id.clone(),
+                new_validator.signer.public_key(),
+                TESTING_INIT_STAKE * 2
+            )]
+        );
+        nightshade.add_validator_proposals(h2, h3, 3, validator_stakes, vec![]).unwrap();
+        nightshade.update(&state_root, 4, &h3, &vec![], &vec![]).0;
+        nightshade.add_validator_proposals(h3, h4, 4, vec![], vec![]).unwrap();
+        {
+            let mut vm = nightshade.validator_manager.write().expect(POISONED_LOCK_ERR);
+            let validators = vm.get_validators(h4).unwrap();
+            assert_eq!(
+                validators,
+                &assignment(
+                    vec![("test3", TESTING_INIT_STAKE * 2), ("test1", TESTING_INIT_STAKE * 2)],
+                    vec![1, 1],
+                    vec![vec![(1, 1), (0, 1)]],
+                    vec![],
+                    6,
+                    vec![
+                        change_stake("test1", TESTING_INIT_STAKE * 2, 0),
+                        change_stake("test2", 0, TESTING_INIT_STAKE),
+                        change_stake("test3", TESTING_INIT_STAKE * 2, 0)
+                    ]
+                )
+            );
+        }
+        state_root = nightshade.update(&state_root, 4, &h3, &vec![], &vec![]).0;
+        nightshade.add_validator_proposals(h3, h4, 4, vec![], vec![]).unwrap();
+        let account = nightshade.view_account(state_root, &block_producers[0].account_id).unwrap();
+        assert_eq!(
+            account,
+            AccountViewCallResult {
+                account_id: block_producers[0].account_id.clone(),
+                nonce: 2,
+                amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE * 4,
+                stake: TESTING_INIT_STAKE * 2,
+                public_keys: vec![block_producers[0].signer.public_key()],
+                code_hash: account.code_hash
+            }
+        );
+        state_root = nightshade.update(&state_root, 5, &h4, &vec![], &vec![]).0;
+        nightshade.add_validator_proposals(h4, h5, 5, vec![], vec![]).unwrap();
+        state_root = nightshade.update(&state_root, 6, &h5, &vec![], &vec![]).0;
+        nightshade.add_validator_proposals(h5, h6, 6, vec![], vec![]).unwrap();
+
+        let account = nightshade.view_account(state_root, &block_producers[1].account_id).unwrap();
+        assert_eq!(
+            account,
+            AccountViewCallResult {
+                account_id: block_producers[1].account_id.clone(),
+                nonce: 0,
+                amount: TESTING_INIT_BALANCE + TESTING_INIT_STAKE,
+                stake: 0,
+                public_keys: vec![block_producers[1].signer.public_key()],
+                code_hash: account.code_hash
+            }
+        );
+
+        let account = nightshade.view_account(state_root, &new_validator.account_id).unwrap();
+        assert_eq!(
+            account,
+            AccountViewCallResult {
+                account_id: new_validator.account_id.clone(),
+                nonce: 1,
+                amount: TESTING_INIT_STAKE,
+                stake: TESTING_INIT_STAKE * 2,
+                public_keys: vec![new_validator.signer.public_key()],
+                code_hash: account.code_hash
+            }
+        );
+    }
+}

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -539,6 +539,8 @@ mod test {
         let block_producers: Vec<_> =
             validators.iter().map(|id| InMemorySigner::from_seed(id, id).into()).collect();
         let staking_transaction = stake(1, &block_producers[0], TESTING_INIT_STAKE * 2);
+        // test1 stakes twice the current stake, because test1 and test2 have the same amount of stake before, test2 will be
+        // kicked out.
         let (new_root, validator_stakes, _) = nightshade.update(
             &state_root,
             0,
@@ -593,6 +595,7 @@ mod test {
 
         state_root = nightshade.update(&state_root, 2, &h1, &receipts, &vec![]).0;
         nightshade.add_validator_proposals(h1, h2, 2, vec![], vec![]).unwrap();
+        // test3 stakes the same amount as test1 and will be confirmed as a validator in the next epoch
         let (new_root, validator_stakes, _) =
             nightshade.update(&state_root, 3, &h2, &vec![], &vec![staking_transaction]);
         state_root = new_root;
@@ -610,6 +613,7 @@ mod test {
         {
             let mut vm = nightshade.validator_manager.write().expect(POISONED_LOCK_ERR);
             let validators = vm.get_validators(h4).unwrap();
+            // at the beginning of epoch 4, test2 will be kicked out and test3 will join
             assert_eq!(
                 validators,
                 &assignment(

--- a/near/src/validator_manager.rs
+++ b/near/src/validator_manager.rs
@@ -128,7 +128,7 @@ fn proposals_to_assignments(
                 let new_stake = ordered_proposals[i].amount;
                 if r.amount != new_stake {
                     let return_stake = if r.amount > new_stake { r.amount - new_stake } else { 0 };
-                    stake_change.insert(r.account_id.clone(), (r.amount, return_stake));
+                    stake_change.insert(r.account_id.clone(), (new_stake, return_stake));
                 }
             }
             Entry::Vacant(e) => {
@@ -156,14 +156,13 @@ fn proposals_to_assignments(
             {
                 stake_change.insert(p.account_id.clone(), (p.amount, 0));
             }
-            //stake_change.insert(p.account_id.clone(), (p.amount, 0));
             final_proposals.push(p);
         } else {
             stake_change
                 .entry(p.account_id)
                 .and_modify(|(new_stake, return_stake)| {
                     if *new_stake != 0 {
-                        *return_stake = *new_stake;
+                        *return_stake += *new_stake;
                         *new_stake = 0;
                     }
                 })

--- a/near/src/validator_manager.rs
+++ b/near/src/validator_manager.rs
@@ -128,6 +128,8 @@ fn proposals_to_assignments(
     let num_seats = epoch_config.num_block_producers + num_fisherman_seats;
     let stakes = ordered_proposals.iter().map(|p| p.amount).collect::<Vec<_>>();
     let threshold = find_threshold(&stakes, num_seats as u64)?;
+    // Remove proposals under threshold.
+    ordered_proposals.retain(|p| p.amount >= threshold);
 
     // Duplicate each proposal for number of seats it has.
     let mut dup_proposals = ordered_proposals
@@ -868,13 +870,7 @@ mod test {
         vm.add_proposals(h1, h2, 2, vec![], vec![]).unwrap().commit().unwrap();
         assert_eq!(
             vm.get_validators(h2).unwrap(),
-            &assignment(
-                vec![("test1", 10), ("test2", amount_staked)],
-                vec![0, 2],
-                vec![vec![(1, 2)]],
-                vec![],
-                4
-            )
+            &assignment(vec![("test2", amount_staked)], vec![2], vec![vec![(0, 2)]], vec![], 4)
         )
     }
 }

--- a/runtime/runtime/src/system.rs
+++ b/runtime/runtime/src/system.rs
@@ -64,8 +64,9 @@ pub fn staking(
     sender: &mut Account,
     validator_proposals: &mut Vec<ValidatorStake>,
 ) -> Result<Vec<ReceiptTransaction>, String> {
-    if sender.amount >= body.amount {
-        if sender.amount == 0 && body.amount == 0 {
+    let increment = if body.amount > sender.staked { body.amount - sender.staked } else { 0 };
+    if sender.amount >= increment {
+        if sender.staked == 0 && body.amount == 0 {
             // if the account hasn't staked, it cannot unstake
             return Err(format!(
                 "Account {} is not yet staked, but tries to unstake",
@@ -79,7 +80,8 @@ pub fn staking(
             amount: body.amount,
         });
         if sender.staked < body.amount {
-            sender.amount -= body.amount - sender.staked;
+            sender.amount -= increment;
+            sender.staked = body.amount;
             set(state_update, key_for_account(sender_account_id), &sender);
         }
         Ok(vec![])

--- a/runtime/runtime/src/system.rs
+++ b/runtime/runtime/src/system.rs
@@ -71,8 +71,12 @@ pub fn staking(
                 .map_err(|err| err.to_string())?,
             amount: body.amount,
         });
-        sender.amount -= body.amount;
-        sender.staked += body.amount;
+        if sender.staked >= body.amount {
+            sender.amount += sender.staked - body.amount;
+        } else {
+            sender.amount -= body.amount - sender.staked;
+        }
+        sender.staked = body.amount;
         set(state_update, key_for_account(sender_account_id), &sender);
         Ok(vec![])
     } else {

--- a/tests/test_cases_runtime.rs
+++ b/tests/test_cases_runtime.rs
@@ -235,4 +235,22 @@ mod test {
         let node = create_runtime_node();
         test_access_key_reject_non_function_call(node);
     }
+
+    #[test]
+    fn test_increase_stake_runtime() {
+        let node = create_runtime_node();
+        test_increase_stake(node);
+    }
+
+    #[test]
+    fn test_decrease_stake_runtime() {
+        let node = create_runtime_node();
+        test_decrease_stake(node);
+    }
+
+    #[test]
+    fn test_unstake_while_not_staked_runtime() {
+        let node = create_runtime_node();
+        test_unstake_while_not_staked(node);
+    }
 }


### PR DESCRIPTION
Enables unstaking and change of stake for validators. Unstaking is done by sending a staking transaction with amount 0 and now the amount in staking transaction means the total amount staked, so it is easy for validators to change their stakes. Fixes #1060.