### PR TITLE
Disable block approval for now

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,7 +1827,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.3.1",
+ "near 0.3.2",
  "near-crypto 0.1.0",
  "near-primitives 0.1.0",
  "node-runtime 0.0.1",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "near"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2321,7 +2321,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.3.1",
+ "near 0.3.2",
  "near-crypto 0.1.0",
  "near-jsonrpc 0.1.0",
  "near-network 0.1.0",
@@ -3356,7 +3356,7 @@ dependencies = [
  "borsh 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.3.1",
+ "near 0.3.2",
  "near-chain 0.1.0",
  "near-crypto 0.1.0",
  "near-network 0.1.0",
@@ -3489,7 +3489,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.3.1",
+ "near 0.3.2",
  "near-chain 0.1.0",
  "near-client 0.1.0",
  "near-crypto 0.1.0",

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -44,6 +44,7 @@ use crate::types::{
 };
 use crate::{sync, StatusResponse};
 use std::cmp::min;
+use std::ops::Sub;
 
 pub struct ClientActor {
     config: ClientConfig,
@@ -674,19 +675,21 @@ impl ClientActor {
             .map_err(|err| Error::Other(err.to_string()))?
             == block_producer.account_id.clone();
         // If epoch changed, and before there was 2 validators and now there is 1 - prev_same_bp is false, but total validators right now is 1.
-        let total_approvals =
+        let _total_approvals =
             total_validators - min(if prev_same_bp { 1 } else { 2 }, total_validators);
-        if self.approvals.len() < total_approvals
-            && self.last_block_processed.elapsed() < self.config.max_block_production_delay
+        // TODO(#1287): Reenable block approval
+        if false
+        //        if self.approvals.len() < total_approvals
+        //            && self.last_block_processed.elapsed() < self.config.max_block_production_delay
         {
             // Schedule itself for (max BP delay - how much time passed).
-            //            ctx.run_later(
-            //                self.config.max_block_production_delay.sub(self.last_block_processed.elapsed()),
-            //                move |act, ctx| {
-            //                    act.produce_block(ctx, head.last_block_hash, last_height, next_height);
-            //                },
-            //            );
-            //            return Ok(());
+            ctx.run_later(
+                self.config.max_block_production_delay.sub(self.last_block_processed.elapsed()),
+                move |act, ctx| {
+                    act.produce_block(ctx, head.last_block_hash, last_height, next_height);
+                },
+            );
+            return Ok(());
         }
 
         // If we are not producing empty blocks, skip this and call handle scheduling for the next block.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -2,7 +2,6 @@
 //! Block production is done in done in this actor as well (at the moment).
 
 use std::collections::HashMap;
-use std::ops::Sub;
 use std::sync::{Arc, RwLock};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -681,13 +680,13 @@ impl ClientActor {
             && self.last_block_processed.elapsed() < self.config.max_block_production_delay
         {
             // Schedule itself for (max BP delay - how much time passed).
-            ctx.run_later(
-                self.config.max_block_production_delay.sub(self.last_block_processed.elapsed()),
-                move |act, ctx| {
-                    act.produce_block(ctx, head.last_block_hash, last_height, next_height);
-                },
-            );
-            return Ok(());
+            //            ctx.run_later(
+            //                self.config.max_block_production_delay.sub(self.last_block_processed.elapsed()),
+            //                move |act, ctx| {
+            //                    act.produce_block(ctx, head.last_block_hash, last_height, next_height);
+            //                },
+            //            );
+            //            return Ok(());
         }
 
         // If we are not producing empty blocks, skip this and call handle scheduling for the next block.

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Testnet is slow due to block approval collection. Disable it for now to make testnet faster and the problem should have been fixed in staging.