### PR TITLE
Fix bug in printing blocks

### DIFF
--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -124,22 +124,23 @@ fn print_chain(
     let mut chain_store = ChainStore::new(store.clone());
     let runtime = NightshadeRuntime::new(&home_dir, store, near_config.genesis_config.clone());
     for index in start_index..=end_index {
-        let block_hash = chain_store.get_block_hash_by_height(index).unwrap();
-        let header = chain_store.get_block_header(&block_hash).unwrap().clone();
-        if index == 0 {
-            println!("{: >3} {}", header.height, format_hash(header.hash()));
-        } else {
-            let parent_header = chain_store.get_block_header(&header.prev_hash).unwrap();
-            let (epoch_id, _) = runtime.get_epoch_offset(header.prev_hash, index).unwrap();
-            let block_producer = runtime.get_block_proposer(&epoch_id, header.height).unwrap();
-            println!(
-                "{: >3} {} | {: >10} | parent: {: >3} {}",
-                header.height,
-                format_hash(header.hash()),
-                block_producer,
-                parent_header.height,
-                format_hash(parent_header.hash()),
-            );
+        if let Ok(block_hash) = chain_store.get_block_hash_by_height(index) {
+            let header = chain_store.get_block_header(&block_hash).unwrap().clone();
+            if index == 0 {
+                println!("{: >3} {}", header.height, format_hash(header.hash()));
+            } else {
+                let parent_header = chain_store.get_block_header(&header.prev_hash).unwrap();
+                let (epoch_id, _) = runtime.get_epoch_offset(header.prev_hash, index).unwrap();
+                let block_producer = runtime.get_block_proposer(&epoch_id, header.height).unwrap();
+                println!(
+                    "{: >3} {} | {: >10} | parent: {: >3} {}",
+                    header.height,
+                    format_hash(header.hash()),
+                    block_producer,
+                    parent_header.height,
+                    format_hash(parent_header.hash()),
+                );
+            }
         }
     }
 }

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -7,12 +7,12 @@ use clap::{App, Arg, SubCommand};
 use protobuf::parse_from_bytes;
 
 use near::{get_default_home, get_store_path, load_config, NearConfig, NightshadeRuntime};
-use near_chain::{ChainStore, ChainStoreAccess};
+use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
 use near_network::peer_store::PeerStore;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::crypto::signature::PublicKey;
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::serialize::{from_base64, to_base64, Decode};
+use near_primitives::serialize::{from_base64, to_base, to_base64, Decode};
 use near_primitives::test_utils::init_integration_logger;
 use near_primitives::transaction::Callback;
 use near_primitives::types::BlockIndex;
@@ -110,12 +110,37 @@ fn load_trie(
     (runtime, *state_root, last_header.height)
 }
 
-fn print_chain(store: Arc<Store>, start_index: BlockIndex, end_index: BlockIndex) {
+pub fn format_hash(h: CryptoHash) -> String {
+    to_base(&h)[..6].to_string()
+}
+
+fn print_chain(
+    store: Arc<Store>,
+    home_dir: &Path,
+    near_config: &NearConfig,
+    start_index: BlockIndex,
+    end_index: BlockIndex,
+) {
     let mut chain_store = ChainStore::new(store.clone());
+    let runtime = NightshadeRuntime::new(&home_dir, store, near_config.genesis_config.clone());
     for index in start_index..=end_index {
         let block_hash = chain_store.get_block_hash_by_height(index).unwrap();
-        let block_header = chain_store.get_block_header(&block_hash).unwrap();
-        println!("{}: {:?}", index, block_header);
+        let header = chain_store.get_block_header(&block_hash).unwrap().clone();
+        if index == 0 {
+            println!("{: >3} {}", header.height, format_hash(header.hash()));
+        } else {
+            let parent_header = chain_store.get_block_header(&header.prev_hash).unwrap();
+            let (epoch_id, _) = runtime.get_epoch_offset(header.prev_hash, index).unwrap();
+            let block_producer = runtime.get_block_proposer(&epoch_id, header.height).unwrap();
+            println!(
+                "{: >3} {} | {: >10} | parent: {: >3} {}",
+                header.height,
+                format_hash(header.hash()),
+                block_producer,
+                parent_header.height,
+                format_hash(parent_header.hash()),
+            );
+        }
     }
 }
 
@@ -198,7 +223,7 @@ fn main() {
             let start_index =
                 args.value_of("start_index").map(|s| s.parse::<u64>().unwrap()).unwrap();
             let end_index = args.value_of("end_index").map(|s| s.parse::<u64>().unwrap()).unwrap();
-            print_chain(store, start_index, end_index);
+            print_chain(store, home_dir, &near_config, start_index, end_index);
         }
         (_, _) => unreachable!(),
     }


### PR DESCRIPTION
If a block at some index doesn't exist we should just skip it instead of panicking.