### PR TITLE
Encode `epoch_hash` as `base58` #1165

### DIFF
--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -47,6 +47,7 @@ pub struct BlockHeader {
     pub validator_proposal: Vec<ValidatorStake>,
     /// Epoch start hash of the previous epoch.
     /// Used for retrieving validator information
+    #[serde(with = "base_format")]
     pub epoch_hash: CryptoHash,
 
     /// Signature of the block producer.


### PR DESCRIPTION
Fix #1165

**Before (Note value of `epoch_hash`):**
```
http post http://127.0.0.1:3030/ jsonrpc=2.0 method=block params:="[426]" id="dontcare"
HTTP/1.1 200 OK
content-length: 664
content-type: application/json
date: Wed, 28 Aug 2019 15:53:16 GMT

{
    "id": "dontcare",
    "jsonrpc": "2.0",
    "result": {
        "header": {
            "approval_mask": [],
            "approval_sigs": [],
            "epoch_hash": [
                60,
                191,
                136,
                124,
                96,
                228,
                240,
                130,
                225,
                200,
                18,
                200,
                156,
                102,
                25,
                27,
                244,
                71,
                122,
                216,
                134,
                198,
                54,
                227,
                63,
                155,
                16,
                102,
                88,
                173,
                84,
                191
            ],
            "hash": "CXWKw82igTY6po1BZwEbnoe1z51dt36xLzMBPghiK8FD",
            "height": 426,
            "prev_hash": "Fgqi9k3ictJGZpYtSbxupHU18T4scLoipQajUsmNKciN",
            "prev_state_root": "8xHDzA2ppi8MdbSJ5VgAkxQJHNWeFMhUJ57Q5TYnTFf",
            "signature": "2NUPcjj2kz6qUn9MnPeTahyMLpxNCuBeWx9qe7AyVhkmqLNa9z7bcfHv5HF61RjJ5uHQ6cs56csSxVTANZi6iAqK",
            "timestamp": 1567007455736745195,
            "total_weight": {
                "num": 426
            },
            "tx_root": "11111111111111111111111111111111",
            "validator_proposal": []
        },
        "transactions": []
    }
}
```

**After:**
```
http post http://127.0.0.1:3030/ jsonrpc=2.0 method=block params:="[426]" id="dontcare"
HTTP/1.1 200 OK
content-length: 591
content-type: application/json
date: Wed, 28 Aug 2019 15:40:09 GMT

{
    "id": "dontcare",
    "jsonrpc": "2.0",
    "result": {
        "header": {
            "approval_mask": [],
            "approval_sigs": [],
            "epoch_hash": "568raPVPjczjDaBPmKFaaSFhhLfzsk8ug23x1igA6UXp",
            "hash": "DryiaCn4SYpVFGJTbZKCg8RQgZP1ib457yiKVpQ2N6E7",
            "height": 426,
            "prev_hash": "AB1LFp3rT7Nc1bDmzGZHUd9tkGbmJNe4JEtWtRn72ev6",
            "prev_state_root": "8xHDzA2ppi8MdbSJ5VgAkxQJHNWeFMhUJ57Q5TYnTFf",
            "signature": "cng7x1qJ3XXooo5EvJ5iUnjJNadXS3Pgi9ZzrV1imCjtUroehV2cQZuQQbokMpgg7zsSkjfMJzmkopkGe9cePmy",
            "timestamp": 1567006801750024215,
            "total_weight": {
                "num": 426
            },
            "tx_root": "11111111111111111111111111111111",
            "validator_proposal": []
        },
        "transactions": []
    }
}
```

**Note:** With this change a next start of a TestNet locally will throw an `IO Error: Failed to deserialize` while trying to open database at "~/.near/data". These data (files) has to be removed before (not sure if there is already a script to clean the `db`)

@frol  `approval_sigs` [is already `base58` encoded](https://github.com/nearprotocol/nearcore/blob/15b2c52281950973afe96d4bd443e9c981eb0d34/core/primitives/src/block.rs#L42-L43). And it seems that `approval_mask` does not need to be encoded as `base58`, because [it's just a `Vec<bool>`](https://github.com/nearprotocol/nearcore/blob/15b2c52281950973afe96d4bd443e9c981eb0d34/core/primitives/src/block.rs#L40). So just fixing ``epoch_hash` should be fine (hopefully).