### PR TITLE
Chain functionality to challenge a block

### DIFF
--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -89,6 +89,9 @@ pub enum ErrorKind {
     /// Epoch out of bounds. Usually if received block is too far in the future or alternative fork.
     #[fail(display = "Epoch Out Of Bounds")]
     EpochOutOfBounds,
+    /// A challenged block is on the chain that was attempted to become the head
+    #[fail(display = "Challenged block on chain")]
+    ChallengedBlockOnChain,
     /// IO Error.
     #[fail(display = "IO Error: {}", _0)]
     IOErr(String),
@@ -139,6 +142,7 @@ impl Error {
             | ErrorKind::ValidatorError(_)
             // TODO: can be either way?
             | ErrorKind::EpochOutOfBounds
+            | ErrorKind::ChallengedBlockOnChain
             | ErrorKind::DBNotFoundErr(_) => false,
             ErrorKind::InvalidBlockPastTime(_, _)
             | ErrorKind::InvalidBlockFutureTime(_)

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -18,9 +18,9 @@ use near_primitives::types::{BlockIndex, ChunkExtra, ShardId};
 use near_primitives::utils::{index_to_bytes, to_timestamp};
 use near_store::{
     read_with_cache, Store, StoreUpdate, WrappedTrieChanges, COL_BLOCK, COL_BLOCKS_TO_CATCHUP,
-    COL_BLOCK_HEADER, COL_BLOCK_INDEX, COL_BLOCK_MISC, COL_CHUNKS, COL_CHUNK_EXTRA,
-    COL_CHUNK_ONE_PARTS, COL_INCOMING_RECEIPTS, COL_OUTGOING_RECEIPTS, COL_STATE_DL_INFOS,
-    COL_TRANSACTION_RESULT,
+    COL_BLOCK_HEADER, COL_BLOCK_INDEX, COL_BLOCK_MISC, COL_CHALLENGED_BLOCKS, COL_CHUNKS,
+    COL_CHUNK_EXTRA, COL_CHUNK_ONE_PARTS, COL_INCOMING_RECEIPTS, COL_OUTGOING_RECEIPTS,
+    COL_STATE_DL_INFOS, COL_TRANSACTION_RESULT,
 };
 
 use crate::error::{Error, ErrorKind};
@@ -127,6 +127,8 @@ pub trait ChainStoreAccess {
     ) -> Result<&Vec<ReceiptProof>, Error>;
     /// Returns transaction result for given tx hash.
     fn get_transaction_result(&mut self, hash: &CryptoHash) -> Result<&ExecutionOutcome, Error>;
+    /// Returns whether the block with the given hash was challenged
+    fn is_block_challenged(&mut self, hash: &CryptoHash) -> Result<bool, Error>;
 
     fn get_blocks_to_catchup(&self, prev_hash: &CryptoHash) -> Result<Vec<CryptoHash>, Error>;
 
@@ -420,6 +422,13 @@ impl ChainStoreAccess for ChainStore {
         self.latest_known = Some(latest_known);
         store_update.commit().map_err(|err| err.into())
     }
+
+    fn is_block_challenged(&mut self, hash: &CryptoHash) -> Result<bool, Error> {
+        return Ok(self
+            .store
+            .get_ser(COL_CHALLENGED_BLOCKS, hash.as_ref())?
+            .unwrap_or_else(|| false));
+    }
 }
 
 /// Provides layer to update chain without touching the underlying database.
@@ -445,6 +454,7 @@ pub struct ChainStoreUpdate<'a, T> {
     remove_blocks_to_catchup: Vec<CryptoHash>,
     add_state_dl_infos: Vec<StateSyncInfo>,
     remove_state_dl_infos: Vec<CryptoHash>,
+    challenged_blocks: HashSet<CryptoHash>,
 }
 
 impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
@@ -469,6 +479,7 @@ impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
             remove_blocks_to_catchup: vec![],
             add_state_dl_infos: vec![],
             remove_state_dl_infos: vec![],
+            challenged_blocks: HashSet::default(),
         }
     }
 
@@ -661,13 +672,20 @@ impl<'a, T: ChainStoreAccess> ChainStoreAccess for ChainStoreUpdate<'a, T> {
     fn save_latest_known(&mut self, latest_known: LatestKnown) -> Result<(), Error> {
         self.chain_store.save_latest_known(latest_known)
     }
+
+    fn is_block_challenged(&mut self, hash: &CryptoHash) -> Result<bool, Error> {
+        if self.challenged_blocks.contains(&hash) {
+            return Ok(true);
+        }
+        return self.chain_store.is_block_challenged(hash);
+    }
 }
 
 impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
     /// Update both header and block body head.
     pub fn save_head(&mut self, t: &Tip) -> Result<(), Error> {
         self.save_body_head(t)?;
-        self.save_header_head(t)
+        self.save_header_head_if_not_challenged(t)
     }
 
     /// Update block body head and latest known height.
@@ -682,7 +700,11 @@ impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
         self.tail = Some(t.clone());
     }
 
-    fn update_block_index(&mut self, height: BlockIndex, hash: CryptoHash) -> Result<(), Error> {
+    fn update_block_index_if_not_challenged(
+        &mut self,
+        height: BlockIndex,
+        hash: CryptoHash,
+    ) -> Result<(), Error> {
         let mut prev_hash = hash;
         let mut prev_height = height;
         loop {
@@ -699,6 +721,9 @@ impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
                     return Ok(());
                 }
                 _ => {
+                    if self.is_block_challenged(&header_hash)? {
+                        return Err(ErrorKind::ChallengedBlockOnChain.into());
+                    }
                     self.block_index.insert(header_height, Some(header_hash));
                     prev_hash = header_prev_hash;
                     prev_height = header_height;
@@ -708,11 +733,26 @@ impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
     }
 
     /// Update header head and height to hash index for this branch.
-    pub fn save_header_head(&mut self, t: &Tip) -> Result<(), Error> {
+    pub fn save_header_head_if_not_challenged(&mut self, t: &Tip) -> Result<(), Error> {
         if t.height > 0 {
-            self.update_block_index(t.height, t.prev_block_hash)?;
+            self.update_block_index_if_not_challenged(t.height, t.prev_block_hash)?;
         }
         self.try_save_latest_known(t.height)?;
+
+        match &self.header_head() {
+            Ok(prev_tip) => {
+                if prev_tip.height > t.height {
+                    for height in (t.height + 1)..=prev_tip.height {
+                        self.block_index.insert(height, None);
+                    }
+                }
+            }
+            Err(err) => match err.kind() {
+                ErrorKind::DBNotFoundErr(_) => {}
+                e => return Err(e.into()),
+            },
+        }
+
         self.block_index.insert(t.height, Some(t.last_block_hash));
         self.header_head = Some(t.clone());
         Ok(())
@@ -821,6 +861,10 @@ impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
 
     pub fn remove_state_dl_info(&mut self, hash: CryptoHash) {
         self.remove_state_dl_infos.push(hash);
+    }
+
+    pub fn save_challenged_block(&mut self, hash: CryptoHash) {
+        self.challenged_blocks.insert(hash);
     }
 
     /// Merge another StoreUpdate into this one
@@ -933,6 +977,9 @@ impl<'a, T: ChainStoreAccess> ChainStoreUpdate<'a, T> {
         }
         for hash in self.remove_state_dl_infos {
             store_update.delete(COL_STATE_DL_INFOS, hash.as_ref());
+        }
+        for hash in self.challenged_blocks {
+            store_update.set_ser(COL_CHALLENGED_BLOCKS, hash.as_ref(), &true)?;
         }
         for other in self.store_updates {
             store_update.merge(other);

--- a/chain/chain/tests/challenges.rs
+++ b/chain/chain/tests/challenges.rs
@@ -1,0 +1,83 @@
+use near_chain::test_utils::setup;
+use near_chain::{Block, ErrorKind, Provenance};
+use near_primitives::test_utils::init_test_logger;
+
+#[test]
+fn challenges_new_head_prev() {
+    init_test_logger();
+    let (mut chain, _, signer) = setup();
+    let mut hashes = vec![];
+    for i in 0..5 {
+        let prev_hash = chain.head_header().unwrap().hash();
+        let prev = chain.get_block(&prev_hash).unwrap();
+        let block = Block::empty(&prev, signer.clone());
+        hashes.push(block.hash());
+        let tip = chain.process_block(&None, block, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+        assert_eq!(tip.unwrap().height, i + 1);
+    }
+
+    assert_eq!(chain.head().unwrap().height, 5);
+
+    // The block to be added below after we invalidated fourth block.
+    let last_block = Block::empty(&chain.get_block(&hashes[3]).unwrap(), signer.clone());
+    assert_eq!(last_block.header.inner.height, 5);
+
+    let prev = chain.get_block(&hashes[1]).unwrap();
+    let challenger_block = Block::empty(&prev, signer.clone());
+    let challenger_hash = challenger_block.hash();
+
+    let _ =
+        chain.process_block(&None, challenger_block, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+
+    // At this point the challenger block is not on canonical chain
+    assert_eq!(chain.head_header().unwrap().inner.height, 5);
+
+    // Challenge fourth block. The third block and the challenger block have the same weight, the
+    //   current logic will choose the third block.
+    chain.mark_block_as_challenged(&hashes[3], &challenger_hash).unwrap();
+
+    assert_eq!(chain.head_header().unwrap().hash(), hashes[2]);
+
+    assert_eq!(chain.get_header_by_height(2).unwrap().hash(), hashes[1]);
+    assert_eq!(chain.get_header_by_height(3).unwrap().hash(), hashes[2]);
+    assert!(chain.get_header_by_height(4).is_err());
+
+    // Try to add a block on top of the fifth block.
+
+    if let Err(e) = chain.process_block(&None, last_block, Provenance::PRODUCED, |_| {}, |_| {}) {
+        assert_eq!(e.kind(), ErrorKind::ChallengedBlockOnChain)
+    } else {
+        assert!(false);
+    }
+    assert_eq!(chain.head_header().unwrap().hash(), hashes[2]);
+
+    // Add two more blocks
+    let b3 = Block::empty(&chain.get_block(&hashes[2]).unwrap().clone(), signer.clone());
+    let _ = chain
+        .process_block(&None, b3.clone(), Provenance::PRODUCED, |_| {}, |_| {})
+        .unwrap()
+        .unwrap();
+
+    let b4 = Block::empty(&b3, signer.clone());
+    let new_head = chain
+        .process_block(&None, b4.clone(), Provenance::PRODUCED, |_| {}, |_| {})
+        .unwrap()
+        .unwrap()
+        .last_block_hash;
+
+    assert_eq!(chain.head_header().unwrap().hash(), new_head);
+
+    // Add two more blocks on an alternative chain
+    let b3 = Block::empty(&chain.get_block(&hashes[2]).unwrap().clone(), signer.clone());
+    let _ = chain.process_block(&None, b3.clone(), Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+
+    let b4 = Block::empty(&b3, signer.clone());
+    let _ = chain.process_block(&None, b4.clone(), Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    let challenger_hash = b4.hash();
+
+    assert_eq!(chain.head_header().unwrap().hash(), new_head);
+
+    chain.mark_block_as_challenged(&new_head, &challenger_hash).unwrap();
+
+    assert_eq!(chain.head_header().unwrap().hash(), challenger_hash);
+}

--- a/chain/chain/tests/simple_chain.rs
+++ b/chain/chain/tests/simple_chain.rs
@@ -128,7 +128,7 @@ fn test_apply_expired_tx() {
     );
     assert!(chain.process_block(&None, b1, Provenance::PRODUCED, |_| {}, |_| {}).is_ok());
     // TODO: MOO add shard tracking.
-    //    assert!(chain.process_block(&None, b2, Provenance::PRODUCED, |_, _, _| {}, |_| {}).is_err());
+    //    assert!(chain.process_block(&None, b2, Provenance::PRODUCED, |_| {}, |_| {}).is_err());
 }
 
 #[test]
@@ -161,5 +161,89 @@ fn test_tx_wrong_fork() {
     );
     assert!(chain.process_block(&None, b1, Provenance::PRODUCED, |_| {}, |_| {}).is_ok());
     // TODO: MOO add shard tracking.
-    //    assert!(chain.process_block(&None, b2, Provenance::PRODUCED, |_, _, _| {}, |_| {}).is_err());
+    //    assert!(chain.process_block(&None, b2, Provenance::PRODUCED, |_| {}, |_| {}).is_err());
+}
+
+/// Verifies that the block at height are updated correctly when blocks from different forks are
+/// processed, especially when certain heights are skipped
+#[test]
+fn blocks_at_height() {
+    init_test_logger();
+    let (mut chain, _, signer) = setup();
+    let genesis = chain.get_block_by_height(0).unwrap();
+    let b_1 = Block::empty_with_height(genesis, 1, signer.clone());
+    let b_2 = Block::empty_with_height(&b_1, 2, signer.clone());
+    let b_3 = Block::empty_with_height(&b_2, 3, signer.clone());
+
+    let c_1 = Block::empty_with_height(&genesis, 1, signer.clone());
+    let c_3 = Block::empty_with_height(&c_1, 3, signer.clone());
+    let c_4 = Block::empty_with_height(&c_3, 4, signer.clone());
+    let c_5 = Block::empty_with_height(&c_4, 5, signer.clone());
+
+    let d_3 = Block::empty_with_height(&b_2, 3, signer.clone());
+    let d_4 = Block::empty_with_height(&d_3, 4, signer.clone());
+    let d_5 = Block::empty_with_height(&d_4, 5, signer.clone());
+
+    let mut e_2 = Block::empty_with_height(&b_1, 2, signer.clone());
+    e_2.header.inner.total_weight = (10 * e_2.header.inner.total_weight.to_num()).into();
+    e_2.header.init();
+    e_2.header.signature = signer.sign(e_2.header.hash().as_ref());
+
+    let b_1_hash = b_1.hash();
+    let b_2_hash = b_2.hash();
+    let b_3_hash = b_3.hash();
+
+    let c_1_hash = c_1.hash();
+    let c_3_hash = c_3.hash();
+    let c_4_hash = c_4.hash();
+    let c_5_hash = c_5.hash();
+
+    let d_3_hash = d_3.hash();
+    let d_4_hash = d_4.hash();
+    let d_5_hash = d_5.hash();
+
+    let e_2_hash = e_2.hash();
+
+    assert_ne!(d_3_hash, b_3_hash);
+
+    chain.process_block(&None, b_1, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    chain.process_block(&None, b_2, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    chain.process_block(&None, b_3, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    assert_eq!(chain.header_head().unwrap().height, 3);
+
+    assert_eq!(chain.get_header_by_height(1).unwrap().hash(), b_1_hash);
+    assert_eq!(chain.get_header_by_height(2).unwrap().hash(), b_2_hash);
+    assert_eq!(chain.get_header_by_height(3).unwrap().hash(), b_3_hash);
+
+    chain.process_block(&None, c_1, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    chain.process_block(&None, c_3, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    chain.process_block(&None, c_4, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    chain.process_block(&None, c_5, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    assert_eq!(chain.header_head().unwrap().height, 5);
+
+    assert_eq!(chain.get_header_by_height(1).unwrap().hash(), c_1_hash);
+    assert!(chain.get_header_by_height(2).is_err());
+    assert_eq!(chain.get_header_by_height(3).unwrap().hash(), c_3_hash);
+    assert_eq!(chain.get_header_by_height(4).unwrap().hash(), c_4_hash);
+    assert_eq!(chain.get_header_by_height(5).unwrap().hash(), c_5_hash);
+
+    chain.process_block(&None, d_3, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    chain.process_block(&None, d_4, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    chain.process_block(&None, d_5, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    assert_eq!(chain.header_head().unwrap().height, 5);
+
+    assert_eq!(chain.get_header_by_height(1).unwrap().hash(), b_1_hash);
+    assert_eq!(chain.get_header_by_height(2).unwrap().hash(), b_2_hash);
+    assert_eq!(chain.get_header_by_height(3).unwrap().hash(), d_3_hash);
+    assert_eq!(chain.get_header_by_height(4).unwrap().hash(), d_4_hash);
+    assert_eq!(chain.get_header_by_height(5).unwrap().hash(), d_5_hash);
+
+    chain.process_block(&None, e_2, Provenance::PRODUCED, |_| {}, |_| {}).unwrap();
+    assert_eq!(chain.header_head().unwrap().height, 2);
+
+    assert_eq!(chain.get_header_by_height(1).unwrap().hash(), b_1_hash);
+    assert_eq!(chain.get_header_by_height(2).unwrap().hash(), e_2_hash);
+    assert!(chain.get_header_by_height(3).is_err());
+    assert!(chain.get_header_by_height(4).is_err());
+    assert!(chain.get_header_by_height(5).is_err());
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -45,7 +45,8 @@ pub const COL_CHUNK_ONE_PARTS: Option<u32> = Some(13);
 pub const COL_BLOCKS_TO_CATCHUP: Option<u32> = Some(14);
 /// Blocks for which the state is being downloaded
 pub const COL_STATE_DL_INFOS: Option<u32> = Some(15);
-const NUM_COLS: u32 = 16;
+pub const COL_CHALLENGED_BLOCKS: Option<u32> = Some(16);
+const NUM_COLS: u32 = 17;
 
 pub struct Store {
     storage: Arc<dyn KeyValueDB>,


### PR DESCRIPTION
- Fixing an issue that `update_block_index` was not erasing the tail of indexes if the new tip has lower height that the last tip.
- Basic challenge functionality, that reverts the Tip to either the parent of the challenged block, or the challenger block.
- Preventing the chain with an invalid block from becoming canonical.