### PR TITLE
Merkle proofs for receipts

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -7,6 +7,7 @@ use chrono::Duration;
 use log::{debug, info};
 
 use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::merklize;
 use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
 use near_primitives::transaction::{ReceiptTransaction, TransactionResult};
 use near_primitives::types::{AccountId, Balance, BlockIndex, ChunkExtra, GasUsage, ShardId};
@@ -1225,6 +1226,40 @@ impl<'a> ChainUpdate<'a> {
                         // TODO: MOO
                         assert!(false);
                         return Err(ErrorKind::InvalidStateRoot.into());
+                    }
+
+                    // It's safe here to get get_chain_store
+                    // because we're asking prev_chunk_header for already committed block
+                    //
+                    let (_, outgoing_receipts) = self
+                        .chain_store_update
+                        .get_chain_store()
+                        .get_outgoing_receipts_for_shard(
+                            block.header.prev_hash,
+                            shard_id,
+                            prev_chunk_header.height_included
+                        )?;
+                    let outgoing_receipts_hashes = self.runtime_adapter.build_receipts_hashes(&outgoing_receipts)?;
+                    let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
+
+                    if outgoing_receipts_root != chunk_header.receipts_root {
+                        // TODO: MOO
+                        println!(
+                            "[FAILED APPLYING CHUNK] {:?} PREV BLOCK HASH: {:?}, BLOCK HASH: {:?} ROOT: {:?}",
+                            chunk_header.height_included,
+                            chunk_header.prev_block_hash,
+                            block.hash(),
+                            chunk_header.prev_state_root
+                        );
+                        println!(
+                            "RECEIPTS_LEN {:?} RECEIPTS_ROOT {:?} chunk_header.receipts_root {:?} prev_chunk_header.receipts_root {:?}",
+                            outgoing_receipts.len(),
+                            outgoing_receipts_root,
+                            chunk_header.receipts_root,
+                            prev_chunk_header.receipts_root
+                        );
+                        assert!(false);
+                        return Err(ErrorKind::InvalidReceiptsProof.into());
                     }
 
                     let receipts: Vec<ReceiptTransaction> = self

--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -45,6 +45,9 @@ pub enum ErrorKind {
     /// Invalid state root hash.
     #[fail(display = "Invalid State Root Hash")]
     InvalidStateRoot,
+    /// Invalid receipts proof.
+    #[fail(display = "Invalid Receipts Proof")]
+    InvalidReceiptsProof,
     /// Invalid state payload on state sync.
     #[fail(display = "Invalid State Payload")]
     InvalidStatePayload(String),
@@ -128,6 +131,7 @@ impl Error {
             | ErrorKind::InvalidBlockWeight
             | ErrorKind::InvalidChunk
             | ErrorKind::InvalidStateRoot
+            | ErrorKind::InvalidReceiptsProof
             | ErrorKind::InvalidStatePayload(_)
             | ErrorKind::IncorrectNumberOfChunkHeaders
             | ErrorKind::InvalidEpochHash

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -527,6 +527,18 @@ impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
 
         Ok(ret)
     }
+
+    // WARNING
+    //
+    // Usually ChainStoreUpdate has some uncommitted changes
+    // and chain_store don't have access to them until they become committed.
+    // Make sure you're doing it right.
+    //
+    pub fn get_chain_store(
+        &mut self,
+    ) -> &mut T {
+        return self.chain_store;
+    }
 }
 
 impl<'a, T: ChainStoreAccess> ChainStoreAccess for ChainStoreUpdate<'a, T> {
@@ -620,7 +632,7 @@ impl<'a, T: ChainStoreAccess> ChainStoreAccess for ChainStoreUpdate<'a, T> {
         self.chain_store.get_block_hash_by_height(height)
     }
 
-    /// Get receipts produced for block with givien hash.
+    /// Get receipts produced for block with given hash.
     fn get_outgoing_receipts(
         &mut self,
         hash: &CryptoHash,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -27,6 +27,7 @@ use near_network::{
 };
 use near_primitives::crypto::signature::{verify, Signature};
 use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::merkle::merklize;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::types::{AccountId, BlockIndex, EpochId, ShardId};
 use near_primitives::unwrap_or_return;
@@ -954,6 +955,22 @@ impl ClientActor {
             last_header.height_included,
         )?;
 
+        // receipts proofs root is calculating here
+        //
+        // for each subset of incoming_receipts_into_shard_i_from_the_current_one
+        // we calculate hash here and save it
+        // and then hash all of them into only receipts_root
+        //
+        // we check validity in two ways:
+        // 1. someone who cares about shard will download all the receipts
+        // and checks that receipts_root equals to all receipts hashed
+        // 2. anyone who just asks for one's incoming receipts
+        // will receive a piece of incoming receipts only
+        // with merkle receipts proofs which can be checked easily
+        //
+        let receipts_hashes = self.runtime_adapter.build_receipts_hashes(&receipts)?;
+        let (receipts_root, _) = merklize(&receipts_hashes);
+
         let encoded_chunk = self
             .shards_mgr
             .create_encoded_shard_chunk(
@@ -966,6 +983,7 @@ impl ClientActor {
                 chunk_extra.validator_proposals.clone(),
                 &transactions,
                 &receipts,
+                receipts_root,
                 block_producer.signer.clone(),
             )
             .map_err(|_e| {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -593,6 +593,15 @@ impl TryFrom<network_proto::PeerMessage> for PeerMessage {
                     .into_iter()
                     .map(TryInto::try_into)
                     .collect::<Result<Vec<_>, _>>()?,
+                receipts_proofs: chunk_header_and_part
+                    .receipts_proofs
+                    .into_iter()
+                    .map(|proof| {
+                        Ok(
+                            MerklePath::decode(proof.as_slice())?,
+                        )
+                    })
+                    .collect::<Result<Vec<MerklePath>, Self::Error>>()?,
                 merkle_path: MerklePath::decode(chunk_header_and_part.merkle_path.as_slice())?,
             })),
             Some(network_proto::PeerMessage_oneof_message_type::announce_account(
@@ -764,7 +773,17 @@ impl From<PeerMessage> for network_proto::PeerMessage {
                     part_id: chunk_header_and_part.part_id,
                     part: (*chunk_header_and_part.part).to_vec(),
                     merkle_path: MerklePath::encode(&chunk_header_and_part.merkle_path).unwrap(),
-                    ..Default::default()
+                    receipts: RepeatedField::from_iter(
+                        chunk_header_and_part.receipts.into_iter().map(std::convert::Into::into),
+                    ),
+                    receipts_proofs: RepeatedField::from_iter(
+                        chunk_header_and_part.receipts_proofs.into_iter().map(
+                        |proof| {
+                            MerklePath::encode(&proof).unwrap()
+                        },
+                    )),
+                    cached_size: Default::default(),
+                    unknown_fields: Default::default(),
                 };
                 Some(network_proto::PeerMessage_oneof_message_type::chunk_header_and_part(
                     chunk_header_and_part,

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -312,6 +312,7 @@ impl Block {
                 shard_id: i,
                 gas_used: 0,
                 gas_limit: initial_gas_limit,
+                receipts_root: CryptoHash::default(),
                 validator_proposal: vec![],
                 signature: DEFAULT_SIGNATURE,
             })

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -54,6 +54,8 @@ pub struct ShardChunkHeader {
     pub gas_used: GasUsage,
     /// Gas limit voted by validators.
     pub gas_limit: GasUsage,
+    /// Receipts merkle root.
+    pub receipts_root: CryptoHash,
     /// Validator proposals.
     pub validator_proposal: Vec<ValidatorStake>,
 
@@ -72,6 +74,7 @@ impl ShardChunkHeader {
             self.height_created,
             self.gas_used,
             self.gas_limit,
+            self.receipts_root,
             self.validator_proposal.clone(),
             self.shard_id,
         )))
@@ -92,6 +95,7 @@ impl TryFrom<chain_proto::ShardChunkHeader> for ShardChunkHeader {
             shard_id: proto.shard_id,
             gas_used: proto.gas_used,
             gas_limit: proto.gas_limit,
+            receipts_root: proto.receipts_root.try_into()?,
             validator_proposal: proto
                 .validator_proposal
                 .into_iter()
@@ -114,6 +118,7 @@ impl From<ShardChunkHeader> for chain_proto::ShardChunkHeader {
             shard_id: header.shard_id,
             gas_used: header.gas_used,
             gas_limit: header.gas_limit,
+            receipts_root: header.receipts_root.into(),
             validator_proposal: RepeatedField::from_iter(
                 header.validator_proposal.drain(..).map(std::convert::Into::into),
             ),
@@ -142,6 +147,7 @@ pub struct ChunkOnePart {
     pub part_id: u64,
     pub part: Box<[u8]>,
     pub receipts: Vec<ReceiptTransaction>,
+    pub receipts_proofs: Vec<MerklePath>,
     pub merkle_path: MerklePath,
 }
 
@@ -188,6 +194,7 @@ impl EncodedShardChunk {
         shard_id: ShardId,
         gas_used: GasUsage,
         gas_limit: GasUsage,
+        receipts_root: CryptoHash,
         validator_proposal: Vec<ValidatorStake>,
 
         encoded_length: u64,
@@ -211,6 +218,7 @@ impl EncodedShardChunk {
             shard_id,
             gas_used,
             gas_limit,
+            receipts_root,
             validator_proposal,
             signature: DEFAULT_SIGNATURE,
         };

--- a/core/protos/protos/chain.proto
+++ b/core/protos/protos/chain.proto
@@ -39,6 +39,7 @@ message ShardChunkHeader {
     repeated ValidatorStake validator_proposal = 9;
     uint64 gas_used = 10;
     uint64 gas_limit = 11;
+    bytes receipts_root = 12;
 }
 
 message Block {

--- a/core/protos/protos/network.proto
+++ b/core/protos/protos/network.proto
@@ -86,6 +86,7 @@ message ChunkOnePart {
     bytes part = 5;
     repeated ReceiptTransaction receipts = 6;
     bytes merkle_path = 7;
+    repeated bytes receipts_proofs = 8;
 }
 
 message AnnounceAccountRoute {


### PR DESCRIPTION
The problem is to make sure that received receipts are trusty.

The common idea is to deliver a pair of (receipts, receipts_proof)
where receipts_proof is a Merkle proof of the receipts are received.

While chunk is producing, we calculate Merkle proof root and put it
into chunk header (check ClientActor::receipts_proof for more details).

Then we should check proofs in two cases:
1. Anyone who cares about shard and applying chunks completely
must compare Merkle root with proof which is stored into chunk header.
2. Sending ChunkOnePart, we must calculate proofs for each subset of
receipts related to some shard, as many as num_shards we have.
Receiving ChunkOnePart, we must check that all proofs are given and
all proofs guarantee that each subset contains in chunk receipts.

TEST PLAN
===
- sanity tests in chain and client folders
- cargo test --all-features --package near-client --test cross_shard_tx tests::test_cross_shard_tx -- --exact --nocapture
- cargo test --all-features --package near --test run_nodes run_nodes_2 -- --exact --nocapture

LOGIC REVIEWER
===
Alex Skidanov