### PR TITLE
Some dependencies changes needed for smart contract testing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,7 +2202,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-fees"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2251,7 +2251,7 @@ name = "near-vm-logic"
 version = "0.2.1"
 dependencies = [
  "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-runtime-fees 0.2.0",
+ "near-runtime-fees 0.2.1",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2339,7 +2339,7 @@ dependencies = [
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-primitives 0.1.0",
- "near-runtime-fees 0.2.0",
+ "near-runtime-fees 0.2.1",
  "near-store 0.1.0",
  "near-verifier 0.1.0",
  "near-vm-logic 0.2.1",
@@ -3468,7 +3468,7 @@ dependencies = [
  "near-client 0.1.0",
  "near-jsonrpc 0.1.0",
  "near-primitives 0.1.0",
- "near-runtime-fees 0.2.0",
+ "near-runtime-fees 0.2.1",
  "near-store 0.1.0",
  "node-runtime 0.0.1",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,13 +550,8 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "bs58"
-version = "0.2.3"
-source = "git+https://github.com/ilblackdragon/bs58-rs?rev=46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b#46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b"
 
 [[package]]
 name = "build_const"
@@ -2185,7 +2180,7 @@ dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
- "bs58 0.2.3 (git+https://github.com/ilblackdragon/bs58-rs?rev=46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b)",
+ "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2255,7 +2250,7 @@ dependencies = [
 name = "near-vm-logic"
 version = "0.2.0"
 dependencies = [
- "bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-runtime-fees 0.2.0",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4238,8 +4233,7 @@ dependencies = [
 "checksum borsh-derive-internal 0.1.0 (git+https://github.com/nearprotocol/borsh.git)" = "<none>"
 "checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 "checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
-"checksum bs58 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0de79cfb98e7aa9988188784d8664b4b5dad6eaaa0863b91d9a4ed871d4f7a42"
-"checksum bs58 0.2.3 (git+https://github.com/ilblackdragon/bs58-rs?rev=46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b)" = "<none>"
+"checksum bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0d9644ad62ff4df43da2e057febbbce576f7124cb5cd8e90e0ce7027f38aa2dd"
 "checksum build_const 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-runtime-fees 0.2.1",
@@ -2258,12 +2258,12 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-logic 0.2.2",
+ "near-vm-logic 0.2.3",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2275,8 +2275,8 @@ name = "near-vm-runner-standalone"
 version = "0.2.2"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-logic 0.2.2",
- "near-vm-runner 0.2.2",
+ "near-vm-logic 0.2.3",
+ "near-vm-runner 0.2.3",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2342,13 +2342,14 @@ dependencies = [
  "near-runtime-fees 0.2.1",
  "near-store 0.1.0",
  "near-verifier 0.1.0",
- "near-vm-logic 0.2.2",
- "near-vm-runner 0.2.2",
+ "near-vm-logic 0.2.3",
+ "near-vm-runner 0.2.3",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sodiumoxide 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "testlib 0.1.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2272,11 +2272,11 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-standalone"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-vm-logic 0.2.3",
- "near-vm-runner 0.2.3",
+ "near-vm-runner 0.2.4",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2343,7 +2343,7 @@ dependencies = [
  "near-store 0.1.0",
  "near-verifier 0.1.0",
  "near-vm-logic 0.2.3",
- "near-vm-runner 0.2.3",
+ "near-vm-runner 0.2.4",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-runtime-fees 0.2.0",
@@ -2258,12 +2258,12 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-logic 0.2.0",
+ "near-vm-logic 0.2.1",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2272,11 +2272,11 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-standalone"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-logic 0.2.0",
- "near-vm-runner 0.2.1",
+ "near-vm-logic 0.2.1",
+ "near-vm-runner 0.2.2",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2342,8 +2342,8 @@ dependencies = [
  "near-runtime-fees 0.2.0",
  "near-store 0.1.0",
  "near-verifier 0.1.0",
- "near-vm-logic 0.2.0",
- "near-vm-runner 0.2.1",
+ "near-vm-logic 0.2.1",
+ "near-vm-runner 0.2.2",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2248,7 +2248,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-runtime-fees 0.2.1",
@@ -2263,7 +2263,7 @@ dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-logic 0.2.1",
+ "near-vm-logic 0.2.2",
  "parity-wasm 0.31.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2275,7 +2275,7 @@ name = "near-vm-runner-standalone"
 version = "0.2.2"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-logic 0.2.1",
+ "near-vm-logic 0.2.2",
  "near-vm-runner 0.2.2",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2342,7 +2342,7 @@ dependencies = [
  "near-runtime-fees 0.2.1",
  "near-store 0.1.0",
  "near-verifier 0.1.0",
- "near-vm-logic 0.2.1",
+ "near-vm-logic 0.2.2",
  "near-vm-runner 0.2.2",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 regex = "1"
 bincode = { version = "1.0", features = ["i128"] }
-bs58 = { git = "https://github.com/ilblackdragon/bs58-rs", rev = "46a818c93cd2ba19c2d5d9aefa8e3062ffb98d9b" }
+bs58 = "0.2.4"
 base64 = "0.10.1"
 byteorder = "1.2"
 chrono = { version = "0.4.4", features = ["serde"] }

--- a/runtime/near-runtime-fees/Cargo.toml
+++ b/runtime/near-runtime-fees/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-runtime-fees"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-logic"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -25,9 +25,6 @@ required-features = ["mocks"]
 
 
 [features]
-default = ["logic_impl"]
+default = []
 # Mocks include some unsafe code to workaround lifetimes and therefore are optional.
-mocks = []
-
-# Implementation of the logic is included by default, but is not needed for the Rust smart contracts.
-logic_impl = ["sodiumoxide"]
+mocks = ["sodiumoxide"]

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-logic"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-logic"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -14,7 +14,7 @@ This crate implements the specification of the interface that Near blockchain ex
 
 [dependencies]
 bs58 = "0.2.2"
-sodiumoxide = "0.2.2"
+sodiumoxide = { version = "0.2.2", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 near-runtime-fees = { path = "../near-runtime-fees", version = "0.2.1" }
 
@@ -30,4 +30,4 @@ default = ["logic_impl"]
 mocks = []
 
 # Implementation of the logic is included by default, but is not needed for the Rust smart contracts.
-logic_impl = []
+logic_impl = ["sodiumoxide"]

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -25,5 +25,9 @@ required-features = ["mocks"]
 
 
 [features]
+default = ["std"]
 # Mocks include some unsafe code to workaround lifetimes and therefore are optional.
 mocks = []
+
+# Implementation of the logic is included by default, but is not needed for the Rust smart contracts.
+logic_impl = []

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -16,7 +16,7 @@ This crate implements the specification of the interface that Near blockchain ex
 bs58 = "0.2.2"
 sodiumoxide = "0.2.2"
 serde = { version = "1.0", features = ["derive"] }
-near-runtime-fees = { path = "../near-runtime-fees", version = "0.2.0" }
+near-runtime-fees = { path = "../near-runtime-fees", version = "0.2.1" }
 
 [[test]]
 name = "test_registers"

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -25,7 +25,7 @@ required-features = ["mocks"]
 
 
 [features]
-default = ["std"]
+default = ["logic_impl"]
 # Mocks include some unsafe code to workaround lifetimes and therefore are optional.
 mocks = []
 

--- a/runtime/near-vm-logic/src/dependencies.rs
+++ b/runtime/near-vm-logic/src/dependencies.rs
@@ -68,6 +68,8 @@ pub trait External {
         attached_deposit: Balance,
         prepaid_gas: Gas,
     ) -> Result<ReceiptIndex>;
+
+    fn sha256(&self, data: &[u8]) -> Result<Vec<u8>>;
 }
 
 impl std::fmt::Display for ExternalError {

--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -2,7 +2,6 @@ mod config;
 mod context;
 mod dependencies;
 mod errors;
-#[cfg(feature = "logic_impl")]
 mod logic;
 #[cfg(feature = "mocks")]
 pub mod mocks;
@@ -13,6 +12,5 @@ pub use config::Config;
 pub use context::VMContext;
 pub use dependencies::{External, ExternalError, MemoryLike};
 pub use errors::HostError;
-#[cfg(feature = "logic_impl")]
 pub use logic::{VMLogic, VMOutcome};
 pub use types::ReturnData;

--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -2,6 +2,7 @@ mod config;
 mod context;
 mod dependencies;
 mod errors;
+#[cfg(feature = "logic_impl")]
 mod logic;
 #[cfg(feature = "mocks")]
 pub mod mocks;
@@ -12,5 +13,6 @@ pub use config::Config;
 pub use context::VMContext;
 pub use dependencies::{External, ExternalError, MemoryLike};
 pub use errors::HostError;
+#[cfg(feature = "logic_impl")]
 pub use logic::{VMLogic, VMOutcome};
 pub use types::ReturnData;

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -369,10 +369,10 @@ impl<'a> VMLogic<'a> {
     /// If `value_len + value_ptr` points outside the memory or the registers use more memory than
     /// the limit with `MemoryAccessViolation`.
     pub fn sha256(&mut self, value_len: u64, value_ptr: u64, register_id: u64) -> Result<()> {
-        let Self { memory, registers, config, .. } = self;
+        let Self { memory, registers, config, ext, .. } = self;
         let value = Self::memory_get(*memory, value_ptr, value_len)?;
-        let value_hash = sodiumoxide::crypto::hash::sha256::hash(&value);
-        Self::internal_write_register(registers, config, register_id, value_hash.as_ref())
+        let value_hash = ext.sha256(&value)?;
+        Self::internal_write_register(registers, config, register_id, &value_hash)
     }
 
     // ################

--- a/runtime/near-vm-logic/src/mocks/mock_external.rs
+++ b/runtime/near-vm-logic/src/mocks/mock_external.rs
@@ -131,7 +131,7 @@ impl External for MockedExternal {
     }
 
     fn sha256(&self, data: &[u8]) -> Result<Vec<u8>, ExternalError> {
-        let value_hash = sodiumoxide::crypto::hash::sha256::hash(&value);
+        let value_hash = sodiumoxide::crypto::hash::sha256::hash(data);
         Ok(value_hash.as_ref().to_vec())
     }
 }

--- a/runtime/near-vm-logic/src/mocks/mock_external.rs
+++ b/runtime/near-vm-logic/src/mocks/mock_external.rs
@@ -129,6 +129,11 @@ impl External for MockedExternal {
         self.next_receipt_index += 1;
         Ok(res)
     }
+
+    fn sha256(&self, data: &[u8]) -> Result<Vec<u8>, ExternalError> {
+        let value_hash = sodiumoxide::crypto::hash::sha256::hash(&value);
+        Ok(value_hash.as_ref().to_vec())
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner-standalone"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,5 +21,5 @@ to make sure it has expected behavior once deployed to the blockchain.
 [dependencies]
 serde_json = "1.0"
 clap = "2.33.0"
-near-vm-logic = { path = "../near-vm-logic", features = ["mocks"] }
-near-vm-runner = { path = "../near-vm-runner" }
+near-vm-logic = { path = "../near-vm-logic", features = ["mocks", "logic_impl"], version =  "0.2.1"}
+near-vm-runner = { path = "../near-vm-runner", version = "0.2.2" }

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner-standalone"
-version = "0.2.2"
+version = "0.2.4"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -22,4 +22,4 @@ to make sure it has expected behavior once deployed to the blockchain.
 serde_json = "1.0"
 clap = "2.33.0"
 near-vm-logic = { path = "../near-vm-logic", features = ["mocks"], version =  "0.2.3"}
-near-vm-runner = { path = "../near-vm-runner", version = "0.2.2" }
+near-vm-runner = { path = "../near-vm-runner", version = "0.2.4" }

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -21,5 +21,5 @@ to make sure it has expected behavior once deployed to the blockchain.
 [dependencies]
 serde_json = "1.0"
 clap = "2.33.0"
-near-vm-logic = { path = "../near-vm-logic", features = ["mocks", "logic_impl"], version =  "0.2.1"}
+near-vm-logic = { path = "../near-vm-logic", features = ["mocks"], version =  "0.2.3"}
 near-vm-runner = { path = "../near-vm-runner", version = "0.2.2" }

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,12 +15,12 @@ This crate implements the specification of the interface that Near blockchain ex
 [dependencies]
 cached = "0.9.0"
 wasmer-runtime = { version = "0.5.7", features = ["singlepass"] }
-near-vm-logic = { path="../near-vm-logic", version = "0.2.1"}
+near-vm-logic = { path="../near-vm-logic", version = "0.2.3"}
 pwasm-utils = "0.7.0"
 parity-wasm = "0.31.3"
 
 [dev-dependencies]
-near-vm-logic = { path="../near-vm-logic", features=["mocks"], version = "0.2.0"}
+near-vm-logic = { path="../near-vm-logic", features=["mocks"], version = "0.2.3"}
 assert_matches = "1.3.0"
 wabt = "0.7.4"
 bencher = "0.1.5"

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ This crate implements the specification of the interface that Near blockchain ex
 [dependencies]
 cached = "0.9.0"
 wasmer-runtime = { version = "0.5.7", features = ["singlepass"] }
-near-vm-logic = { path="../near-vm-logic", version = "0.2.0"}
+near-vm-logic = { path="../near-vm-logic", version = "0.2.1"}
 pwasm-utils = "0.7.0"
 parity-wasm = "0.31.3"
 

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -57,7 +57,7 @@ impl<'a> ContractModule<'a> {
         let Self { module, config } = self;
         // TODO(#194): Re-enable .with_forbidden_floats() once AssemblyScript is fixed.
         let gas_rules = rules::Set::new(config.regular_op_cost, Default::default())
-            .with_forbidden_floats()
+            //            .with_forbidden_floats()
             .with_grow_cost(config.grow_mem_cost);
         let module = pwasm_utils::inject_gas_counter(module, &gas_rules)
             .map_err(|_| PrepareError::GasInstrumentation)?;

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -16,6 +16,7 @@ rand = "0.6"
 rand_xorshift = "0.1"
 ethash = "0.3"
 ethereum-bigint = "0.2"
+sodiumoxide = "0.2.2"
 
 near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store" }

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -192,7 +192,7 @@ impl<'a> External for RuntimeExt<'a> {
     }
 
     fn sha256(&self, data: &[u8]) -> Result<Vec<u8>, ExternalError> {
-        let value_hash = sodiumoxide::crypto::hash::sha256::hash(&value);
+        let value_hash = sodiumoxide::crypto::hash::sha256::hash(data);
         Ok(value_hash.as_ref().to_vec())
     }
 }

--- a/runtime/runtime/src/ext.rs
+++ b/runtime/runtime/src/ext.rs
@@ -190,4 +190,9 @@ impl<'a> External for RuntimeExt<'a> {
         self.action_receipts.push((receiver_id, new_receipt));
         Ok(new_receipt_index)
     }
+
+    fn sha256(&self, data: &[u8]) -> Result<Vec<u8>, ExternalError> {
+        let value_hash = sodiumoxide::crypto::hash::sha256::hash(&value);
+        Ok(value_hash.as_ref().to_vec())
+    }
 }


### PR DESCRIPTION
* Allowing floats until we solve json;
* Using old bs58;
* Extracting sodiumoxide from near-vm-logic;
* Bumping version of crates.