### PR TITLE
Encrypt secret key of Keyfile (rebased)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,6 +882,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "crypto-mac"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2203,6 +2208,7 @@ dependencies = [
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -3695,6 +3701,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiny-keccak"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tokio"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,6 +4461,7 @@ dependencies = [
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
+"checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum crypto-mac 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "779015233ac67d65098614aec748ac1c756ab6677fa2e14cf8b37c08dfed1198"
 "checksum ct-logs 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1b4660f8b07a560a88c02d76286edb9f0d5d64e495d2b0f233186155aa51be1f"
 "checksum derive_more 0.14.1 (registry+https://github.com/rust-lang/crates.io-index)" = "6d944ac6003ed268757ef1ee686753b57efc5fcf0ebe7b64c9fc81e7e32ff839"
@@ -4712,6 +4727,7 @@ dependencies = [
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+"checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-buf 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -16,6 +16,8 @@ serde_json = "1.0"
 
 lazy_static = "1.4"
 rand = "0.6"
+tiny-keccak = "1.5"
+
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/core/crypto/src/key_file.rs
+++ b/core/crypto/src/key_file.rs
@@ -1,8 +1,14 @@
+extern crate sodiumoxide;
+extern crate tiny_keccak;
+
 use std::fs::File;
-use std::io::{Read, Write};
+use std::io::{Read, Write, Error,  ErrorKind};
 use std::path::Path;
 
 use serde_derive::{Deserialize, Serialize};
+use sodiumoxide::crypto::secretbox;
+use sodiumoxide::crypto::secretbox::xsalsa20poly1305::Key;
+use tiny_keccak::keccak256;
 
 use crate::signature::{PublicKey, SecretKey};
 
@@ -11,21 +17,268 @@ pub struct KeyFile {
     pub account_id: String,
     pub public_key: PublicKey,
     pub secret_key: SecretKey,
+    #[serde(default)]
+    pub key_hash: KeyHash
 }
 
 impl KeyFile {
-    pub fn write_to_file(&self, path: &Path) {
+    fn write_to_file(&self, path: &Path) {
         let mut file = File::create(path).expect("Failed to create / write a key file.");
         let str = serde_json::to_string_pretty(self).expect("Error serializing the key file.");
         if let Err(err) = file.write_all(str.as_bytes()) {
             panic!("Failed to write a key file {}", err);
         }
     }
+    // is_encrypted checks if current keyhash struct matches default one
+    fn is_encrypted(&self)-> bool {
+        let keyhash = self.key_hash; 
+        let default_keyhash = KeyHash::default(); //?
+        keyhash.eq(&default_keyhash)
+    }
+    //asks for a password in console and encrypt a  private key ( secret_key field from keyFile structure) with an entered password
+    // if password is empty just write to the file
+    fn write_to_encrypted_file(&mut self, path: &Path, ssb: &SodiumoxideSecretBox) -> Result<(), Error> {   
+        let password_input = PasswordInput::process()?;//ask for input of password
+        if password_input.not_empty() {
+            // TODO adapt to keyType
+            let secretkey_vec = Vec::<u8>::from(self.secret_key);
+            let encryption_key = password_input.gen_key_from_password_input()?;
+            let key_hash = KeyHash::new(&password_input.content);
+            let encrypted_secretkey = ssb.encrypt(&secretkey_vec, &encryption_key);//Vec<u8>
+            //ToDO convert encrypted_secretkey: vec<U8> to SecretKey
+            //adapt it to 2 curve types
+           // TODO self.secret_key = KeyType
+            self.key_hash = key_hash;
+            self.write_to_file(path);
+            Ok(())
+        } else {
+            // console input is empty do not encryot, just write to the file
+            self.write_to_file(path); //self.key_hash will be default
+            Ok(())
+          }
+    }
 
-    pub fn from_file(path: &Path) -> Self {
+    fn read_from_file(path: &Path) -> Self {  
         let mut file = File::open(path).expect("Could not open key file.");
         let mut content = String::new();
         file.read_to_string(&mut content).expect("Could not read from key file.");
         serde_json::from_str(&content).expect("Failed to deserialize KeyFile")
     }
+     //decrypts a file and return an instance of the file
+    fn read_from_encrypted_file(&mut self, path: &Path, key : &Key, ssb: &SodiumoxideSecretBox) { //-> Self 
+      // reads the file and the decodes it with the password
+        let ssb = SodiumoxideSecretBox::new();
+        let decrypted_secretkey = ssb.decrypt(&self.secret_key, &key); //Vec<u8>
+
+        // TODO to adjust it to KeyType 
+        //let secret_key_value = SecretKey::From(decrypted_secretkey);
+        //return decrypted Keyfile.secret_key
+    }
+
+    //if a private key is encrypted , ask for a password in console
+    //if an entered password matches a password entered in step 3, decode an encrypted password otherwise keep asking for a correct password
+    
+    fn read_from_encrypted_file_with_password(path : &Path, ssb: &SodiumoxideSecretBox) -> Result<KeyFile, Error>  {  
+        let keyfile = KeyFile::read_from_file(path);
+        if keyfile.is_encrypted()   {
+            let password_input = PasswordInput::process()?;//ask for a password in command line
+            if  password_input.not_empty() {   //password is not empty decode a file with a passwordm if password empty do nothing
+                    let decryption_keyhash = KeyHash::new(&password_input.content);
+                    if decryption_keyhash.eq(&keyfile.key_hash) { //if hashes of passwords match then decrypt Keyfile.secret_key
+                        let decryption_key  = password_input.gen_key_from_password_input()?;
+                        keyfile.read_from_encrypted_file(path, &decryption_key, ssb);
+                        Ok(key_file)
+                    }  
+            } 
+        } else {
+         //keyfile is not encrypted or imported password is empty
+        Ok(keyfile)
+        }
+    }
 }
+
+
+pub fn perform_encryption(
+    key_file : &KeyFile,
+    key_store_path: &Path,
+    home_dir: &Path,
+    ) -> Result<(), Error> {
+        key_file.write_to_file(&key_store_path);
+
+        let ssb = SodiumoxideSecretBox::new();
+        
+        if home_dir.join("config.json").exists() {
+            //add password corrrectness validation to read_from_encrypted_file_with_password
+            KeyFile::read_from_encrypted_file_with_password(&key_store_path, &ssb)?;
+        } else {
+            key_file.write_to_encrypted_file(&key_store_path, &ssb)?;
+        }
+        Ok(())
+}
+
+pub struct PasswordInput {
+    pub content: Vec<u8>,
+    pub length: usize
+}
+
+impl PasswordInput {
+    // should support that user might not want to encrypt the key
+    pub fn enter_from_console() -> Self {
+        println!("Enter a password for a secret key: ");
+        let mut input = String::new();
+        let _ = std::io::stdin().read_line(&mut input).expect("Could not read from stdin");
+        let content = input.trim().as_bytes().to_vec();
+        let length = input.len();
+        PasswordInput { content, length }
+    }
+
+    pub fn exceed_max_length(&self) -> bool {
+        const MAX_LENGTH: usize = 32;
+        self.length > MAX_LENGTH
+    }
+
+    // xsalsa20poly1305 restricts key size to 32
+    // https://github.com/sodiumoxide/sodiumoxide/blob/master/src/crypto/secretbox/xsalsa20poly1305.rs#L50
+    pub fn pad_content(&self) -> Vec<u8> {
+        let mut buf = [0u8; 32];
+        buf.copy_from_slice(&self.content[..]);
+        buf.to_vec()
+    }
+
+    pub fn not_empty(&self) -> bool {
+        self.length > 0
+    }
+
+    pub fn process() -> Result<PasswordInput, Error> {  
+        let mut password_input = PasswordInput::enter_from_console();
+        if password_input.exceed_max_length() {
+            return Err(Error::new(ErrorKind::InvalidInput, "Input is too long"))
+        }
+       if password_input.not_empty() {
+            let content = password_input.pad_content();
+            let length = content.len();
+            password_input = PasswordInput{content, length};
+            Ok(password_input)
+        }
+         //  if user didn't enter password - don't encrypt or decrypt
+        Ok(password_input)
+    }
+
+    pub fn gen_key_from_password_input(&self) -> Result<Key, Error>  {
+        let key = SodiumoxideSecretBox::gen_key(&self.content)?;
+        Ok(key)
+    }
+}
+
+trait Operation {
+    fn encrypt(&self, m: &[u8], k: &Key) -> Vec<u8>;
+    fn decrypt(&self, c: &[u8], k: &Key) -> Vec<u8>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct SodiumoxideSecretBox {
+    nonce: secretbox::Nonce,
+}
+
+impl SodiumoxideSecretBox {
+    pub fn new() -> Self {
+        let nonce = secretbox::gen_nonce();
+        SodiumoxideSecretBox { nonce }
+    }
+
+    //need to be tested
+    pub fn gen_key(bytes: &[u8]) -> Result<Key, Error> {
+        Key::from_slice(bytes).map(Ok).unwrap_or_else(|| {
+            Err(Error::new(
+                ErrorKind::InvalidInput,
+                "Failed to create key from slice".to_string(),
+            ))
+        })
+    }
+
+}
+
+impl Operation for SodiumoxideSecretBox {
+    fn encrypt(&self, m: &[u8], k: &Key) -> Vec<u8> {
+        secretbox::seal(m, &self.nonce, &k)
+    }
+
+    fn decrypt(&self, c: &[u8], k: &Key) -> Vec<u8>{
+        secretbox::open(c, &self.nonce, &k).unwrap()
+    }
+}
+
+#[derive(Deserialize, Serialize)]
+pub struct KeyHash {
+    pub bytes: [u8; 32]
+}
+
+impl Default for KeyHash {
+    fn default() -> Self {
+        let zero_vec = vec![0u8, 32];
+        KeyHash::new(&zero_vec)
+    }
+}
+
+impl PartialEq for KeyHash {
+    fn eq(&self, other: &KeyHash) -> bool {
+        self.bytes.iter().zip(other.bytes.iter()).all(|(a,b)| a == b) 
+    }
+}
+
+impl KeyHash {
+    fn new(byte_slice : &[u8])-> Self { 
+        let bytes = keccak256(byte_slice); //[u8,32]
+        KeyHash{bytes}
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+   #[test] 
+    fn test_process() {
+        //helper
+        fn password_input_helper(input : &str) -> Result<PasswordInput, Error> {
+            let mut content = input.trim().as_bytes().to_vec();
+            let mut length = content.len();
+            let password_input = PasswordInput { content, length };
+            if password_input.exceed_max_length() {
+                return Err(Error::new(ErrorKind::InvalidInput, "Input is too long"))
+             }
+            if password_input.not_empty() {
+                content = password_input.pad_content();
+                length = content.len();
+                password_input = PasswordInput{content, length};
+                Ok(password_input)
+            }
+            Ok(password_input)
+        }
+        //helper
+        fn process_input(input: &str, expected_len: usize)  {
+            let password_input = password_input_helper(input).unwrap();
+            let content_slice = password_input.content.as_slice();
+            let expected = input.as_bytes();
+            let len = password_input.length;
+            assert_eq!(content_slice, expected);
+            assert_eq!(len, expected_len);
+        }
+        //testing normal input
+        process_input("qwerty", 32);
+
+         //testing empty input
+        process_input("", 0);
+
+        fn larger_max_length_input(len: usize){
+            let zero_vec = vec![0u8; len];
+            let s = String::from_utf8(zero_vec).expect("Found invalid UTF-8");
+            let password_input = password_input_helper(&s);
+            assert!(password_input.is_err());
+        }
+        //error_input(33);
+    }
+}
+
+

--- a/core/crypto/src/key_file.rs
+++ b/core/crypto/src/key_file.rs
@@ -3,7 +3,8 @@ extern crate tiny_keccak;
 
 use std::mem;
 use std::fs::File;
-use std::io::{Read, Write, Error,  ErrorKind};
+use std::result::Result;
+use std::io::{Read, Write, Error, ErrorKind};
 use std::path::Path;
 
 use serde_derive::{Deserialize, Serialize};
@@ -13,13 +14,99 @@ use tiny_keccak::keccak256;
 
 use crate::signature::{PublicKey, SecretKey};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Default, PartialEq, Clone, Deserialize, Serialize)]
+pub struct KeyHash([u8; 32]);
+
+impl KeyHash {
+    fn new(byte_slice : &[u8])-> Self { 
+        let bytes = keccak256(byte_slice); //[u8,32]
+        KeyHash(bytes)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
 pub struct KeyFile {
     pub account_id: String,
     pub public_key: PublicKey,
     pub secret_key: SecretKey,
-    #[serde(default)]
     pub key_hash: KeyHash
+}
+
+impl KeyFile {
+    pub fn write_to_file(&self, path: &Path) {
+        let mut file = File::create(path).expect("Failed to create / write a key file.");
+        let str = serde_json::to_string_pretty(self).expect("Error serializing the key file.");
+        if let Err(err) = file.write_all(str.as_bytes()) {
+            panic!("Failed to write a key file {}", err);
+        }
+    }
+
+    //asks for a password in console and encrypt a  private key ( secret_key field from keyFile structure) with an entered password
+    // if password is empty just write to the file
+    pub fn write_to_encrypted_file(&mut self, path: &Path) -> Result<(), Error> {   
+        let input = PasswordInput::enter_from_console();//ask for input of password , think about string 
+        let password_input = PasswordInput::process_input(&input)?;
+        let password_slice = password_input.0.as_bytes();
+        if !password_input.0.is_empty() {
+            let secretkey_vec = secretKeyToVec(self.secret_key.clone());
+            let encryption_key = SodiumoxideSecretBox::gen_key(password_slice)?;
+            let key_hash = KeyHash::new(password_slice);
+            let ssb = SodiumoxideSecretBox::new();
+            let encrypted_secretkey = ssb.encrypt(&secretkey_vec, &encryption_key);
+            self.secret_key = secretKeyFromVec(encrypted_secretkey);
+            self.key_hash = key_hash;
+        } else {
+            self.key_hash = KeyHash::default();//?
+        }
+        self.write_to_file(path);
+        Ok(())
+    }
+
+    pub fn from_file(path: &Path) -> Self {  
+        let mut file = File::open(path).expect("Could not open key file.");
+        let mut content = String::new();
+        file.read_to_string(&mut content).expect("Could not read from key file.");
+        serde_json::from_str(&content).expect("Failed to deserialize KeyFile")
+    }
+    
+    // decrypts a file and return an instance of the file
+    pub fn from_encrypted_file(path: &Path, key : &Key, key_file: KeyFile) -> Self {
+        let ssb = SodiumoxideSecretBox::new();
+        let decrypted_secretkey = ssb.decrypt(&secretKeyToVec(key_file.secret_key), &key);
+        KeyFile {
+            account_id: key_file.account_id,
+            public_key: key_file.public_key,
+            secret_key: secretKeyFromVec(decrypted_secretkey),
+            key_hash: KeyHash::default(),
+        }
+    }
+
+    // if a private key is encrypted , ask for a password in console
+    // if an entered password matches a password entered in step 3, decode an encrypted password otherwise keep asking for a correct password
+    pub fn from_encrypted_file_with_password(path : &Path) -> Result<Self, std::io::Error>  {  
+        let mut key_file = KeyFile::from_file(path);
+        //password is encrypted proceed further, if not Ok(key_file)
+        if !key_file.key_hash.eq(&KeyHash::default()) {
+        //ask for a password in console
+        //infinite loop
+            loop {
+                let input = PasswordInput::enter_from_console();
+                let password_input = PasswordInput::process_input(&input)?; 
+                let password_slice = password_input.0.as_bytes();
+                // password is not empty decode a file with a passwordm if password empty do nothing
+                if !password_input.0.is_empty() { 
+                    let decryption_keyhash = KeyHash::new(password_slice);
+                    if decryption_keyhash.eq(&key_file.key_hash) { // if hashes of passwords match then decrypt Keyfile.secret_key
+                        let decryption_key = SodiumoxideSecretBox::gen_key(password_slice)?;
+                        let cloned_keyfile = key_file.clone();
+                        key_file = KeyFile::from_encrypted_file(path, &decryption_key, cloned_keyfile);
+                        break;
+                    }
+                }
+            }
+        }
+        Ok(key_file)
+    }
 }
 
 fn secretKeyToVec(secret_key: SecretKey) -> Vec<u8> {
@@ -48,146 +135,33 @@ fn secretKeyFromVec(vec: Vec<u8>) -> SecretKey {
     }
 }
 
-impl KeyFile {
-    pub fn write_to_file(&self, path: &Path) {
-        let mut file = File::create(path).expect("Failed to create / write a key file.");
-        let str = serde_json::to_string_pretty(self).expect("Error serializing the key file.");
-        if let Err(err) = file.write_all(str.as_bytes()) {
-            panic!("Failed to write a key file {}", err);
-        }
-    }
-
-    //asks for a password in console and encrypt a  private key ( secret_key field from keyFile structure) with an entered password
-    // if password is empty just write to the file
-    pub fn write_to_encrypted_file(&mut self, path: &Path) -> Result<(), Error> {   
-        let password_input = PasswordInput::process()?;//ask for input of password
-        if password_input.not_empty() {
-            let secretkey_vec = secretKeyToVec(self.secret_key.clone());
-            let encryption_key = password_input.gen_key_from_password_input()?;
-            let key_hash = KeyHash::new(&password_input.content);
-            let ssb = SodiumoxideSecretBox::new();
-            let encrypted_secretkey = ssb.encrypt(&secretkey_vec, &encryption_key);
-            self.secret_key = secretKeyFromVec(encrypted_secretkey);
-            self.key_hash = key_hash;
-        }
-
-        self.write_to_file(path);
-        Ok(())
-    }
-
-    pub fn from_file(path: &Path) -> Self {  
-        let mut file = File::open(path).expect("Could not open key file.");
-        let mut content = String::new();
-        file.read_to_string(&mut content).expect("Could not read from key file.");
-        serde_json::from_str(&content).expect("Failed to deserialize KeyFile")
-    }
-    
-    // decrypts a file and return an instance of the file
-    pub fn from_encrypted_file(path: &Path, key : &Key) -> Self {
-        let key_file = KeyFile::from_file(path);
-        let ssb = SodiumoxideSecretBox::new();
-        let decrypted_secretkey = ssb.decrypt(&secretKeyToVec(key_file.secret_key), &key);
-        KeyFile {
-            account_id: key_file.account_id,
-            public_key: key_file.public_key,
-            secret_key: secretKeyFromVec(decrypted_secretkey),
-            key_hash: KeyHash::default(),
-        }
-    }
-
-    // if a private key is encrypted , ask for a password in console
-    // if an entered password matches a password entered in step 3, decode an encrypted password otherwise keep asking for a correct password
-    pub fn from_encrypted_file_with_password(path : &Path) -> Result<Self, Error>  {  
-        let mut key_file = KeyFile::from_file(path);
-        if key_file.key_hash.eq(&KeyHash::default()) {
-            let password_input = PasswordInput::process()?; // ask for a password in command line
-            if  password_input.not_empty() { // password is not empty decode a file with a passwordm if password empty do nothing
-                let decryption_keyhash = KeyHash::new(&password_input.content);
-                if decryption_keyhash.eq(&key_file.key_hash) { // if hashes of passwords match then decrypt Keyfile.secret_key
-                    let decryption_key = password_input.gen_key_from_password_input()?;
-                    key_file = KeyFile::from_encrypted_file(path, &decryption_key);
-                }
-            }
-        }
-
-        Ok(key_file)
-    }
-}
-
-pub fn perform_encryption(
-    key_file : &mut KeyFile,
-    key_store_path: &Path,
-    home_dir: &Path,
-) -> Result<(), Error> {
-    key_file.write_to_file(&key_store_path);
-    
-    if home_dir.join("config.json").exists() {
-        //add password corrrectness validation to from_encrypted_file_with_password
-        KeyFile::from_encrypted_file_with_password(&key_store_path)?;
-    } else {
-        key_file.write_to_encrypted_file(&key_store_path)?;
-    }
-
-    Ok(())
-}
-
-pub struct PasswordInput {
-    pub content: Vec<u8>,
-    pub length: usize
-}
+struct PasswordInput(String);
 
 impl PasswordInput {
     // should support that user might not want to encrypt the key
-    pub fn enter_from_console() -> Self {
+    pub fn enter_from_console() -> String {
         println!("Enter a password for a secret key: ");
         let mut input = String::new();
         let _ = std::io::stdin().read_line(&mut input).expect("Could not read from stdin");
-        let content = input.trim().as_bytes().to_vec();
-        let length = input.len();
-        PasswordInput { content, length }
+        input = input.trim().to_string(); //&str copy type
+        input
     }
 
-    pub fn exceed_max_length(&self) -> bool {
-        const MAX_LENGTH: usize = 32;
-        self.length > MAX_LENGTH
-    }
-
-    // xsalsa20poly1305 restricts key size to 32
-    // https://github.com/sodiumoxide/sodiumoxide/blob/master/src/crypto/secretbox/xsalsa20poly1305.rs#L50
-    pub fn pad_content(&self) -> Vec<u8> {
+    pub fn process_input(content: &str) -> Result<Self, Error>  {
+         const MAX_LENGTH: usize = 32;
+        if content.len() > MAX_LENGTH {
+           return Err(Error::new(ErrorKind::InvalidInput, "Input is too long"));
+        }
+        if content.is_empty() {
+            let content_str = String::from_utf8(content.as_bytes().to_vec()).unwrap();
+            return Ok(PasswordInput(content_str));
+        }
         let mut buf = [0u8; 32];
-        buf.copy_from_slice(&self.content[..]);
-        buf.to_vec()
+        let content_slice = content.as_bytes();
+        buf.copy_from_slice(&content_slice[..]);
+        let buf_str = String::from_utf8(buf.to_vec()).unwrap();
+        Ok(PasswordInput(buf_str))
     }
-
-    pub fn not_empty(&self) -> bool {
-        self.length > 0
-    }
-
-    pub fn process() -> Result<PasswordInput, Error> {  
-        let mut password_input = PasswordInput::enter_from_console();
-        if password_input.exceed_max_length() {
-            return Err(Error::new(ErrorKind::InvalidInput, "Input is too long"))
-        }
-       
-        if password_input.not_empty() {
-            let content = password_input.pad_content();
-            let length = content.len();
-            password_input = PasswordInput{content, length};
-        }
-
-        Ok(password_input)
-    }
-
-    pub fn gen_key_from_password_input(&self) -> Result<Key, Error>  {
-        let key = SodiumoxideSecretBox::gen_key(&self.content)?;
-        Ok(key)
-    }
-}
-
-trait Operation {
-    fn encrypt(&self, m: &[u8], k: &Key) -> Vec<u8>;
-    fn decrypt(&self, c: &[u8], k: &Key) -> Vec<u8>;
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -210,7 +184,11 @@ impl SodiumoxideSecretBox {
             ))
         })
     }
+}
 
+trait Operation {
+    fn encrypt(&self, m: &[u8], k: &Key) -> Vec<u8>;
+    fn decrypt(&self, c: &[u8], k: &Key) -> Vec<u8>;
 }
 
 impl Operation for SodiumoxideSecretBox {
@@ -223,75 +201,58 @@ impl Operation for SodiumoxideSecretBox {
     }
 }
 
-#[derive(Deserialize, Serialize)]
-pub struct KeyHash {
-    pub bytes: [u8; 32]
-}
-
-impl Default for KeyHash {
-    fn default() -> Self {
-        let zero_vec = vec![0u8, 32];
-        KeyHash::new(&zero_vec)
+pub fn perform_encryption(key_file : &mut KeyFile,
+    key_store_path: &Path,home_dir: &Path,
+    ) -> Result<(), std::io::Error> {
+        key_file.write_to_file(&key_store_path);
+    
+    if home_dir.join("config.json").exists() {
+        //add password corrrectness validation to from_encrypted_file_with_password
+        KeyFile::from_encrypted_file_with_password(&key_store_path)?;
+    } else {
+        key_file.write_to_encrypted_file(&key_store_path)?;
     }
-}
 
-impl PartialEq for KeyHash {
-    fn eq(&self, other: &KeyHash) -> bool {
-        self.bytes.iter().zip(other.bytes.iter()).all(|(a,b)| a == b) 
-    }
+    Ok(())
 }
-
-impl KeyHash {
-    fn new(byte_slice : &[u8])-> Self { 
-        let bytes = keccak256(byte_slice); //[u8,32]
-        KeyHash{bytes}
-    }
-}
-
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-   #[test] 
+    #[test] 
     fn test_process() {
-        //helper
-        fn password_input_helper(input : &str) -> Result<PasswordInput, Error> {
-            let mut content = input.trim().as_bytes().to_vec();
-            let mut length = content.len();
-            let mut password_input = PasswordInput { content, length };
-            if password_input.exceed_max_length() {
-                return Err(Error::new(ErrorKind::InvalidInput, "Input is too long"))
+        fn process_test_input(input: &str, expected_len: usize)  {
+            assert!(PasswordInput::process_input(input).is_ok());      
+            let password_input = PasswordInput::process_input(input).unwrap();
+            let password_input_str = password_input.0;
+            if input.is_empty() {
+                assert_eq!(&password_input_str, input);
+                assert_eq!(password_input_str.len(), expected_len);
+            } else {
+                let mut buf = [0u8; 32];
+                let input_slice = input.as_bytes();
+                buf.copy_from_slice(&input_slice[..]);
+                let expected_str = String::from_utf8(buf.to_vec()).unwrap();
+                let len = password_input_str.len();
+                assert_eq!(&password_input_str, &expected_str);
+                assert_eq!(len, expected_len);
             }
-            if password_input.not_empty() {
-                content = password_input.pad_content();
-                length = content.len();
-                password_input = PasswordInput{content, length};
-            }
-            Ok(password_input)
-        }
-        //helper
-        fn process_input(input: &str, expected_len: usize)  {
-            let password_input = password_input_helper(input).unwrap();
-            let content_slice = password_input.content.as_slice();
-            let expected = input.as_bytes();
-            let len = password_input.length;
-            assert_eq!(content_slice, expected);
-            assert_eq!(len, expected_len);
         }
         //testing normal input
-        process_input("qwerty", 32);
+        process_test_input("qwerty", 32);
 
          //testing empty input
-        process_input("", 0);
+        process_test_input("", 0);
 
         fn larger_max_length_input(len: usize){
             let zero_vec = vec![0u8; len];
             let s = String::from_utf8(zero_vec).expect("Found invalid UTF-8");
-            let password_input = password_input_helper(&s);
-            assert!(password_input.is_err());
+            let err_result = PasswordInput::process_input(&s);
+            assert!( err_result.is_err() );
         }
-        //error_input(33);
+
+        larger_max_length_input(33);
     }
 }
 

--- a/core/crypto/src/signer.rs
+++ b/core/crypto/src/signer.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::key_file::KeyFile;
+use crate::key_file::{KeyFile, KeyHash};
 use crate::signature::{KeyType, PublicKey, SecretKey, Signature};
 
 /// Generic signer trait, that can sign with some subset of supported curves.
@@ -87,6 +87,7 @@ impl From<&InMemorySigner> for KeyFile {
             account_id: signer.account_id.clone(),
             public_key: signer.public_key.clone(),
             secret_key: signer.secret_key.clone(),
+            key_hash: KeyHash::default(),
         }
     }
 }
@@ -97,6 +98,7 @@ impl From<Arc<InMemorySigner>> for KeyFile {
             account_id: signer.account_id.clone(),
             public_key: signer.public_key.clone(),
             secret_key: signer.secret_key.clone(),
+            key_hash: KeyHash::default(),
         }
     }
 }

--- a/core/crypto/src/signer.rs
+++ b/core/crypto/src/signer.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::key_file::{KeyFile, KeyHash};
+use crate::key_file::{KeyFile, KeyHash, SodiumoxideSecretBox};
 use crate::signature::{KeyType, PublicKey, SecretKey, Signature};
 
 /// Generic signer trait, that can sign with some subset of supported curves.
@@ -88,6 +88,7 @@ impl From<&InMemorySigner> for KeyFile {
             public_key: signer.public_key.clone(),
             secret_key: signer.secret_key.clone(),
             key_hash: KeyHash::default(),
+            ssb: SodiumoxideSecretBox::default(),
         }
     }
 }
@@ -99,6 +100,7 @@ impl From<Arc<InMemorySigner>> for KeyFile {
             public_key: signer.public_key.clone(),
             secret_key: signer.secret_key.clone(),
             key_hash: KeyHash::default(),
+            ssb: SodiumoxideSecretBox::default(),
         }
     }
 }


### PR DESCRIPTION
[Resolves] #1069 
[Part of] #1211 

I have rebased to current state of staging branch.

I have some questions:
1) I guess i should serialize the [nonce](https://github.com/cyberbono3/nearcore/blob/encrypt-keyfile-sk/core/crypto/src/key_file.rs#L202) used for encryption and decryption of secret_key. Shouldn't I?
2) Should I use seal_detached[](https://github.com/sodiumoxide/sodiumoxide/blob/master/src/crypto/secretbox/xsalsa20poly1305.rs#L87) in addition of seal method? seal_detached produces MAC tag to ensure message authenticity
3) the next step is to convert[ enum SecretKey](https://github.com/nearprotocol/nearcore/blob/staging/core/crypto/src/signature.rs#L251) to Vec<u8>  to use it in encrypt() and decrypt() isnt it?

@nearmax, @k06a Can you review my draft and give me more information?
