### PR TITLE
Fix block producer assignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,6 +2014,7 @@ dependencies = [
  "git-version 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb-memorydb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-chain 0.1.0",
  "near-client 0.1.0",

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -75,8 +75,8 @@ impl RuntimeAdapter for KeyValueRuntime {
         &self,
         _parent_hash: CryptoHash,
         _height: BlockIndex,
-    ) -> Result<Vec<(AccountId, u64)>, Box<dyn std::error::Error>> {
-        Ok(self.validators.iter().map(|x| (x.account_id.clone(), 1)).collect())
+    ) -> Result<Vec<AccountId>, Box<dyn std::error::Error>> {
+        Ok(self.validators.iter().map(|x| x.account_id.clone()).collect())
     }
 
     fn get_block_proposer(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -62,7 +62,7 @@ pub trait RuntimeAdapter: Send + Sync {
         &self,
         parent_hash: CryptoHash,
         height: BlockIndex,
-    ) -> Result<Vec<(AccountId, u64)>, Box<dyn std::error::Error>>;
+    ) -> Result<Vec<AccountId>, Box<dyn std::error::Error>>;
 
     /// Block proposer for given height for the main block. Return error if outside of known boundaries.
     fn get_block_proposer(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -253,10 +253,7 @@ impl Handler<Status> for ClientActor {
         let validators = self
             .runtime_adapter
             .get_epoch_block_proposers(head.last_block_hash, head.height)
-            .map_err(|err| err.to_string())?
-            .drain(..)
-            .map(|(account_id, _)| account_id)
-            .collect();
+            .map_err(|err| err.to_string())?;
         Ok(StatusResponse {
             version: self.config.version.clone(),
             chain_id: self.config.chain_id.clone(),
@@ -342,7 +339,7 @@ impl ClientActor {
         &self,
         parent_hash: CryptoHash,
         height: BlockIndex,
-    ) -> Result<Vec<(AccountId, u64)>, Error> {
+    ) -> Result<Vec<AccountId>, Error> {
         self.runtime_adapter
             .get_epoch_block_proposers(parent_hash, height)
             .map_err(|err| Error::Other(err.to_string()))
@@ -359,7 +356,6 @@ impl ClientActor {
                 if let Ok(validators) = self
                     .runtime_adapter
                     .get_epoch_block_proposers(block.header.prev_hash, block.header.height)
-                    .map(|mut x| x.drain(..).map(|v| v.0).collect::<Vec<_>>())
                 {
                     if validators.contains(&block_producer.account_id) {
                         return Some(BlockApproval::new(
@@ -854,7 +850,7 @@ impl ClientActor {
         ctx.run_later(self.config.log_summary_period, move |act, ctx| {
             // TODO: collect traffic, tx, blocks.
             let head = unwrap_or_return!(act.chain.head(), ());
-            let validators = unwrap_or_return!(act.get_epoch_block_proposers(head.prev_block_hash, head.height), ()).drain(..).map(|(account_id, _)| account_id).collect::<Vec<_>>();
+            let validators = unwrap_or_return!(act.get_epoch_block_proposers(head.prev_block_hash, head.height), ());
             let num_validators = validators.len();
             let is_validator = if let Some(block_producer) = &act.block_producer {
                 validators.contains(&block_producer.account_id)
@@ -892,7 +888,7 @@ impl ClientActor {
 
         // If given account is not current block proposer.
         let position = match self.get_epoch_block_proposers(header.prev_hash, header.height) {
-            Ok(validators) => validators.iter().position(|x| &(x.0) == account_id),
+            Ok(validators) => validators.iter().position(|x| x == account_id),
             Err(err) => {
                 error!(target: "client", "Block approval error: {}", err);
                 return false;

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -20,6 +20,7 @@ serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
 dirs = "1.0.5"
+lazy_static = "1.3"
 
 near-primitives = { path = "../core/primitives" }
 near-store = { path = "../core/store" }

--- a/near/src/test_utils.rs
+++ b/near/src/test_utils.rs
@@ -1,7 +1,7 @@
 use crate::validator_manager::ValidatorAssignment;
 use near_primitives::test_utils::get_key_pair_from_seed;
 use near_primitives::types::{AccountId, Balance, BlockIndex, ValidatorStake};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 pub fn change_stake(stake_changes: Vec<(&str, Balance)>) -> BTreeMap<AccountId, Balance> {
     stake_changes.into_iter().map(|(k, v)| (k.to_string(), v)).collect()
@@ -9,26 +9,27 @@ pub fn change_stake(stake_changes: Vec<(&str, Balance)>) -> BTreeMap<AccountId, 
 
 pub fn assignment(
     mut accounts: Vec<(&str, Balance)>,
-    block_producers: Vec<u64>,
+    block_producers: Vec<usize>,
     chunk_producers: Vec<Vec<(usize, u64)>>,
     fishermen: Vec<(usize, u64)>,
     expected_epoch_start: BlockIndex,
     stake_change: BTreeMap<AccountId, Balance>,
 ) -> ValidatorAssignment {
+    accounts.sort();
+    let validator_to_index = accounts.iter().enumerate().fold(HashMap::new(), |mut acc, (i, x)| {
+        acc.insert(x.0.to_string(), i);
+        acc
+    });
     ValidatorAssignment {
         validators: accounts
-            .drain(..)
-            .map(|(account_id, amount)| {
-                (
-                    account_id.to_string(),
-                    ValidatorStake {
-                        account_id: account_id.to_string(),
-                        public_key: get_key_pair_from_seed(account_id).0,
-                        amount,
-                    },
-                )
+            .into_iter()
+            .map(|(account_id, amount)| ValidatorStake {
+                account_id: account_id.to_string(),
+                public_key: get_key_pair_from_seed(account_id).0,
+                amount,
             })
             .collect(),
+        validator_to_index,
         block_producers,
         chunk_producers,
         fishermen,

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -1,5 +1,6 @@
 use actix::{Actor, Addr, System};
 use futures::future::Future;
+use lazy_static::lazy_static;
 use tempdir::TempDir;
 
 use near::config::{TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
@@ -9,10 +10,23 @@ use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
 use near_network::NetworkClientMessages;
 use near_primitives::rpc::QueryResponse;
 use near_primitives::serialize::BaseEncode;
-use near_primitives::test_utils::{init_integration_logger, init_test_logger};
+use near_primitives::test_utils::init_integration_logger;
 use near_primitives::transaction::{StakeTransaction, TransactionBody};
 use near_primitives::types::AccountId;
 use rand::Rng;
+use std::sync::Mutex;
+
+lazy_static! {
+    static ref HEAVY_TESTS_LOCK: Mutex<()> = Mutex::new(());
+}
+
+fn heavy_test<F>(f: F)
+where
+    F: FnOnce() -> (),
+{
+    let _guard = HEAVY_TESTS_LOCK.lock();
+    f();
+}
 
 #[derive(Clone)]
 struct TestNode {
@@ -56,63 +70,167 @@ fn init_test_staking(num_accounts: usize, num_nodes: usize, epoch_length: u64) -
 /// waits until it becomes a validator.
 #[test]
 fn test_stake_nodes() {
-    init_test_logger();
+    heavy_test(|| {
+        let system = System::new("NEAR");
+        let test_nodes = init_test_staking(2, 1, 10);
 
-    let mut genesis_config = GenesisConfig::testing_spec(2, 1);
-    genesis_config.epoch_length = 10;
-    genesis_config.num_block_producers = 2;
-    let first_node = open_port();
-    let near1 = load_test_config("near.0", first_node, &genesis_config);
-    let mut near2 = load_test_config("near.1", open_port(), &genesis_config);
-    near2.network_config.boot_nodes = convert_boot_nodes(vec![("near.0", first_node)]);
+        let tx = TransactionBody::Stake(StakeTransaction {
+            nonce: 1,
+            originator: test_nodes[1].account_id.clone(),
+            amount: TESTING_INIT_STAKE,
+            public_key: test_nodes[1]
+                .config
+                .block_producer
+                .clone()
+                .unwrap()
+                .signer
+                .public_key()
+                .to_base(),
+        })
+        .sign(&*test_nodes[1].config.block_producer.clone().unwrap().signer);
+        actix::spawn(
+            test_nodes[0]
+                .client
+                .send(NetworkClientMessages::Transaction(tx))
+                .map(|_| ())
+                .map_err(|_| ()),
+        );
 
-    let system = System::new("NEAR");
+        WaitOrTimeout::new(
+            Box::new(move |_ctx| {
+                actix::spawn(test_nodes[0].client.send(Status {}).then(|res| {
+                    if res.unwrap().unwrap().validators.len() == 2 {
+                        System::current().stop();
+                    }
+                    futures::future::ok(())
+                }));
+            }),
+            100,
+            5000,
+        )
+        .start();
 
-    let dir1 = TempDir::new("sync_nodes_1").unwrap();
-    let (client1, _view_client1) = start_with_config(dir1.path(), near1);
-    let dir2 = TempDir::new("sync_nodes_2").unwrap();
-    let (client2, _view_client2) = start_with_config(dir2.path(), near2.clone());
-
-    let tx = TransactionBody::Stake(StakeTransaction {
-        nonce: 1,
-        originator: "near.1".to_string(),
-        amount: 50_000_000,
-        public_key: near2.block_producer.clone().unwrap().signer.public_key().to_base(),
-    })
-    .sign(&*near2.block_producer.clone().unwrap().signer);
-    actix::spawn(client1.send(NetworkClientMessages::Transaction(tx)).map(|_| ()).map_err(|_| ()));
-
-    WaitOrTimeout::new(
-        Box::new(move |_ctx| {
-            actix::spawn(client2.send(Status {}).then(|res| {
-                if res.unwrap().unwrap().validators.len() == 2 {
-                    System::current().stop();
-                }
-                futures::future::ok(())
-            }));
-        }),
-        100,
-        5000,
-    )
-    .start();
-
-    system.run().unwrap();
+        system.run().unwrap();
+    });
 }
 
 #[test]
 fn test_kickout() {
-    let system = System::new("NEAR");
-    let test_nodes = init_test_staking(4, 4, 16);
-    let num_nodes = test_nodes.len();
-    let mut rng = rand::thread_rng();
-    let stakes = (0..num_nodes / 2).map(|_| rng.gen_range(1, 100));
-    let stake_transactions = stakes.enumerate().map(|(i, stake)| {
-        let test_node = &test_nodes[i];
-        TransactionBody::Stake(StakeTransaction {
+    heavy_test(|| {
+        let system = System::new("NEAR");
+        let test_nodes = init_test_staking(4, 4, 16);
+        let num_nodes = test_nodes.len();
+        let mut rng = rand::thread_rng();
+        let stakes = (0..num_nodes / 2).map(|_| rng.gen_range(1, 100));
+        let stake_transactions = stakes.enumerate().map(|(i, stake)| {
+            let test_node = &test_nodes[i];
+            TransactionBody::Stake(StakeTransaction {
+                nonce: 1,
+                originator: test_node.account_id.clone(),
+                amount: stake,
+                public_key: test_node
+                    .config
+                    .block_producer
+                    .as_ref()
+                    .unwrap()
+                    .signer
+                    .public_key()
+                    .to_base(),
+            })
+            .sign(&*test_node.config.block_producer.as_ref().unwrap().signer)
+        });
+
+        for (i, stake_transaction) in stake_transactions.enumerate() {
+            let test_node = &test_nodes[i];
+            actix::spawn(
+                test_node
+                    .client
+                    .send(NetworkClientMessages::Transaction(stake_transaction))
+                    .map(|_| ())
+                    .map_err(|_| ()),
+            );
+        }
+
+        WaitOrTimeout::new(
+            Box::new(move |_ctx| {
+                let test_nodes = test_nodes.clone();
+                let test_node1 = test_nodes[0].clone();
+                actix::spawn(test_node1.client.send(Status {}).then(move |res| {
+                    let expected: Vec<_> = (num_nodes / 2..num_nodes)
+                        .cycle()
+                        .take(num_nodes)
+                        .map(|i| format!("near.{}", i))
+                        .collect();
+                    if res.unwrap().unwrap().validators == expected {
+                        for i in 0..num_nodes / 2 {
+                            actix::spawn(
+                                test_node1
+                                    .view_client
+                                    .send(Query {
+                                        path: format!(
+                                            "account/{}",
+                                            test_nodes[i].account_id.clone()
+                                        ),
+                                        data: vec![],
+                                    })
+                                    .then(|res| match res.unwrap().unwrap() {
+                                        QueryResponse::ViewAccount(result) => {
+                                            assert_eq!(result.stake, 0);
+                                            assert_eq!(result.amount, TESTING_INIT_BALANCE);
+                                            futures::future::ok(())
+                                        }
+                                        _ => panic!("wrong return result"),
+                                    }),
+                            );
+                        }
+                        for i in num_nodes / 2..num_nodes {
+                            actix::spawn(
+                                test_node1
+                                    .view_client
+                                    .send(Query {
+                                        path: format!(
+                                            "account/{}",
+                                            test_nodes[i].account_id.clone()
+                                        ),
+                                        data: vec![],
+                                    })
+                                    .then(|res| match res.unwrap().unwrap() {
+                                        QueryResponse::ViewAccount(result) => {
+                                            assert_eq!(result.stake, TESTING_INIT_STAKE);
+                                            assert_eq!(
+                                                result.amount,
+                                                TESTING_INIT_BALANCE - TESTING_INIT_STAKE
+                                            );
+                                            futures::future::ok(())
+                                        }
+                                        _ => panic!("wrong return result"),
+                                    }),
+                            );
+                        }
+                        System::current().stop();
+                    }
+                    futures::future::ok(())
+                }));
+            }),
+            1000,
+            10000,
+        )
+        .start();
+
+        system.run().unwrap();
+    })
+}
+
+#[test]
+fn test_validator_join() {
+    heavy_test(|| {
+        let system = System::new("NEAR");
+        let test_nodes = init_test_staking(4, 2, 16);
+        let unstake_transaction = TransactionBody::Stake(StakeTransaction {
             nonce: 1,
-            originator: test_node.account_id.clone(),
-            amount: stake,
-            public_key: test_node
+            originator: test_nodes[1].account_id.clone(),
+            amount: 0,
+            public_key: test_nodes[1]
                 .config
                 .block_producer
                 .as_ref()
@@ -121,37 +239,53 @@ fn test_kickout() {
                 .public_key()
                 .to_base(),
         })
-        .sign(&*test_node.config.block_producer.as_ref().unwrap().signer)
-    });
-
-    for (i, stake_transaction) in stake_transactions.enumerate() {
-        let test_node = &test_nodes[i];
+        .sign(&*test_nodes[1].config.block_producer.as_ref().unwrap().signer);
+        let stake_transaction = TransactionBody::Stake(StakeTransaction {
+            nonce: 1,
+            originator: test_nodes[2].account_id.clone(),
+            amount: TESTING_INIT_STAKE,
+            public_key: test_nodes[2]
+                .config
+                .block_producer
+                .as_ref()
+                .unwrap()
+                .signer
+                .public_key()
+                .to_base(),
+        })
+        .sign(&*test_nodes[2].config.block_producer.as_ref().unwrap().signer);
         actix::spawn(
-            test_node
+            test_nodes[1]
+                .client
+                .send(NetworkClientMessages::Transaction(unstake_transaction))
+                .map(|_| ())
+                .map_err(|_| ()),
+        );
+        actix::spawn(
+            test_nodes[0]
                 .client
                 .send(NetworkClientMessages::Transaction(stake_transaction))
                 .map(|_| ())
                 .map_err(|_| ()),
         );
-    }
 
-    WaitOrTimeout::new(
-        Box::new(move |_ctx| {
-            let test_nodes = test_nodes.clone();
-            let test_node1 = test_nodes[0].clone();
-            actix::spawn(test_node1.client.send(Status {}).then(move |res| {
-                let expected: Vec<_> = (num_nodes / 2..num_nodes)
-                    .cycle()
-                    .take(num_nodes)
-                    .map(|i| format!("near.{}", i))
-                    .collect();
-                if res.unwrap().unwrap().validators == expected {
-                    for i in 0..num_nodes / 2 {
+        WaitOrTimeout::new(
+            Box::new(move |_ctx| {
+                let test_nodes = test_nodes.clone();
+                let test_node1 = test_nodes[0].clone();
+                actix::spawn(test_node1.client.send(Status {}).then(move |res| {
+                    let expected = vec![
+                        "near.0".to_string(),
+                        "near.2".to_string(),
+                        "near.0".to_string(),
+                        "near.2".to_string(),
+                    ];
+                    if res.unwrap().unwrap().validators == expected {
                         actix::spawn(
                             test_node1
                                 .view_client
                                 .send(Query {
-                                    path: format!("account/{}", test_nodes[i].account_id.clone()),
+                                    path: format!("account/{}", test_nodes[1].account_id.clone()),
                                     data: vec![],
                                 })
                                 .then(|res| match res.unwrap().unwrap() {
@@ -163,13 +297,11 @@ fn test_kickout() {
                                     _ => panic!("wrong return result"),
                                 }),
                         );
-                    }
-                    for i in num_nodes / 2..num_nodes {
                         actix::spawn(
                             test_node1
                                 .view_client
                                 .send(Query {
-                                    path: format!("account/{}", test_nodes[i].account_id.clone()),
+                                    path: format!("account/{}", test_nodes[2].account_id.clone()),
                                     data: vec![],
                                 })
                                 .then(|res| match res.unwrap().unwrap() {
@@ -184,123 +316,16 @@ fn test_kickout() {
                                     _ => panic!("wrong return result"),
                                 }),
                         );
+                        System::current().stop();
                     }
-                    System::current().stop();
-                }
-                futures::future::ok(())
-            }));
-        }),
-        1000,
-        10000,
-    )
-    .start();
+                    futures::future::ok(())
+                }));
+            }),
+            1000,
+            5000,
+        )
+        .start();
 
-    system.run().unwrap();
-}
-
-#[test]
-fn test_validator_join() {
-    let system = System::new("NEAR");
-    let test_nodes = init_test_staking(4, 2, 16);
-    let unstake_transaction = TransactionBody::Stake(StakeTransaction {
-        nonce: 1,
-        originator: test_nodes[1].account_id.clone(),
-        amount: 0,
-        public_key: test_nodes[1]
-            .config
-            .block_producer
-            .as_ref()
-            .unwrap()
-            .signer
-            .public_key()
-            .to_base(),
-    })
-    .sign(&*test_nodes[1].config.block_producer.as_ref().unwrap().signer);
-    let stake_transaction = TransactionBody::Stake(StakeTransaction {
-        nonce: 1,
-        originator: test_nodes[2].account_id.clone(),
-        amount: TESTING_INIT_STAKE,
-        public_key: test_nodes[2]
-            .config
-            .block_producer
-            .as_ref()
-            .unwrap()
-            .signer
-            .public_key()
-            .to_base(),
-    })
-    .sign(&*test_nodes[2].config.block_producer.as_ref().unwrap().signer);
-    actix::spawn(
-        test_nodes[1]
-            .client
-            .send(NetworkClientMessages::Transaction(unstake_transaction))
-            .map(|_| ())
-            .map_err(|_| ()),
-    );
-    actix::spawn(
-        test_nodes[0]
-            .client
-            .send(NetworkClientMessages::Transaction(stake_transaction))
-            .map(|_| ())
-            .map_err(|_| ()),
-    );
-
-    WaitOrTimeout::new(
-        Box::new(move |_ctx| {
-            let test_nodes = test_nodes.clone();
-            let test_node1 = test_nodes[0].clone();
-            actix::spawn(test_node1.client.send(Status {}).then(move |res| {
-                let expected = vec![
-                    "near.0".to_string(),
-                    "near.2".to_string(),
-                    "near.0".to_string(),
-                    "near.2".to_string(),
-                ];
-                if res.unwrap().unwrap().validators == expected {
-                    actix::spawn(
-                        test_node1
-                            .view_client
-                            .send(Query {
-                                path: format!("account/{}", test_nodes[1].account_id.clone()),
-                                data: vec![],
-                            })
-                            .then(|res| match res.unwrap().unwrap() {
-                                QueryResponse::ViewAccount(result) => {
-                                    assert_eq!(result.stake, 0);
-                                    assert_eq!(result.amount, TESTING_INIT_BALANCE);
-                                    futures::future::ok(())
-                                }
-                                _ => panic!("wrong return result"),
-                            }),
-                    );
-                    actix::spawn(
-                        test_node1
-                            .view_client
-                            .send(Query {
-                                path: format!("account/{}", test_nodes[2].account_id.clone()),
-                                data: vec![],
-                            })
-                            .then(|res| match res.unwrap().unwrap() {
-                                QueryResponse::ViewAccount(result) => {
-                                    assert_eq!(result.stake, TESTING_INIT_STAKE);
-                                    assert_eq!(
-                                        result.amount,
-                                        TESTING_INIT_BALANCE - TESTING_INIT_STAKE
-                                    );
-                                    futures::future::ok(())
-                                }
-                                _ => panic!("wrong return result"),
-                            }),
-                    );
-                    System::current().stop();
-                }
-                futures::future::ok(())
-            }));
-        }),
-        1000,
-        5000,
-    )
-    .start();
-
-    system.run().unwrap();
+        system.run().unwrap();
+    });
 }


### PR DESCRIPTION
Fix block producer assignment calculation in `proposals_to_assignments` so that `block_producers` are now indices into validators in each epoch. Still need to properly keep track of random seeds for each epoch.