### PR TITLE
Fix inflation calculation

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -662,6 +662,10 @@ impl RuntimeAdapter for KeyValueRuntime {
             None => Ok(0),
         }
     }
+
+    fn get_epoch_inflation(&self, _epoch_id: &EpochId) -> Result<u128, Error> {
+        Ok(0)
+    }
 }
 
 pub fn setup() -> (Chain, Arc<KeyValueRuntime>, Arc<InMemorySigner>) {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -197,6 +197,9 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Get epoch start for given block hash.
     fn get_epoch_start_height(&self, block_hash: &CryptoHash) -> Result<BlockIndex, Error>;
 
+    /// Get inflation for a certain epoch
+    fn get_epoch_inflation(&self, epoch_id: &EpochId) -> Result<Balance, Error>;
+
     /// Add proposals for validators.
     fn add_validator_proposals(
         &self,

--- a/chain/chain/tests/simple_chain.rs
+++ b/chain/chain/tests/simple_chain.rs
@@ -47,7 +47,7 @@ fn build_chain_with_orhpans() {
         vec![],
         HashMap::default(),
         0,
-        0,
+        Some(0),
         signer.clone(),
     );
     assert_eq!(
@@ -132,7 +132,7 @@ fn test_apply_expired_tx() {
         vec![tx],
         HashMap::default(),
         0,
-        0,
+        Some(0),
         signer.clone(),
     );
     assert!(chain.process_block(&None, b1, Provenance::PRODUCED, |_, _, _| {}, |_| {}).is_ok());
@@ -165,7 +165,7 @@ fn test_tx_wrong_fork() {
         vec![tx],
         HashMap::default(),
         0,
-        0,
+        Some(0),
         signer.clone(),
     );
     assert!(chain.process_block(&None, b1, Provenance::PRODUCED, |_, _, _| {}, |_| {}).is_ok());

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -132,7 +132,7 @@ fn receive_network_block() {
                 vec![],
                 HashMap::default(),
                 0,
-                0,
+                None,
                 signer,
             );
             client.do_send(NetworkClientMessages::Block(block, PeerInfo::random().id, false));
@@ -182,7 +182,7 @@ fn receive_network_block_header() {
                 vec![],
                 HashMap::default(),
                 0,
-                0,
+                None,
                 signer,
             );
             client.do_send(NetworkClientMessages::BlockHeader(
@@ -228,7 +228,7 @@ fn produce_block_with_approvals() {
                 vec![],
                 HashMap::default(),
                 0,
-                0,
+                Some(0),
                 signer1,
             );
             for i in 3..11 {
@@ -289,7 +289,7 @@ fn invalid_blocks() {
                 vec![],
                 HashMap::default(),
                 0,
-                0,
+                Some(0),
                 signer.clone(),
             );
             block.header.inner.prev_state_root = hash(&[1]);
@@ -307,7 +307,7 @@ fn invalid_blocks() {
                 vec![],
                 HashMap::default(),
                 0,
-                0,
+                Some(0),
                 signer.clone(),
             );
             client.do_send(NetworkClientMessages::Block(block2, PeerInfo::random().id, false));
@@ -320,7 +320,7 @@ fn invalid_blocks() {
                 vec![],
                 HashMap::default(),
                 0,
-                0,
+                Some(0),
                 signer,
             );
             client.do_send(NetworkClientMessages::Block(block3, PeerInfo::random().id, false));

--- a/chain/epoch_manager/src/proposals.rs
+++ b/chain/epoch_manager/src/proposals.rs
@@ -42,6 +42,7 @@ pub fn proposals_to_epoch_info(
     validator_kickout: HashSet<AccountId>,
     validator_reward: HashMap<AccountId, Balance>,
     total_gas_used: Gas,
+    inflation: Balance,
 ) -> Result<EpochInfo, EpochError> {
     // Combine proposals with rollovers.
     //println!("validator reward: {:?}", validator_reward);
@@ -151,6 +152,7 @@ pub fn proposals_to_epoch_info(
         stake_change: final_stake_change,
         total_gas_used,
         validator_reward,
+        inflation,
     })
 }
 
@@ -179,6 +181,7 @@ mod tests {
                 HashSet::new(),
                 HashMap::default(),
                 0,
+                0
             )
             .unwrap(),
             epoch_info(
@@ -189,6 +192,7 @@ mod tests {
                 change_stake(vec![("test1", 1_000_000)]),
                 0,
                 HashMap::default(),
+                0
             )
         );
         assert_eq!(
@@ -211,6 +215,7 @@ mod tests {
                 HashSet::new(),
                 HashMap::default(),
                 0,
+                0
             )
             .unwrap(),
             epoch_info(
@@ -232,6 +237,7 @@ mod tests {
                 ]),
                 0,
                 HashMap::default(),
+                0
             )
         );
     }

--- a/chain/epoch_manager/src/reward_calculator.rs
+++ b/chain/epoch_manager/src/reward_calculator.rs
@@ -20,20 +20,22 @@ impl RewardCalculator {
         total_gas_used: Gas,
         gas_price: Balance,
         total_supply: Balance,
-    ) -> HashMap<AccountId, Balance> {
+    ) -> (HashMap<AccountId, Balance>, Balance) {
         let mut res = HashMap::new();
         let num_validators = validator_online_ratio.len();
-        let total_tx_fee = gas_price * total_gas_used as u128;
         let max_inflation =
             self.max_inflation_rate as u128 * total_supply * self.epoch_length as u128
                 / (100 * self.num_blocks_per_year as u128);
+        // TODO: correctly calculate total fees
+        let total_tx_fee = gas_price * total_gas_used as u128;
+        let inflation = if max_inflation > total_tx_fee { max_inflation - total_tx_fee } else { 0 };
         let epoch_total_reward =
             max(max_inflation, self.validator_reward_percentage as u128 * total_tx_fee / 100);
         let epoch_protocol_treasury =
             epoch_total_reward * self.protocol_reward_percentage as u128 / 100;
         res.insert(self.protocol_treasury_account.clone(), epoch_protocol_treasury);
         if num_validators == 0 {
-            return res;
+            return (res, inflation);
         }
         let epoch_per_validator_reward =
             (epoch_total_reward - epoch_protocol_treasury) / num_validators as u128;
@@ -45,6 +47,6 @@ impl RewardCalculator {
             };
             res.insert(account_id, reward);
         }
-        res
+        (res, inflation)
     }
 }

--- a/chain/epoch_manager/src/reward_calculator.rs
+++ b/chain/epoch_manager/src/reward_calculator.rs
@@ -26,7 +26,7 @@ impl RewardCalculator {
         let max_inflation =
             self.max_inflation_rate as u128 * total_supply * self.epoch_length as u128
                 / (100 * self.num_blocks_per_year as u128);
-        // TODO: correctly calculate total fees
+        // TODO(#1281): correctly calculate total fees
         let total_tx_fee = gas_price * total_gas_used as u128;
         let inflation = if max_inflation > total_tx_fee { max_inflation - total_tx_fee } else { 0 };
         let epoch_total_reward =

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -32,6 +32,7 @@ pub fn epoch_info(
     stake_change: BTreeMap<AccountId, Balance>,
     total_gas_used: Gas,
     validator_reward: HashMap<AccountId, Balance>,
+    inflation: u128,
 ) -> EpochInfo {
     accounts.sort();
     let validator_to_index = accounts.iter().enumerate().fold(HashMap::new(), |mut acc, (i, x)| {
@@ -54,6 +55,7 @@ pub fn epoch_info(
         stake_change,
         total_gas_used,
         validator_reward,
+        inflation,
     }
 }
 

--- a/chain/epoch_manager/src/types.rs
+++ b/chain/epoch_manager/src/types.rs
@@ -50,6 +50,8 @@ pub struct EpochInfo {
     pub total_gas_used: Gas,
     /// Validator reward for the epoch
     pub validator_reward: HashMap<AccountId, Balance>,
+    /// Total inflation in the epoch
+    pub inflation: Balance,
 }
 
 /// Information per each block.

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -45,7 +45,7 @@ fn create_block() -> Block {
         transactions,
         HashMap::default(),
         0,
-        0,
+        Some(0),
         signer.clone(),
     )
 }

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -243,7 +243,7 @@ impl Block {
         transactions: Vec<SignedTransaction>,
         mut approvals: HashMap<usize, Signature>,
         gas_price_adjustment_rate: u8,
-        max_inflation_rate: u8,
+        inflation: Option<Balance>,
         signer: Arc<dyn Signer>,
     ) -> Self {
         // TODO: merkelize transactions.
@@ -283,10 +283,7 @@ impl Block {
             // If there are no new chunks included in this block, use previous price.
             prev.inner.gas_price
         };
-        let total_tx_fee = gas_used as u128 * prev.inner.gas_price;
-        let max_inflation = max_inflation_rate as u128 * prev.inner.total_supply / (100 * 365);
-        let inflation = if max_inflation > total_tx_fee { max_inflation - total_tx_fee } else { 0 };
-        let new_total_supply = prev.inner.total_supply + inflation;
+        let new_total_supply = prev.inner.total_supply + inflation.unwrap_or(0);
 
         let total_weight =
             (prev.inner.total_weight.to_num() + (approval_sigs.len() as u64) + 1).into();

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -164,7 +164,7 @@ impl Block {
             vec![],
             approvals,
             0,
-            0,
+            Some(0),
             signer,
         )
     }

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -410,6 +410,11 @@ impl RuntimeAdapter for NightshadeRuntime {
         epoch_manager.get_epoch_start_height(block_hash).map_err(|err| Error::from(err))
     }
 
+    fn get_epoch_inflation(&self, epoch_id: &EpochId) -> Result<Balance, Error> {
+        let mut epoch_manager = self.epoch_manager.write().expect(POISONED_LOCK_ERR);
+        Ok(epoch_manager.get_epoch_inflation(epoch_id)?)
+    }
+
     fn validate_tx(
         &self,
         _shard_id: ShardId,

--- a/near/tests/sync_nodes.rs
+++ b/near/tests/sync_nodes.rs
@@ -44,7 +44,7 @@ fn add_blocks(
             vec![],
             HashMap::default(),
             0,
-            0,
+            Some(0),
             signer.clone(),
         );
         let _ = client.do_send(NetworkClientMessages::Block(


### PR DESCRIPTION
Previously we incorrectly computed inflation at every block whereas it should be only updated once per epoch. However, this PR doesn't fix the calculation entirely as doing so requires exposing the transaction fees from runtime.