### PR TITLE
Replace access keys (implements NEP#0005)

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -196,10 +196,8 @@ impl RuntimeAdapter for KeyValueRuntime {
         let path = path.split("/").collect::<Vec<_>>();
         Ok(QueryResponse::ViewAccount(AccountViewCallResult {
             account_id: path[1].to_string(),
-            nonce: 0,
             amount: 1000,
             stake: 0,
-            public_keys: vec![],
             code_hash: CryptoHash::default(),
         }))
     }

--- a/core/primitives/src/account.rs
+++ b/core/primitives/src/account.rs
@@ -1,25 +1,19 @@
 use std::convert::{TryFrom, TryInto};
-use std::fmt;
-use std::iter::FromIterator;
 
-use protobuf::well_known_types::{BytesValue, StringValue};
-use protobuf::{RepeatedField, SingularPtrField};
+use protobuf::well_known_types::StringValue;
+use protobuf::SingularPtrField;
 
 use near_protos::access_key as access_key_proto;
 use near_protos::account as account_proto;
 
-use crate::crypto::signature::PublicKey;
 use crate::hash::CryptoHash;
-use crate::logging;
-use crate::serialize::{u128_dec_format, vec_base_format};
+use crate::serialize::{option_u128_dec_format, u128_dec_format};
 use crate::types::{AccountId, Balance, BlockIndex, Nonce, StorageUsage};
+use crate::utils::proto_to_type;
 
 /// Per account information stored in the state.
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
 pub struct Account {
-    #[serde(with = "vec_base_format")]
-    pub public_keys: Vec<PublicKey>,
-    pub nonce: Nonce,
     // amount + staked is the total value of the account
     #[serde(with = "u128_dec_format")]
     pub amount: Balance,
@@ -33,21 +27,8 @@ pub struct Account {
 }
 
 impl Account {
-    pub fn new(
-        public_keys: Vec<PublicKey>,
-        amount: Balance,
-        code_hash: CryptoHash,
-        storage_paid_at: BlockIndex,
-    ) -> Self {
-        Account {
-            public_keys,
-            nonce: 0,
-            amount,
-            staked: 0,
-            code_hash,
-            storage_usage: 0,
-            storage_paid_at,
-        }
+    pub fn new(amount: Balance, code_hash: CryptoHash, storage_paid_at: BlockIndex) -> Self {
+        Account { amount, staked: 0, code_hash, storage_usage: 0, storage_paid_at }
     }
 
     /// Try debiting the balance by the given amount.
@@ -67,14 +48,8 @@ impl TryFrom<account_proto::Account> for Account {
 
     fn try_from(account: account_proto::Account) -> Result<Self, Self::Error> {
         Ok(Account {
-            public_keys: account
-                .public_keys
-                .into_iter()
-                .map(TryInto::try_into)
-                .collect::<Result<Vec<_>, _>>()?,
-            nonce: account.nonce,
-            amount: account.amount.unwrap_or_default().try_into()?,
-            staked: account.staked.unwrap_or_default().try_into()?,
+            amount: proto_to_type(account.amount)?,
+            staked: proto_to_type(account.staked)?,
             code_hash: account.code_hash.try_into()?,
             storage_usage: account.storage_usage,
             storage_paid_at: account.storage_paid_at,
@@ -85,80 +60,134 @@ impl TryFrom<account_proto::Account> for Account {
 impl From<Account> for account_proto::Account {
     fn from(account: Account) -> Self {
         account_proto::Account {
-            public_keys: RepeatedField::from_iter(
-                account.public_keys.iter().map(std::convert::Into::into),
-            ),
-            nonce: account.nonce,
             amount: SingularPtrField::some(account.amount.into()),
             staked: SingularPtrField::some(account.staked.into()),
             code_hash: account.code_hash.into(),
             storage_usage: account.storage_usage,
             storage_paid_at: account.storage_paid_at,
+
             cached_size: Default::default(),
             unknown_fields: Default::default(),
         }
     }
 }
 
-/// Limited Access key to use owner's account with the fixed public_key.
-/// Access Key is stored under the key of owner's `account_id` and the `public_key`.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone)]
+/// Access key provides limited access to an account. Each access key belongs to some account and
+/// is identified by a unique (within the account) public key. One account may have large number of
+/// access keys. Access keys allow to act on behalf of the account by restricting transactions
+/// that can be issued.
+/// `account_id,public_key` is a key in the state
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug)]
 pub struct AccessKey {
-    /// Balance amount on this Access Key. Can be used to pay for the transactions.
-    #[serde(with = "u128_dec_format")]
-    pub amount: Balance,
-    /// Owner of the balance of this Access Key. None means the account owner.
-    pub balance_owner: Option<AccountId>,
-    /// Contract ID that can be called with this Access Key. None means the account owner.
-    /// Access key only allows to call given contract_id.
-    pub contract_id: Option<AccountId>,
-    /// The only method name that can be called with this Access Key. None means any method name.
-    pub method_name: Option<Vec<u8>>,
+    /// The nonce for this access key.
+    /// NOTE: In some cases the access key needs to be recreated. If the new access key reuses the
+    /// same public key, the nonce of the new access key should be equal to the nonce of the old
+    /// access key. It's required to avoid replaying old transactions again.
+    pub nonce: Nonce,
+
+    /// Defines permissions for this access key.
+    pub permission: AccessKeyPermission,
 }
 
-impl fmt::Debug for AccessKey {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("AccessKey")
-            .field("amount", &self.amount)
-            .field("balance_owner", &self.balance_owner)
-            .field("contract_id", &self.contract_id)
-            .field("method_name", &self.method_name.as_ref().map(|v| logging::pretty_utf8(&v)))
-            .finish()
-    }
+/// Defines permissions for AccessKey
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug)]
+pub enum AccessKeyPermission {
+    FunctionCall(FunctionCallPermission),
+
+    /// Grants full access to the account.
+    /// NOTE: It's used to replace account-level public keys.
+    FullAccess,
 }
 
 impl TryFrom<access_key_proto::AccessKey> for AccessKey {
     type Error = Box<dyn std::error::Error>;
 
-    fn try_from(access_key: access_key_proto::AccessKey) -> Result<Self, Self::Error> {
+    fn try_from(proto: access_key_proto::AccessKey) -> Result<Self, Self::Error> {
         Ok(AccessKey {
-            amount: access_key.amount.unwrap_or_default().try_into()?,
-            balance_owner: access_key.balance_owner.into_option().map(|s| s.value),
-            contract_id: access_key.contract_id.into_option().map(|s| s.value),
-            method_name: access_key.method_name.into_option().map(|s| s.value),
+            nonce: proto.nonce,
+            permission: match proto.permission {
+                Some(access_key_proto::AccessKey_oneof_permission::full_access(_)) => {
+                    AccessKeyPermission::FullAccess
+                }
+                Some(access_key_proto::AccessKey_oneof_permission::function_call(fc)) => {
+                    AccessKeyPermission::FunctionCall(FunctionCallPermission::try_from(fc)?)
+                }
+                None => return Err("No such permission".into()),
+            },
         })
     }
 }
 
 impl From<AccessKey> for access_key_proto::AccessKey {
     fn from(access_key: AccessKey) -> Self {
+        let permission = match access_key.permission {
+            AccessKeyPermission::FullAccess => {
+                access_key_proto::AccessKey_oneof_permission::full_access(
+                    access_key_proto::FullAccessPermission::default(),
+                )
+            }
+            AccessKeyPermission::FunctionCall(fc) => {
+                access_key_proto::AccessKey_oneof_permission::function_call(fc.into())
+            }
+        };
         access_key_proto::AccessKey {
-            amount: SingularPtrField::some(access_key.amount.into()),
-            balance_owner: SingularPtrField::from_option(access_key.balance_owner.map(|v| {
+            nonce: access_key.nonce,
+            permission: Some(permission),
+
+            cached_size: Default::default(),
+            unknown_fields: Default::default(),
+        }
+    }
+}
+
+/// Grants limited permission to issue transactions with a single function call action.
+/// Those function calls can't have attached balance.
+/// The permission can limit the allowed balance to be spent on the prepaid gas.
+/// It also restrict the account ID of the receiver for this function call.
+/// It also can restrict the method name for the allowed function calls.
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug)]
+pub struct FunctionCallPermission {
+    /// Allowance is a balance limit to use by this access key to pay for function call gas and
+    /// transaction fees. When this access key is used, both account balance and the allowance is
+    /// decreased by the same value.
+    /// `None` means unlimited allowance.
+    /// NOTE: To change or increase the allowance, the old access key needs to be deleted and a new
+    /// access key should be created.
+    #[serde(with = "option_u128_dec_format")]
+    pub allowance: Option<Balance>,
+
+    /// The access key only allows transactions with the given receiver's account id.
+    pub receiver_id: AccountId,
+
+    /// `Some` means the access key only allows transactions with the function call of the given
+    /// method name.
+    /// `None` means any method name can be used.
+    pub method_name: Option<String>,
+}
+
+impl TryFrom<access_key_proto::FunctionCallPermission> for FunctionCallPermission {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(proto: access_key_proto::FunctionCallPermission) -> Result<Self, Self::Error> {
+        Ok(FunctionCallPermission {
+            allowance: proto.allowance.into_option().map(|a| a.try_into()).transpose()?,
+            receiver_id: proto.receiver_id,
+            method_name: proto.method_name.into_option().map(|s| s.value),
+        })
+    }
+}
+
+impl From<FunctionCallPermission> for access_key_proto::FunctionCallPermission {
+    fn from(f: FunctionCallPermission) -> Self {
+        access_key_proto::FunctionCallPermission {
+            allowance: SingularPtrField::from_option(f.allowance.map(|a| a.into())),
+            receiver_id: f.receiver_id,
+            method_name: SingularPtrField::from_option(f.method_name.map(|v| {
                 let mut res = StringValue::new();
                 res.set_value(v);
                 res
             })),
-            contract_id: SingularPtrField::from_option(access_key.contract_id.map(|v| {
-                let mut res = StringValue::new();
-                res.set_value(v);
-                res
-            })),
-            method_name: SingularPtrField::from_option(access_key.method_name.map(|v| {
-                let mut res = BytesValue::new();
-                res.set_value(v);
-                res
-            })),
+
             cached_size: Default::default(),
             unknown_fields: Default::default(),
         }

--- a/core/primitives/src/account.rs
+++ b/core/primitives/src/account.rs
@@ -89,6 +89,12 @@ pub struct AccessKey {
     pub permission: AccessKeyPermission,
 }
 
+impl AccessKey {
+    pub fn full_access() -> Self {
+        Self { nonce: 0, permission: AccessKeyPermission::FullAccess }
+    }
+}
+
 /// Defines permissions for AccessKey
 #[derive(Serialize, Deserialize, PartialEq, Eq, Hash, Clone, Debug)]
 pub enum AccessKeyPermission {

--- a/core/primitives/src/rpc.rs
+++ b/core/primitives/src/rpc.rs
@@ -7,19 +7,16 @@ use serde::{Deserialize, Serialize};
 use crate::account::AccessKey;
 use crate::crypto::signature::PublicKey;
 use crate::hash::CryptoHash;
-use crate::serialize::{u128_dec_format, vec_base_format};
-use crate::types::{AccountId, Balance, BlockIndex, MerkleHash, Nonce, Version};
+use crate::serialize::u128_dec_format;
+use crate::types::{AccountId, Balance, BlockIndex, MerkleHash, Version};
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub struct AccountViewCallResult {
     pub account_id: AccountId,
-    pub nonce: Nonce,
     #[serde(with = "u128_dec_format")]
     pub amount: Balance,
     #[serde(with = "u128_dec_format")]
     pub stake: Balance,
-    #[serde(with = "vec_base_format")]
-    pub public_keys: Vec<PublicKey>,
     pub code_hash: CryptoHash,
 }
 

--- a/core/primitives/src/serialize.rs
+++ b/core/primitives/src/serialize.rs
@@ -229,6 +229,34 @@ pub mod u128_dec_format {
     }
 }
 
+pub mod option_u128_dec_format {
+    use serde::de;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(data: &Option<u128>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(ref num) = data {
+            serializer.serialize_str(&format!("{}", num))
+        } else {
+            serializer.serialize_none()
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<u128>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s: Option<String> = Option::deserialize(deserializer)?;
+        if let Some(s) = s {
+            Ok(Some(u128::from_str_radix(&s, 10).map_err(de::Error::custom)?))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/core/protos/protos/access_key.proto
+++ b/core/protos/protos/access_key.proto
@@ -44,8 +44,8 @@ message FunctionCallPermission {
     // The access key only allows transactions with the given receiver's account id.
     string receiver_id = 2;
 
-    // `Some` means the access key only allows transactions with the function call of the given
-    // method name.
-    // `None` means any method name can be used.
-    google.protobuf.StringValue method_name = 3;
+    // A list of method names that can be used. The access key only allows transactions with the
+    // function call of one of the given method names.
+    // Empty list means any method name can be used.
+    repeated string method_names = 3;
 }

--- a/core/protos/protos/access_key.proto
+++ b/core/protos/protos/access_key.proto
@@ -3,16 +3,49 @@ syntax = "proto3";
 import "wrappers.proto";
 import "uint128.proto";
 
-// Limited Access key to use owner's account with the fixed public_key.
-// Access Key is stored under the key of owner's `account_id` and the `public_key`.
+// Access key provides limited access to an account. Each access key belongs to some account and
+// is identified by a unique (within the account) public key. One account may have large number of
+// access keys. Access keys allow to act on behalf of the account by restricting transactions
+// that can be issued.
 message AccessKey {
-    // Balance amount on this Access Key. Can be used to pay for the transactions.
-    Uint128 amount = 1;
-    // Owner of the balance of this Access Key. None means the account owner.
-    google.protobuf.StringValue balance_owner = 2;
-    // Contract ID that can be called with this Access Key. None means the account owner.
-    // Access key only allows to call given contract_id.
-    google.protobuf.StringValue contract_id = 3;
-    // The only method name that can be called with this Access Key. None means any method name.
-    google.protobuf.BytesValue method_name = 4;
+    // The nonce for this access key.
+    // NOTE: In some cases the access key needs to be recreated. If the new access key reuses the
+    // same public key, the nonce of the new access key should be equal to the nonce of the old
+    // access key. It's required to avoid replaying old transactions again.
+    uint64 nonce = 1;
+
+    // Defines permissions for this access key.
+    oneof permission {
+        FullAccessPermission full_access = 2;
+        FunctionCallPermission function_call = 3;
+    }
+}
+
+// Grants full access to the account.
+// NOTE: It's used to replace account-level public keys.
+message FullAccessPermission {
+    // empty
+}
+
+// Grants limited permission to issue transactions with a single function call action.
+// Those function calls can't have attached balance.
+// The permission can limit the allowed balance to be spent on the prepaid gas.
+// It also restrict the account ID of the receiver for this function call.
+// It also can restrict the method name for the allowed function calls.
+message FunctionCallPermission {
+    // Allowance is a balance limit to use by this access key to pay for function call gas and
+    // transaction fees. When this access key is used, both account balance and the allowance is
+    // decreased by the same value.
+    // `None` means unlimited allowance.
+    // NOTE: To change or increase the allowance, the old access key needs to be deleted and a new
+    // access key should be created.
+    Uint128 allowance = 1;
+
+    // The access key only allows transactions with the given receiver's account id.
+    string receiver_id = 2;
+
+    // `Some` means the access key only allows transactions with the function call of the given
+    // method name.
+    // `None` means any method name can be used.
+    google.protobuf.StringValue method_name = 3;
 }

--- a/core/protos/protos/account.proto
+++ b/core/protos/protos/account.proto
@@ -4,11 +4,9 @@ import "wrappers.proto";
 import "uint128.proto";
 
 message Account {
-    repeated bytes public_keys = 1;
-    uint64 nonce = 2;
-    Uint128 amount = 3;
-    Uint128 staked = 4;
-    bytes code_hash = 5;
-    uint64 storage_usage = 6;
-    uint64 storage_paid_at = 7;
+    Uint128 amount = 1;
+    Uint128 staked = 2;
+    bytes code_hash = 3;
+    uint64 storage_usage = 4;
+    uint64 storage_paid_at = 5;
 }

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -19,9 +19,10 @@ use near_jsonrpc::RpcConfig;
 use near_network::test_utils::open_port;
 use near_network::types::PROTOCOL_VERSION;
 use near_network::NetworkConfig;
-use near_primitives::account::Account;
+use near_primitives::account::{AccessKey, AccessKeyPermission, Account};
+use near_primitives::crypto::signature::PublicKey;
 use near_primitives::crypto::signer::{EDSigner, InMemorySigner, KeyFile};
-use near_primitives::hash::hash;
+use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::serialize::{to_base64, u128_dec_format};
 use near_primitives::types::{AccountId, Balance, BlockIndex, ReadablePublicKey, ValidatorId};
 use near_telemetry::TelemetryConfig;
@@ -336,19 +337,16 @@ impl GenesisConfig {
                     amount: TESTING_INIT_STAKE,
                 });
             }
-            records[0].push(StateRecord::Account {
-                account_id: account.to_string(),
-                account: Account {
-                    nonce: 0,
-                    amount: TESTING_INIT_BALANCE
-                        - if i < num_validators { TESTING_INIT_STAKE } else { 0 },
-                    public_keys: vec![signer.public_key],
+            records[0].extend(
+                state_records_account_with_key(
+                    account,
+                    &signer.public_key,
+                    TESTING_INIT_BALANCE - if i < num_validators { TESTING_INIT_STAKE } else { 0 },
+                    if i < num_validators { TESTING_INIT_STAKE } else { 0 },
                     code_hash,
-                    staked: if i < num_validators { TESTING_INIT_STAKE } else { 0 },
-                    storage_usage: 0,
-                    storage_paid_at: 0,
-                },
-            });
+                )
+                .into_iter(),
+            );
             records[0].push(StateRecord::Contract {
                 account_id: account.to_string(),
                 code: encoded_test_contract.clone(),
@@ -388,12 +386,16 @@ impl GenesisConfig {
                     amount: TESTING_INIT_STAKE,
                 });
             }
-            records.push(StateRecord::account(
-                &account_id,
-                &signer.public_key.to_readable().0,
-                TESTING_INIT_BALANCE - if i < num_validators { TESTING_INIT_STAKE } else { 0 },
-                if i < num_validators { TESTING_INIT_STAKE } else { 0 },
-            ));
+            records.extend(
+                state_records_account_with_key(
+                    &account_id,
+                    &signer.public_key,
+                    TESTING_INIT_BALANCE - if i < num_validators { TESTING_INIT_STAKE } else { 0 },
+                    if i < num_validators { TESTING_INIT_STAKE } else { 0 },
+                    CryptoHash::default(),
+                )
+                .into_iter(),
+            );
         }
         GenesisConfig {
             protocol_version: PROTOCOL_VERSION,
@@ -446,6 +448,26 @@ impl From<&str> for GenesisConfig {
 
 fn random_chain_id() -> String {
     format!("test-chain-{}", thread_rng().sample_iter(&Alphanumeric).take(5).collect::<String>())
+}
+
+fn state_records_account_with_key(
+    account_id: &str,
+    public_key: &PublicKey,
+    amount: u128,
+    staked: u128,
+    code_hash: CryptoHash,
+) -> Vec<StateRecord> {
+    vec![
+        StateRecord::Account {
+            account_id: account_id.to_string(),
+            account: Account { amount, staked, code_hash, storage_usage: 0, storage_paid_at: 0 },
+        },
+        StateRecord::AccessKey {
+            account_id: account_id.to_string(),
+            public_key: public_key.to_readable(),
+            access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
+        },
+    ]
 }
 
 /// Official TestNet configuration.
@@ -545,12 +567,13 @@ pub fn init_configs(
                     public_key: signer.public_key.to_readable(),
                     amount: TESTING_INIT_STAKE,
                 }],
-                records: vec![vec![StateRecord::account(
+                records: vec![state_records_account_with_key(
                     &account_id,
-                    &signer.public_key.to_readable().0,
+                    &signer.public_key,
                     TESTING_INIT_BALANCE,
                     TESTING_INIT_STAKE,
-                )]],
+                    CryptoHash::default(),
+                )],
             };
             genesis_config.write_to_file(&dir.join(config.genesis_file));
             info!(target: "near", "Generated node key, validator key, genesis file in {}", dir.to_str().unwrap());
@@ -570,12 +593,16 @@ pub fn create_testnet_configs_from_seeds(
         (0..seeds.len()).map(|_| InMemorySigner::from_random()).collect::<Vec<_>>();
     let mut records = vec![vec![]];
     for (i, seed) in seeds.iter().enumerate() {
-        records[0].push(StateRecord::account(
-            seed,
-            &signers[i].public_key.to_readable().0,
-            TESTING_INIT_BALANCE,
-            TESTING_INIT_STAKE,
-        ));
+        records[0].extend(
+            state_records_account_with_key(
+                seed,
+                &signers[i].public_key,
+                TESTING_INIT_BALANCE,
+                TESTING_INIT_STAKE,
+                CryptoHash::default(),
+            )
+            .into_iter(),
+        );
     }
     let validators = seeds
         .iter()

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -19,7 +19,7 @@ use near_jsonrpc::RpcConfig;
 use near_network::test_utils::open_port;
 use near_network::types::PROTOCOL_VERSION;
 use near_network::NetworkConfig;
-use near_primitives::account::{AccessKey, AccessKeyPermission, Account};
+use near_primitives::account::{AccessKey, Account};
 use near_primitives::crypto::signature::PublicKey;
 use near_primitives::crypto::signer::{EDSigner, InMemorySigner, KeyFile};
 use near_primitives::hash::{hash, CryptoHash};
@@ -465,7 +465,7 @@ fn state_records_account_with_key(
         StateRecord::AccessKey {
             account_id: account_id.to_string(),
             public_key: public_key.to_readable(),
-            access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
+            access_key: AccessKey::full_access(),
         },
     ]
 }

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -581,12 +581,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[0].account_id.clone(),
-                nonce: 1,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE * 2,
                 stake: TESTING_INIT_STAKE * 2,
-                public_keys: vec![block_producers[0].signer.public_key()],
                 code_hash: account.code_hash,
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[0].account_id,
+                    &block_producers[0].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            1
         );
 
         nightshade
@@ -606,12 +616,7 @@ mod test {
                 Action::Transfer(TransferAction { deposit: TESTING_INIT_STAKE * 3 }),
                 Action::AddKey(AddKeyAction {
                     public_key: new_validator.signer.public_key(),
-                    access_key: AccessKey {
-                        amount: 0,
-                        balance_owner: None,
-                        contract_id: None,
-                        method_name: None,
-                    },
+                    access_key: AccessKey::full_access(),
                 }),
             ],
         );
@@ -666,13 +671,24 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[0].account_id.clone(),
-                nonce: 2,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE * 5,
                 stake: TESTING_INIT_STAKE * 2,
-                public_keys: vec![block_producers[0].signer.public_key()],
                 code_hash: account.code_hash
             }
         );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[0].account_id,
+                    &block_producers[0].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            2
+        );
+
         state_root = nightshade.update(&state_root, 5, &h4, &h5, &vec![], &vec![]).0;
         nightshade.add_validator_proposals(h4, h5, 5, vec![], vec![], vec![]).unwrap();
         state_root = nightshade.update(&state_root, 6, &h5, &h6, &vec![], &vec![]).0;
@@ -683,12 +699,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[1].account_id.clone(),
-                nonce: 0,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
                 stake: TESTING_INIT_STAKE,
-                public_keys: vec![block_producers[1].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[1].account_id,
+                    &block_producers[1].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            0
         );
 
         let account = nightshade.view_account(state_root, &new_validator.account_id).unwrap();
@@ -696,12 +722,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: new_validator.account_id.clone(),
-                nonce: 1,
                 amount: TESTING_INIT_STAKE,
                 stake: TESTING_INIT_STAKE * 2,
-                public_keys: vec![new_validator.signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &new_validator.account_id,
+                    &new_validator.signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            1
         );
 
         state_root = nightshade.update(&state_root, 7, &h6, &h7, &vec![], &vec![]).0;
@@ -714,12 +750,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[1].account_id.clone(),
-                nonce: 0,
                 amount: TESTING_INIT_BALANCE,
                 stake: 0,
-                public_keys: vec![block_producers[1].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[1].account_id,
+                    &block_producers[1].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            0
         );
 
         state_root = nightshade.update(&state_root, 9, &h8, &h9, &vec![], &vec![]).0;
@@ -733,12 +779,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[1].account_id.clone(),
-                nonce: 0,
                 amount: TESTING_INIT_BALANCE,
                 stake: 0,
-                public_keys: vec![block_producers[1].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[1].account_id,
+                    &block_producers[1].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            0
         );
     }
 
@@ -782,12 +838,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[0].account_id.clone(),
-                nonce: 1,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
                 stake: TESTING_INIT_STAKE,
-                public_keys: vec![block_producers[0].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[0].account_id,
+                    &block_producers[0].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            1
         );
 
         nightshade
@@ -811,12 +877,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[0].account_id.clone(),
-                nonce: 1,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
                 stake: TESTING_INIT_STAKE,
-                public_keys: vec![block_producers[0].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[0].account_id,
+                    &block_producers[0].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            1
         );
 
         state_root = nightshade.update(&state_root, 5, &h4, &h5, &vec![], &vec![]).0;
@@ -830,12 +906,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[0].account_id.clone(),
-                nonce: 1,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE + 1,
                 stake: TESTING_INIT_STAKE - 1,
-                public_keys: vec![block_producers[0].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[0].account_id,
+                    &block_producers[0].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            1
         );
     }
 
@@ -882,14 +968,23 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[0].account_id.clone(),
-                nonce: 2,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
                 stake: TESTING_INIT_STAKE,
-                public_keys: vec![block_producers[0].signer.public_key()],
                 code_hash: account.code_hash
             }
         );
-
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[0].account_id,
+                    &block_producers[0].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            2
+        );
         nightshade
             .add_validator_proposals(CryptoHash::default(), h0, 0, validator_stakes, vec![], vec![])
             .unwrap();
@@ -923,12 +1018,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[0].account_id.clone(),
-                nonce: 3,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE - 1,
                 stake: TESTING_INIT_STAKE + 1,
-                public_keys: vec![block_producers[0].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[0].account_id,
+                    &block_producers[0].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            3
         );
 
         let account = nightshade.view_account(state_root, &block_producers[1].account_id).unwrap();
@@ -936,12 +1041,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[1].account_id.clone(),
-                nonce: 3,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE - 1,
                 stake: TESTING_INIT_STAKE + 1,
-                public_keys: vec![block_producers[1].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[1].account_id,
+                    &block_producers[1].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            3
         );
 
         state_root = nightshade.update(&state_root, 5, &h4, &h5, &vec![], &vec![]).0;
@@ -955,12 +1070,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[0].account_id.clone(),
-                nonce: 3,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE - 1,
                 stake: TESTING_INIT_STAKE + 1,
-                public_keys: vec![block_producers[0].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[0].account_id,
+                    &block_producers[0].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            3
         );
 
         let account = nightshade.view_account(state_root, &block_producers[1].account_id).unwrap();
@@ -968,12 +1093,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[1].account_id.clone(),
-                nonce: 3,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE - 1,
                 stake: TESTING_INIT_STAKE + 1,
-                public_keys: vec![block_producers[1].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[1].account_id,
+                    &block_producers[1].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            3
         );
 
         state_root = nightshade.update(&state_root, 7, &h6, &h7, &vec![], &vec![]).0;
@@ -987,12 +1122,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[0].account_id.clone(),
-                nonce: 3,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE - 1,
                 stake: TESTING_INIT_STAKE + 1,
-                public_keys: vec![block_producers[0].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[0].account_id,
+                    &block_producers[0].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            3
         );
 
         let account = nightshade.view_account(state_root, &block_producers[1].account_id).unwrap();
@@ -1000,12 +1145,22 @@ mod test {
             account,
             AccountViewCallResult {
                 account_id: block_producers[1].account_id.clone(),
-                nonce: 3,
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE + 1,
                 stake: TESTING_INIT_STAKE - 1,
-                public_keys: vec![block_producers[1].signer.public_key()],
                 code_hash: account.code_hash
             }
+        );
+        assert_eq!(
+            nightshade
+                .view_access_key(
+                    state_root,
+                    &block_producers[1].account_id,
+                    &block_producers[1].signer.public_key()
+                )
+                .unwrap()
+                .unwrap()
+                .nonce,
+            3
         );
     }
 

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 
 use kvdb::DBValue;
 
-use near_primitives::account::Account;
+use near_primitives::account::{AccessKeyPermission, Account};
 use near_primitives::contract::ContractCode;
 use near_primitives::crypto::signature::PublicKey;
 use near_primitives::hash::CryptoHash;
@@ -141,26 +141,38 @@ impl Runtime {
         debug!(target: "runtime", "{}", log_str);
     }
 
-    /// node receives signed_transaction, processes it
-    /// and generates the receipt to send to receiver
+    /// Processes signed transaction, charges fees and generates the receipt
     fn apply_signed_transaction(
         &self,
         state_update: &mut TrieUpdate,
         apply_state: &ApplyState,
         signed_transaction: &SignedTransaction,
     ) -> Result<Receipt, Box<dyn std::error::Error>> {
-        let VerificationData { signer_id, mut signer, public_key, .. } = {
+        let VerificationData { signer_id, mut signer, public_key, mut access_key } = {
             let verifier = TransactionVerifier::new(state_update);
             verifier.verify_transaction(signed_transaction)?
         };
         apply_rent(&signer_id, &mut signer, apply_state.block_index, &self.config);
-        signer.nonce = signed_transaction.transaction.nonce;
+        access_key.nonce = signed_transaction.transaction.nonce;
         let gas_price = 1;
         let total_cost = self
             .config
             .transaction_costs
             .total_cost(gas_price, &signed_transaction.transaction.actions)?;
         signer.checked_sub(total_cost)?;
+        if let AccessKeyPermission::FunctionCall(ref mut function_call_permission) =
+            access_key.permission
+        {
+            if let Some(ref mut allowance) = function_call_permission.allowance {
+                *allowance = allowance.checked_sub(total_cost).ok_or_else(|| {
+                    format!(
+                        "Access Key does not have enough balance {} for transaction costing {}",
+                        allowance, total_cost
+                    )
+                })?;
+            }
+        }
+        set_access_key(state_update, &signer_id, &public_key, &access_key);
 
         if !check_rent(&signer_id, &mut signer, &self.config, apply_state.epoch_length) {
             return Err(format!("Failed to execute, because the account {} wouldn't have enough to pay required rent", signer_id).into());
@@ -278,10 +290,10 @@ impl Runtime {
                 action_stake(account, &mut result, account_id, stake);
             }
             Action::AddKey(add_key) => {
-                action_add_key(state_update, account, &mut result, account_id, add_key);
+                action_add_key(state_update, &mut result, account_id, add_key);
             }
             Action::DeleteKey(delete_key) => {
-                action_delete_key(state_update, account, &mut result, account_id, delete_key);
+                action_delete_key(state_update, &mut result, account_id, delete_key);
             }
             Action::DeleteAccount(delete_account) => {
                 action_delete_account(

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -750,7 +750,7 @@ mod tests {
     fn test_get_and_set_accounts() {
         let trie = create_trie();
         let mut state_update = TrieUpdate::new(trie, MerkleHash::default());
-        let test_account = Account::new(vec![], 10, hash(&[]), 0);
+        let test_account = Account::new(10, hash(&[]), 0);
         let account_id = bob_account();
         set_account(&mut state_update, &account_id, &test_account);
         let get_res = get_account(&state_update, &account_id).unwrap();
@@ -762,7 +762,7 @@ mod tests {
         let trie = create_trie();
         let root = MerkleHash::default();
         let mut state_update = TrieUpdate::new(trie.clone(), root);
-        let test_account = Account::new(vec![], 10, hash(&[]), 0);
+        let test_account = Account::new(10, hash(&[]), 0);
         let account_id = bob_account();
         set_account(&mut state_update, &account_id, &test_account);
         let (store_update, new_root) = state_update.finalize().unwrap().into(trie.clone()).unwrap();

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -38,10 +38,8 @@ impl TrieViewer {
         match get_account(state_update, &account_id) {
             Some(account) => Ok(AccountViewCallResult {
                 account_id: account_id.clone(),
-                nonce: account.nonce,
                 amount: account.amount,
                 stake: account.staked,
-                public_keys: account.public_keys,
                 code_hash: account.code_hash,
             }),
             _ => Err(format!("account {} does not exist while viewing", account_id).into()),
@@ -59,14 +57,6 @@ impl TrieViewer {
         }
 
         Ok(get_access_key(state_update, account_id, public_key))
-    }
-
-    pub fn get_public_keys_for_account(
-        &self,
-        state_update: &TrieUpdate,
-        account_id: &AccountId,
-    ) -> Result<Vec<PublicKey>, Box<dyn std::error::Error>> {
-        self.view_account(state_update, account_id).map(|account| account.public_keys)
     }
 
     pub fn view_state(

--- a/runtime/runtime/src/store.rs
+++ b/runtime/runtime/src/store.rs
@@ -1,7 +1,4 @@
-use std::convert::TryFrom;
-
 use near_primitives::account::{AccessKey, Account};
-use near_primitives::crypto::signature::PublicKey;
 use near_primitives::types::{AccountId, ReadablePublicKey};
 
 /// Record in the state storage.
@@ -16,21 +13,4 @@ pub enum StateRecord {
     /// Access key associated with some account.
     AccessKey { account_id: AccountId, public_key: ReadablePublicKey, access_key: AccessKey },
     // TODO: DATA
-}
-
-impl StateRecord {
-    pub fn account(account_id: &str, public_key: &str, amount: u128, staked: u128) -> Self {
-        StateRecord::Account {
-            account_id: account_id.to_string(),
-            account: Account {
-                public_keys: vec![PublicKey::try_from(public_key).unwrap()],
-                nonce: 0,
-                amount,
-                staked,
-                code_hash: Default::default(),
-                storage_usage: 0,
-                storage_paid_at: 0,
-            },
-        }
-    }
 }

--- a/runtime/verifier/src/lib.rs
+++ b/runtime/verifier/src/lib.rs
@@ -1,6 +1,5 @@
-use near_primitives::account::{AccessKey, Account};
+use near_primitives::account::{AccessKey, AccessKeyPermission, Account};
 use near_primitives::crypto::signature::{verify, PublicKey};
-use near_primitives::logging;
 use near_primitives::transaction::{Action, SignedTransaction};
 use near_primitives::types::AccountId;
 use near_primitives::utils::is_valid_account_id;
@@ -10,7 +9,7 @@ pub struct VerificationData {
     pub signer_id: AccountId,
     pub signer: Account,
     pub public_key: PublicKey,
-    pub access_key: Option<AccessKey>,
+    pub access_key: AccessKey,
 }
 
 pub struct TransactionVerifier<'a> {
@@ -34,98 +33,88 @@ impl<'a> TransactionVerifier<'a> {
                 signer_id
             ));
         }
-        let signer = get_account(self.state_update, signer_id);
-        match signer {
-            Some(signer) => {
-                if transaction.nonce <= signer.nonce {
+        let signer = match get_account(self.state_update, signer_id) {
+            Some(signer) => signer,
+            None => {
+                return Err(format!("Signer {:?} does not exist", signer_id));
+            }
+        };
+        let access_key =
+            match get_access_key(self.state_update, &signer_id, &transaction.public_key) {
+                Some(access_key) => access_key,
+                None => {
                     return Err(format!(
-                        "Transaction nonce {} must be larger than originator's nonce {}",
-                        transaction.nonce, signer.nonce,
+                        "Signer {:?} doesn't have access key with the given public_key {:?}",
+                        signer_id, &transaction.public_key,
                     ));
                 }
+            };
 
-                if !is_valid_account_id(&transaction.receiver_id) {
-                    return Err(format!(
-                        "Invalid receiver account ID {:?} according to requirements",
-                        transaction.receiver_id
-                    ));
+        if transaction.nonce <= access_key.nonce {
+            return Err(format!(
+                "Transaction nonce {} must be larger than nonce of the used access key {}",
+                transaction.nonce, access_key.nonce,
+            ));
+        }
+
+        if !is_valid_account_id(&transaction.receiver_id) {
+            return Err(format!(
+                "Invalid receiver account ID {:?} according to requirements",
+                transaction.receiver_id
+            ));
+        }
+
+        let hash = signed_transaction.get_hash();
+        if !verify(hash.as_ref(), &signed_transaction.signature, &transaction.public_key) {
+            return Err(format!(
+                "Transaction is not signed with a public key of the signer {:?}",
+                signer_id,
+            ));
+        }
+
+        // TODO: Calculate transaction cost
+
+        match access_key.permission {
+            AccessKeyPermission::FullAccess => Ok(VerificationData {
+                signer_id: signer_id.clone(),
+                signer,
+                public_key: transaction.public_key.clone(),
+                access_key,
+            }),
+            AccessKeyPermission::FunctionCall(ref function_call_permission) => {
+                if transaction.actions.len() != 1 {
+                    return Err(
+                        "Transaction has more than 1 actions and is using function call access key"
+                            .to_string(),
+                    );
                 }
-
-                let hash = signed_transaction.get_hash();
-                let hash = hash.as_ref();
-                let public_key = signer
-                    .public_keys
-                    .iter()
-                    .find(|key| verify(&hash, &signed_transaction.signature, &key))
-                    .cloned();
-
-                if let Some(public_key) = public_key {
-                    if &public_key != &transaction.public_key {
-                        return Err("Transaction is signed with different public key than given"
-                            .to_string());
+                if let Some(Action::FunctionCall(ref function_call)) = transaction.actions.get(0) {
+                    if transaction.receiver_id != function_call_permission.receiver_id {
+                        return Err(format!(
+                            "Transaction receiver_id {:?} doesn't match the access key receiver_id {:?}",
+                            &transaction.receiver_id,
+                            &function_call_permission.receiver_id,
+                        ));
+                    }
+                    if let Some(ref method_name) = function_call_permission.method_name {
+                        if &function_call.method_name != method_name {
+                            return Err(format!(
+                                "Transaction method name {:?} doesn't match the access key method name {:?}",
+                                &function_call.method_name,
+                                &method_name,
+                            ));
+                        }
                     }
                     Ok(VerificationData {
                         signer_id: signer_id.clone(),
                         signer,
-                        public_key,
-                        access_key: None,
+                        public_key: transaction.public_key.clone(),
+                        access_key,
                     })
                 } else {
-                    let access_key =
-                        get_access_key(self.state_update, &signer_id, &transaction.public_key);
-                    if let Some(access_key) = access_key {
-                        if transaction.actions.len() != 1 {
-                            return Err(
-                                "Transaction has more than 1 actions and is using access key"
-                                    .to_string(),
-                            );
-                        }
-                        if let Some(Action::FunctionCall(ref function_call)) =
-                            transaction.actions.get(0)
-                        {
-                            let access_contract_id =
-                                access_key.contract_id.as_ref().unwrap_or(&signer_id);
-
-                            if &transaction.receiver_id != access_contract_id {
-                                return Err(format!(
-                                    "Access key contract ID {:?} doesn't match TX receiver account ID {:?}",
-                                    access_contract_id,
-                                    &transaction.receiver_id,
-                                ));
-                            }
-                            if let Some(ref access_method_name) = access_key.method_name {
-                                let access_method_name_str =
-                                    std::str::from_utf8(access_method_name).map_err(|_| {
-                                        "Can't convert access_key.method_name to utf8 string"
-                                            .to_string()
-                                    })?;
-                                if &function_call.method_name != access_method_name_str {
-                                    return Err(format!(
-                                        "Transaction method name `{}` doesn't match the access key method name {:?}",
-                                        &function_call.method_name,
-                                        logging::pretty_utf8(access_method_name),
-                                    ));
-                                }
-                            }
-                            Ok(VerificationData {
-                                signer_id: signer_id.clone(),
-                                signer,
-                                public_key: transaction.public_key.clone(),
-                                access_key: Some(access_key),
-                            })
-                        } else {
-                            Err("Access key can only be used with the exactly one FunctionCall action"
-                                .to_string())
-                        }
-                    } else {
-                        Err(format!(
-                            "Transaction is not signed with a public key of the signer {:?}",
-                            signer_id,
-                        ))
-                    }
+                    Err("The used access key requires exactly one FunctionCall action".to_string())
                 }
             }
-            _ => Err(format!("Signer {:?} does not exist", signer_id)),
         }
     }
 }

--- a/runtime/verifier/src/lib.rs
+++ b/runtime/verifier/src/lib.rs
@@ -96,12 +96,16 @@ impl<'a> TransactionVerifier<'a> {
                             &function_call_permission.receiver_id,
                         ));
                     }
-                    if let Some(ref method_name) = function_call_permission.method_name {
-                        if &function_call.method_name != method_name {
+                    if !function_call_permission.method_names.is_empty() {
+                        if function_call_permission
+                            .method_names
+                            .iter()
+                            .find(|method_name| &function_call.method_name == *method_name)
+                            .is_none()
+                        {
                             return Err(format!(
-                                "Transaction method name {:?} doesn't match the access key method name {:?}",
-                                &function_call.method_name,
-                                &method_name,
+                                "Transaction method name {:?} isn't allowed by the access key",
+                                &function_call.method_name
                             ));
                         }
                     }

--- a/test-utils/testlib/src/node/mod.rs
+++ b/test-utils/testlib/src/node/mod.rs
@@ -55,6 +55,10 @@ pub trait Node: Send + Sync {
         self.user().view_account(account_id)
     }
 
+    fn get_access_key_nonce_for_signer(&self, account_id: &AccountId) -> Result<u64, String> {
+        self.user().get_access_key_nonce_for_signer(account_id)
+    }
+
     fn view_balance(&self, account_id: &AccountId) -> Result<Balance, String> {
         self.user().view_balance(account_id)
     }

--- a/test-utils/testlib/src/node/mod.rs
+++ b/test-utils/testlib/src/node/mod.rs
@@ -63,10 +63,6 @@ pub trait Node: Send + Sync {
         self.user().add_transaction(transaction)
     }
 
-    fn get_account_nonce(&self, account_id: &AccountId) -> Option<u64> {
-        self.user().get_account_nonce(account_id)
-    }
-
     fn signer(&self) -> Arc<dyn EDSigner>;
 
     fn is_running(&self) -> bool;

--- a/test-utils/testlib/src/standard_test_cases.rs
+++ b/test-utils/testlib/src/standard_test_cases.rs
@@ -1,5 +1,5 @@
 use near::config::{TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
-use near_primitives::account::AccessKey;
+use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
 use near_primitives::crypto::signer::InMemorySigner;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::rpc::AccountViewCallResult;
@@ -206,26 +206,24 @@ pub fn test_send_money(node: impl Node) {
     assert_eq!(transaction_result.transactions.len(), 2);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
+    assert_eq!(node_user.get_account_nonce(account_id).unwrap(), 1);
+
     let result1 = node_user.view_account(account_id);
     assert_eq!(
         result1.unwrap(),
         AccountViewCallResult {
-            nonce: 1,
             account_id: account_id.clone(),
-            public_keys: vec![node.signer().public_key()],
             amount: TESTING_INIT_BALANCE - money_used - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
         }
     );
+    assert_eq!(node_user.get_account_nonce(&bob_account()).unwrap(), 0);
     let result2 = node_user.view_account(&bob_account()).unwrap();
-    let public_keys = result2.public_keys.clone();
     assert_eq!(
         result2,
         AccountViewCallResult {
-            nonce: 0,
             account_id: bob_account(),
-            public_keys,
             amount: TESTING_INIT_BALANCE + money_used - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
@@ -243,26 +241,23 @@ pub fn test_send_money_over_balance(node: impl Node) {
     assert_eq!(transaction_result.transactions.len(), 1);
     let new_root = node_user.get_state_root();
     assert_eq!(root, new_root);
+    assert_eq!(node_user.get_account_nonce(account_id).unwrap(), 0);
+
     let result1 = node_user.view_account(account_id);
     assert_eq!(
         result1.unwrap(),
         AccountViewCallResult {
-            nonce: 0,
             account_id: account_id.clone(),
-            public_keys: vec![node.signer().public_key()],
             amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
         }
     );
     let result2 = node_user.view_account(&bob_account()).unwrap();
-    let public_keys = result2.public_keys.clone();
     assert_eq!(
         result2,
         AccountViewCallResult {
-            nonce: 0,
             account_id: bob_account(),
-            public_keys,
             amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
@@ -280,13 +275,12 @@ pub fn test_refund_on_send_money_to_non_existent_account(node: impl Node) {
     assert_eq!(transaction_result.transactions.len(), 3);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
+    assert_eq!(node_user.get_account_nonce(account_id).unwrap(), 1);
     let result1 = node_user.view_account(account_id);
     assert_eq!(
         result1.unwrap(),
         AccountViewCallResult {
-            nonce: 1,
             account_id: account_id.clone(),
-            public_keys: vec![node.signer().public_key()],
             amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
@@ -312,14 +306,13 @@ pub fn test_create_account(node: impl Node) {
     assert_eq!(transaction_result.transactions.len(), 2);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
+    assert_eq!(node_user.get_account_nonce(account_id).unwrap(), 1);
 
     let result1 = node_user.view_account(account_id);
     assert_eq!(
         result1.unwrap(),
         AccountViewCallResult {
-            nonce: 1,
             account_id: account_id.clone(),
-            public_keys: vec![node.signer().public_key()],
             amount: TESTING_INIT_BALANCE - money_used - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
@@ -327,18 +320,20 @@ pub fn test_create_account(node: impl Node) {
     );
 
     let result2 = node_user.view_account(&eve_account()).unwrap();
-    let public_keys = result2.public_keys.clone();
     assert_eq!(
         result2,
         AccountViewCallResult {
-            nonce: 0,
             account_id: eve_account(),
-            public_keys,
             amount: money_used,
             stake: 0,
             code_hash: CryptoHash::default(),
         }
     );
+    let access_key = node_user.get_access_key(&eve_account(), &node.signer().public_key()).unwrap();
+    assert_eq!(
+        access_key,
+        Some(AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess })
+    )
 }
 
 pub fn test_create_account_again(node: impl Node) {
@@ -353,13 +348,13 @@ pub fn test_create_account_again(node: impl Node) {
         money_used,
     );
 
+    assert_eq!(node_user.get_account_nonce(account_id).unwrap(), 1);
+
     let result1 = node_user.view_account(account_id);
     assert_eq!(
         result1.unwrap(),
         AccountViewCallResult {
-            nonce: 1,
             account_id: account_id.clone(),
-            public_keys: vec![node.signer().public_key()],
             amount: TESTING_INIT_BALANCE - money_used - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
@@ -367,13 +362,10 @@ pub fn test_create_account_again(node: impl Node) {
     );
 
     let result2 = node_user.view_account(&eve_account()).unwrap();
-    let public_keys = result2.public_keys.clone();
     assert_eq!(
         result2,
         AccountViewCallResult {
-            nonce: 0,
             account_id: eve_account(),
-            public_keys,
             amount: money_used,
             stake: 0,
             code_hash: CryptoHash::default(),
@@ -391,14 +383,13 @@ pub fn test_create_account_again(node: impl Node) {
     assert_eq!(transaction_result.transactions.len(), 3);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
+    assert_eq!(node_user.get_account_nonce(account_id).unwrap(), 2);
 
     let result1 = node_user.view_account(account_id);
     assert_eq!(
         result1.unwrap(),
         AccountViewCallResult {
-            nonce: 2,
             account_id: account_id.clone(),
-            public_keys: vec![node.signer().public_key()],
             amount: TESTING_INIT_BALANCE - money_used - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
@@ -429,15 +420,14 @@ pub fn test_create_account_failure_invalid_name(node: impl Node) {
 
         assert_eq!(transaction_result.status, FinalTransactionStatus::Failed);
         assert_eq!(transaction_result.transactions.len(), 1);
+        assert_eq!(node_user.get_account_nonce(account_id).unwrap(), 0);
         let new_root = node_user.get_state_root();
         assert_eq!(root, new_root);
         let account = node_user.view_account(account_id).unwrap();
         assert_eq!(
             account,
             AccountViewCallResult {
-                nonce: 0,
                 account_id: account_id.clone(),
-                public_keys: vec![node.signer().public_key()],
                 amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
                 stake: TESTING_INIT_STAKE,
                 code_hash: default_code_hash(),
@@ -462,14 +452,13 @@ pub fn test_create_account_failure_already_exists(node: impl Node) {
     assert_eq!(transaction_result.transactions.len(), 3);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
+    assert_eq!(node_user.get_account_nonce(account_id).unwrap(), 1);
 
     let result1 = node_user.view_account(account_id);
     assert_eq!(
         result1.unwrap(),
         AccountViewCallResult {
-            nonce: 1,
             account_id: account_id.clone(),
-            public_keys: vec![node.signer().public_key()],
             amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
@@ -477,13 +466,10 @@ pub fn test_create_account_failure_already_exists(node: impl Node) {
     );
 
     let result2 = node_user.view_account(&bob_account()).unwrap();
-    let public_keys = result2.public_keys.clone();
     assert_eq!(
         result2,
         AccountViewCallResult {
-            nonce: 0,
             account_id: bob_account(),
-            public_keys,
             amount: TESTING_INIT_BALANCE - TESTING_INIT_STAKE,
             stake: TESTING_INIT_STAKE,
             code_hash: default_code_hash(),
@@ -510,15 +496,18 @@ pub fn test_swap_key(node: impl Node) {
         eve_account(),
         node.signer().public_key(),
         signer2.public_key.clone(),
-        AccessKey { amount: 0, balance_owner: None, contract_id: None, method_name: None },
+        AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
     );
     assert_eq!(transaction_result.status, FinalTransactionStatus::Completed);
     assert_eq!(transaction_result.transactions.len(), 2);
     let new_root1 = node_user.get_state_root();
     assert_ne!(new_root, new_root1);
 
-    let account = node_user.view_account(&eve_account()).unwrap();
-    assert_eq!(account.public_keys, vec![signer2.public_key]);
+    assert!(node_user
+        .get_access_key(&eve_account(), &node.signer().public_key())
+        .unwrap()
+        .is_none());
+    assert!(node_user.get_access_key(&eve_account(), &signer2.public_key).unwrap().is_some());
 }
 
 pub fn test_add_key(node: impl Node) {
@@ -529,13 +518,12 @@ pub fn test_add_key(node: impl Node) {
     add_access_key(
         &node,
         node_user.as_ref(),
-        &AccessKey { amount: 0, balance_owner: None, contract_id: None, method_name: None },
+        &AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
         &signer2,
     );
 
-    let account = node_user.view_account(account_id).unwrap();
-    assert_eq!(account.public_keys.len(), 2);
-    assert_eq!(account.public_keys[1], signer2.public_key);
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_some());
 }
 
 pub fn test_add_existing_key(node: impl Node) {
@@ -545,15 +533,14 @@ pub fn test_add_existing_key(node: impl Node) {
     let transaction_result = node_user.add_key(
         account_id.clone(),
         node.signer().public_key(),
-        AccessKey { amount: 0, balance_owner: None, contract_id: None, method_name: None },
+        AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
     );
     assert_eq!(transaction_result.status, FinalTransactionStatus::Failed);
     assert_eq!(transaction_result.transactions.len(), 2);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 
-    let account = node_user.view_account(account_id).unwrap();
-    assert_eq!(account.public_keys.len(), 1);
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
 }
 
 pub fn test_delete_key(node: impl Node) {
@@ -563,7 +550,7 @@ pub fn test_delete_key(node: impl Node) {
     add_access_key(
         &node,
         node_user.as_ref(),
-        &AccessKey { amount: 0, balance_owner: None, contract_id: None, method_name: None },
+        &AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
         &signer2,
     );
     let root = node_user.get_state_root();
@@ -573,9 +560,8 @@ pub fn test_delete_key(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    let account = node_user.view_account(account_id).unwrap();
-    assert_eq!(account.public_keys.len(), 1);
-    assert_eq!(account.public_keys[0], signer2.public_key);
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_none());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_some());
 }
 
 pub fn test_delete_key_not_owned(node: impl Node) {
@@ -590,8 +576,8 @@ pub fn test_delete_key_not_owned(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    let account = node_user.view_account(account_id).unwrap();
-    assert_eq!(account.public_keys.len(), 1);
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_none());
 }
 
 pub fn test_delete_key_last(node: impl Node) {
@@ -605,24 +591,24 @@ pub fn test_delete_key_last(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    let account = node_user.view_account(account_id).unwrap();
-    assert_eq!(account.public_keys.len(), 0);
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_none());
 }
 
-pub fn test_add_access_key(node: impl Node) {
+pub fn test_add_access_key_function_call(node: impl Node) {
     let node_user = node.user();
     let account_id = &node.account_id().unwrap();
     let access_key = AccessKey {
-        amount: 0,
-        balance_owner: None,
-        contract_id: Some(account_id.clone()),
-        method_name: None,
+        nonce: 0,
+        permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: None,
+            receiver_id: account_id.clone(),
+            method_name: None,
+        }),
     };
     let signer2 = InMemorySigner::from_random();
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
 
-    let account = node_user.view_account(account_id).unwrap();
-    assert_eq!(account.public_keys.len(), 1);
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
 
     let view_access_key = node_user.get_access_key(account_id, &signer2.public_key).unwrap();
     assert_eq!(view_access_key, Some(access_key));
@@ -632,10 +618,12 @@ pub fn test_delete_access_key(node: impl Node) {
     let node_user = node.user();
     let account_id = &node.account_id().unwrap();
     let access_key = AccessKey {
-        amount: 0,
-        balance_owner: None,
-        contract_id: Some(account_id.clone()),
-        method_name: None,
+        nonce: 0,
+        permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: None,
+            receiver_id: account_id.clone(),
+            method_name: None,
+        }),
     };
     let signer2 = InMemorySigner::from_random();
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
@@ -647,21 +635,19 @@ pub fn test_delete_access_key(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    let account = node_user.view_account(account_id).unwrap();
-    assert_eq!(account.public_keys.len(), 1);
-    assert_eq!(account.public_keys[0], node.signer().public_key());
-
-    let view_access_key = node_user.get_access_key(account_id, &signer2.public_key).unwrap();
-    assert_eq!(view_access_key, None);
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_none());
 }
 
-pub fn test_add_access_key_with_funding(node: impl Node) {
+pub fn test_add_access_key_with_allowance(node: impl Node) {
     let account_id = &node.account_id().unwrap();
     let access_key = AccessKey {
-        amount: 10,
-        balance_owner: None,
-        contract_id: Some(account_id.clone()),
-        method_name: None,
+        nonce: 0,
+        permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: Some(10),
+            receiver_id: account_id.clone(),
+            method_name: None,
+        }),
     };
     let node_user = node.user();
     let signer2 = InMemorySigner::from_random();
@@ -670,20 +656,22 @@ pub fn test_add_access_key_with_funding(node: impl Node) {
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
 
     let account = node_user.view_account(account_id).unwrap();
-    assert_eq!(account.public_keys.len(), 1);
-    assert_eq!(account.amount, initial_balance - 10);
+    assert_eq!(account.amount, initial_balance);
 
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
     let view_access_key = node_user.get_access_key(account_id, &signer2.public_key).unwrap();
     assert_eq!(view_access_key, Some(access_key));
 }
 
-pub fn test_delete_access_key_with_owner_refund(node: impl Node) {
+pub fn test_delete_access_key_with_allowance(node: impl Node) {
     let account_id = &node.account_id().unwrap();
     let access_key = AccessKey {
-        amount: 10,
-        balance_owner: None,
-        contract_id: Some(account_id.clone()),
-        method_name: None,
+        nonce: 0,
+        permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: Some(10),
+            receiver_id: account_id.clone(),
+            method_name: None,
+        }),
     };
     let node_user = node.user();
     let signer2 = InMemorySigner::from_random();
@@ -699,43 +687,58 @@ pub fn test_delete_access_key_with_owner_refund(node: impl Node) {
     assert_ne!(new_root, root);
 
     let account = node_user.view_account(account_id).unwrap();
-    assert_eq!(account.public_keys.len(), 1);
-    assert_eq!(account.public_keys[0], node.signer().public_key());
-    // Shit Happens. AccessKey should be switched to allowance and currently don't give refunds.
-    assert_eq!(account.amount, initial_balance - 10);
+    assert_eq!(account.amount, initial_balance);
 
-    let view_access_key = node_user.get_access_key(account_id, &signer2.public_key).unwrap();
-    assert_eq!(view_access_key, None);
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_none());
 }
 
 pub fn test_access_key_smart_contract(node: impl Node) {
     let access_key = AccessKey {
-        amount: FUNCTION_CALL_AMOUNT,
-        balance_owner: None,
-        contract_id: Some(bob_account()),
-        method_name: None,
+        nonce: 0,
+        permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: Some(FUNCTION_CALL_AMOUNT),
+            receiver_id: bob_account(),
+            method_name: None,
+        }),
     };
     let mut node_user = node.user();
     let account_id = &node.account_id().unwrap();
-    let signer2 = InMemorySigner::from_random();
+    let signer2 = Arc::new(InMemorySigner::from_random());
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
-    node_user.set_signer(Arc::new(signer2));
+    node_user.set_signer(signer2.clone());
 
+    let gas = 1000000;
     let root = node_user.get_state_root();
     let transaction_result =
-        node_user.function_call(account_id.clone(), bob_account(), "run_test", vec![], 1000000, 0);
+        node_user.function_call(account_id.clone(), bob_account(), "run_test", vec![], gas, 0);
     assert_eq!(transaction_result.status, FinalTransactionStatus::Completed);
     assert_eq!(transaction_result.transactions.len(), 3);
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
+
+    let view_access_key = node_user.get_access_key(account_id, &signer2.public_key).unwrap();
+    assert_eq!(
+        view_access_key,
+        Some(AccessKey {
+            nonce: 1,
+            permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+                allowance: Some(FUNCTION_CALL_AMOUNT - gas as Balance),
+                receiver_id: bob_account(),
+                method_name: None,
+            }),
+        })
+    );
 }
 
 pub fn test_access_key_smart_contract_reject_method_name(node: impl Node) {
     let access_key = AccessKey {
-        amount: FUNCTION_CALL_AMOUNT,
-        balance_owner: None,
-        contract_id: Some(bob_account()),
-        method_name: Some(b"log_something".to_vec()),
+        nonce: 0,
+        permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: Some(FUNCTION_CALL_AMOUNT),
+            receiver_id: bob_account(),
+            method_name: Some("log_something".to_string()),
+        }),
     };
     let mut node_user = node.user();
     let account_id = &node.account_id().unwrap();
@@ -754,10 +757,12 @@ pub fn test_access_key_smart_contract_reject_method_name(node: impl Node) {
 
 pub fn test_access_key_smart_contract_reject_contract_id(node: impl Node) {
     let access_key = AccessKey {
-        amount: FUNCTION_CALL_AMOUNT,
-        balance_owner: None,
-        contract_id: Some(bob_account()),
-        method_name: None,
+        nonce: 0,
+        permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: Some(FUNCTION_CALL_AMOUNT),
+            receiver_id: bob_account(),
+            method_name: None,
+        }),
     };
     let mut node_user = node.user();
     let account_id = &node.account_id().unwrap();
@@ -777,10 +782,12 @@ pub fn test_access_key_smart_contract_reject_contract_id(node: impl Node) {
 pub fn test_access_key_reject_non_function_call(node: impl Node) {
     let account_id = &node.account_id().unwrap();
     let access_key = AccessKey {
-        amount: 0,
-        balance_owner: None,
-        contract_id: Some(account_id.clone()),
-        method_name: None,
+        nonce: 0,
+        permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+            allowance: Some(FUNCTION_CALL_AMOUNT),
+            receiver_id: account_id.to_string(),
+            method_name: None,
+        }),
     };
     let mut node_user = node.user();
     let signer2 = InMemorySigner::from_random();

--- a/test-utils/testlib/src/standard_test_cases.rs
+++ b/test-utils/testlib/src/standard_test_cases.rs
@@ -585,7 +585,7 @@ pub fn test_add_access_key_function_call(node: impl Node) {
         permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
             allowance: None,
             receiver_id: account_id.clone(),
-            method_name: None,
+            method_names: vec![],
         }),
     };
     let signer2 = InMemorySigner::from_random();
@@ -605,7 +605,7 @@ pub fn test_delete_access_key(node: impl Node) {
         permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
             allowance: None,
             receiver_id: account_id.clone(),
-            method_name: None,
+            method_names: vec![],
         }),
     };
     let signer2 = InMemorySigner::from_random();
@@ -629,7 +629,7 @@ pub fn test_add_access_key_with_allowance(node: impl Node) {
         permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
             allowance: Some(10),
             receiver_id: account_id.clone(),
-            method_name: None,
+            method_names: vec![],
         }),
     };
     let node_user = node.user();
@@ -653,7 +653,7 @@ pub fn test_delete_access_key_with_allowance(node: impl Node) {
         permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
             allowance: Some(10),
             receiver_id: account_id.clone(),
-            method_name: None,
+            method_names: vec![],
         }),
     };
     let node_user = node.user();
@@ -682,7 +682,7 @@ pub fn test_access_key_smart_contract(node: impl Node) {
         permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
             allowance: Some(FUNCTION_CALL_AMOUNT),
             receiver_id: bob_account(),
-            method_name: None,
+            method_names: vec![],
         }),
     };
     let mut node_user = node.user();
@@ -708,7 +708,7 @@ pub fn test_access_key_smart_contract(node: impl Node) {
             permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
                 allowance: Some(FUNCTION_CALL_AMOUNT - gas as Balance),
                 receiver_id: bob_account(),
-                method_name: None,
+                method_names: vec![],
             }),
         })
     );
@@ -720,7 +720,7 @@ pub fn test_access_key_smart_contract_reject_method_name(node: impl Node) {
         permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
             allowance: Some(FUNCTION_CALL_AMOUNT),
             receiver_id: bob_account(),
-            method_name: Some("log_something".to_string()),
+            method_names: vec!["log_something".to_string()],
         }),
     };
     let mut node_user = node.user();
@@ -744,7 +744,7 @@ pub fn test_access_key_smart_contract_reject_contract_id(node: impl Node) {
         permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
             allowance: Some(FUNCTION_CALL_AMOUNT),
             receiver_id: bob_account(),
-            method_name: None,
+            method_names: vec![],
         }),
     };
     let mut node_user = node.user();
@@ -769,7 +769,7 @@ pub fn test_access_key_reject_non_function_call(node: impl Node) {
         permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
             allowance: Some(FUNCTION_CALL_AMOUNT),
             receiver_id: account_id.to_string(),
-            method_name: None,
+            method_names: vec![],
         }),
     };
     let mut node_user = node.user();

--- a/test-utils/testlib/src/user/mod.rs
+++ b/test-utils/testlib/src/user/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use futures::Future;
 
 use near_chain::Block;
-use near_primitives::account::{AccessKey, AccessKeyPermission};
+use near_primitives::account::AccessKey;
 use near_primitives::crypto::signature::PublicKey;
 use near_primitives::crypto::signer::EDSigner;
 use near_primitives::hash::CryptoHash;
@@ -41,7 +41,11 @@ pub trait User {
 
     fn add_receipt(&self, receipt: Receipt) -> Result<(), String>;
 
-    fn get_account_nonce(&self, account_id: &AccountId) -> Option<u64>;
+    fn get_access_key_nonce_for_signer(&self, account_id: &AccountId) -> Result<u64, String> {
+        self.get_access_key(account_id, &self.signer().public_key()).and_then(|access_key| {
+            access_key.ok_or_else(|| "Access key doesn't exist".to_string()).map(|a| a.nonce)
+        })
+    }
 
     fn get_best_block_index(&self) -> Option<u64>;
 
@@ -72,7 +76,7 @@ pub trait User {
         actions: Vec<Action>,
     ) -> FinalTransactionResult {
         let signed_transaction = SignedTransaction::from_actions(
-            self.get_account_nonce(&signer_id).unwrap_or_default() + 1,
+            self.get_access_key_nonce_for_signer(&signer_id).unwrap_or_default() + 1,
             signer_id,
             receiver_id,
             self.signer(),
@@ -136,10 +140,7 @@ pub trait User {
             vec![
                 Action::CreateAccount(CreateAccountAction {}),
                 Action::Transfer(TransferAction { deposit: amount }),
-                Action::AddKey(AddKeyAction {
-                    public_key,
-                    access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
-                }),
+                Action::AddKey(AddKeyAction { public_key, access_key: AccessKey::full_access() }),
             ],
         )
     }

--- a/test-utils/testlib/src/user/mod.rs
+++ b/test-utils/testlib/src/user/mod.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use futures::Future;
 
 use near_chain::Block;
-use near_primitives::account::AccessKey;
+use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::crypto::signature::PublicKey;
 use near_primitives::crypto::signer::EDSigner;
 use near_primitives::hash::CryptoHash;
@@ -138,12 +138,7 @@ pub trait User {
                 Action::Transfer(TransferAction { deposit: amount }),
                 Action::AddKey(AddKeyAction {
                     public_key,
-                    access_key: AccessKey {
-                        amount: 0,
-                        balance_owner: None,
-                        contract_id: None,
-                        method_name: None,
-                    },
+                    access_key: AccessKey { nonce: 0, permission: AccessKeyPermission::FullAccess },
                 }),
             ],
         )

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -70,12 +70,6 @@ impl User for RpcUser {
         unimplemented!()
     }
 
-    fn get_account_nonce(&self, account_id: &AccountId) -> Option<u64> {
-        self.get_access_key(account_id, &self.signer.public_key())
-            .ok()
-            .and_then(|access_key| access_key.map(|a| a.nonce))
-    }
-
     fn get_best_block_index(&self) -> Option<u64> {
         self.get_status().map(|status| status.sync_info.latest_block_height)
     }

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -70,8 +70,10 @@ impl User for RpcUser {
         unimplemented!()
     }
 
-    fn get_account_nonce(&self, account_id: &String) -> Option<u64> {
-        self.view_account(account_id).ok().map(|acc| acc.nonce)
+    fn get_account_nonce(&self, account_id: &AccountId) -> Option<u64> {
+        self.get_access_key(account_id, &self.signer.public_key())
+            .ok()
+            .and_then(|access_key| access_key.map(|a| a.nonce))
     }
 
     fn get_best_block_index(&self) -> Option<u64> {

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -188,12 +188,6 @@ impl User for RuntimeUser {
         Ok(())
     }
 
-    fn get_account_nonce(&self, account_id: &AccountId) -> Option<u64> {
-        self.get_access_key(account_id, &self.signer.public_key())
-            .ok()
-            .and_then(|access_key| access_key.map(|a| a.nonce))
-    }
-
     fn get_best_block_index(&self) -> Option<u64> {
         unimplemented!("get_best_block_index should not be implemented for RuntimeUser");
     }

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -189,7 +189,9 @@ impl User for RuntimeUser {
     }
 
     fn get_account_nonce(&self, account_id: &AccountId) -> Option<u64> {
-        self.view_account(account_id).ok().map(|account| account.nonce)
+        self.get_access_key(account_id, &self.signer.public_key())
+            .ok()
+            .and_then(|access_key| access_key.map(|a| a.nonce))
     }
 
     fn get_best_block_index(&self) -> Option<u64> {

--- a/tests/test_cases_runtime.rs
+++ b/tests/test_cases_runtime.rs
@@ -174,9 +174,9 @@ mod test {
     }
 
     #[test]
-    fn test_add_access_key_runtime() {
+    fn test_add_access_key_function_call_runtime() {
         let node = create_runtime_node();
-        test_add_access_key(node);
+        test_add_access_key_function_call(node);
     }
 
     #[test]
@@ -186,15 +186,15 @@ mod test {
     }
 
     #[test]
-    fn test_add_access_key_with_funding_runtime() {
+    fn test_add_access_key_with_allowance_runtime() {
         let node = create_runtime_node();
-        test_add_access_key_with_funding(node);
+        test_add_access_key_with_allowance(node);
     }
 
     #[test]
-    fn test_delete_access_key_with_owner_refund_runtime() {
+    fn test_delete_access_key_with_allowance_runtime() {
         let node = create_runtime_node();
-        test_delete_access_key_with_owner_refund(node);
+        test_delete_access_key_with_allowance(node);
     }
 
     #[test]

--- a/tests/test_errors.rs
+++ b/tests/test_errors.rs
@@ -35,12 +35,7 @@ fn test_check_tx_error_log() {
             Action::Transfer(TransferAction { deposit: 1_000 }),
             Action::AddKey(AddKeyAction {
                 public_key: signer.public_key.clone(),
-                access_key: AccessKey {
-                    amount: 0,
-                    balance_owner: None,
-                    contract_id: None,
-                    method_name: None,
-                },
+                access_key: AccessKey::full_access(),
             }),
         ],
     );
@@ -48,7 +43,7 @@ fn test_check_tx_error_log() {
     let tx_result = node.user().commit_transaction(tx);
     assert_eq!(
         tx_result,
-        Err("RpcError { code: -32000, message: \"Server error\", data: Some(String(\"Transaction is not signed with a public key of the signer \\\"bob.near\\\"\")) }".to_string())
+        Err("RpcError { code: -32000, message: \"Server error\", data: Some(String(\"Signer \\\"bob.near\\\" doesn\\'t have access key with the given public_key `22skMptHjFWNyuEWY22ftn2AbLPSYpmYwGJRGwpNHbTV`\")) }".to_string())
     );
 }
 
@@ -66,12 +61,7 @@ fn test_deliver_tx_error_log() {
             Action::Transfer(TransferAction { deposit: TESTING_INIT_BALANCE + 1 }),
             Action::AddKey(AddKeyAction {
                 public_key: signer.public_key.clone(),
-                access_key: AccessKey {
-                    amount: 0,
-                    balance_owner: None,
-                    contract_id: None,
-                    method_name: None,
-                },
+                access_key: AccessKey::full_access(),
             }),
         ],
     );

--- a/tests/test_rejoin.rs
+++ b/tests/test_rejoin.rs
@@ -38,8 +38,8 @@ mod test {
             .unwrap()
             .add_transaction(SignedTransaction::send_money(
                 nonces[from],
-                account_names[from].as_str(),
-                account_names[to].as_str(),
+                account_names[from].clone(),
+                account_names[to].clone(),
                 nodes[from].read().unwrap().signer(),
                 1000,
             ))
@@ -79,8 +79,13 @@ mod test {
         let mut expected_balances = vec![0; num_nodes];
         let mut nonces = vec![1; num_nodes];
         for i in 0..num_nodes {
+            nonces[i] = nodes[0]
+                .read()
+                .unwrap()
+                .get_access_key_nonce_for_signer(&account_names[i])
+                .unwrap()
+                + 1;
             let account = nodes[0].read().unwrap().view_account(&account_names[i]).unwrap();
-            nonces[i] = account.nonce + 1;
             expected_balances[i] = account.amount;
         }
         let trial_duration = 60000;

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -28,12 +28,16 @@ mod test {
             println!("TRIAL #{}", trial);
             let (i, j) = sample_two_nodes(num_nodes);
             let (k, r) = sample_two_nodes(num_nodes);
-            let account_i = nodes[k].read().unwrap().view_account(&account_names[i]).unwrap();
+            let nonce_i = nodes[k]
+                .read()
+                .unwrap()
+                .get_access_key_nonce_for_signer(&account_names[i])
+                .unwrap();
             let account_j = nodes[k].read().unwrap().view_account(&account_names[j]).unwrap();
             let transaction = SignedTransaction::send_money(
-                account_i.nonce + 1,
-                account_names[i].as_str(),
-                account_names[j].as_str(),
+                nonce_i + 1,
+                account_names[i].clone(),
+                account_names[j].clone(),
                 nodes[i].read().unwrap().signer(),
                 amount_to_send,
             );


### PR DESCRIPTION
Reworking access keys, by introducing permissions to access keys. See https://github.com/nearprotocol/NEPs/blob/master/text/0005-access-keys.md

This change removes `public_keys` from the account and replaces them with full access access keys.
It also removes `nonce` from the account and moves it to `access_key` which means there can be multiple TX nonces per account. It's probably not correctly handled in the mempool, but it also needs additional work to make sure TX verification correctly addresses costs.