### PR TITLE
[WIP] Storage errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,6 +596,14 @@ dependencies = [
 
 [[package]]
 name = "cached"
+version = "0.8.0"
+source = "git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be#7e472eddef68607e344d5a106a0e6705d92e55be"
+dependencies = [
+ "once_cell 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "cached"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -4369,6 +4377,8 @@ dependencies = [
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+"checksum c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7d64d04786e0f528460fc884753cf8dddcc466be308f6026f8e355c41a0e4101"
+"checksum cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)" = "<none>"
 "checksum cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "24f3f5ca5651b8360fb859d6fd1b80fb4c25bc3cbf3ffc3a74d3d6a79fba328e"
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cexpr 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a7fa24eb00d5ffab90eaeaf1092ac85c04c64aaf358ea6f84505b8116d24c6af"

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -394,7 +394,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         _shard_id: ShardId,
         _state_root: MerkleHash,
         transaction: SignedTransaction,
-    ) -> Result<ValidTransaction, String> {
+    ) -> Result<ValidTransaction, Box<dyn std::error::Error>> {
         Ok(ValidTransaction { transaction })
     }
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -107,7 +107,7 @@ pub trait RuntimeAdapter: Send + Sync {
         shard_id: ShardId,
         state_root: MerkleHash,
         transaction: SignedTransaction,
-    ) -> Result<ValidTransaction, String>;
+    ) -> Result<ValidTransaction, Box<dyn std::error::Error>>;
 
     /// Verify validator signature for the given epoch.
     fn verify_validator_signature(

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -1378,7 +1378,7 @@ impl ClientActor {
                     NetworkClientResponses::ForwardTx(validator, valid_transaction.transaction)
                 }
             }
-            Err(err) => NetworkClientResponses::InvalidTx(err),
+            Err(err) => NetworkClientResponses::InvalidTx(err.to_string()),
         }
     }
 

--- a/runtime/near-vm-logic/src/dependencies.rs
+++ b/runtime/near-vm-logic/src/dependencies.rs
@@ -35,6 +35,7 @@ pub enum ExternalError {
     InvalidIteratorIndex,
     InvalidAccountId,
     InvalidMethodName,
+    StorageError,
 }
 
 pub type Result<T> = ::std::result::Result<T, ExternalError>;
@@ -80,6 +81,7 @@ impl std::fmt::Display for ExternalError {
             InvalidIteratorIndex => write!(f, "VM Logic returned an invalid iterator index"),
             InvalidAccountId => write!(f, "VM Logic returned an invalid account id"),
             InvalidMethodName => write!(f, "VM Logic returned an invalid method name"),
+            StorageError => write!(f, "Storage error"),
         }
     }
 }

--- a/runtime/near-vm-runner/src/errors.rs
+++ b/runtime/near-vm-runner/src/errors.rs
@@ -52,6 +52,7 @@ impl std::fmt::Display for PrepareError {
 
 #[derive(Debug, Clone, PartialEq)]
 /// Error that occurs when trying to run a method from a smart contract.
+/// TODO handling for StorageError
 pub enum VMError {
     /// Error occurs during the preparation of smart contract.
     PrepareError(String),

--- a/runtime/runtime/src/cache.rs
+++ b/runtime/runtime/src/cache.rs
@@ -4,19 +4,23 @@ use cached::{cached_key, SizedCache};
 
 use near_primitives::contract::ContractCode;
 use near_primitives::hash::CryptoHash;
+use near_store::StorageError;
 
 /// Cache size in number of cached modules to hold.
 const CACHE_SIZE: usize = 1024;
 
 cached_key! {
-    CODE: SizedCache<CryptoHash, Result<Arc<ContractCode>, String>> = SizedCache::with_size(CACHE_SIZE);
+    CODE: SizedCache<CryptoHash, Result<Option<Arc<ContractCode>>, StorageError>> = SizedCache::with_size(CACHE_SIZE);
     Key = {
         code_hash
     };
 
-    fn get_code_with_cache(code_hash: CryptoHash, f: impl FnOnce() -> Result<ContractCode, String>) -> Result<Arc<ContractCode>, String> = {
+    fn get_code_with_cache
+    (code_hash: CryptoHash, f: impl FnOnce() -> Result<Option<ContractCode>, StorageError>) -> Result<Option<Arc<ContractCode>>, StorageError> = {
         let code = f()?;
-        assert_eq!(code_hash, code.get_hash());
-        Ok(Arc::new(code))
+        Ok(code.map(|code| {
+            assert_eq!(code_hash, code.get_hash());
+            Arc::new(code)
+        }))
     }
 }


### PR DESCRIPTION
Divide storage errors into three cases:
```
pub enum StorageError {
    /// Key-value db internal failure
    StorageInternalError,
    /// Storage is PartialStorage and requested a missing trie node
    TrieNodeMissing,
    /// Either invalid state or key-value db is corrupted.
    /// For PartialStorage it cannot be corrupted.
    /// Error message is unreliable and for debugging purposes only. It's also probably ok to
    /// panic in every place that produces this error.
    /// We can check if db is corrupted by verifying everything in the state trie.
    StorageInconsistentState(String),
}
```
1st error - nothing we can do about it, node has to manually recover
2nd error - normal case when verifying challenges, code that runs in challenge verification context should be able to handle
3rd error - Either state is invalid, or storage failure (very unlikely and can be checked by verifying the trie). Possible if the node started verifying from an invalid state.