### PR TITLE
Recording partial trie for storage proofs

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -14,7 +14,7 @@ use near_primitives::transaction::{
 };
 use near_primitives::types::{AccountId, BlockIndex, MerkleHash, ShardId, ValidatorStake};
 use near_store::test_utils::create_test_store;
-use near_store::{Store, StoreUpdate, Trie, TrieChanges, WrappedTrieChanges};
+use near_store::{PartialStorage, Store, StoreUpdate, Trie, TrieChanges, WrappedTrieChanges};
 
 use crate::error::{Error, ErrorKind};
 use crate::types::{BlockHeader, ReceiptResult, RuntimeAdapter, Weight};
@@ -152,7 +152,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         Ok((parent_hash, 0))
     }
 
-    fn apply_transactions(
+    fn apply_transactions_with_optional_storage_proof(
         &self,
         _shard_id: ShardId,
         state_root: &MerkleHash,
@@ -161,10 +161,19 @@ impl RuntimeAdapter for KeyValueRuntime {
         _block_hash: &CryptoHash,
         _receipts: &Vec<Vec<Receipt>>,
         transactions: &Vec<SignedTransaction>,
+        generate_storage_proof: bool,
     ) -> Result<
-        (WrappedTrieChanges, MerkleHash, Vec<TransactionLog>, ReceiptResult, Vec<ValidatorStake>),
+        (
+            WrappedTrieChanges,
+            MerkleHash,
+            Vec<TransactionLog>,
+            ReceiptResult,
+            Vec<ValidatorStake>,
+            Option<PartialStorage>,
+        ),
         Box<dyn std::error::Error>,
     > {
+        assert!(!generate_storage_proof);
         let mut tx_results = vec![];
         for tx in transactions {
             tx_results.push(TransactionLog {
@@ -183,6 +192,7 @@ impl RuntimeAdapter for KeyValueRuntime {
             tx_results,
             HashMap::default(),
             vec![],
+            None,
         ))
     }
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -8,7 +8,7 @@ use near_primitives::receipt::Receipt;
 use near_primitives::rpc::QueryResponse;
 use near_primitives::transaction::{SignedTransaction, TransactionLog};
 use near_primitives::types::{AccountId, BlockIndex, MerkleHash, ShardId, ValidatorStake};
-use near_store::{StoreUpdate, WrappedTrieChanges};
+use near_store::{PartialStorage, StoreUpdate, WrappedTrieChanges};
 
 use crate::error::Error;
 
@@ -126,7 +126,7 @@ pub trait RuntimeAdapter: Send + Sync {
     fn apply_transactions(
         &self,
         shard_id: ShardId,
-        merkle_hash: &MerkleHash,
+        state_root: &MerkleHash,
         block_index: BlockIndex,
         prev_block_hash: &CryptoHash,
         block_hash: &CryptoHash,
@@ -134,6 +134,49 @@ pub trait RuntimeAdapter: Send + Sync {
         transactions: &Vec<SignedTransaction>,
     ) -> Result<
         (WrappedTrieChanges, MerkleHash, Vec<TransactionLog>, ReceiptResult, Vec<ValidatorStake>),
+        Box<dyn std::error::Error>,
+    > {
+        self.apply_transactions_with_optional_storage_proof(
+            shard_id,
+            state_root,
+            block_index,
+            prev_block_hash,
+            block_hash,
+            receipts,
+            transactions,
+            false,
+        )
+        .map(
+            |(
+                trie_changes,
+                root,
+                tx_results,
+                receipt_result,
+                validator_proposals,
+                _partial_storage,
+            )| (trie_changes, root, tx_results, receipt_result, validator_proposals),
+        )
+    }
+
+    fn apply_transactions_with_optional_storage_proof(
+        &self,
+        shard_id: ShardId,
+        state_root: &MerkleHash,
+        block_index: BlockIndex,
+        prev_block_hash: &CryptoHash,
+        block_hash: &CryptoHash,
+        receipts: &Vec<Vec<Receipt>>,
+        transactions: &Vec<SignedTransaction>,
+        generate_storage_proof: bool,
+    ) -> Result<
+        (
+            WrappedTrieChanges,
+            MerkleHash,
+            Vec<TransactionLog>,
+            ReceiptResult,
+            Vec<ValidatorStake>,
+            Option<PartialStorage>,
+        ),
         Box<dyn std::error::Error>,
     >;
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -22,8 +22,8 @@ use near_protos::access_key as access_key_proto;
 use near_protos::account as account_proto;
 
 pub use crate::trie::{
-    update::TrieUpdate, update::TrieUpdateIterator, Trie, TrieChanges, TrieIterator,
-    WrappedTrieChanges,
+    update::TrieUpdate, update::TrieUpdateIterator, PartialStorage, Trie, TrieChanges,
+    TrieIterator, WrappedTrieChanges,
 };
 
 pub mod test_utils;

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -21,6 +21,11 @@ pub mod update;
 
 const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 
+/// For fraud proofs
+pub struct PartialStorage {
+    nodes: Vec<(CryptoHash, Vec<u8>)>,
+}
+
 #[derive(Clone, Hash, Debug, Copy)]
 struct StorageHandle(usize);
 
@@ -309,6 +314,57 @@ impl RcTrieNode {
     }
 }
 
+pub trait TrieStorage: Send + Sync {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Option<(Vec<u8>)>;
+
+    fn retrieve_rc(&self, hash: &CryptoHash) -> Option<u32>;
+
+    fn as_caching_storage(&self) -> Option<&TrieCachingStorage> {
+        None
+    }
+
+    fn as_recording_storage(&self) -> Option<&TrieRecordingStorage> {
+        None
+    }
+}
+
+pub struct TrieRecordingStorage {
+    storage: TrieCachingStorage,
+    recorded: Arc<Mutex<HashMap<CryptoHash, Option<Vec<u8>>>>>,
+}
+
+impl TrieStorage for TrieRecordingStorage {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Option<Vec<u8>> {
+        let result = self.storage.retrieve_raw_bytes(hash);
+        self.recorded.lock().expect(POISONED_LOCK_ERR).insert(*hash, result.clone());
+        result
+    }
+
+    fn retrieve_rc(&self, hash: &CryptoHash) -> Option<u32> {
+        debug_assert!(false, "retrieve_rc should not be called when recording");
+        self.storage.retrieve_rc(hash)
+    }
+
+    fn as_recording_storage(&self) -> Option<&TrieRecordingStorage> {
+        Some(self)
+    }
+}
+
+pub struct TrieMemoryPartialStorage {
+    recorded_storage: HashMap<CryptoHash, Vec<u8>>,
+}
+
+impl TrieStorage for TrieMemoryPartialStorage {
+    fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Option<Vec<u8>> {
+        self.recorded_storage.get(hash).cloned()
+    }
+
+    fn retrieve_rc(&self, _hash: &CryptoHash) -> Option<u32> {
+        debug_assert!(false, "retrieve_rc should not be called when replaying recorded");
+        None
+    }
+}
+
 pub struct TrieCachingStorage {
     store: Arc<Store>,
     cache: Arc<Mutex<SizedCache<CryptoHash, Option<Vec<u8>>>>>,
@@ -319,20 +375,29 @@ impl TrieCachingStorage {
         // TODO defend from huge values in cache
         TrieCachingStorage { store, cache: Arc::new(Mutex::new(SizedCache::with_size(10000))) }
     }
+}
 
+impl TrieStorage for TrieCachingStorage {
     fn retrieve_raw_bytes(&self, hash: &CryptoHash) -> Option<(Vec<u8>)> {
-        let mut guard = self.cache.lock().expect(POISONED_LOCK_ERR);
-        if let Some(val) = (*guard).cache_get(hash) {
-            val.clone()
-        } else {
-            let result = if let Ok(Some(bytes)) = self.store.get(COL_STATE, hash.as_ref()) {
-                Some(bytes)
+        let result = {
+            let mut guard = self.cache.lock().expect(POISONED_LOCK_ERR);
+            if let Some(val) = (*guard).cache_get(hash) {
+                val.as_ref().map(|vec| vec[0..vec.len() - 4].to_vec())
             } else {
-                None
-            };
-            (*guard).cache_set(*hash, result.clone());
-            result
-        }
+                let result = if let Ok(Some(bytes)) = self.store.get(COL_STATE, hash.as_ref()) {
+                    Some(bytes)
+                } else {
+                    None
+                };
+                let raw_node = result.as_ref().map(|vec| vec[0..vec.len() - 4].to_vec());
+                (*guard).cache_set(*hash, result);
+                raw_node
+            }
+        };
+        // the only time a node can be missing from storage is if we're validating with partial
+        // storage and try to read something that's not there.
+        debug_assert!(result.is_some());
+        result
     }
 
     fn retrieve_rc(&self, hash: &CryptoHash) -> Option<u32> {
@@ -352,20 +417,13 @@ impl TrieCachingStorage {
         }
     }
 
-    fn retrieve_node(&self, hash: &CryptoHash) -> Result<TrieNode, String> {
-        if let Some(bytes) = self.retrieve_raw_bytes(hash) {
-            match RcTrieNode::decode(&bytes) {
-                Ok((value, _)) => Ok(TrieNode::new(value)),
-                Err(_) => Err(format!("Failed to decode node {}", hash)),
-            }
-        } else {
-            Err(format!("Node {} not found in storage", hash))
-        }
+    fn as_caching_storage(&self) -> Option<&TrieCachingStorage> {
+        Some(self)
     }
 }
 
 pub struct Trie {
-    storage: TrieCachingStorage,
+    storage: Box<dyn TrieStorage>,
 }
 
 ///
@@ -440,8 +498,15 @@ impl TrieChanges {
         self,
         trie: Arc<Trie>,
     ) -> Result<(StoreUpdate, CryptoHash), Box<dyn std::error::Error>> {
-        let mut store_update =
-            StoreUpdate::new_with_trie(trie.storage.store.storage.clone(), trie.clone());
+        let mut store_update = StoreUpdate::new_with_trie(
+            trie.storage
+                .as_caching_storage()
+                .expect("Storage should be TrieCachingStorage")
+                .store
+                .storage
+                .clone(),
+            trie.clone(),
+        );
         self.insertions_into(trie.clone(), &mut store_update)?;
         self.deletions_into(trie.clone(), &mut store_update)?;
         Ok((store_update, self.new_root))
@@ -481,11 +546,47 @@ enum FlattenNodesCrumb {
 
 impl Trie {
     pub fn new(store: Arc<Store>) -> Self {
-        Trie { storage: TrieCachingStorage::new(store) }
+        Trie { storage: Box::new(TrieCachingStorage::new(store)) }
+    }
+
+    pub fn recording_reads(&self) -> Self {
+        let storage =
+            self.storage.as_caching_storage().expect("Storage should be TrieCachingStorage");
+        let storage = TrieRecordingStorage {
+            storage: TrieCachingStorage {
+                store: Arc::clone(&storage.store),
+                cache: Arc::clone(&storage.cache),
+            },
+            recorded: Arc::new(Mutex::new(Default::default())),
+        };
+        Trie { storage: Box::new(storage) }
     }
 
     pub fn empty_root() -> CryptoHash {
         CryptoHash::default()
+    }
+
+    pub fn recorded_storage(&self) -> Option<PartialStorage> {
+        let storage = self.storage.as_recording_storage()?;
+        let mut guard = storage.recorded.lock().expect(POISONED_LOCK_ERR);
+        let mut nodes = Vec::new();
+        for (k, v) in guard.drain() {
+            if let Some(v) = v {
+                nodes.push((k, v));
+            } else {
+                debug_assert!(
+                    false,
+                    "Recorded a read of a missing node. This should never happen."
+                );
+            }
+        }
+        nodes.sort();
+        Some(PartialStorage { nodes })
+    }
+
+    fn from_recorded_storage(partial_storage: PartialStorage) -> Self {
+        let mut map = partial_storage.nodes.into_iter().collect();
+        Trie { storage: Box::new(TrieMemoryPartialStorage { recorded_storage: map }) }
     }
 
     fn move_node_to_mutable(
@@ -497,21 +598,13 @@ impl Trie {
             Ok(memory.store(TrieNode::Empty))
         } else {
             if let Some(bytes) = self.storage.retrieve_raw_bytes(hash) {
-                match RcTrieNode::decode(&bytes) {
-                    Ok((value, _)) => {
+                match RawTrieNode::decode(&bytes) {
+                    Ok(value) => {
                         let result = memory.store(TrieNode::new(value));
                         memory
                             .refcount_changes
                             .entry(*hash)
-                            .or_insert_with(|| {
-                                (
-                                    RcTrieNode::decode_raw(&bytes)
-                                        .expect("calling after decode()")
-                                        .0
-                                        .to_vec(),
-                                    0,
-                                )
-                            })
+                            .or_insert_with(|| (bytes.to_vec(), 0))
                             .1 -= 1;
                         Ok(result)
                     }
@@ -527,7 +620,14 @@ impl Trie {
         if *hash == Trie::empty_root() {
             return Ok(TrieNode::Empty);
         }
-        self.storage.retrieve_node(hash)
+        if let Some(bytes) = self.storage.retrieve_raw_bytes(hash) {
+            match RawTrieNode::decode(&bytes) {
+                Ok(value) => Ok(TrieNode::new(value)),
+                Err(_) => Err(format!("Failed to decode node {}", hash)),
+            }
+        } else {
+            Err(format!("Node {} not found in storage", hash))
+        }
     }
 
     fn lookup(&self, root: &CryptoHash, mut key: NibbleSlice) -> Result<Option<Vec<u8>>, String> {
@@ -538,9 +638,9 @@ impl Trie {
                 return Ok(None);
             }
             let node = match self.storage.retrieve_raw_bytes(&hash) {
-                Some(bytes) => RcTrieNode::decode(&bytes)
-                    .map(|trie_node| trie_node.0)
-                    .map_err(|_| "Failed to decode node".to_string())?,
+                Some(bytes) => {
+                    RawTrieNode::decode(&bytes).map_err(|_| "Failed to decode node".to_string())?
+                }
                 _ => return Err(format!("Node {} not found in storage", hash)),
             };
 
@@ -1063,7 +1163,9 @@ impl Trie {
 
     #[inline]
     pub fn update_cache(&self, transaction: &DBTransaction) -> std::io::Result<()> {
-        let mut guard = self.storage.cache.lock().expect(POISONED_LOCK_ERR);
+        let storage =
+            self.storage.as_caching_storage().expect("Storage should be TrieCachingStorage");
+        let mut guard = storage.cache.lock().expect(POISONED_LOCK_ERR);
         for op in &transaction.ops {
             match op {
                 DBOp::Insert { col, ref key, ref value } if *col == COL_STATE => (*guard)
@@ -1617,5 +1719,67 @@ mod tests {
 
         let trie2 = Arc::new(Trie::new(store));
         assert_eq!(trie2.get(&root, b"doge"), Some(b"coin".to_vec()));
+    }
+
+    // TODO: somehow also test that we don't record unnecessary nodes
+    #[test]
+    fn test_trie_recording_reads() {
+        let store = create_test_store();
+        let trie1 = Arc::new(Trie::new(store.clone()));
+        let empty_root = Trie::empty_root();
+        let changes = vec![
+            (b"doge".to_vec(), Some(b"coin".to_vec())),
+            (b"docu".to_vec(), Some(b"value".to_vec())),
+            (b"do".to_vec(), Some(b"verb".to_vec())),
+            (b"horse".to_vec(), Some(b"stallion".to_vec())),
+            (b"dog".to_vec(), Some(b"puppy".to_vec())),
+            (b"h".to_vec(), Some(b"value".to_vec())),
+        ];
+        let root = test_populate_trie(trie1, &empty_root, changes.clone());
+
+        let trie2 = Trie::new(store).recording_reads();
+        trie2.get(&root, b"dog");
+        trie2.get(&root, b"horse");
+        let partial_storage = trie2.recorded_storage();
+
+        let trie3 = Trie::from_recorded_storage(partial_storage.unwrap());
+
+        assert_eq!(trie3.get(&root, b"dog"), Some(b"puppy".to_vec()));
+        assert_eq!(trie3.get(&root, b"horse"), Some(b"stallion".to_vec()));
+    }
+
+    #[test]
+    fn test_trie_recording_reads_update() {
+        let store = create_test_store();
+        let trie1 = Arc::new(Trie::new(store.clone()));
+        let empty_root = Trie::empty_root();
+        let changes = vec![
+            (b"doge".to_vec(), Some(b"coin".to_vec())),
+            (b"docu".to_vec(), Some(b"value".to_vec())),
+        ];
+        let root = test_populate_trie(trie1, &empty_root, changes.clone());
+        // Trie: extension -> branch -> 2 leaves
+        {
+            let trie2 = Trie::new(Arc::clone(&store)).recording_reads();
+            trie2.get(&root, b"doge");
+            // record extension, branch and one leaf, but not the other
+            assert_eq!(trie2.recorded_storage().unwrap().nodes.len(), 3);
+        }
+
+        {
+            let trie2 = Trie::new(Arc::clone(&store)).recording_reads();
+            let updates = vec![(b"doge".to_vec(), None)];
+            trie2.update(&root, updates.into_iter());
+            // record extension, branch and both leaves
+            assert_eq!(trie2.recorded_storage().unwrap().nodes.len(), 4);
+        }
+
+        {
+            let trie2 = Trie::new(Arc::clone(&store)).recording_reads();
+            let updates = vec![(b"dodo".to_vec(), Some(b"asdf".to_vec()))];
+            trie2.update(&root, updates.into_iter());
+            // record extension and branch, but not leaves
+            assert_eq!(trie2.recorded_storage().unwrap().nodes.len(), 2);
+        }
     }
 }

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -20,8 +20,8 @@ use near_primitives::transaction::{SignedTransaction, TransactionLog};
 use near_primitives::types::{AccountId, BlockIndex, MerkleHash, ShardId, ValidatorStake};
 use near_primitives::utils::prefix_for_access_key;
 use near_store::{
-    get_access_key_raw, get_account, set_account, Store, StoreUpdate, Trie, TrieUpdate,
-    WrappedTrieChanges,
+    get_access_key_raw, get_account, set_account, PartialStorage, Store, StoreUpdate, Trie,
+    TrieUpdate, WrappedTrieChanges,
 };
 use near_verifier::TransactionVerifier;
 use node_runtime::adapter::query_client;
@@ -261,7 +261,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         Ok(vm.get_epoch_offset(parent_hash, block_index)?)
     }
 
-    fn apply_transactions(
+    fn apply_transactions_with_optional_storage_proof(
         &self,
         shard_id: ShardId,
         state_root: &MerkleHash,
@@ -270,11 +270,24 @@ impl RuntimeAdapter for NightshadeRuntime {
         block_hash: &CryptoHash,
         receipts: &Vec<Vec<Receipt>>,
         transactions: &Vec<SignedTransaction>,
+        generate_storage_proof: bool,
     ) -> Result<
-        (WrappedTrieChanges, MerkleHash, Vec<TransactionLog>, ReceiptResult, Vec<ValidatorStake>),
+        (
+            WrappedTrieChanges,
+            MerkleHash,
+            Vec<TransactionLog>,
+            ReceiptResult,
+            Vec<ValidatorStake>,
+            Option<PartialStorage>,
+        ),
         Box<dyn std::error::Error>,
     > {
-        let mut state_update = TrieUpdate::new(self.trie.clone(), *state_root);
+        let trie = if generate_storage_proof {
+            Arc::new(self.trie.recording_reads())
+        } else {
+            self.trie.clone()
+        };
+        let mut state_update = TrieUpdate::new(trie.clone(), *state_root);
         {
             let mut vm = self.validator_manager.write().expect(POISONED_LOCK_ERR);
             let (epoch_hash, offset) = vm.get_epoch_offset(*prev_block_hash, block_index)?;
@@ -325,6 +338,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             apply_result.tx_result,
             apply_result.new_receipts,
             apply_result.validator_proposals,
+            trie.recorded_storage(),
         ))
     }
 


### PR DESCRIPTION
Record every read of a trie node from storage to use
the recorded values for a proof of execution.

This includes all key paths for keys requested for reads, but also
in case of updates can include additional nodes which are
necessary to provide a canonical resulting trie (i.e. no branch nodes
with <= 1 branch and extension is always followed by a branch).