### PR TITLE
Fix stake test

### DIFF
--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -98,8 +98,10 @@ fn test_stake_nodes() {
 
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
-                actix::spawn(test_nodes[0].client.send(Status {}).then(|res| {
-                    if res.unwrap().unwrap().validators.len() == 2 {
+                let account_id_1 = test_nodes[1].account_id.clone();
+
+                actix::spawn(test_nodes[0].client.send(Status {}).then(move |res| {
+                    if res.unwrap().unwrap().validators.contains(&account_id_1) {
                         System::current().stop();
                     }
                     futures::future::ok(())

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -98,7 +98,7 @@ fn test_stake_nodes() {
 
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
-                actix::spawn(test_nodes[0].client.send(Status {}).then(move |res| {
+                actix::spawn(test_nodes[0].client.send(Status {}).then(|res| {
                     if res.unwrap().unwrap().validators == vec!["near.1", "near.0"] {
                         System::current().stop();
                     }

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -98,12 +98,8 @@ fn test_stake_nodes() {
 
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
-                let expected_validators: Vec<_> =
-                    test_nodes.iter().map(|node| node.account_id.clone()).collect();
-
                 actix::spawn(test_nodes[0].client.send(Status {}).then(move |res| {
-                    let current_validators = res.unwrap().unwrap().validators;
-                    if expected_validators.iter().all(|x| current_validators.contains(x)) {
+                    if res.unwrap().unwrap().validators == vec!["near.1", "near.0"] {
                         System::current().stop();
                     }
                     futures::future::ok(())

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -98,10 +98,12 @@ fn test_stake_nodes() {
 
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
-                let account_id_1 = test_nodes[1].account_id.clone();
+                let expected_validators: Vec<_> =
+                    test_nodes.iter().map(|node| node.account_id.clone()).collect();
 
                 actix::spawn(test_nodes[0].client.send(Status {}).then(move |res| {
-                    if res.unwrap().unwrap().validators.contains(&account_id_1) {
+                    let current_validators = res.unwrap().unwrap().validators;
+                    if expected_validators.iter().all(|x| current_validators.contains(x)) {
                         System::current().stop();
                     }
                     futures::future::ok(())


### PR DESCRIPTION
Working on validator propagation I noticed this test was stopping earlier because at the beginning there are two validators (specified in the config) and both are the same account (`near.0`). The test was exiting successfully without testing that `near.1` join the validators.