### PR TITLE
Create out/assembly dir so that hello contract can compile

### DIFF
--- a/tests/hello/package.json
+++ b/tests/hello/package.json
@@ -6,7 +6,7 @@
         "near-runtime-ts": "github:nearprotocol/near-runtime-ts#staging"
     },
     "scripts": {
-        "build": "mkdir -p ./out && near build && cp ./out/main.wasm ../hello.wasm"
+        "build": "mkdir -p ./out && mkdir -p ./out/assembly && near build && cp ./out/main.wasm ../hello.wasm"
     },
     "devDependencies": {
         "bignum": "github:MaxGraey/bignum.wasm",


### PR DESCRIPTION
   This is needed because out was added to //@nearfile annotation, and right
   now it requires out/assembly to exist