### PR TITLE
Fix borsh version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,25 +513,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "borsh"
-version = "0.1.0"
-source = "git+https://github.com/nearprotocol/borsh.git#1331099024ad28a4541aa453b75867ebd30123f9"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "borsh-derive 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.1.0"
-source = "git+https://github.com/nearprotocol/borsh.git#1331099024ad28a4541aa453b75867ebd30123f9"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "borsh-derive-internal 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh-derive-internal 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.1.0"
-source = "git+https://github.com/nearprotocol/borsh.git#1331099024ad28a4541aa453b75867ebd30123f9"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1821,7 +1821,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "loadtester"
 version = "0.0.1"
 dependencies = [
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2030,7 +2030,7 @@ name = "near"
 version = "0.3.1"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2066,7 +2066,7 @@ dependencies = [
 name = "near-chain"
 version = "0.1.0"
 dependencies = [
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2086,7 +2086,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2110,7 +2110,7 @@ name = "near-crypto"
 version = "0.1.0"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2131,7 +2131,7 @@ dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-utils 0.1.0",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2170,7 +2170,7 @@ name = "near-network"
 version = "0.1.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2210,7 +2210,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2243,7 +2243,7 @@ name = "near-store"
 version = "0.1.0"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)",
  "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2361,7 +2361,7 @@ name = "node-runtime"
 version = "0.0.1"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)",
  "ethash 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3353,7 +3353,7 @@ name = "state-viewer"
 version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "near 0.3.1",
@@ -3483,7 +3483,7 @@ name = "testlib"
 version = "0.1.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)",
+ "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -4256,9 +4256,9 @@ dependencies = [
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum blockchain 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25c0f727a410bef0ea87d7437aa403f669ec4d7de1b302f4d819f83d3b4c561"
-"checksum borsh 0.1.0 (git+https://github.com/nearprotocol/borsh.git)" = "<none>"
-"checksum borsh-derive 0.1.0 (git+https://github.com/nearprotocol/borsh.git)" = "<none>"
-"checksum borsh-derive-internal 0.1.0 (git+https://github.com/nearprotocol/borsh.git)" = "<none>"
+"checksum borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8d2e860d2a6c167d6769bd176ed9610abaa9ecc1fcf999c14ecf093857512eec"
+"checksum borsh-derive 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fd084432bd2b3bf89e6d439205138796f8ce0e7de0c990d1272007985f823496"
+"checksum borsh-derive-internal 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e86f9dee6a5749aba8206ab14d5847fdc206f724efbffdedda5ee68adef2568"
 "checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 "checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
 "checksum bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0d9644ad62ff4df43da2e057febbbce576f7124cb5cd8e90e0ce7027f38aa2dd"

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0"
 serde_derive = "1.0"
 cached = { git = "https://github.com/nearprotocol/cached", rev = "7e472eddef68607e344d5a106a0e6705d92e55be" }
 
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0"
 
 sysinfo = "0.9.0"
 
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -11,7 +11,7 @@ use actix::{
     Actor, ActorFuture, Addr, AsyncContext, Context, ContextFutureSpawner, Handler, Recipient,
     WrapFuture,
 };
-use borsh::Serializable;
+use borsh::BorshSerialize;
 use chrono::{DateTime, Utc};
 use futures::Future;
 use log::{debug, error, info, warn};

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = "0.1.15"
 uuid = { version = "~0.6", features = ["v4"] }
 
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 async-utils = { path = "../../async-utils" }
 near-crypto = { path = "../../core/crypto" }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 use actix::{Addr, MailboxError};
 use actix_cors::Cors;
 use actix_web::{App, Error as HttpError, http, HttpResponse, HttpServer, middleware, web};
-use borsh::Deserializable;
+use borsh::BorshDeserialize;
 use futures03::{compat::Future01CompatExt as _, FutureExt as _, TryFutureExt as _};
 use futures::future::Future;
 use serde::de::DeserializeOwned;

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -1,7 +1,7 @@
 use std::sync::{Arc, Mutex};
 
 use actix::{Actor, System};
-use borsh::Serializable;
+use borsh::BorshSerialize;
 use futures::future::Future;
 
 use futures::future;

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0"
 serde_derive = "1.0"
 rand = "0.6.5"
 
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -3,7 +3,7 @@ use std::io::{Error, ErrorKind};
 use bytes::{BufMut, BytesMut};
 use tokio::codec::{Decoder, Encoder};
 
-use borsh::{Deserializable, Serializable};
+use borsh::{BorshDeserialize, BorshSerialize};
 
 use crate::types::PeerMessage;
 

--- a/chain/network/src/peer_store.rs
+++ b/chain/network/src/peer_store.rs
@@ -2,7 +2,7 @@ use std::collections::{hash_map::Iter, HashMap, HashSet};
 use std::convert::TryInto;
 use std::sync::Arc;
 
-use borsh::Serializable;
+use borsh::BorshSerialize;
 use chrono::Utc;
 use log::debug;
 use rand::seq::SliceRandom;

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use actix::dev::{MessageResponse, ResponseChannel};
 use actix::{Actor, Addr, Message};
-use borsh::{BorshDeserialize, BorshSerialize, Deserializable, Serializable};
+use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::{DateTime, Utc};
 use tokio::net::TcpStream;
 

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -9,7 +9,7 @@ sodiumoxide = "0.2.2"
 eth-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1" }
 
 bs58 = "0.2.4"
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -2,7 +2,7 @@ use std::convert::{TryFrom, TryInto};
 use std::fmt::{Display, Formatter};
 use std::io::{Error, ErrorKind, Read, Write};
 
-use borsh::{Deserializable, Serializable};
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde_derive::{Deserialize, Serialize};
 
 use lazy_static::lazy_static;
@@ -137,15 +137,15 @@ impl Display for PublicKey {
     }
 }
 
-impl Serializable for PublicKey {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+impl BorshSerialize for PublicKey {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         match self {
             PublicKey::ED25519(public_key) => {
-                0u8.write(writer)?;
+                0u8.serialize(writer)?;
                 writer.write(&public_key.0)?;
             }
             PublicKey::SECP256K1(public_key) => {
-                1u8.write(writer)?;
+                1u8.serialize(writer)?;
                 writer.write(&public_key.0)?;
             }
         }
@@ -153,9 +153,9 @@ impl Serializable for PublicKey {
     }
 }
 
-impl Deserializable for PublicKey {
-    fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        let key_type = KeyType::try_from(u8::read(reader)?)
+impl BorshDeserialize for PublicKey {
+    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, Error> {
+        let key_type = KeyType::try_from(u8::deserialize(reader)?)
             .map_err(|err| Error::new(ErrorKind::InvalidData, err.to_string()))?;
         match key_type {
             KeyType::ED25519 => {
@@ -189,7 +189,7 @@ impl<'de> serde::Deserialize<'de> for PublicKey {
     where
         D: serde::Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
+        let s = <String as serde::Deserialize<'de>>::deserialize(deserializer)?;
         ReadablePublicKey::new(&s.as_str())
             .try_into()
             .map_err(|err: Box<std::error::Error>| serde::de::Error::custom(err.to_string()))
@@ -332,7 +332,7 @@ impl<'de> serde::Deserialize<'de> for SecretKey {
     where
         D: serde::Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
+        let s = <String as serde::Deserialize<'de>>::deserialize(deserializer)?;
         let (key_type, key_data) =
             split_key_type_data(s).map_err(|err| serde::de::Error::custom(err.to_string()))?;
         match key_type {
@@ -435,15 +435,15 @@ impl Signature {
     }
 }
 
-impl Serializable for Signature {
-    fn write<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
+impl BorshSerialize for Signature {
+    fn serialize<W: Write>(&self, writer: &mut W) -> Result<(), Error> {
         match self {
             Signature::ED25519(signature) => {
-                0u8.write(writer)?;
+                0u8.serialize(writer)?;
                 writer.write(&signature.0)?;
             }
             Signature::SECP256K1(signature) => {
-                1u8.write(writer)?;
+                1u8.serialize(writer)?;
                 writer.write(&signature.0)?;
             }
         }
@@ -451,9 +451,9 @@ impl Serializable for Signature {
     }
 }
 
-impl Deserializable for Signature {
-    fn read<R: Read>(reader: &mut R) -> Result<Self, Error> {
-        let key_type = KeyType::try_from(u8::read(reader)?)
+impl BorshDeserialize for Signature {
+    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, Error> {
+        let key_type = KeyType::try_from(u8::deserialize(reader)?)
             .map_err(|err| Error::new(ErrorKind::InvalidData, err.to_string()))?;
         match key_type {
             KeyType::ED25519 => {
@@ -497,7 +497,7 @@ impl<'de> serde::Deserialize<'de> for Signature {
     where
         D: serde::Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
+        let s = <String as serde::Deserialize<'de>>::deserialize(deserializer)?;
         let (key_type, key_data) =
             split_key_type_data(s).map_err(|err| serde::de::Error::custom(err.to_string()))?;
         match key_type {

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4"
 reed-solomon-erasure = "3.1.1"
 jemallocator = { version = "0.3.0", optional = true }
 
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 near-crypto = { path = "../crypto" }
 

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use bencher::Bencher;
-use borsh::{Deserializable, Serializable};
+use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::Utc;
 
 use near_crypto::{InMemorySigner, KeyType, PublicKey, Signature};

--- a/core/primitives/src/account.rs
+++ b/core/primitives/src/account.rs
@@ -83,7 +83,7 @@ pub struct FunctionCallPermission {
 
 #[cfg(test)]
 mod tests {
-    use borsh::Serializable;
+    use borsh::BorshSerialize;
 
     use crate::hash::hash;
     use crate::serialize::to_base;

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use borsh::{BorshDeserialize, BorshSerialize, Serializable};
+use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::prelude::{DateTime, Utc};
 
 use near_crypto::{KeyType, PublicKey, Signature, Signer};

--- a/core/primitives/src/crypto/signature.rs
+++ b/core/primitives/src/crypto/signature.rs
@@ -117,7 +117,7 @@ impl TryFrom<&str> for PublicKey {
     }
 }
 
-impl borsh::Serializable for PublicKey {
+impl borsh::BorshSerialize for PublicKey {
     fn write<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // TODO: support other curves here.
         writer.write(&vec![0])?;
@@ -126,7 +126,7 @@ impl borsh::Serializable for PublicKey {
     }
 }
 
-impl borsh::Deserializable for PublicKey {
+impl borsh::BorshDeserialize for PublicKey {
     fn read<R: Read>(reader: &mut R) -> Result<Self, std::io::Error> {
         let mut bytes = [0; sodiumoxide::crypto::sign::ed25519::PUBLICKEYBYTES + 1];
         reader.read(&mut bytes)?;
@@ -214,7 +214,7 @@ impl TryFrom<&str> for Signature {
     }
 }
 
-impl borsh::Serializable for Signature {
+impl borsh::BorshSerialize for Signature {
     fn write<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         // TODO: add crypto curve.
         writer.write(&vec![0])?;
@@ -223,7 +223,7 @@ impl borsh::Serializable for Signature {
     }
 }
 
-impl borsh::Deserializable for Signature {
+impl borsh::BorshDeserialize for Signature {
     fn read<R: Read>(reader: &mut R) -> Result<Self, std::io::Error> {
         // TODO: add crypto curve.
         let mut bytes = [0; sodiumoxide::crypto::sign::ed25519::SIGNATUREBYTES + 1];

--- a/core/primitives/src/hash.rs
+++ b/core/primitives/src/hash.rs
@@ -46,15 +46,15 @@ impl AsMut<[u8]> for CryptoHash {
 
 impl BaseDecode for CryptoHash {}
 
-impl borsh::Serializable for CryptoHash {
-    fn write<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
+impl borsh::BorshSerialize for CryptoHash {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> Result<(), std::io::Error> {
         writer.write(&(self.0).0)?;
         Ok(())
     }
 }
 
-impl borsh::Deserializable for CryptoHash {
-    fn read<R: Read>(reader: &mut R) -> Result<Self, std::io::Error> {
+impl borsh::BorshDeserialize for CryptoHash {
+    fn deserialize<R: Read>(reader: &mut R) -> Result<Self, std::io::Error> {
         let mut bytes = [0; 32];
         reader.read(&mut bytes)?;
         Ok(CryptoHash(Digest(bytes)))

--- a/core/primitives/src/merkle.rs
+++ b/core/primitives/src/merkle.rs
@@ -1,6 +1,6 @@
 use crate::hash::hash;
 use crate::types::MerkleHash;
-use borsh::Serializable;
+use borsh::BorshSerialize;
 
 pub type MerklePath = Vec<(MerkleHash, Direction)>;
 
@@ -17,7 +17,7 @@ fn combine_hash(hash1: MerkleHash, hash2: MerkleHash) -> MerkleHash {
 }
 
 /// Merklize an array of items. If the array is empty, returns hash of 0
-pub fn merklize<T: Serializable>(arr: &[T]) -> (MerkleHash, Vec<MerklePath>) {
+pub fn merklize<T: BorshSerialize>(arr: &[T]) -> (MerkleHash, Vec<MerklePath>) {
     if arr.is_empty() {
         return (MerkleHash::default(), vec![]);
     }
@@ -75,7 +75,7 @@ pub fn merklize<T: Serializable>(arr: &[T]) -> (MerkleHash, Vec<MerklePath>) {
 }
 
 /// Verify merkle path for given item and corresponding path.
-pub fn verify_path<T: Serializable>(root: MerkleHash, path: &MerklePath, item: &T) -> bool {
+pub fn verify_path<T: BorshSerialize>(root: MerkleHash, path: &MerklePath, item: &T) -> bool {
     let mut hash = hash(&item.try_to_vec().expect("Failed to serialize"));
     for (h, d) in path {
         match d {

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use borsh::{BorshDeserialize, BorshSerialize, Serializable};
+use borsh::{BorshDeserialize, BorshSerialize};
 
 use near_crypto::{PublicKey, Signature, Signer};
 
@@ -267,7 +267,7 @@ pub fn check_tx_history(
 mod tests {
     use std::convert::TryInto;
 
-    use borsh::Deserializable;
+    use borsh::BorshDeserialize;
 
     use near_crypto::{InMemorySigner, KeyType, ReadablePublicKey, Signature};
 

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -1,7 +1,7 @@
 use std::convert::AsRef;
 use std::fmt;
 
-use borsh::Serializable;
+use borsh::BorshSerialize;
 use byteorder::{LittleEndian, WriteBytesExt};
 use chrono::{DateTime, NaiveDateTime, Utc};
 use regex::Regex;

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = "1.0"
 cached = { git = "https://github.com/nearprotocol/cached", rev = "7e472eddef68607e344d5a106a0e6705d92e55be" }
 log = "0.4"
 
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 near-crypto = { path = "../crypto" }
 near-primitives = { path = "../primitives" }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::{fmt, io};
 
-use borsh::{Deserializable, Serializable};
+use borsh::{BorshDeserialize, BorshSerialize};
 use cached::{Cached, SizedCache};
 pub use kvdb::DBValue;
 use kvdb::{DBOp, DBTransaction, KeyValueDB};
@@ -55,7 +55,7 @@ impl Store {
         self.storage.get(column, key).map(|a| a.map(|b| b.to_vec()))
     }
 
-    pub fn get_ser<T: Deserializable>(
+    pub fn get_ser<T: BorshDeserialize>(
         &self,
         column: Option<u32>,
         key: &[u8],
@@ -109,7 +109,7 @@ impl StoreUpdate {
         self.transaction.put(column, key, value)
     }
 
-    pub fn set_ser<T: Serializable>(
+    pub fn set_ser<T: BorshSerialize>(
         &mut self,
         column: Option<u32>,
         key: &[u8],
@@ -167,7 +167,7 @@ impl fmt::Debug for StoreUpdate {
     }
 }
 
-pub fn read_with_cache<'a, T: Deserializable + 'a>(
+pub fn read_with_cache<'a, T: BorshDeserialize + 'a>(
     storage: &Store,
     col: Option<u32>,
     cache: &'a mut SizedCache<Vec<u8>, T>,
@@ -191,12 +191,12 @@ pub fn create_store(path: &str) -> Arc<Store> {
 }
 
 /// Reads an object from Trie.
-pub fn get<T: Deserializable>(state_update: &TrieUpdate, key: &[u8]) -> Option<T> {
+pub fn get<T: BorshDeserialize>(state_update: &TrieUpdate, key: &[u8]) -> Option<T> {
     state_update.get(key).and_then(|data| T::try_from_slice(&data).ok())
 }
 
 /// Writes an object into Trie.
-pub fn set<T: Serializable>(state_update: &mut TrieUpdate, key: Vec<u8>, value: &T) {
+pub fn set<T: BorshSerialize>(state_update: &mut TrieUpdate, key: Vec<u8>, value: &T) {
     value
         .try_to_vec()
         .ok()

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0"
 dirs = "1.0.5"
 lazy_static = "1.3"
 
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 near-crypto = { path = "../core/crypto" }
 near-primitives = { path = "../core/primitives" }

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -4,7 +4,7 @@ use std::io::{Cursor, Read, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex, RwLock};
 
-use borsh::Deserializable;
+use borsh::BorshDeserialize;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use kvdb::DBValue;
 use log::{debug, error, info};

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -26,7 +26,7 @@ near-runtime-fees = { path = "../../runtime/near-runtime-fees" }
 near-vm-logic = { path = "../../runtime/near-vm-logic" }
 near-vm-runner = { path = "../../runtime/near-vm-runner" }
 cached = { git = "https://github.com/nearprotocol/cached", rev = "7e472eddef68607e344d5a106a0e6705d92e55be" }
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 [features]
 test-utils = []

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -1,7 +1,7 @@
 use crate::config::RuntimeConfig;
 use crate::ext::RuntimeExt;
 use crate::{ActionResult, ApplyState};
-use borsh::ser::Serializable;
+use borsh::ser::BorshSerialize;
 use near_primitives::account::Account;
 use near_primitives::contract::ContractCode;
 use near_primitives::hash::CryptoHash;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -7,7 +7,7 @@ use std::collections::{hash_map::Entry, HashMap};
 use std::convert::TryInto;
 use std::sync::{Arc, Mutex};
 
-use borsh::ser::Serializable;
+use borsh::ser::BorshSerialize;
 use kvdb::DBValue;
 
 use near_crypto::{PublicKey, ReadablePublicKey};

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -3,7 +3,7 @@ use std::str;
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
-use borsh::Serializable;
+use borsh::BorshSerialize;
 
 use near_crypto::{KeyType, PublicKey};
 use near_primitives::account::{AccessKey, Account};

--- a/test-utils/loadtester/Cargo.toml
+++ b/test-utils/loadtester/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.1.25"
 tokio = "0.1"
 serde_json = "1.0.0"
 
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/test-utils/loadtester/src/remote_node.rs
+++ b/test-utils/loadtester/src/remote_node.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use borsh::Serializable;
+use borsh::BorshSerialize;
 use futures::Future;
 use reqwest::r#async::Client as AsyncClient;
 use reqwest::Client as SyncClient;

--- a/test-utils/state-viewer/Cargo.toml
+++ b/test-utils/state-viewer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 clap = "2.32.0"
 hex = "0.3"
 ansi_term = "0.12.0"
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 use std::path::Path;
 use std::sync::Arc;
 
-use borsh::Deserializable;
+use borsh::BorshDeserialize;
 use clap::{App, Arg, SubCommand};
 
 use ansi_term::Color::Red;

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.2"
 tempdir = "0.3"
 tokio-signal = "0.2"
 
-borsh = { git = "https://github.com/nearprotocol/borsh.git" }
+borsh = "0.2.2"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -2,7 +2,7 @@ use std::convert::TryInto;
 use std::sync::{Arc, RwLock};
 
 use actix::System;
-use borsh::Serializable;
+use borsh::BorshSerialize;
 
 use near_client::StatusResponse;
 use near_crypto::{PublicKey, Signer};


### PR DESCRIPTION
The borsh version used in nearcore has a bug with boolean serialization/deserialization. Bumped to the latest version to fix the bug.