### PR TITLE
Fixed a minor Python 3.x compatibility issue in the deployment scripts

### DIFF
--- a/scripts/nodelib.py
+++ b/scripts/nodelib.py
@@ -102,7 +102,7 @@ def print_staking_key(home_dir):
 def docker_stop_if_exists(name):
     try:
         result = subprocess.check_output(['docker', 'ps', '-f', 'name=%s' % name])
-        if name in result:
+        if name.encode('utf-8') in result:
             subprocess.check_output(['docker', 'stop', name])
             subprocess.check_output(['docker', 'rm', name])
     except subprocess.CalledProcessError:


### PR DESCRIPTION
Running the scripts with Python 3.x crashes due to str/bytes difference:

```
Starting NEAR client and Watchtower dockers...
Traceback (most recent call last):
  File "./scripts/start_testnet.py", line 30, in <module>
    args.boot_nodes, args.verbose)
  File "/mnt/storage/projects/near.ai/nearcore-testnet/scripts/nodelib.py", line 171, in setup_and_run
    run_docker(image, home_dir, boot_nodes, verbose)
  File "/mnt/storage/projects/near.ai/nearcore-testnet/scripts/nodelib.py", line 120, in run_docker
    docker_stop_if_exists('watchtower')
  File "/mnt/storage/projects/near.ai/nearcore-testnet/scripts/nodelib.py", line 105, in docker_stop_if_exists
    if name in result:
TypeError: a bytes-like object is required, not 'str'
```

P.S. I have checked that this fix does not break Python 2.x compatibility.