### PR TITLE
Merkle proofs for receipts

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -7,6 +7,7 @@ use chrono::Duration;
 use log::{debug, info};
 
 use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::merklize;
 use near_primitives::sharding::{ShardChunk, ShardChunkHeader};
 use near_primitives::transaction::{ReceiptTransaction, TransactionResult};
 use near_primitives::types::{AccountId, Balance, BlockIndex, ChunkExtra, GasUsage, ShardId};
@@ -1225,6 +1226,40 @@ impl<'a> ChainUpdate<'a> {
                         // TODO: MOO
                         assert!(false);
                         return Err(ErrorKind::InvalidStateRoot.into());
+                    }
+
+                    // It's safe here to get get_chain_store
+                    // because we're asking prev_chunk_header for already committed block
+                    //
+                    let (_, outgoing_receipts) = self
+                        .chain_store_update
+                        .get_chain_store()
+                        .get_outgoing_receipts_for_shard(
+                            block.header.prev_hash,
+                            shard_id,
+                            prev_chunk_header.height_included
+                        )?;
+                    let outgoing_receipts_hashes = self.runtime_adapter.build_receipts_hashes(&outgoing_receipts)?;
+                    let (outgoing_receipts_root, _) = merklize(&outgoing_receipts_hashes);
+
+                    if outgoing_receipts_root != chunk_header.receipts_root {
+                        // TODO: MOO
+                        println!(
+                            "[FAILED APPLYING CHUNK] {:?} PREV BLOCK HASH: {:?}, BLOCK HASH: {:?} ROOT: {:?}",
+                            chunk_header.height_included,
+                            chunk_header.prev_block_hash,
+                            block.hash(),
+                            chunk_header.prev_state_root
+                        );
+                        println!(
+                            "RECEIPTS_LEN {:?} RECEIPTS_ROOT {:?} chunk_header.receipts_root {:?} prev_chunk_header.receipts_root {:?}",
+                            outgoing_receipts.len(),
+                            outgoing_receipts_root,
+                            chunk_header.receipts_root,
+                            prev_chunk_header.receipts_root
+                        );
+                        assert!(false);
+                        return Err(ErrorKind::InvalidReceiptsProof.into());
                     }
 
                     let receipts: Vec<ReceiptTransaction> = self

--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -45,6 +45,9 @@ pub enum ErrorKind {
     /// Invalid state root hash.
     #[fail(display = "Invalid State Root Hash")]
     InvalidStateRoot,
+    /// Invalid receipts proof.
+    #[fail(display = "Invalid Receipts Proof")]
+    InvalidReceiptsProof,
     /// Invalid state payload on state sync.
     #[fail(display = "Invalid State Payload")]
     InvalidStatePayload(String),
@@ -128,6 +131,7 @@ impl Error {
             | ErrorKind::InvalidBlockWeight
             | ErrorKind::InvalidChunk
             | ErrorKind::InvalidStateRoot
+            | ErrorKind::InvalidReceiptsProof
             | ErrorKind::InvalidStatePayload(_)
             | ErrorKind::IncorrectNumberOfChunkHeaders
             | ErrorKind::InvalidEpochHash

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -527,6 +527,18 @@ impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
 
         Ok(ret)
     }
+
+    // WARNING
+    //
+    // Usually ChainStoreUpdate has some uncommitted changes
+    // and chain_store don't have access to them until they become committed.
+    // Make sure you're doing it right.
+    //
+    pub fn get_chain_store(
+        &mut self,
+    ) -> &mut T {
+        return self.chain_store;
+    }
 }
 
 impl<'a, T: ChainStoreAccess> ChainStoreAccess for ChainStoreUpdate<'a, T> {
@@ -620,7 +632,7 @@ impl<'a, T: ChainStoreAccess> ChainStoreAccess for ChainStoreUpdate<'a, T> {
         self.chain_store.get_block_hash_by_height(height)
     }
 
-    /// Get receipts produced for block with givien hash.
+    /// Get receipts produced for block with given hash.
     fn get_outgoing_receipts(
         &mut self,
         hash: &CryptoHash,

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -5,12 +5,12 @@ use cached::Cached;
 use cached::SizedCache;
 use log::{debug, error};
 use near_chain::{ErrorKind, RuntimeAdapter, ValidTransaction};
-use near_network::types::{ChunkPartMsg, ChunkPartRequestMsg, PeerId};
+use near_network::types::{ChunkPartMsg, ChunkPartRequestMsg, ChunkOnePartRequestMsg, PeerId};
 use near_network::NetworkRequests;
 use near_pool::{Error, TransactionPool};
 use near_primitives::crypto::signer::EDSigner;
 use near_primitives::hash::CryptoHash;
-use near_primitives::merkle::{verify_path, MerklePath};
+use near_primitives::merkle::{verify_path, MerklePath, merklize};
 use near_primitives::serialize::{Decode, Encode};
 use near_primitives::sharding::{
     ChunkHash, ChunkOnePart, EncodedShardChunk, ShardChunk, ShardChunkHeader,
@@ -143,11 +143,12 @@ impl ShardsManager {
                                 .runtime_adapter
                                 .get_chunk_producer(&epoch_id, height, shard_id)
                                 .unwrap(),
-                            part_request: ChunkPartRequestMsg {
+                            one_part_request: ChunkOnePartRequestMsg {
                                 shard_id,
                                 chunk_hash: chunk_hash.clone(),
                                 height,
                                 part_id,
+                                recipient: self.me.clone().unwrap(),
                             },
                         });
                     }
@@ -180,11 +181,12 @@ impl ShardsManager {
                                 .runtime_adapter
                                 .get_chunk_producer(&epoch_id, height, shard_id)
                                 .unwrap(),
-                            part_request: ChunkPartRequestMsg {
+                            one_part_request: ChunkOnePartRequestMsg {
                                 shard_id,
                                 chunk_hash: chunk_hash.clone(),
                                 height,
                                 part_id,
+                                recipient: self.me.clone().unwrap(),
                             },
                         })
                         .unwrap(); // TODO XXX MOO no unwrap here!
@@ -317,9 +319,41 @@ impl ShardsManager {
 
         Ok(())
     }
+
+    fn receipts_recipient_filter(
+        &self,
+        recipient: &AccountId,
+        prev_block_hash: CryptoHash,
+        receipts: &Vec<ReceiptTransaction>,
+        receipts_proofs: &Vec<MerklePath>,
+    ) -> (Vec<ReceiptTransaction>, Vec<MerklePath>) {
+        let one_part_receipts = receipts
+            .iter()
+            .filter(|&receipt| {
+                self.cares_about_shard_this_or_next_epoch(
+                    recipient,
+                    prev_block_hash,
+                    self.runtime_adapter.account_id_to_shard_id(&receipt.receiver),
+                )
+            })
+            .cloned()
+            .collect();
+        let mut one_part_receipts_proofs = vec![];
+        for shard in 0..self.runtime_adapter.num_shards() {
+            if self.cares_about_shard_this_or_next_epoch(
+                recipient,
+                prev_block_hash,
+                shard,
+            ) {
+                one_part_receipts_proofs.push(receipts_proofs[shard as usize].clone())
+            }
+        }
+        (one_part_receipts, one_part_receipts_proofs)
+    }
+
     pub fn process_chunk_one_part_request(
         &mut self,
-        request: ChunkPartRequestMsg,
+        request: ChunkOnePartRequestMsg,
         peer_id: PeerId,
     ) -> Result<(), Box<dyn std::error::Error>> {
         if let Some(encoded_chunk) = self.encoded_chunks.get(&request.chunk_hash) {
@@ -338,6 +372,11 @@ impl ShardsManager {
                     peer_id,
                     self.me.clone().unwrap()
                 );
+                let receipts_hashes = self.runtime_adapter.build_receipts_hashes(&chunk.receipts)?;
+                let (receipts_root, receipts_proofs) = merklize(&receipts_hashes);
+                let (one_part_receipts, one_part_receipts_proofs) =
+                    self.receipts_recipient_filter(&request.recipient, chunk.header.prev_block_hash, &chunk.receipts, &receipts_proofs);
+                assert_eq!(chunk.header.receipts_root, receipts_root);
                 let _ = self.peer_mgr.do_send(NetworkRequests::ChunkOnePartResponse {
                     peer_id,
                     header_and_part: self.create_chunk_one_part(
@@ -345,7 +384,8 @@ impl ShardsManager {
                         encoded_chunk,
                         // TODO: we may want to add set of shards this peer is interested in chunks for.
                         request.part_id,
-                        chunk.receipts,
+                        one_part_receipts,
+                        one_part_receipts_proofs,
                     ),
                 });
             }
@@ -546,6 +586,30 @@ impl ShardsManager {
             return Err(ErrorKind::Other("Invalid merkle proof".to_string()).into());
         }
 
+        // Checking one_part's receipts validity here
+        //
+        let receipts_hashes = self.runtime_adapter.build_receipts_hashes(&one_part.receipts)?;
+        let mut proof_index = 0;
+        for shard_id in 0..self.runtime_adapter.num_shards() {
+            if self.cares_about_shard_this_or_next_epoch(
+                self.me.as_ref().unwrap(),
+                prev_block_hash,
+                shard_id,
+            ) {
+                if proof_index == one_part.receipts_proofs.len() || !verify_path(one_part.header.receipts_root,
+                                                                                 &one_part.receipts_proofs[proof_index],
+                                                                                 &receipts_hashes[shard_id as usize]) {
+                    assert!(false); // TODO XXX MOO remove
+                    return Err(ErrorKind::InvalidReceiptsProof.into());
+                }
+                proof_index += 1;
+            }
+        }
+        if proof_index != one_part.receipts_proofs.len() {
+            assert!(false); // TODO XXX MOO remove
+            return Err(ErrorKind::InvalidReceiptsProof.into());
+        }
+
         if let Some(send_to) =
             self.requests.remove(&(one_part.shard_id, chunk_hash.clone(), one_part.part_id))
         {
@@ -678,6 +742,7 @@ impl ShardsManager {
         validator_proposal: Vec<ValidatorStake>,
         transactions: &Vec<SignedTransaction>,
         receipts: &Vec<ReceiptTransaction>,
+        receipts_root: CryptoHash,
         signer: Arc<dyn EDSigner>,
     ) -> Result<EncodedShardChunk, io::Error> {
         let mut bytes = Encode::encode(&(transactions, receipts))?;
@@ -711,6 +776,7 @@ impl ShardsManager {
             shard_id,
             gas_used,
             gas_limit,
+            receipts_root,
             validator_proposal,
             encoded_length as u64,
             parts,
@@ -733,6 +799,7 @@ impl ShardsManager {
         encoded_chunk: &EncodedShardChunk,
         part_id: u64,
         receipts: Vec<ReceiptTransaction>,
+        receipts_proofs: Vec<MerklePath>,
     ) -> ChunkOnePart {
         ChunkOnePart {
             shard_id: encoded_chunk.header.shard_id,
@@ -741,6 +808,7 @@ impl ShardsManager {
             part_id,
             part: encoded_chunk.content.parts[part_id as usize].clone().unwrap(),
             receipts,
+            receipts_proofs,
             // It should be impossible to have a part but not the merkle path
             merkle_path: self.merkle_paths.get(&(chunk_hash.clone(), part_id)).unwrap().clone(),
         }
@@ -756,24 +824,20 @@ impl ShardsManager {
         let mut processed_one_part = false;
         let chunk_hash = encoded_chunk.chunk_hash();
         let shard_id = encoded_chunk.header.shard_id;
+        let receipts_hashes = self.runtime_adapter.build_receipts_hashes(&receipts).unwrap();
+        let (receipts_root, receipts_proofs) = merklize(&receipts_hashes);
+        assert_eq!(encoded_chunk.header.receipts_root, receipts_root);
         for part_ord in 0..self.runtime_adapter.num_total_parts(&prev_block_hash) {
             let part_ord = part_ord as u64;
             let to_whom = self.runtime_adapter.get_part_owner(&prev_block_hash, part_ord).unwrap();
+            let (one_part_receipts, one_part_receipts_proofs) =
+                self.receipts_recipient_filter(&to_whom, prev_block_hash, &receipts, &receipts_proofs);
             let one_part = self.create_chunk_one_part(
                 chunk_hash.clone(),
                 &encoded_chunk,
                 part_ord,
-                receipts
-                    .iter()
-                    .filter(|&receipt| {
-                        self.cares_about_shard_this_or_next_epoch(
-                            &to_whom,
-                            prev_block_hash,
-                            self.runtime_adapter.account_id_to_shard_id(&receipt.receiver),
-                        )
-                    })
-                    .cloned()
-                    .collect(),
+                one_part_receipts,
+                one_part_receipts_proofs,
             );
 
             // 1/2 This is a weird way to introduce the chunk to the producer's storage

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -27,6 +27,7 @@ use near_network::{
 };
 use near_primitives::crypto::signature::{verify, Signature};
 use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::merkle::merklize;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::types::{AccountId, BlockIndex, EpochId, ShardId};
 use near_primitives::unwrap_or_return;
@@ -954,6 +955,22 @@ impl ClientActor {
             last_header.height_included,
         )?;
 
+        // receipts proofs root is calculating here
+        //
+        // for each subset of incoming_receipts_into_shard_i_from_the_current_one
+        // we calculate hash here and save it
+        // and then hash all of them into only receipts_root
+        //
+        // we check validity in two ways:
+        // 1. someone who cares about shard will download all the receipts
+        // and checks that receipts_root equals to all receipts hashed
+        // 2. anyone who just asks for one's incoming receipts
+        // will receive a piece of incoming receipts only
+        // with merkle receipts proofs which can be checked easily
+        //
+        let receipts_hashes = self.runtime_adapter.build_receipts_hashes(&receipts)?;
+        let (receipts_root, _) = merklize(&receipts_hashes);
+
         let encoded_chunk = self
             .shards_mgr
             .create_encoded_shard_chunk(
@@ -966,6 +983,7 @@ impl ClientActor {
                 chunk_extra.validator_proposals.clone(),
                 &transactions,
                 &receipts,
+                receipts_root,
                 block_producer.signer.clone(),
             )
             .map_err(|_e| {

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -196,13 +196,13 @@ pub fn setup_mock_all_validators(
                         }
                         NetworkRequests::ChunkOnePartRequest {
                             account_id: their_account_id,
-                            part_request,
+                            one_part_request,
                         } => {
                             for (i, name) in validators_clone2.iter().flatten().enumerate() {
                                 if name == their_account_id {
                                     connectors1.write().unwrap()[i].0.do_send(
                                         NetworkClientMessages::ChunkOnePartRequest(
-                                            part_request.clone(),
+                                            one_part_request.clone(),
                                             my_key_pair.id,
                                         ),
                                     );

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -551,11 +551,11 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                 );
                 NetworkResponses::NoResponse
             }
-            NetworkRequests::ChunkOnePartRequest { account_id, part_request } => {
+            NetworkRequests::ChunkOnePartRequest { account_id, one_part_request } => {
                 self.send_message_to_account(
                     ctx,
                     account_id,
-                    SendMessage { message: PeerMessage::ChunkOnePartRequest(part_request) },
+                    SendMessage { message: PeerMessage::ChunkOnePartRequest(one_part_request) },
                 );
                 NetworkResponses::NoResponse
             }

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -319,6 +319,7 @@ impl Block {
                 shard_id: i,
                 gas_used: 0,
                 gas_limit: initial_gas_limit,
+                receipts_root: CryptoHash::default(),
                 validator_proposal: vec![],
                 signature: DEFAULT_SIGNATURE,
             })

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -54,6 +54,8 @@ pub struct ShardChunkHeader {
     pub gas_used: GasUsage,
     /// Gas limit voted by validators.
     pub gas_limit: GasUsage,
+    /// Receipts merkle root.
+    pub receipts_root: CryptoHash,
     /// Validator proposals.
     pub validator_proposal: Vec<ValidatorStake>,
 
@@ -72,6 +74,7 @@ impl ShardChunkHeader {
             self.height_created,
             self.gas_used,
             self.gas_limit,
+            self.receipts_root,
             self.validator_proposal.clone(),
             self.shard_id,
         )))
@@ -92,6 +95,7 @@ impl TryFrom<chain_proto::ShardChunkHeader> for ShardChunkHeader {
             shard_id: proto.shard_id,
             gas_used: proto.gas_used,
             gas_limit: proto.gas_limit,
+            receipts_root: proto.receipts_root.try_into()?,
             validator_proposal: proto
                 .validator_proposal
                 .into_iter()
@@ -114,6 +118,7 @@ impl From<ShardChunkHeader> for chain_proto::ShardChunkHeader {
             shard_id: header.shard_id,
             gas_used: header.gas_used,
             gas_limit: header.gas_limit,
+            receipts_root: header.receipts_root.into(),
             validator_proposal: RepeatedField::from_iter(
                 header.validator_proposal.drain(..).map(std::convert::Into::into),
             ),
@@ -142,6 +147,7 @@ pub struct ChunkOnePart {
     pub part_id: u64,
     pub part: Box<[u8]>,
     pub receipts: Vec<ReceiptTransaction>,
+    pub receipts_proofs: Vec<MerklePath>,
     pub merkle_path: MerklePath,
 }
 
@@ -188,6 +194,7 @@ impl EncodedShardChunk {
         shard_id: ShardId,
         gas_used: GasUsage,
         gas_limit: GasUsage,
+        receipts_root: CryptoHash,
         validator_proposal: Vec<ValidatorStake>,
 
         encoded_length: u64,
@@ -211,6 +218,7 @@ impl EncodedShardChunk {
             shard_id,
             gas_used,
             gas_limit,
+            receipts_root,
             validator_proposal,
             signature: DEFAULT_SIGNATURE,
         };

--- a/core/protos/protos/chain.proto
+++ b/core/protos/protos/chain.proto
@@ -40,6 +40,7 @@ message ShardChunkHeader {
     repeated ValidatorStake validator_proposal = 9;
     uint64 gas_used = 10;
     uint64 gas_limit = 11;
+    bytes receipts_root = 12;
 }
 
 message Block {

--- a/core/protos/protos/network.proto
+++ b/core/protos/protos/network.proto
@@ -65,11 +65,18 @@ message StateResponse {
     repeated StateResponseReceipts incoming_receipts = 9;
 }
 
-message ChunkPartRequest{
+message ChunkPartRequest {
     uint64 shard_id = 1;
     bytes chunk_hash = 2;
     uint64 height = 3;
     uint64 part_id = 4;
+}
+message ChunkOnePartRequest {
+    uint64 shard_id = 1;
+    bytes chunk_hash = 2;
+    uint64 height = 3;
+    uint64 part_id = 4;
+    string recipient = 5;
 }
 message ChunkPart {
     uint64 shard_id = 1;
@@ -86,6 +93,7 @@ message ChunkOnePart {
     bytes part = 5;
     repeated ReceiptTransaction receipts = 6;
     bytes merkle_path = 7;
+    repeated bytes receipts_proofs = 8;
 }
 
 message AnnounceAccountRoute {
@@ -118,7 +126,7 @@ message PeerMessage {
         AnnounceAccount announce_account = 13;
 
         ChunkPartRequest chunk_part_request = 14;
-        ChunkPartRequest chunk_one_part_request = 15;
+        ChunkOnePartRequest chunk_one_part_request = 15;
         ChunkPart chunk_part = 16;
         ChunkOnePart chunk_header_and_part = 17;
     }


### PR DESCRIPTION
The problem is to make sure that received receipts are trusty.

The common idea is to deliver a pair of (receipts, receipts_proof)
where receipts_proof is a Merkle proof of the receipts are received.

While chunk is producing, we calculate Merkle proof root and put it
into chunk header (check ClientActor::receipts_proof for more details).

Then we should check proofs in two cases:
1. Anyone who cares about shard and applying chunks completely
must compare Merkle root with proof which is stored into chunk header.
2. Sending ChunkOnePart, we must calculate proofs for each subset of
receipts related to some shard, as many as num_shards we have.
Receiving ChunkOnePart, we must check that all proofs are given and
all proofs guarantee that each subset contains in chunk receipts.

TEST PLAN
===
- sanity tests in chain and client folders
- cargo test --all-features --package near-client --test cross_shard_tx tests::test_cross_shard_tx -- --exact --nocapture
(10 iterations)
- cargo test --all-features --package near --test run_nodes run_nodes_2 -- --exact --nocapture
- cargo test --package near --test stake_nodes test_validator_join -- --exact --nocapture

LOGIC REVIEWER
===
Alex Skidanov