### PR TITLE
Provide total rent paid in ApplyResult

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1323,7 +1323,7 @@ impl<'a> ChainUpdate<'a> {
                         ChunkExtra::new(
                             &apply_result.new_root,
                             apply_result.validator_proposals,
-                            apply_result.gas_used,
+                            apply_result.total_gas_burnt,
                             gas_limit,
                         ),
                     );

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -600,7 +600,8 @@ impl RuntimeAdapter for KeyValueRuntime {
             transaction_results: tx_results,
             receipt_result: new_receipts,
             validator_proposals: vec![],
-            gas_used: 0,
+            total_gas_burnt: 0,
+            total_rent_paid: 0,
             proof: None,
         })
     }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -82,7 +82,8 @@ pub struct ApplyTransactionResult {
     pub transaction_results: Vec<TransactionLog>,
     pub receipt_result: ReceiptResult,
     pub validator_proposals: Vec<ValidatorStake>,
-    pub gas_used: Gas,
+    pub total_gas_burnt: Gas,
+    pub total_rent_paid: Balance,
     pub proof: Option<PartialStorage>,
 }
 

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -552,6 +552,8 @@ impl RuntimeAdapter for NightshadeRuntime {
                 .or_insert_with(|| vec![])
                 .push(receipt);
         }
+        let total_gas_burnt =
+            apply_result.tx_result.iter().map(|tx_result| tx_result.result.gas_burnt).sum();
 
         let result = ApplyTransactionResult {
             trie_changes: WrappedTrieChanges::new(self.trie.clone(), apply_result.trie_changes),
@@ -559,7 +561,8 @@ impl RuntimeAdapter for NightshadeRuntime {
             transaction_results: apply_result.tx_result,
             receipt_result,
             validator_proposals: apply_result.validator_proposals,
-            gas_used: 0,
+            total_gas_burnt,
+            total_rent_paid: apply_result.total_rent_paid,
             proof: trie.recorded_storage(),
         };
 

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -72,11 +72,13 @@ pub(crate) fn apply_rent(
     account: &mut Account,
     block_index: BlockIndex,
     runtime_config: &RuntimeConfig,
-) {
+) -> Balance {
     let charge = ((block_index - account.storage_paid_at) as u128)
         * cost_per_block(account_id, account, runtime_config);
-    account.amount = account.amount.saturating_sub(charge);
+    let actual_charge = std::cmp::min(account.amount, charge);
+    account.amount -= actual_charge;
     account.storage_paid_at = block_index;
+    actual_charge
 }
 
 pub(crate) fn get_code_with_cache(


### PR DESCRIPTION
Not sure where to test the rent. Ideally we should have the total coinbase test with 0% inflation to verify we don't burn or lose tokens anywhere. There is still situation when the refund arrives on the non-existing account, then these tokens are considered burned.