### PR TITLE
Account for storage rent in economics

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -234,6 +234,7 @@ impl Chain {
                         vec![],
                         0,
                         chain_genesis.gas_price,
+                        0,
                         chain_genesis.total_supply,
                     )?;
                     store_update.save_block_header(genesis.header.clone());
@@ -244,7 +245,7 @@ impl Chain {
                         store_update.save_chunk_extra(
                             &genesis.hash(),
                             chunk_header.inner.shard_id,
-                            ChunkExtra::new(state_root, vec![], 0, chain_genesis.gas_limit),
+                            ChunkExtra::new(state_root, vec![], 0, chain_genesis.gas_limit, 0),
                         );
                     }
 
@@ -395,6 +396,7 @@ impl Chain {
                     header.inner.chunk_mask.clone(),
                     header.inner.gas_used,
                     header.inner.gas_price,
+                    header.inner.rent_paid,
                     header.inner.total_supply,
                 )?;
             }
@@ -1091,6 +1093,7 @@ impl Chain {
             apply_result.validator_proposals,
             apply_result.total_gas_burnt,
             gas_limit,
+            apply_result.total_rent_paid,
         );
         chain_store_update.save_chunk_extra(&block_header.hash, shard_id, chunk_extra);
         // Saving outgoing receipts.
@@ -1626,7 +1629,7 @@ impl<'a> ChainUpdate<'a> {
                     }
                     let gas_limit = chunk.header.inner.gas_limit;
 
-                    // Apply block to runtime.
+                    // Apply transactions and receipts
                     let mut apply_result = self
                         .runtime_adapter
                         .apply_transactions(
@@ -1651,6 +1654,7 @@ impl<'a> ChainUpdate<'a> {
                             apply_result.validator_proposals,
                             apply_result.total_gas_burnt,
                             gas_limit,
+                            apply_result.total_rent_paid,
                         ),
                     );
                     // Save resulting receipts.
@@ -1838,6 +1842,7 @@ impl<'a> ChainUpdate<'a> {
             block.header.inner.chunk_mask.clone(),
             block.header.inner.gas_used,
             block.header.inner.gas_price,
+            block.header.inner.rent_paid,
             block.header.inner.total_supply,
         )?;
 

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -428,6 +428,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         _validator_mask: Vec<bool>,
         _gas_used: Gas,
         _gas_price: Balance,
+        _rent_paid: Balance,
         _total_supply: Balance,
     ) -> Result<(), Error> {
         Ok(())

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -232,6 +232,7 @@ pub trait RuntimeAdapter: Send + Sync {
         validator_mask: Vec<bool>,
         gas_used: Gas,
         gas_price: Balance,
+        rent_paid: Balance,
         total_supply: Balance,
     ) -> Result<(), Error>;
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -24,7 +24,9 @@ use near_primitives::sharding::{
     ShardChunkHeaderInner, ShardProof,
 };
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockIndex, EpochId, Gas, ShardId, ValidatorStake};
+use near_primitives::types::{
+    AccountId, Balance, BlockIndex, EpochId, Gas, ShardId, ValidatorStake,
+};
 use near_store::{Store, COL_CHUNKS, COL_CHUNK_ONE_PARTS};
 
 pub use crate::types::Error;
@@ -712,6 +714,7 @@ impl ShardsManager {
         shard_id: ShardId,
         gas_used: Gas,
         gas_limit: Gas,
+        rent_paid: Balance,
         validator_proposals: Vec<ValidatorStake>,
         transactions: &Vec<SignedTransaction>,
         receipts: &Vec<Receipt>,
@@ -730,6 +733,7 @@ impl ShardsManager {
             data_parts,
             gas_used,
             gas_limit,
+            rent_paid,
             tx_root,
             validator_proposals,
             transactions,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -359,6 +359,7 @@ impl Client {
             shard_id,
             chunk_extra.gas_used,
             chunk_extra.gas_limit,
+            chunk_extra.rent_paid,
             chunk_extra.validator_proposals.clone(),
             &filtered_transactions,
             &receipts,

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -113,6 +113,7 @@ fn create_block_with_invalid_chunk(
         12,
         0,
         0,
+        0,
         MerkleHash::default(),
         vec![],
         &vec![],

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -153,6 +153,7 @@ impl EpochManager {
         let mut block_validator_tracker = HashMap::new();
         let mut chunk_validator_tracker = HashMap::new();
         let mut total_gas_used = 0;
+        let mut total_storage_rent = 0;
 
         let epoch_info = self.get_epoch_info(epoch_id)?.clone();
 
@@ -195,6 +196,7 @@ impl EpochManager {
             }
 
             total_gas_used += info.gas_used;
+            total_storage_rent += info.rent_paid;
 
             hash = info.prev_hash;
         }
@@ -227,6 +229,7 @@ impl EpochManager {
             validator_kickout,
             validator_online_ratio,
             total_gas_used,
+            total_storage_rent,
         })
     }
 
@@ -244,6 +247,7 @@ impl EpochManager {
             validator_kickout,
             validator_online_ratio,
             total_gas_used,
+            total_storage_rent,
         } = self.collect_blocks_info(&block_info.epoch_id, last_block_hash)?;
         let next_epoch_id = self.get_next_epoch_id(last_block_hash)?;
         let next_epoch_info = self.get_epoch_info(&next_epoch_id)?.clone();
@@ -255,6 +259,7 @@ impl EpochManager {
             validator_online_ratio,
             total_gas_used,
             block_info.gas_price,
+            total_storage_rent,
             block_info.total_supply,
         );
         let next_next_epoch_info = match proposals_to_epoch_info(
@@ -999,6 +1004,7 @@ mod tests {
                     slashed,
                     0,
                     DEFAULT_GAS_PRICE,
+                    0,
                     DEFAULT_TOTAL_SUPPLY,
                 ),
                 [0; 32],
@@ -1103,6 +1109,7 @@ mod tests {
                     slashed: Default::default(),
                     gas_used: 0,
                     gas_price: DEFAULT_GAS_PRICE,
+                    rent_paid: 0,
                     total_supply,
                 },
                 rng_seed,
@@ -1121,6 +1128,7 @@ mod tests {
                     slashed: Default::default(),
                     gas_used: 10,
                     gas_price: DEFAULT_GAS_PRICE,
+                    rent_paid: 10,
                     total_supply,
                 },
                 rng_seed,
@@ -1139,6 +1147,7 @@ mod tests {
                     slashed: Default::default(),
                     gas_used: 10,
                     gas_price: DEFAULT_GAS_PRICE,
+                    rent_paid: 10,
                     total_supply,
                 },
                 rng_seed,
@@ -1151,6 +1160,7 @@ mod tests {
             validator_online_ratio,
             20,
             DEFAULT_GAS_PRICE,
+            20,
             total_supply,
         );
         let test2_reward = *validator_reward.get("test2").unwrap();
@@ -1202,6 +1212,7 @@ mod tests {
                     slashed: Default::default(),
                     gas_used: 0,
                     gas_price: DEFAULT_GAS_PRICE,
+                    rent_paid: 0,
                     total_supply,
                 },
                 rng_seed,
@@ -1220,6 +1231,7 @@ mod tests {
                     slashed: Default::default(),
                     gas_used: 10,
                     gas_price: DEFAULT_GAS_PRICE,
+                    rent_paid: 10,
                     total_supply,
                 },
                 rng_seed,
@@ -1238,6 +1250,7 @@ mod tests {
                     slashed: Default::default(),
                     gas_used: 10,
                     gas_price: DEFAULT_GAS_PRICE,
+                    rent_paid: 10,
                     total_supply,
                 },
                 rng_seed,
@@ -1249,6 +1262,7 @@ mod tests {
             validator_online_ratio,
             20,
             DEFAULT_GAS_PRICE,
+            20,
             total_supply,
         );
         let test2_reward = *validator_reward.get("test2").unwrap();

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -173,6 +173,7 @@ pub fn record_block(
                 HashSet::default(),
                 0,
                 DEFAULT_GAS_PRICE,
+                0,
                 DEFAULT_TOTAL_SUPPLY,
             ),
             [0; 32],

--- a/chain/epoch_manager/src/types.rs
+++ b/chain/epoch_manager/src/types.rs
@@ -65,8 +65,13 @@ pub struct BlockInfo {
     pub proposals: Vec<ValidatorStake>,
     pub chunk_mask: Vec<bool>,
     pub slashed: HashSet<AccountId>,
+    /// Total gas used in this block.
     pub gas_used: Gas,
+    /// Current gas price.
     pub gas_price: Balance,
+    /// Total rent paid in this block.
+    pub rent_paid: Balance,
+    /// Total supply at this block.
     pub total_supply: Balance,
 }
 
@@ -79,6 +84,7 @@ impl BlockInfo {
         slashed: HashSet<AccountId>,
         gas_used: Gas,
         gas_price: Balance,
+        rent_paid: Balance,
         total_supply: Balance,
     ) -> Self {
         Self {
@@ -89,6 +95,7 @@ impl BlockInfo {
             slashed,
             gas_used,
             gas_price,
+            rent_paid,
             total_supply,
             // These values are not set. This code is suboptimal
             epoch_first_block: CryptoHash::default(),
@@ -172,4 +179,5 @@ pub struct EpochSummary {
     pub validator_kickout: HashSet<AccountId>,
     pub validator_online_ratio: HashMap<AccountId, (u64, u64)>,
     pub total_gas_used: Gas,
+    pub total_storage_rent: Balance,
 }

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -9,7 +9,7 @@ use crate::hash::{hash, CryptoHash};
 use crate::merkle::{merklize, MerklePath};
 use crate::receipt::Receipt;
 use crate::transaction::SignedTransaction;
-use crate::types::{BlockIndex, Gas, MerkleHash, ShardId, ValidatorStake};
+use crate::types::{Balance, BlockIndex, Gas, MerkleHash, ShardId, ValidatorStake};
 
 #[derive(BorshSerialize, BorshDeserialize, Hash, Eq, PartialEq, Clone, Debug, Default)]
 pub struct ChunkHash(pub CryptoHash);
@@ -34,6 +34,8 @@ pub struct ShardChunkHeaderInner {
     pub gas_used: Gas,
     /// Gas limit voted by validators.
     pub gas_limit: Gas,
+    /// Rent paid in the previous chunk
+    pub rent_paid: Balance,
     /// Outgoing receipts merkle root.
     pub outgoing_receipts_root: CryptoHash,
     /// Tx merkle root.
@@ -77,6 +79,7 @@ impl ShardChunkHeader {
         shard_id: ShardId,
         gas_used: Gas,
         gas_limit: Gas,
+        rent_paid: Balance,
         outgoing_receipts_root: CryptoHash,
         tx_root: CryptoHash,
         validator_proposals: Vec<ValidatorStake>,
@@ -91,6 +94,7 @@ impl ShardChunkHeader {
             shard_id,
             gas_used,
             gas_limit,
+            rent_paid,
             outgoing_receipts_root,
             tx_root,
             validator_proposals,
@@ -187,6 +191,7 @@ impl EncodedShardChunk {
         data_parts: usize,
         gas_used: Gas,
         gas_limit: Gas,
+        rent_paid: Balance,
         tx_root: CryptoHash,
         validator_proposals: Vec<ValidatorStake>,
         transactions: &Vec<SignedTransaction>,
@@ -224,6 +229,7 @@ impl EncodedShardChunk {
             shard_id,
             gas_used,
             gas_limit,
+            rent_paid,
             receipts_root,
             tx_root,
             validator_proposals,
@@ -243,6 +249,7 @@ impl EncodedShardChunk {
         shard_id: ShardId,
         gas_used: Gas,
         gas_limit: Gas,
+        rent_paid: Balance,
         receipts_root: CryptoHash,
         tx_root: CryptoHash,
         validator_proposals: Vec<ValidatorStake>,
@@ -267,6 +274,7 @@ impl EncodedShardChunk {
             shard_id,
             gas_used,
             gas_limit,
+            rent_paid,
             receipts_root,
             tx_root,
             validator_proposals,

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -75,6 +75,8 @@ pub struct ChunkExtra {
     pub gas_used: Gas,
     /// Gas limit, allows to increase or decrease limit based on expected time vs real time for computing the chunk.
     pub gas_limit: Gas,
+    /// Total rent paid after processing the current chunk
+    pub rent_paid: Balance,
 }
 
 impl ChunkExtra {
@@ -83,8 +85,9 @@ impl ChunkExtra {
         validator_proposals: Vec<ValidatorStake>,
         gas_used: Gas,
         gas_limit: Gas,
+        rent_paid: Balance,
     ) -> Self {
-        Self { state_root: *state_root, validator_proposals, gas_used, gas_limit }
+        Self { state_root: *state_root, validator_proposals, gas_used, gas_limit, rent_paid }
     }
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -293,6 +293,8 @@ pub struct BlockHeaderView {
     #[serde(with = "u128_dec_format")]
     pub gas_price: Balance,
     #[serde(with = "u128_dec_format")]
+    pub rent_paid: Balance,
+    #[serde(with = "u128_dec_format")]
     pub total_supply: Balance,
     pub signature: Signature,
 }
@@ -323,6 +325,7 @@ impl From<BlockHeader> for BlockHeaderView {
             gas_used: header.inner.gas_used,
             gas_limit: header.inner.gas_limit,
             gas_price: header.inner.gas_price,
+            rent_paid: header.inner.rent_paid,
             total_supply: header.inner.total_supply,
             signature: header.signature,
         }
@@ -355,6 +358,7 @@ impl From<BlockHeaderView> for BlockHeader {
                 gas_price: view.gas_price,
                 gas_used: view.gas_used,
                 total_supply: view.total_supply,
+                rent_paid: view.rent_paid,
             },
             signature: view.signature,
             hash: CryptoHash::default(),
@@ -375,6 +379,8 @@ pub struct ChunkHeaderView {
     pub shard_id: ShardId,
     pub gas_used: Gas,
     pub gas_limit: Gas,
+    #[serde(with = "u128_dec_format")]
+    pub rent_paid: Balance,
     pub outgoing_receipts_root: CryptoHashView,
     pub tx_root: CryptoHashView,
     pub validator_proposals: Vec<ValidatorStakeView>,
@@ -393,6 +399,7 @@ impl From<ShardChunkHeader> for ChunkHeaderView {
             shard_id: chunk.inner.shard_id,
             gas_used: chunk.inner.gas_used,
             gas_limit: chunk.inner.gas_limit,
+            rent_paid: chunk.inner.rent_paid,
             outgoing_receipts_root: chunk.inner.outgoing_receipts_root.into(),
             tx_root: chunk.inner.tx_root.into(),
             validator_proposals: chunk
@@ -418,6 +425,7 @@ impl From<ChunkHeaderView> for ShardChunkHeader {
                 shard_id: view.shard_id,
                 gas_used: view.gas_used,
                 gas_limit: view.gas_limit,
+                rent_paid: view.rent_paid,
                 outgoing_receipts_root: view.outgoing_receipts_root.into(),
                 tx_root: view.tx_root.into(),
                 validator_proposals: view.validator_proposals.into_iter().map(Into::into).collect(),

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -466,6 +466,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         chunk_mask: Vec<bool>,
         gas_used: Gas,
         gas_price: Balance,
+        rent_paid: Balance,
         total_supply: Balance,
     ) -> Result<(), Error> {
         // Check that genesis block doesn't have any proposals.
@@ -485,6 +486,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             slashed,
             gas_used,
             gas_price,
+            rent_paid,
             total_supply,
         );
         // TODO: add randomness here
@@ -888,6 +890,7 @@ mod test {
                     vec![],
                     0,
                     genesis_config.gas_price,
+                    0,
                     genesis_config.total_supply,
                 )
                 .unwrap();
@@ -941,6 +944,7 @@ mod test {
                     chunk_mask,
                     0,
                     self.runtime.genesis_config.gas_price,
+                    0,
                     self.runtime.genesis_config.total_supply,
                 )
                 .unwrap();
@@ -1331,6 +1335,7 @@ mod test {
                     vec![true],
                     0,
                     new_env.runtime.genesis_config.gas_price,
+                    0,
                     new_env.runtime.genesis_config.total_supply,
                 )
                 .unwrap();

--- a/near/src/shard_tracker.rs
+++ b/near/src/shard_tracker.rs
@@ -291,6 +291,7 @@ mod tests {
                     HashSet::default(),
                     0,
                     DEFAULT_GAS_PRICE,
+                    0,
                     DEFAULT_TOTAL_SUPPLY,
                 ),
                 [0; 32],

--- a/runtime/near-vm-logic/tests/test_storage_usage.rs
+++ b/runtime/near-vm-logic/tests/test_storage_usage.rs
@@ -45,7 +45,6 @@ fn test_storage_remove() {
     let mut memory = MockedMemory::default();
     let mut logic = VMLogic::new(&mut ext, context, &config, &promise_results, &mut memory);
 
-    let data_record_cost = config.runtime_fees.storage_usage_config.data_record_cost;
     let key = b"foo";
     let val = b"bar";
 

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -242,6 +242,7 @@ fn replay_chain(
                     vec![],
                     header.inner.gas_used,
                     header.inner.gas_price,
+                    header.inner.rent_paid,
                     header.inner.total_supply,
                 )
                 .unwrap();


### PR DESCRIPTION
Fixes #1281. Account for storage rent in economics calculations. Economics is now fully implemented except for voting on gas limit, which we do not plan to support before mainnet.