### PR TITLE
Bump borsh and nearcore version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,24 +513,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "borsh"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "borsh-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "borsh-derive-internal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh-derive-internal 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.36 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1821,13 +1821,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "loadtester"
 version = "0.0.1"
 dependencies = [
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.3.3",
+ "near 0.3.4",
  "near-crypto 0.1.0",
  "near-primitives 0.1.0",
  "node-runtime 0.0.1",
@@ -2027,10 +2027,10 @@ dependencies = [
 
 [[package]]
 name = "near"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2066,7 +2066,7 @@ dependencies = [
 name = "near-chain"
 version = "0.1.0"
 dependencies = [
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2086,7 +2086,7 @@ version = "0.1.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2110,7 +2110,7 @@ name = "near-crypto"
 version = "0.1.0"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.7 (git+https://github.com/paritytech/rust-secp256k1)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2131,7 +2131,7 @@ dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-utils 0.1.0",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2170,7 +2170,7 @@ name = "near-network"
 version = "0.1.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2210,7 +2210,7 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2243,7 +2243,7 @@ name = "near-store"
 version = "0.1.0"
 dependencies = [
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)",
  "elastic-array 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2321,7 +2321,7 @@ dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.3.3",
+ "near 0.3.4",
  "near-crypto 0.1.0",
  "near-jsonrpc 0.1.0",
  "near-network 0.1.0",
@@ -2361,7 +2361,7 @@ name = "node-runtime"
 version = "0.0.1"
 dependencies = [
  "bincode 1.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.8.0 (git+https://github.com/nearprotocol/cached?rev=7e472eddef68607e344d5a106a0e6705d92e55be)",
  "ethash 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3353,10 +3353,10 @@ name = "state-viewer"
 version = "0.1.0"
 dependencies = [
  "ansi_term 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.3.3",
+ "near 0.3.4",
  "near-chain 0.1.0",
  "near-crypto 0.1.0",
  "near-network 0.1.0",
@@ -3483,13 +3483,13 @@ name = "testlib"
 version = "0.1.0"
 dependencies = [
  "actix 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.3.3",
+ "near 0.3.4",
  "near-chain 0.1.0",
  "near-client 0.1.0",
  "near-crypto 0.1.0",
@@ -4257,9 +4257,9 @@ dependencies = [
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum blockchain 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25c0f727a410bef0ea87d7437aa403f669ec4d7de1b302f4d819f83d3b4c561"
-"checksum borsh 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d2e5c862266f33764cc95583fd37d944a99edceab309805aa128210ec4f06f89"
-"checksum borsh-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "42704e77224ab9d2a744ee4333fa0f1ccee3780c1e6a1ed6e6273605e3f2ce70"
-"checksum borsh-derive-internal 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cab08d029c5dd9a9edcc8c2346ede901e30e121db31d07994a67566f05a58d92"
+"checksum borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "b51e61e52798ec08df9b9d6c432843c6b4c03cea21c09a22663ca967c08b87e7"
+"checksum borsh-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ccc866c2518347712c7dc4bd02f9eeaac6f519f57cb2e0b388bc82fb80d0d01e"
+"checksum borsh-derive-internal 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e6e0938eb83fc1dca271c2e2a55ba2c25dded7ac99fe49d966c231c9a0c82913"
 "checksum brotli-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4445dea95f4c2b41cde57cc9fee236ae4dbae88d8fcbdb4750fc1bb5d86aaecd"
 "checksum brotli2 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0cb036c3eade309815c15ddbacec5b22c4d1f3983a774ab2eac2e3e9ea85568e"
 "checksum bs58 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0d9644ad62ff4df43da2e057febbbce576f7124cb5cd8e90e0ce7027f38aa2dd"

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -14,7 +14,7 @@ serde = "1.0"
 serde_derive = "1.0"
 cached = { git = "https://github.com/nearprotocol/cached", rev = "7e472eddef68607e344d5a106a0e6705d92e55be" }
 
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0"
 
 sysinfo = "0.9.0"
 
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/chain/jsonrpc/Cargo.toml
+++ b/chain/jsonrpc/Cargo.toml
@@ -21,7 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = "0.1.15"
 uuid = { version = "~0.6", features = ["v4"] }
 
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 async-utils = { path = "../../async-utils" }
 near-crypto = { path = "../../core/crypto" }

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0"
 serde_derive = "1.0"
 rand = "0.6.5"
 
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/core/crypto/Cargo.toml
+++ b/core/crypto/Cargo.toml
@@ -9,7 +9,7 @@ sodiumoxide = "0.2.2"
 eth-secp256k1 = { git = "https://github.com/paritytech/rust-secp256k1" }
 
 bs58 = "0.2.4"
-borsh = "0.2.3"
+borsh = "0.2.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.4"
 reed-solomon-erasure = "3.1.1"
 jemallocator = { version = "0.3.0", optional = true }
 
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 near-crypto = { path = "../crypto" }
 

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -15,7 +15,7 @@ serde_derive = "1.0"
 cached = { git = "https://github.com/nearprotocol/cached", rev = "7e472eddef68607e344d5a106a0e6705d92e55be" }
 log = "0.4"
 
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 near-crypto = { path = "../crypto" }
 near-primitives = { path = "../primitives" }

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 
@@ -22,7 +22,7 @@ serde_json = "1.0"
 dirs = "1.0.5"
 lazy_static = "1.3"
 
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 near-crypto = { path = "../core/crypto" }
 near-primitives = { path = "../core/primitives" }

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -26,7 +26,7 @@ near-runtime-fees = { path = "../../runtime/near-runtime-fees" }
 near-vm-logic = { path = "../../runtime/near-vm-logic" }
 near-vm-runner = { path = "../../runtime/near-vm-runner" }
 cached = { git = "https://github.com/nearprotocol/cached", rev = "7e472eddef68607e344d5a106a0e6705d92e55be" }
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 [features]
 test-utils = []

--- a/test-utils/loadtester/Cargo.toml
+++ b/test-utils/loadtester/Cargo.toml
@@ -15,7 +15,7 @@ futures = "0.1.25"
 tokio = "0.1"
 serde_json = "1.0.0"
 
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/test-utils/state-viewer/Cargo.toml
+++ b/test-utils/state-viewer/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 clap = "2.32.0"
 hex = "0.3"
 ansi_term = "0.12.0"
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/test-utils/testlib/Cargo.toml
+++ b/test-utils/testlib/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = "1.2"
 tempdir = "0.3"
 tokio-signal = "0.2"
 
-borsh = "0.2.3"
+borsh = "0.2.5"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }


### PR DESCRIPTION
Incorporate borsh fix on the problem https://github.com/nearprotocol/borsh/issues/2 that would crash the testnet.