### PR TITLE
Fix incorrect epoch hash computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1804,7 +1804,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.2.7",
+ "near 0.2.8",
  "near-primitives 0.1.0",
  "near-protos 0.1.0",
  "node-runtime 0.0.1",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "near"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2265,7 +2265,7 @@ dependencies = [
  "keystore 0.1.0",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.2.7",
+ "near 0.2.8",
  "near-jsonrpc 0.1.0",
  "near-network 0.1.0",
  "near-primitives 0.1.0",
@@ -3348,7 +3348,7 @@ dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.2.7",
+ "near 0.2.8",
  "near-chain 0.1.0",
  "near-network 0.1.0",
  "near-primitives 0.1.0",
@@ -3465,7 +3465,7 @@ dependencies = [
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.2.7",
+ "near 0.2.8",
  "near-chain 0.1.0",
  "near-client 0.1.0",
  "near-jsonrpc 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -523,8 +523,8 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.2.3"
-source = "git+https://github.com/ilblackdragon/bs58-rs?rev=46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b#46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byte-tools"
@@ -2185,7 +2185,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "bs58 0.2.3 (git+https://github.com/ilblackdragon/bs58-rs?rev=46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b)",
+ "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4246,7 +4246,7 @@ dependencies = [
 "checksum blockchain 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25c0f727a410bef0ea87d7437aa403f669ec4d7de1b302f4d819f83d3b4c561"
 "checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 "checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
-"checksum bs58 0.2.3 (git+https://github.com/ilblackdragon/bs58-rs?rev=46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b)" = "<none>"
+"checksum bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0d9644ad62ff4df43da2e057febbbce576f7124cb5cd8e90e0ce7027f38aa2dd"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -41,7 +41,7 @@ use crate::types::{
     BlockProducer, ClientConfig, Error, ShardSyncStatus, Status, StatusSyncInfo, SyncStatus,
 };
 use crate::{sync, StatusResponse};
-use std::cmp::max;
+use std::cmp::min;
 
 pub struct ClientActor {
     config: ClientConfig,
@@ -656,7 +656,7 @@ impl ClientActor {
             == block_producer.account_id.clone();
         // If epoch changed, and before there was 2 validators and now there is 1 - prev_same_bp is false, but total validators right now is 1.
         let total_approvals =
-            total_validators - max(if prev_same_bp { 1 } else { 2 }, total_validators);
+            total_validators - min(if prev_same_bp { 1 } else { 2 }, total_validators);
         if self.approvals.len() < total_approvals
             && self.last_block_processed.elapsed() < self.config.max_block_production_delay
         {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -629,7 +629,12 @@ impl ClientActor {
             return Ok(());
         }
         // Check that we are were called at the block that we are producer for.
-        let next_block_proposer = self.get_block_proposer(&head.epoch_hash, next_height)?;
+        let (epoch_hash, _) = self
+            .runtime_adapter
+            .get_epoch_offset(head.last_block_hash, next_height)
+            .map_err(|e| Error::from(ErrorKind::Other(e.to_string())))?;
+
+        let next_block_proposer = self.get_block_proposer(&epoch_hash, next_height)?;
         if block_producer.account_id != next_block_proposer {
             info!(target: "client", "Produce block: chain at {}, not block producer for next block.", next_height);
             return Ok(());

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 regex = "1"
 bincode = { version = "1.0", features = ["i128"] }
-bs58 = { git = "https://github.com/ilblackdragon/bs58-rs", rev = "46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b" }
+bs58 = "0.2.4"
 base64 = "0.10.1"
 byteorder = "1.2"
 chrono = { version = "0.4.4", features = ["serde"] }

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near"
-version = "0.2.7"
+version = "0.2.8"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Currently we incorrectly use `head.epoch_hash` for computing block proposer for the next block, which could be in a new epoch. https://github.com/nearprotocol/nearcore/blob/38d2c76ca7bf7fd8d9ad44d14efe4159d66998aa/chain/client/src/client.rs#L632.