### PR TITLE
Add epoch hash to block headers

### DIFF
--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -44,6 +44,9 @@ pub enum ErrorKind {
     /// Invalid state payload on state sync.
     #[fail(display = "Invalid State Payload")]
     InvalidStatePayload(String),
+    /// Invalid epoch hash
+    #[fail(display = "Invalid Epoch Hash")]
+    InvalidEpochHash,
     /// IO Error.
     #[fail(display = "IO Error: {}", _0)]
     IOErr(String),
@@ -98,7 +101,8 @@ impl Error {
             | ErrorKind::InvalidBlockConfirmation
             | ErrorKind::InvalidBlockWeight
             | ErrorKind::InvalidStateRoot
-            | ErrorKind::InvalidStatePayload(_) => true,
+            | ErrorKind::InvalidStatePayload(_)
+            | ErrorKind::InvalidEpochHash => true,
         }
     }
 

--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -47,6 +47,9 @@ pub enum ErrorKind {
     /// Invalid epoch hash
     #[fail(display = "Invalid Epoch Hash")]
     InvalidEpochHash,
+    /// Invalid Signature
+    #[fail(display = "Invalid Signature")]
+    InvalidSignature,
     /// IO Error.
     #[fail(display = "IO Error: {}", _0)]
     IOErr(String),
@@ -102,7 +105,8 @@ impl Error {
             | ErrorKind::InvalidBlockWeight
             | ErrorKind::InvalidStateRoot
             | ErrorKind::InvalidStatePayload(_)
-            | ErrorKind::InvalidEpochHash => true,
+            | ErrorKind::InvalidEpochHash
+            | ErrorKind::InvalidSignature => true,
         }
     }
 

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -128,6 +128,14 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok(())
     }
 
+    fn get_epoch_offset(
+        &self,
+        _parent_hash: CryptoHash,
+        _block_index: BlockIndex,
+    ) -> Result<(CryptoHash, BlockIndex), Box<dyn std::error::Error>> {
+        Ok((CryptoHash::default(), 0))
+    }
+
     fn apply_transactions(
         &self,
         _shard_id: ShardId,

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -73,8 +73,7 @@ impl RuntimeAdapter for KeyValueRuntime {
 
     fn get_epoch_block_proposers(
         &self,
-        _parent_hash: CryptoHash,
-        _height: BlockIndex,
+        _epoch_hash: CryptoHash,
     ) -> Result<Vec<AccountId>, Box<dyn std::error::Error>> {
         Ok(self.validators.iter().map(|x| x.account_id.clone()).collect())
     }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -106,6 +106,13 @@ pub trait RuntimeAdapter: Send + Sync {
         validator_mask: Vec<bool>,
     ) -> Result<(), Box<dyn std::error::Error>>;
 
+    /// Get epoch offset for given block index
+    fn get_epoch_offset(
+        &self,
+        parent_hash: CryptoHash,
+        block_index: BlockIndex,
+    ) -> Result<(CryptoHash, BlockIndex), Box<dyn std::error::Error>>;
+
     /// Apply transactions to given state root and return store update and new state root.
     /// Also returns transaction result for each transaction and new receipts.
     fn apply_transactions(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -56,18 +56,17 @@ pub trait RuntimeAdapter: Send + Sync {
         header: &BlockHeader,
     ) -> Result<Weight, Error>;
 
-    /// Epoch block proposers with number of seats they have for given shard.
+    /// Epoch block proposers (ordered by their order in the proposals) for given shard.
     /// Returns error if height is outside of known boundaries.
     fn get_epoch_block_proposers(
         &self,
-        parent_hash: CryptoHash,
-        height: BlockIndex,
+        epoch_hash: CryptoHash,
     ) -> Result<Vec<AccountId>, Box<dyn std::error::Error>>;
 
     /// Block proposer for given height for the main block. Return error if outside of known boundaries.
     fn get_block_proposer(
         &self,
-        parent_hash: CryptoHash,
+        epoch_hash: CryptoHash,
         height: BlockIndex,
     ) -> Result<AccountId, Box<dyn std::error::Error>>;
 
@@ -174,6 +173,8 @@ pub struct Tip {
     pub prev_block_hash: CryptoHash,
     /// Total weight on that fork
     pub total_weight: Weight,
+    /// Previous epoch hash. Used for getting validator info.
+    pub epoch_hash: CryptoHash,
 }
 
 impl Tip {
@@ -184,6 +185,7 @@ impl Tip {
             last_block_hash: header.hash(),
             prev_block_hash: header.prev_hash,
             total_weight: header.total_weight,
+            epoch_hash: header.epoch_hash,
         }
     }
 }
@@ -221,6 +223,7 @@ mod tests {
             &genesis.header,
             1,
             MerkleHash::default(),
+            CryptoHash::default(),
             vec![],
             HashMap::default(),
             vec![],
@@ -235,6 +238,7 @@ mod tests {
             &b1.header,
             2,
             MerkleHash::default(),
+            CryptoHash::default(),
             vec![],
             approvals,
             vec![],

--- a/chain/chain/tests/simple_chain.rs
+++ b/chain/chain/tests/simple_chain.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 
 use near_chain::test_utils::setup;
 use near_chain::{Block, ErrorKind, Provenance};
+use near_primitives::hash::CryptoHash;
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::types::MerkleHash;
 
@@ -68,6 +69,7 @@ fn build_chain_with_skips_and_forks() {
         chain.genesis(),
         2,
         MerkleHash::default(),
+        CryptoHash::default(),
         vec![],
         HashMap::default(),
         vec![],
@@ -78,6 +80,7 @@ fn build_chain_with_skips_and_forks() {
         &b2.header,
         4,
         MerkleHash::default(),
+        CryptoHash::default(),
         vec![],
         HashMap::default(),
         vec![],

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -384,7 +384,6 @@ impl ClientActor {
         last_height: BlockIndex,
         check_height: BlockIndex,
     ) {
-        // TODO: check this block producer is at all involved in this epoch. If not, check back after some time.
         let (epoch_hash, _) = unwrap_or_return!(
             self.runtime_adapter.get_epoch_offset(block_hash, check_height + 1),
             ()
@@ -519,10 +518,11 @@ impl ClientActor {
         // Take transactions from the pool.
         let transactions = self.tx_pool.prepare_transactions(self.config.block_expected_weight)?;
 
+        // At this point, the previous epoch hash must be available
         let (epoch_hash, _) = self
             .runtime_adapter
             .get_epoch_offset(head.last_block_hash, next_height)
-            .map_err(|e| Error::Other(e.to_string()))?;
+            .expect("Epoch hash should exist at this point");
 
         let block = Block::produce(
             &prev_header,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -252,7 +252,7 @@ impl Handler<Status> for ClientActor {
             self.chain.get_post_state_root(&head.last_block_hash).map_err(|err| err.to_string())?;
         let validators = self
             .runtime_adapter
-            .get_epoch_block_proposers(head.last_block_hash, head.height)
+            .get_epoch_block_proposers(head.epoch_hash)
             .map_err(|err| err.to_string())?;
         Ok(StatusResponse {
             version: self.config.version.clone(),
@@ -327,36 +327,41 @@ impl ClientActor {
 
     fn get_block_proposer(
         &self,
-        parent_hash: CryptoHash,
+        epoch_hash: CryptoHash,
         height: BlockIndex,
     ) -> Result<AccountId, Error> {
         self.runtime_adapter
-            .get_block_proposer(parent_hash, height)
+            .get_block_proposer(epoch_hash, height)
             .map_err(|err| Error::Other(err.to_string()))
     }
 
-    fn get_epoch_block_proposers(
-        &self,
-        parent_hash: CryptoHash,
-        height: BlockIndex,
-    ) -> Result<Vec<AccountId>, Error> {
+    fn get_epoch_block_proposers(&self, epoch_hash: CryptoHash) -> Result<Vec<AccountId>, Error> {
         self.runtime_adapter
-            .get_epoch_block_proposers(parent_hash, height)
+            .get_epoch_block_proposers(epoch_hash)
             .map_err(|err| Error::Other(err.to_string()))
     }
 
     /// Create approval for given block or return none if not a block producer.
     fn get_block_approval(&mut self, block: &Block) -> Option<BlockApproval> {
+        let (mut epoch_hash, offset) = self
+            .runtime_adapter
+            .get_epoch_offset(block.header.epoch_hash, block.header.height + 1)
+            .ok()?;
         let next_block_producer_account =
-            self.get_block_proposer(block.header.hash(), block.header.height + 1);
+            self.get_block_proposer(epoch_hash, block.header.height + 1);
         if let (Some(block_producer), Ok(next_block_producer_account)) =
             (&self.block_producer, &next_block_producer_account)
         {
             if &block_producer.account_id != next_block_producer_account {
-                if let Ok(validators) = self
-                    .runtime_adapter
-                    .get_epoch_block_proposers(block.header.prev_hash, block.header.height)
-                {
+                // TODO: fix this suboptimal code
+                if offset == 0 {
+                    epoch_hash = self
+                        .runtime_adapter
+                        .get_epoch_offset(block.header.prev_hash, block.header.height)
+                        .ok()?
+                        .0;
+                }
+                if let Ok(validators) = self.runtime_adapter.get_epoch_block_proposers(epoch_hash) {
                     if validators.contains(&block_producer.account_id) {
                         return Some(BlockApproval::new(
                             block.hash(),
@@ -380,8 +385,12 @@ impl ClientActor {
         check_height: BlockIndex,
     ) {
         // TODO: check this block producer is at all involved in this epoch. If not, check back after some time.
+        let (epoch_hash, _) = unwrap_or_return!(
+            self.runtime_adapter.get_epoch_offset(block_hash, check_height + 1),
+            ()
+        );
         let next_block_producer_account =
-            unwrap_or_return!(self.get_block_proposer(block_hash, check_height + 1), ());
+            unwrap_or_return!(self.get_block_proposer(epoch_hash, check_height + 1), ());
         if let Some(block_producer) = &self.block_producer {
             if block_producer.account_id.clone() == next_block_producer_account {
                 ctx.run_later(self.config.min_block_production_delay, move |act, ctx| {
@@ -453,7 +462,7 @@ impl ClientActor {
             return Ok(());
         }
         // Check that we are were called at the block that we are producer for.
-        let next_block_proposer = self.get_block_proposer(head.last_block_hash, next_height)?;
+        let next_block_proposer = self.get_block_proposer(head.epoch_hash, next_height)?;
         if block_producer.account_id != next_block_proposer {
             info!(target: "client", "Produce block: chain at {}, not block producer for next block.", next_height);
             return Ok(());
@@ -465,12 +474,12 @@ impl ClientActor {
         // Wait until we have all approvals or timeouts per max block production delay.
         let validators = self
             .runtime_adapter
-            .get_epoch_block_proposers(head.last_block_hash, next_height)
+            .get_epoch_block_proposers(head.epoch_hash)
             .map_err(|err| Error::Other(err.to_string()))?;
         let total_validators = validators.len();
         let prev_same_bp = self
             .runtime_adapter
-            .get_block_proposer(head.prev_block_hash, last_height)
+            .get_block_proposer(head.epoch_hash, last_height)
             .map_err(|err| Error::Other(err.to_string()))?
             == block_producer.account_id.clone();
         // If epoch changed, and before there was 2 validators and now there is 1 - prev_same_bp is false, but total validators right now is 1.
@@ -509,22 +518,22 @@ impl ClientActor {
 
         // Take transactions from the pool.
         let transactions = self.tx_pool.prepare_transactions(self.config.block_expected_weight)?;
-        let mut block = Block::produce(
+
+        let (epoch_hash, _) = self
+            .runtime_adapter
+            .get_epoch_offset(head.last_block_hash, next_height)
+            .map_err(|e| Error::Other(e.to_string()))?;
+
+        let block = Block::produce(
             &prev_header,
             next_height,
             state_root,
+            epoch_hash,
             transactions,
             self.approvals.drain().collect(),
             vec![],
             block_producer.signer.clone(),
         );
-        let (_, offset) = self
-            .runtime_adapter
-            .get_epoch_offset(prev_header.hash(), next_height)
-            .map_err(|e| Error::Other(e.to_string()))?;
-        if offset == 0 {
-            block.header.epoch_hash = block.hash();
-        }
 
         self.process_block(ctx, block, Provenance::PRODUCED).map(|_| ()).map_err(|err| err.into())
     }
@@ -840,8 +849,9 @@ impl ClientActor {
                     act.network_info.received_bytes_per_sec = received_bytes_per_sec;
                     actix::fut::ok(())
                 }
-                _ => {
-                    error!(target: "client", "Sync: recieved error or incorrect result.");
+                Ok(NetworkResponses::NoResponse) => actix::fut::ok(()),
+                Err(e) => {
+                    error!(target: "client", "Sync: recieved error or incorrect result: {}", e);
                     actix::fut::err(())
                 }
             })
@@ -857,7 +867,7 @@ impl ClientActor {
         ctx.run_later(self.config.log_summary_period, move |act, ctx| {
             // TODO: collect traffic, tx, blocks.
             let head = unwrap_or_return!(act.chain.head(), ());
-            let validators = unwrap_or_return!(act.get_epoch_block_proposers(head.prev_block_hash, head.height), ());
+            let validators = unwrap_or_return!(act.get_epoch_block_proposers(head.epoch_hash), ());
             let num_validators = validators.len();
             let is_validator = if let Some(block_producer) = &act.block_producer {
                 validators.contains(&block_producer.account_id)
@@ -894,7 +904,7 @@ impl ClientActor {
         let header = unwrap_or_return!(self.chain.get_block_header(&hash), true).clone();
 
         // If given account is not current block proposer.
-        let position = match self.get_epoch_block_proposers(header.prev_hash, header.height) {
+        let position = match self.get_epoch_block_proposers(header.epoch_hash) {
             Ok(validators) => validators.iter().position(|x| x == account_id),
             Err(err) => {
                 error!(target: "client", "Block approval error: {}", err);

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -12,7 +12,7 @@ use near_network::test_utils::wait_or_panic;
 use near_network::types::{FullPeerInfo, PeerChainInfo};
 use near_network::{NetworkClientMessages, NetworkRequests, NetworkResponses, PeerInfo};
 use near_primitives::crypto::signer::InMemorySigner;
-use near_primitives::hash::hash;
+use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::MerkleHash;
@@ -91,6 +91,7 @@ fn receive_network_block() {
                 &last_block.header,
                 last_block.header.height + 1,
                 MerkleHash::default(),
+                CryptoHash::default(),
                 vec![],
                 HashMap::default(),
                 vec![],
@@ -139,6 +140,7 @@ fn receive_network_block_header() {
                 &last_block.header,
                 last_block.header.height + 1,
                 MerkleHash::default(),
+                CryptoHash::default(),
                 vec![],
                 HashMap::default(),
                 vec![],
@@ -180,6 +182,7 @@ fn produce_block_with_approvals() {
                 &last_block.header,
                 last_block.header.height + 1,
                 MerkleHash::default(),
+                CryptoHash::default(),
                 vec![],
                 HashMap::default(),
                 vec![],
@@ -228,6 +231,7 @@ fn invalid_blocks() {
                 &last_block.header,
                 last_block.header.height + 1,
                 hash(&[0]),
+                CryptoHash::default(),
                 vec![],
                 HashMap::default(),
                 vec![],
@@ -243,6 +247,7 @@ fn invalid_blocks() {
                 &block.header,
                 block.header.height + 1,
                 hash(&[1]),
+                CryptoHash::default(),
                 vec![],
                 HashMap::default(),
                 vec![],
@@ -254,6 +259,7 @@ fn invalid_blocks() {
                 &last_block.header,
                 last_block.header.height + 1,
                 MerkleHash::default(),
+                CryptoHash::default(),
                 vec![],
                 HashMap::default(),
                 vec![],

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -171,10 +171,8 @@ impl Peer {
     }
 
     fn fetch_client_chain_info(&mut self, ctx: &mut Context<Peer>) {
-        ctx.wait(self.client_addr
-            .send(NetworkClientMessages::GetChainInfo)
-            .into_actor(self)
-            .then(move |res, act, _ctx| match res {
+        ctx.wait(self.client_addr.send(NetworkClientMessages::GetChainInfo).into_actor(self).then(
+            move |res, act, _ctx| match res {
                 Ok(NetworkClientResponses::ChainInfo { genesis, .. }) => {
                     act.genesis = genesis;
                     actix::fut::ok(())
@@ -184,7 +182,8 @@ impl Peer {
                     actix::fut::err(())
                 }
                 _ => actix::fut::err(()),
-            }));
+            },
+        ));
     }
 
     fn send_handshake(&mut self, ctx: &mut Context<Peer>) {
@@ -254,7 +253,7 @@ impl Peer {
             }
             PeerMessage::StateRequest(shard_id, hash) => {
                 NetworkClientMessages::StateRequest(shard_id, hash)
-            },
+            }
             PeerMessage::StateResponse(shard_id, hash, payload, receipts) => {
                 NetworkClientMessages::StateResponse(shard_id, hash, payload, receipts)
             }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -19,7 +19,7 @@ use near_primitives::crypto::signature::{PublicKey, SecretKey, Signature};
 use near_primitives::hash::CryptoHash;
 use near_primitives::logging::pretty_str;
 use near_primitives::serialize::{BaseEncode, Decode};
-use near_primitives::transaction::{SignedTransaction, ReceiptTransaction};
+use near_primitives::transaction::{ReceiptTransaction, SignedTransaction};
 use near_primitives::types::{AccountId, BlockIndex, ShardId};
 use near_primitives::utils::{proto_to_type, to_string_value};
 use near_protos::network as network_proto;
@@ -371,7 +371,11 @@ impl TryFrom<network_proto::PeerMessage> for PeerMessage {
                     state_response.shard_id,
                     state_response.hash.try_into()?,
                     state_response.payload,
-                    state_response.receipts.into_iter().map(TryInto::try_into).collect::<Result<Vec<_>, _>>()?,
+                    state_response
+                        .receipts
+                        .into_iter()
+                        .map(TryInto::try_into)
+                        .collect::<Result<Vec<_>, _>>()?,
                 ))
             }
             None => unreachable!(),
@@ -454,7 +458,9 @@ impl From<PeerMessage> for network_proto::PeerMessage {
                     shard_id,
                     hash: hash.into(),
                     payload,
-                    receipts: RepeatedField::from_iter(receipts.into_iter().map(std::convert::Into::into)),
+                    receipts: RepeatedField::from_iter(
+                        receipts.into_iter().map(std::convert::Into::into),
+                    ),
                     cached_size: Default::default(),
                     unknown_fields: Default::default(),
                 };
@@ -659,6 +665,7 @@ pub struct FullPeerInfo {
     pub chain_info: PeerChainInfo,
 }
 
+#[derive(Debug)]
 pub enum NetworkResponses {
     NoResponse,
     Info {
@@ -726,7 +733,12 @@ pub enum NetworkClientResponses {
     /// Headers response.
     BlockHeaders(Vec<BlockHeader>),
     /// Response to state request.
-    StateResponse { shard_id: ShardId, hash: CryptoHash, payload: Vec<u8>, receipts: Vec<ReceiptTransaction> },
+    StateResponse {
+        shard_id: ShardId,
+        hash: CryptoHash,
+        payload: Vec<u8>,
+        receipts: Vec<ReceiptTransaction>,
+    },
 }
 
 impl<A, M> MessageResponse<A, M> for NetworkClientResponses

--- a/core/protos/protos/chain.proto
+++ b/core/protos/protos/chain.proto
@@ -19,6 +19,7 @@ message BlockHeaderBody {
 message BlockHeader {
     BlockHeaderBody body = 1;
     bytes signature = 2;
+    bytes epoch_hash = 3;
 }
 
 message Block {

--- a/core/protos/protos/chain.proto
+++ b/core/protos/protos/chain.proto
@@ -14,12 +14,12 @@ message BlockHeaderBody {
     repeated bytes approval_sigs = 7;
     uint64 total_weight = 8;
     repeated ValidatorStake validator_proposal = 9;
+    bytes epoch_hash = 10;
 }
 
 message BlockHeader {
     BlockHeaderBody body = 1;
     bytes signature = 2;
-    bytes epoch_hash = 3;
 }
 
 message Block {

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -123,7 +123,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     ) -> Result<Weight, Error> {
         let mut vm = self.validator_manager.write().expect(POISONED_LOCK_ERR);
         let validator = vm
-            .get_block_proposer_info(header.prev_hash, header.height)
+            .get_block_proposer_info(header.epoch_hash, header.height)
             .map_err(|err| ErrorKind::Other(err.to_string()))?;
         if !header.verify_block_producer(&validator.public_key) {
             return Err(ErrorKind::InvalidBlockProposer.into());
@@ -133,11 +133,9 @@ impl RuntimeAdapter for NightshadeRuntime {
 
     fn get_epoch_block_proposers(
         &self,
-        parent_hash: CryptoHash,
-        height: BlockIndex,
+        epoch_hash: CryptoHash,
     ) -> Result<Vec<AccountId>, Box<dyn std::error::Error>> {
         let mut vm = self.validator_manager.write().expect(POISONED_LOCK_ERR);
-        let (epoch_hash, _) = vm.get_epoch_offset(parent_hash, height)?;
         let validator_assignment = vm.get_validators(epoch_hash)?;
         Ok(validator_assignment
             .block_producers
@@ -148,11 +146,11 @@ impl RuntimeAdapter for NightshadeRuntime {
 
     fn get_block_proposer(
         &self,
-        parent_hash: CryptoHash,
+        epoch_hash: CryptoHash,
         height: BlockIndex,
     ) -> Result<AccountId, Box<dyn std::error::Error>> {
         let mut vm = self.validator_manager.write().expect(POISONED_LOCK_ERR);
-        Ok(vm.get_block_proposer_info(parent_hash, height)?.account_id)
+        Ok(vm.get_block_proposer_info(epoch_hash, height)?.account_id)
     }
 
     fn get_chunk_proposer(

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -224,6 +224,15 @@ impl RuntimeAdapter for NightshadeRuntime {
             .map_err(|err| err.into())
     }
 
+    fn get_epoch_offset(
+        &self,
+        parent_hash: CryptoHash,
+        block_index: BlockIndex,
+    ) -> Result<(CryptoHash, BlockIndex), Box<dyn std::error::Error>> {
+        let vm = self.validator_manager.read().expect(POISONED_LOCK_ERR);
+        Ok(vm.get_epoch_offset(parent_hash, block_index)?)
+    }
+
     fn apply_transactions(
         &self,
         shard_id: ShardId,

--- a/near/tests/runtime_fork.rs
+++ b/near/tests/runtime_fork.rs
@@ -6,6 +6,7 @@ use tempdir::TempDir;
 use near::{get_store_path, GenesisConfig, NightshadeRuntime};
 use near_chain::{Block, Chain, Provenance};
 use near_primitives::crypto::signer::InMemorySigner;
+use near_primitives::hash::CryptoHash;
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::transaction::TransactionBody;
 use near_store::create_store;
@@ -31,6 +32,7 @@ fn runtime_hanldle_fork() {
         chain.genesis(),
         1,
         state_root,
+        CryptoHash::default(),
         vec![tx1],
         HashMap::default(),
         vec![],
@@ -41,6 +43,7 @@ fn runtime_hanldle_fork() {
         chain.genesis(),
         2,
         state_root,
+        CryptoHash::default(),
         vec![tx2],
         HashMap::default(),
         vec![],
@@ -52,6 +55,7 @@ fn runtime_hanldle_fork() {
         &b1.header,
         3,
         state_root3,
+        CryptoHash::default(),
         vec![tx3],
         HashMap::default(),
         vec![],

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -115,7 +115,7 @@ fn test_stake_nodes() {
 }
 
 #[test]
-fn test_kickout() {
+fn test_validator_kickout() {
     heavy_test(|| {
         let system = System::new("NEAR");
         let test_nodes = init_test_staking(4, 4, 24);


### PR DESCRIPTION
Block headers now record the epoch hash that the block belongs to.