### PR TITLE
Fixing catchup tests

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -348,10 +348,10 @@ impl RuntimeAdapter for KeyValueRuntime {
         shard_id: ShardId,
         _is_me: bool,
     ) -> bool {
-        let epoch_valset = match self.get_epoch_and_valset(*parent_hash) {
-            Ok(epoch_valset) => epoch_valset,
-            Err(_) => return false,
-        };
+        // This `unwrap` here tests that in all code paths we check that the epoch exists before
+        //    we check if we care about a shard. Please do not remove the unwrap, fix the logic of
+        //    the calling function.
+        let epoch_valset = self.get_epoch_and_valset(*parent_hash).unwrap();
         let validators = &self.validators[epoch_valset.1];
         assert_eq!((validators.len() as u64) % self.num_shards(), 0);
         assert_eq!(0, validators.len() as u64 % self.validator_groups);
@@ -376,10 +376,10 @@ impl RuntimeAdapter for KeyValueRuntime {
         shard_id: ShardId,
         _is_me: bool,
     ) -> bool {
-        let epoch_valset = match self.get_epoch_and_valset(*parent_hash) {
-            Ok(epoch_valset) => epoch_valset,
-            Err(_) => return false,
-        };
+        // This `unwrap` here tests that in all code paths we check that the epoch exists before
+        //    we check if we care about a shard. Please do not remove the unwrap, fix the logic of
+        //    the calling function.
+        let epoch_valset = self.get_epoch_and_valset(*parent_hash).unwrap();
         let validators = &self.validators[(epoch_valset.1 + 1) % self.validators.len()];
         assert_eq!((validators.len() as u64) % self.num_shards(), 0);
         assert_eq!(0, validators.len() as u64 % self.validator_groups);

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -546,6 +546,15 @@ impl ShardsManager {
         let chunk_hash = one_part.chunk_hash.clone();
         let prev_block_hash = one_part.header.inner.prev_block_hash;
 
+        match self.runtime_adapter.get_epoch_id_from_prev_block(&prev_block_hash) {
+            Ok(_) => {}
+            Err(err) => {
+                self.orphaned_one_parts
+                    .cache_set((prev_block_hash, one_part.shard_id, one_part.part_id), one_part);
+                return Err(err);
+            }
+        }
+
         if !self.runtime_adapter.verify_chunk_header_signature(&one_part.header)? {
             byzantine_assert!(false);
             return Err(ErrorKind::Other(


### PR DESCRIPTION
- Tests now skip the first block (because by the time the nodes launch the timeout for the first block is already expired), address it by expecting the first block to be the second block
- Changing the expected prev_block for transactions to be the previous of the last known block (which in the catchup tests always known to all the nodes)
- Adding a new mode for one of the `catchup` tests that exposes a bug Kourpin is presently fixing. The test in that mode is currently ignored.