### PR TITLE
Specify custom toolchain version

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,2 @@
-nightly
+nightly-2019-05-22
+


### PR DESCRIPTION
Currently our code is not working with `cargo 1.38.0-nightly` due to an error in library `hex-literal`.
If the last version of nightly installed in a computer is `1.38` cargo will try to use it on this configuration, and throw an error.
Particularly for me doesn't work `cargo test --all --verbose`.

For now let's have the toolchain we know that works `1.36.0-nightly` (`nightly-2019-05-22`) This is the one we are using to run the CI right now.