### PR TITLE
Query block by hash through rpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3494,6 +3494,7 @@ dependencies = [
  "near-client 0.1.0",
  "near-crypto 0.1.0",
  "near-jsonrpc 0.1.0",
+ "near-jsonrpc-client 0.1.0",
  "near-primitives 0.1.0",
  "near-runtime-fees 0.2.1",
  "near-store 0.1.0",

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -2,15 +2,24 @@ use std::time::Duration;
 
 use actix_web::client::Client;
 use futures::Future;
+use serde::Deserialize;
 use serde::Serialize;
 
 use near_primitives::types::BlockIndex;
 use near_primitives::views::{
-    BlockView, FinalTransactionResult, QueryResponse, StatusResponse, TransactionResultView,
+    BlockView, CryptoHashView, FinalTransactionResult, QueryResponse, StatusResponse,
+    TransactionResultView,
 };
 
 pub mod message;
 use crate::message::{from_slice, Message};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BlockId {
+    Height(BlockIndex),
+    Hash(CryptoHashView),
+}
 
 /// Timeout for establishing connection.
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
@@ -169,7 +178,7 @@ jsonrpc_client!(pub struct JsonRpcClient {
     pub fn health(&mut self) -> RpcRequest<()>;
     pub fn tx(&mut self, hash: String) -> RpcRequest<FinalTransactionResult>;
     pub fn tx_details(&mut self, hash: String) -> RpcRequest<TransactionResultView>;
-    pub fn block(&mut self, height: BlockIndex) -> RpcRequest<BlockView>;
+    pub fn block(&mut self, id: BlockId) -> RpcRequest<BlockView>;
 });
 
 /// Create new JSON RPC client that connects to the given address.

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -18,13 +18,12 @@ use message::{Request, RpcError};
 use message::Message;
 use near_client::{ClientActor, GetBlock, Query, Status, TxDetails, TxStatus, ViewClientActor};
 pub use near_jsonrpc_client as client;
-use near_jsonrpc_client::message as message;
+use near_jsonrpc_client::{message as message, BlockId};
 use near_network::{NetworkClientMessages, NetworkClientResponses};
 use near_primitives::hash::CryptoHash;
-use near_primitives::views::FinalTransactionStatus;
+use near_primitives::views::{FinalTransactionStatus};
 use near_primitives::serialize::{BaseEncode, from_base, from_base64};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::BlockIndex;
 
 pub mod test_utils;
 
@@ -212,8 +211,11 @@ impl JsonRpcHandler {
     }
 
     async fn block(&self, params: Option<Value>) -> Result<Value, RpcError> {
-        let (height,) = parse_params::<(BlockIndex,)>(params)?;
-        jsonify(self.view_client_addr.send(GetBlock::Height(height)).compat().await)
+        let (block_id,) = parse_params::<(BlockId,)>(params)?;
+        jsonify(self.view_client_addr.send(match block_id {
+            BlockId::Height(height) => GetBlock::Height(height),
+            BlockId::Hash(hash) => GetBlock::Hash(hash.into()),
+        }).compat().await)
     }
 }
 

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -4,6 +4,7 @@ use futures::future::Future;
 
 use near_jsonrpc::client::new_client;
 use near_jsonrpc::test_utils::start_all;
+use near_jsonrpc_client::BlockId;
 use near_primitives::test_utils::init_test_logger;
 
 /// Retrieve blocks via json rpc
@@ -15,7 +16,8 @@ fn test_block() {
         let (_view_client_addr, addr) = start_all(false);
 
         let mut client = new_client(&format!("http://{}", addr));
-        actix::spawn(client.block(0).then(|res| {
+
+        actix::spawn(client.block(BlockId::Height(0)).then(|res| {
             let res = res.unwrap();
             assert_eq!(res.header.height, 0);
             assert_eq!(res.header.epoch_hash.0, &[0; 32]);
@@ -29,7 +31,30 @@ fn test_block() {
             assert_eq!(res.header.total_weight, 0);
             assert_eq!(res.header.validator_proposals.len(), 0);
             System::current().stop();
-            future::result(Ok(()))
+            future::ok(())
+        }));
+    })
+    .unwrap();
+}
+
+/// Retrieve blocks via json rpc
+#[test]
+fn test_block_by_hash() {
+    init_test_logger();
+
+    System::run(|| {
+        let (_view_client_addr, addr) = start_all(false);
+
+        let mut client = new_client(&format!("http://{}", addr.clone()));
+        actix::spawn(client.block(BlockId::Height(0)).then(move |res| {
+            let res = res.unwrap();
+            let mut client = new_client(&format!("http://{}", addr));
+            client.block(BlockId::Hash(res.header.hash)).then(move |res| {
+                let res = res.unwrap();
+                assert_eq!(res.header.height, 0);
+                System::current().stop();
+                future::ok(())
+            })
         }));
     })
     .unwrap();

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -31,6 +31,7 @@ node-runtime = { path = "../../runtime/runtime" }
 near-chain = { path = "../../chain/chain" }
 near-client = { path = "../../chain/client" }
 near-jsonrpc = { path = "../../chain/jsonrpc" }
+near-jsonrpc-client = { path = "../../chain/jsonrpc/client" }
 near = { path = "../../near" }
 near-runtime-fees = { path = "../../runtime/near-runtime-fees" }
 

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -18,6 +18,7 @@ use near_primitives::views::{
 };
 
 use crate::user::User;
+use near_jsonrpc_client::BlockId;
 
 pub struct RpcUser {
     signer: Arc<dyn Signer>,
@@ -77,7 +78,9 @@ impl User for RpcUser {
     }
 
     fn get_block(&self, index: u64) -> Option<BlockView> {
-        System::new("actix").block_on(self.client.write().unwrap().block(index)).ok()
+        System::new("actix")
+            .block_on(self.client.write().unwrap().block(BlockId::Height(index)))
+            .ok()
     }
 
     fn get_transaction_result(&self, hash: &CryptoHash) -> TransactionResultView {


### PR DESCRIPTION
Currently we can only query block by index. This PR allows one to query block by its hash through rpc.