### PR TITLE
Remove block transactions

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -800,3 +800,17 @@ pub fn display_chain(chain: &mut Chain, tail: bool) {
         }
     }
 }
+
+impl ChainGenesis {
+    pub fn test() -> Self {
+        ChainGenesis {
+            time: Utc::now(),
+            gas_limit: 1_000_000,
+            gas_price: 1,
+            total_supply: 1_000_000_000,
+            max_inflation_rate: 0,
+            gas_price_adjustment_rate: 0,
+            transaction_validity_period: 100,
+        }
+    }
+}

--- a/chain/chain/tests/simple_chain.rs
+++ b/chain/chain/tests/simple_chain.rs
@@ -1,10 +1,7 @@
-use near_chain::test_utils::{setup, setup_with_tx_validity_period};
+use near_chain::test_utils::setup;
 use near_chain::{Block, ErrorKind, Provenance};
-use near_crypto::{KeyType, Signature, Signer};
-use near_primitives::hash::hash;
+use near_crypto::Signer;
 use near_primitives::test_utils::init_test_logger;
-use near_primitives::transaction::{SignedTransaction, Transaction};
-use near_primitives::types::EpochId;
 use std::collections::HashMap;
 
 #[test]
@@ -43,7 +40,6 @@ fn build_chain_with_orhpans() {
         10,
         last_block.chunks.clone(),
         last_block.header.inner.epoch_id.clone(),
-        vec![],
         HashMap::default(),
         0,
         Some(0),
@@ -96,72 +92,6 @@ fn build_chain_with_skips_and_forks() {
     assert!(chain.process_block(&None, b5, Provenance::PRODUCED, |_| {}, |_| {}).is_ok());
     assert!(chain.get_header_by_height(1).is_err());
     assert_eq!(chain.get_header_by_height(5).unwrap().inner.height, 5);
-}
-
-#[test]
-fn test_apply_expired_tx() {
-    init_test_logger();
-    let (mut chain, _, signer) = setup_with_tx_validity_period(0);
-    let genesis = chain.get_block_by_height(0).unwrap().clone();
-    let b1 = Block::empty(&genesis, signer.clone());
-    let tx = SignedTransaction::new(
-        Signature::empty(KeyType::ED25519),
-        Transaction {
-            signer_id: "".to_string(),
-            public_key: signer.public_key(),
-            nonce: 0,
-            receiver_id: "".to_string(),
-            block_hash: b1.hash(),
-            actions: vec![],
-        },
-    );
-    let _b2 = Block::produce(
-        &chain.genesis(),
-        2,
-        genesis.chunks.clone(),
-        EpochId::default(),
-        vec![tx],
-        HashMap::default(),
-        0,
-        Some(0),
-        signer.clone(),
-    );
-    assert!(chain.process_block(&None, b1, Provenance::PRODUCED, |_| {}, |_| {}).is_ok());
-    // TODO: MOO add shard tracking.
-    //    assert!(chain.process_block(&None, b2, Provenance::PRODUCED, |_| {}, |_| {}).is_err());
-}
-
-#[test]
-fn test_tx_wrong_fork() {
-    init_test_logger();
-    let (mut chain, _, signer) = setup();
-    let genesis = chain.get_block_by_height(0).unwrap();
-    let b1 = Block::empty(genesis, signer.clone());
-    let tx = SignedTransaction::new(
-        Signature::empty(KeyType::ED25519),
-        Transaction {
-            signer_id: "".to_string(),
-            public_key: signer.public_key(),
-            nonce: 0,
-            receiver_id: "".to_string(),
-            block_hash: hash(&[2]),
-            actions: vec![],
-        },
-    );
-    let _b2 = Block::produce(
-        &genesis.header,
-        2,
-        genesis.chunks.clone(),
-        EpochId::default(),
-        vec![tx],
-        HashMap::default(),
-        0,
-        Some(0),
-        signer.clone(),
-    );
-    assert!(chain.process_block(&None, b1, Provenance::PRODUCED, |_| {}, |_| {}).is_ok());
-    // TODO: MOO add shard tracking.
-    //    assert!(chain.process_block(&None, b2, Provenance::PRODUCED, |_| {}, |_| {}).is_err());
 }
 
 /// Verifies that the block at height are updated correctly when blocks from different forks are

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use cached::{Cached, SizedCache};
 use chrono::Utc;
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 
 use near_chain::types::{
     AcceptedBlock, LatestKnown, ReceiptResponse, ValidatorSignatureVerificationResult,
@@ -20,19 +20,20 @@ use near_chain::{
 use near_chunks::{NetworkAdapter, ShardsManager};
 use near_crypto::Signature;
 use near_network::types::{ChunkPartMsg, PeerId, ReasonForBan};
-use near_network::NetworkRequests;
+use near_network::{NetworkClientResponses, NetworkRequests};
 use near_primitives::block::{Block, BlockHeader};
 use near_primitives::hash::CryptoHash;
+use near_primitives::merkle::merklize;
 use near_primitives::sharding::{ChunkOnePart, ShardChunkHeader};
+use near_primitives::transaction::{check_tx_history, SignedTransaction};
 use near_primitives::types::{AccountId, BlockIndex, EpochId, ShardId};
+use near_primitives::unwrap_or_return;
 use near_primitives::utils::to_timestamp;
 use near_store::Store;
 
-use crate::sync::{BlockSync, HeaderSync, StateSync};
+use crate::sync::{BlockSync, HeaderSync, StateSync, StateSyncResult};
 use crate::types::{Error, ShardSyncStatus};
 use crate::{BlockProducer, ClientConfig, SyncStatus};
-use near_primitives::merkle::merklize;
-use near_primitives::transaction::check_tx_history;
 
 /// Block economics config taken from genesis config
 struct BlockEconomicsConfig {
@@ -75,6 +76,9 @@ impl Client {
         network_adapter: Arc<dyn NetworkAdapter>,
         block_producer: Option<BlockProducer>,
     ) -> Result<Self, Error> {
+        // TODO(1364): dedup ClientConfig and ChainGenesis transaction_validity_period field.
+        // Check consistency of two configs that have the same field.
+        assert_eq!(config.transaction_validity_period, chain_genesis.transaction_validity_period);
         let chain = Chain::new(store.clone(), runtime_adapter.clone(), &chain_genesis)?;
         let shards_mgr = ShardsManager::new(
             block_producer.as_ref().map(|x| x.account_id.clone()),
@@ -230,9 +234,6 @@ impl Client {
 
         let prev_header = self.chain.get_block_header(&head.last_block_hash)?;
 
-        // This is kept here in case we want to revive txs on the block level.
-        let transactions = vec![];
-
         // At this point, the previous epoch hash must be available
         let epoch_id = self
             .runtime_adapter
@@ -252,7 +253,6 @@ impl Client {
             next_height,
             chunks,
             epoch_id,
-            transactions,
             self.approvals.drain().collect(),
             self.block_economics_config.gas_price_adjustment_rate,
             inflation,
@@ -710,5 +710,162 @@ impl Client {
         debug!(target: "client", "Received approval for {} from {}", hash, account_id);
         self.approvals.insert(position, signature.clone());
         true
+    }
+
+    /// Process transaction and either add it to the mempool or return to redirect to another validator.
+    pub fn process_tx(&mut self, tx: SignedTransaction) -> NetworkClientResponses {
+        let head = unwrap_or_return!(self.chain.head(), NetworkClientResponses::NoResponse);
+        let me = self.block_producer.as_ref().map(|bp| &bp.account_id);
+        let shard_id = self.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id);
+        if !check_tx_history(
+            self.chain.get_block_header(&tx.transaction.block_hash).ok(),
+            head.height,
+            self.config.transaction_validity_period,
+        ) {
+            debug!(target: "client", "Invalid tx: expired or from a different fork -- {:?}", tx);
+            return NetworkClientResponses::InvalidTx(
+                "Transaction has either expired or from a different fork".to_string(),
+            );
+        }
+        let gas_price = unwrap_or_return!(
+            self.chain.get_block_header(&head.last_block_hash),
+            NetworkClientResponses::NoResponse
+        )
+        .inner
+        .gas_price;
+        let state_root = unwrap_or_return!(
+            self.chain.get_chunk_extra(&head.last_block_hash, shard_id),
+            NetworkClientResponses::NoResponse
+        )
+        .state_root
+        .clone();
+
+        match self.runtime_adapter.validate_tx(head.height + 1, gas_price, state_root, tx) {
+            Ok(valid_transaction) => {
+                let active_validator = unwrap_or_return!(self.active_validator(), {
+                    warn!(target: "client", "Me: {:?} Dropping tx: {:?}", me, valid_transaction);
+                    NetworkClientResponses::NoResponse
+                });
+
+                // If I'm not an active validator I should forward tx to next validators.
+                if active_validator {
+                    debug!(
+                        "Recording a transaction. I'm {:?}, {}",
+                        self.block_producer.as_ref().map(|bp| bp.account_id.clone()),
+                        shard_id
+                    );
+                    self.shards_mgr.insert_transaction(shard_id, valid_transaction);
+                    NetworkClientResponses::ValidTx
+                } else {
+                    // TODO(MarX): Forward tx even if I am a validator.
+                    // TODO(MarX): How many validators ahead of current time should we forward tx?
+                    let target_height = head.height + 2;
+
+                    debug!(target: "client",
+                           "{:?} Routing a transaction. {}",
+                           self.block_producer.as_ref().map(|bp| bp.account_id.clone()),
+                           shard_id
+                    );
+
+                    let validator = unwrap_or_return!(
+                        self.runtime_adapter.get_chunk_producer(
+                            &head.epoch_id,
+                            target_height,
+                            shard_id
+                        ),
+                        {
+                            warn!(target: "client", "Me: {:?} Dropping tx: {:?}", me, valid_transaction);
+                            NetworkClientResponses::NoResponse
+                        }
+                    );
+
+                    NetworkClientResponses::ForwardTx(validator, valid_transaction.transaction)
+                }
+            }
+            Err(err) => {
+                debug!(target: "client", "Invalid tx: {:?}", err);
+                NetworkClientResponses::InvalidTx(err.to_string())
+            }
+        }
+    }
+
+    /// Determine if I am a validator in current epoch for specified shard.
+    fn active_validator(&self) -> Result<bool, Error> {
+        let head = self.chain.head()?;
+
+        let account_id = if let Some(bp) = self.block_producer.as_ref() {
+            &bp.account_id
+        } else {
+            return Ok(false);
+        };
+
+        let block_proposers = self
+            .runtime_adapter
+            .get_epoch_block_producers(&head.epoch_id, &head.last_block_hash)
+            .map_err(|e| Error::Other(e.to_string()))?;
+
+        // I am a validator if I am in the assignment for current epoch and I'm not slashed.
+        Ok(block_proposers
+            .into_iter()
+            .find_map(
+                |(validator, slashed)| if &validator == account_id { Some(!slashed) } else { None },
+            )
+            .unwrap_or(false))
+    }
+
+    /// Walks through all the ongoing state syncs for future epochs and processes them
+    pub fn run_catchup(&mut self) -> Result<Vec<AcceptedBlock>, Error> {
+        let me = &self.block_producer.as_ref().map(|x| x.account_id.clone());
+        for (sync_hash, state_sync_info) in self.chain.store().iterate_state_sync_infos() {
+            assert_eq!(sync_hash, state_sync_info.epoch_tail_hash);
+            let network_adapter1 = self.network_adapter.clone();
+
+            let (state_sync, new_shard_sync) = self
+                .catchup_state_syncs
+                .entry(sync_hash)
+                .or_insert_with(|| (StateSync::new(network_adapter1), HashMap::new()));
+
+            debug!(
+                target: "client",
+                "Catchup me: {:?}: sync_hash: {:?}, sync_info: {:?}", me, sync_hash, new_shard_sync
+            );
+
+            match state_sync.run(
+                sync_hash,
+                new_shard_sync,
+                &mut self.chain,
+                &self.runtime_adapter,
+                state_sync_info.shards.iter().map(|tuple| tuple.0).collect(),
+            )? {
+                StateSyncResult::Unchanged => {}
+                StateSyncResult::Changed(fetch_block) => {
+                    assert!(!fetch_block);
+                }
+                StateSyncResult::Completed => {
+                    let accepted_blocks = Arc::new(RwLock::new(vec![]));
+                    let blocks_missing_chunks = Arc::new(RwLock::new(vec![]));
+
+                    self.chain.catchup_blocks(
+                        me,
+                        &sync_hash,
+                        |accepted_block| {
+                            accepted_blocks.write().unwrap().push(accepted_block);
+                        },
+                        |missing_chunks| {
+                            blocks_missing_chunks.write().unwrap().push(missing_chunks)
+                        },
+                    )?;
+
+                    for missing_chunks in blocks_missing_chunks.write().unwrap().drain(..) {
+                        self.shards_mgr.request_chunks(missing_chunks).unwrap();
+                    }
+                    let unwrapped_accepted_blocks =
+                        accepted_blocks.write().unwrap().drain(..).collect();
+                    return Ok(unwrapped_accepted_blocks);
+                }
+            }
+        }
+
+        Ok(vec![])
     }
 }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -27,7 +27,6 @@ use near_network::{
     NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses,
 };
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::transaction::{check_tx_history, SignedTransaction};
 use near_primitives::types::{BlockIndex, EpochId};
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::{from_timestamp, to_timestamp};
@@ -37,9 +36,10 @@ use near_telemetry::TelemetryActor;
 
 use crate::client::Client;
 use crate::info::InfoHelper;
-use crate::sync::{most_weight_peer, StateSync, StateSyncResult};
+use crate::sync::{most_weight_peer, StateSyncResult};
 use crate::types::{
-    BlockProducer, ClientConfig, Error, ShardSyncStatus, Status, StatusSyncInfo, SyncStatus, GetNetworkInfo, NetworkInfoResponse
+    BlockProducer, ClientConfig, Error, GetNetworkInfo, NetworkInfoResponse, ShardSyncStatus,
+    Status, StatusSyncInfo, SyncStatus,
 };
 use crate::{sync, StatusResponse};
 
@@ -186,31 +186,6 @@ impl ClientActor {
             Err(reason_for_ban) => AccountAnnounceVerificationResult::Invalid(reason_for_ban),
         }
     }
-
-    /// Determine if I am a validator in current epoch for specified shard.
-    fn active_validator(&self) -> Result<bool, Error> {
-        let head = self.client.chain.head()?;
-
-        let account_id = if let Some(bp) = self.client.block_producer.as_ref() {
-            &bp.account_id
-        } else {
-            return Ok(false);
-        };
-
-        let block_proposers = self
-            .client
-            .runtime_adapter
-            .get_epoch_block_producers(&head.epoch_id, &head.last_block_hash)
-            .map_err(|e| Error::Other(e.to_string()))?;
-
-        // I am a validator if I am in the assignment for current epoch and I'm not slashed.
-        Ok(block_proposers
-            .into_iter()
-            .find_map(
-                |(validator, slashed)| if &validator == account_id { Some(!slashed) } else { None },
-            )
-            .unwrap_or(false))
-    }
 }
 
 impl Actor for ClientActor {
@@ -241,7 +216,7 @@ impl Handler<NetworkClientMessages> for ClientActor {
 
     fn handle(&mut self, msg: NetworkClientMessages, _ctx: &mut Context<Self>) -> Self::Result {
         match msg {
-            NetworkClientMessages::Transaction(tx) => self.process_tx(tx),
+            NetworkClientMessages::Transaction(tx) => self.client.process_tx(tx),
             NetworkClientMessages::BlockHeader(header, peer_id) => {
                 self.receive_header(header, peer_id)
             }
@@ -307,7 +282,6 @@ impl Handler<NetworkClientMessages> for ClientActor {
                     chunk,
                     chunk_proof,
                     prev_payload,
-                    block_transactions,
                     incoming_receipts_proofs,
                     root_proofs,
                 )) = self.client.chain.get_state_for_shard(shard_id, hash)
@@ -318,7 +292,6 @@ impl Handler<NetworkClientMessages> for ClientActor {
                         chunk,
                         chunk_proof,
                         prev_payload,
-                        block_transactions,
                         incoming_receipts_proofs,
                         root_proofs,
                     });
@@ -331,7 +304,6 @@ impl Handler<NetworkClientMessages> for ClientActor {
                 chunk,
                 chunk_proof,
                 prev_payload,
-                block_transactions,
                 incoming_receipts_proofs,
                 root_proofs,
             }) => {
@@ -372,7 +344,6 @@ impl Handler<NetworkClientMessages> for ClientActor {
                         chunk,
                         chunk_proof,
                         prev_payload,
-                        block_transactions,
                         incoming_receipts_proofs,
                         root_proofs,
                     ) {
@@ -823,84 +794,6 @@ impl ClientActor {
         Ok(headers)
     }
 
-    /// Validate transaction and return transaction information relevant to ordering it in the mempool.
-    fn process_tx(&mut self, tx: SignedTransaction) -> NetworkClientResponses {
-        let head = unwrap_or_return!(self.client.chain.head(), NetworkClientResponses::NoResponse);
-        let me = self.client.block_producer.as_ref().map(|bp| &bp.account_id);
-        let shard_id =
-            self.client.runtime_adapter.account_id_to_shard_id(&tx.transaction.signer_id);
-        if !check_tx_history(
-            self.client.chain.get_block_header(&tx.transaction.block_hash).ok(),
-            head.height,
-            self.client.config.transaction_validity_period,
-        ) {
-            debug!(target: "client", "Invalid tx: expired or from a different fork -- {:?}", tx);
-            return NetworkClientResponses::InvalidTx(
-                "Transaction has either expired or from a different fork".to_string(),
-            );
-        }
-        let gas_price = unwrap_or_return!(
-            self.client.chain.get_block_header(&head.last_block_hash),
-            NetworkClientResponses::NoResponse
-        )
-        .inner
-        .gas_price;
-        let state_root = unwrap_or_return!(
-            self.client.chain.get_chunk_extra(&head.last_block_hash, shard_id),
-            NetworkClientResponses::NoResponse
-        )
-        .state_root
-        .clone();
-
-        match self.client.runtime_adapter.validate_tx(head.height + 1, gas_price, state_root, tx) {
-            Ok(valid_transaction) => {
-                let active_validator = unwrap_or_return!(self.active_validator(), {
-                    warn!(target: "client", "Me: {:?} Dropping tx: {:?}", me, valid_transaction);
-                    NetworkClientResponses::NoResponse
-                });
-
-                // If I'm not an active validator I should forward tx to next validators.
-                if active_validator {
-                    debug!(
-                        "Recording a transaction. I'm {:?}, {}",
-                        self.client.block_producer.as_ref().map(|bp| bp.account_id.clone()),
-                        shard_id
-                    );
-                    self.client.shards_mgr.insert_transaction(shard_id, valid_transaction);
-                    NetworkClientResponses::ValidTx
-                } else {
-                    // TODO(MarX): Forward tx even if I am a validator.
-                    // TODO(MarX): How many validators ahead of current time should we forward tx?
-                    let target_height = head.height + 2;
-
-                    debug!(target: "client",
-                           "{:?} Routing a transaction. {}",
-                           self.client.block_producer.as_ref().map(|bp| bp.account_id.clone()),
-                           shard_id
-                    );
-
-                    let validator = unwrap_or_return!(
-                        self.client.runtime_adapter.get_chunk_producer(
-                            &head.epoch_id,
-                            target_height,
-                            shard_id
-                        ),
-                        {
-                            warn!(target: "client", "Me: {:?} Dropping tx: {:?}", me, valid_transaction);
-                            NetworkClientResponses::NoResponse
-                        }
-                    );
-
-                    NetworkClientResponses::ForwardTx(validator, valid_transaction.transaction)
-                }
-            }
-            Err(err) => {
-                debug!(target: "client", "Invalid transaction: {:?}", err);
-                NetworkClientResponses::InvalidTx(err.to_string())
-            }
-        }
-    }
-
     /// Check whether need to (continue) sync.
     fn needs_syncing(&self) -> Result<(bool, u64), near_chain::Error> {
         let head = self.client.chain.head()?;
@@ -965,68 +858,13 @@ impl ClientActor {
         Ok(sync_hash)
     }
 
-    /// Walks through all the ongoing state syncs for future epochs and processes them
-    fn run_catchup(&mut self) -> Result<(), Error> {
-        let me = &self.client.block_producer.as_ref().map(|x| x.account_id.clone());
-        for (sync_hash, state_sync_info) in self.client.chain.store().iterate_state_sync_infos() {
-            assert_eq!(sync_hash, state_sync_info.epoch_tail_hash);
-            let network_adapter1 = self.network_adapter.clone();
-
-            let (state_sync, new_shard_sync) = self
-                .client
-                .catchup_state_syncs
-                .entry(sync_hash)
-                .or_insert_with(|| (StateSync::new(network_adapter1), HashMap::new()));
-
-            debug!(
-                target: "client",
-                "Catchup me: {:?}: sync_hash: {:?}, sync_info: {:?}", me, sync_hash, new_shard_sync
-            );
-
-            match state_sync.run(
-                sync_hash,
-                new_shard_sync,
-                &mut self.client.chain,
-                &self.client.runtime_adapter,
-                state_sync_info.shards.iter().map(|tuple| tuple.0).collect(),
-            )? {
-                StateSyncResult::Unchanged => {}
-                StateSyncResult::Changed(fetch_block) => {
-                    assert!(!fetch_block);
-                }
-                StateSyncResult::Completed => {
-                    let accepted_blocks = Arc::new(RwLock::new(vec![]));
-                    let blocks_missing_chunks = Arc::new(RwLock::new(vec![]));
-
-                    self.client.chain.catchup_blocks(
-                        me,
-                        &sync_hash,
-                        |accepted_block| {
-                            accepted_blocks.write().unwrap().push(accepted_block);
-                        },
-                        |missing_chunks| {
-                            blocks_missing_chunks.write().unwrap().push(missing_chunks)
-                        },
-                    )?;
-
-                    self.process_accepted_blocks(
-                        accepted_blocks.write().unwrap().drain(..).collect(),
-                    );
-                    for missing_chunks in blocks_missing_chunks.write().unwrap().drain(..) {
-                        self.client.shards_mgr.request_chunks(missing_chunks).unwrap();
-                    }
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     /// Runs catchup on repeat, if this client is a validator.
     fn catchup(&mut self, ctx: &mut Context<ClientActor>) {
         if let Some(_) = self.client.block_producer {
-            match self.run_catchup() {
-                Ok(_) => {}
+            match self.client.run_catchup() {
+                Ok(accepted_blocks) => {
+                    self.process_accepted_blocks(accepted_blocks);
+                }
                 Err(err) => {
                     error!(target: "client", "{:?} Error occurred during catchup for the next epoch: {:?}", self.client.block_producer.as_ref().map(|bp| bp.account_id.clone()), err)
                 }

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -20,9 +20,10 @@ use near_network::{
 use near_primitives::block::Block;
 use near_primitives::types::{BlockIndex, ShardId};
 use near_store::test_utils::create_test_store;
+use near_store::Store;
 use near_telemetry::TelemetryActor;
 
-use crate::{BlockProducer, ClientActor, ClientConfig, ViewClientActor};
+use crate::{BlockProducer, Client, ClientActor, ClientConfig, ViewClientActor};
 
 pub type NetworkMock = Mocker<PeerManagerActor>;
 
@@ -396,4 +397,27 @@ impl BlockProducer {
     pub fn test(seed: &str) -> Self {
         Arc::new(InMemorySigner::from_seed(seed, KeyType::ED25519, seed)).into()
     }
+}
+
+pub fn setup_client(
+    store: Arc<Store>,
+    validators: Vec<Vec<&str>>,
+    validator_groups: u64,
+    num_shards: ShardId,
+    account_id: &str,
+    network_adapter: Arc<dyn NetworkAdapter>,
+    chain_genesis: ChainGenesis,
+) -> Client {
+    let num_validators = validators.iter().map(|x| x.len()).sum();
+    let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(
+        store.clone(),
+        validators.into_iter().map(|inner| inner.into_iter().map(Into::into).collect()).collect(),
+        validator_groups,
+        num_shards,
+    ));
+    let signer = Arc::new(InMemorySigner::from_seed(account_id, KeyType::ED25519, account_id));
+    let mut config = ClientConfig::test(true, 10, num_validators);
+    config.transaction_validity_period = chain_genesis.transaction_validity_period;
+    Client::new(config, store, chain_genesis, runtime_adapter, network_adapter, Some(signer.into()))
+        .unwrap()
 }

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -5,21 +5,25 @@ use std::sync::{Arc, RwLock};
 use actix::System;
 use futures::{future, Future};
 
-use near_chain::{Block, BlockApproval};
+use near_chain::{Block, BlockApproval, ChainGenesis, Provenance};
 use near_chunks::{ChunkStatus, ShardsManager};
-use near_client::test_utils::setup_mock;
-use near_client::GetBlock;
-use near_crypto::{InMemorySigner, KeyType};
+use near_client::test_utils::{setup_client, setup_mock, MockNetworkAdapter};
+use near_client::{Client, GetBlock};
+use near_crypto::{InMemorySigner, KeyType, Signature, Signer};
 use near_network::test_utils::wait_or_panic;
 use near_network::types::{FullPeerInfo, NetworkInfo, PeerChainInfo};
-use near_network::{NetworkClientMessages, NetworkRequests, NetworkResponses, PeerInfo};
+use near_network::{
+    NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses, PeerInfo,
+};
 use near_primitives::block::BlockHeader;
-use near_primitives::hash::hash;
+use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::merklize;
 use near_primitives::sharding::EncodedShardChunk;
 use near_primitives::test_utils::init_test_logger;
-use near_primitives::transaction::SignedTransaction;
+use near_primitives::transaction::{SignedTransaction, Transaction};
 use near_primitives::types::{EpochId, MerkleHash};
+use near_store::test_utils::create_test_store;
+use std::time::Duration;
 
 /// Runs block producing client and stops after network mock received two blocks.
 #[test]
@@ -127,7 +131,6 @@ fn receive_network_block() {
                 last_block.header.height + 1,
                 last_block.chunks.into_iter().map(Into::into).collect(),
                 EpochId::default(),
-                vec![],
                 HashMap::default(),
                 0,
                 None,
@@ -177,7 +180,6 @@ fn receive_network_block_header() {
                 last_block.header.height + 1,
                 last_block.chunks.into_iter().map(Into::into).collect(),
                 EpochId::default(),
-                vec![],
                 HashMap::default(),
                 0,
                 None,
@@ -223,7 +225,6 @@ fn produce_block_with_approvals() {
                 last_block.header.height + 1,
                 last_block.chunks.into_iter().map(Into::into).collect(),
                 EpochId::default(),
-                vec![],
                 HashMap::default(),
                 0,
                 Some(0),
@@ -284,7 +285,6 @@ fn invalid_blocks() {
                 last_block.header.height + 1,
                 last_block.chunks.iter().cloned().map(Into::into).collect(),
                 EpochId::default(),
-                vec![],
                 HashMap::default(),
                 0,
                 Some(0),
@@ -302,7 +302,6 @@ fn invalid_blocks() {
                 block.header.inner.height + 1,
                 block.chunks.clone(),
                 EpochId::default(),
-                vec![],
                 HashMap::default(),
                 0,
                 Some(0),
@@ -315,7 +314,6 @@ fn invalid_blocks() {
                 last_block.header.height + 1,
                 last_block.chunks.into_iter().map(Into::into).collect(),
                 EpochId::default(),
-                vec![],
                 HashMap::default(),
                 0,
                 Some(0),
@@ -374,7 +372,7 @@ fn client_sync_headers() {
                             genesis: Default::default(),
                             height: 5,
                             total_weight: 100.into(),
-                        }
+                        },
                     }],
                     num_active_peers: 1,
                     peer_max_count: 1,
@@ -403,4 +401,67 @@ fn client_sync_headers() {
         wait_or_panic(2000);
     })
     .unwrap();
+}
+
+fn produce_blocks(client: &mut Client, num: u64) {
+    for i in 1..num {
+        let b = client.produce_block(i, Duration::from_millis(100)).unwrap().unwrap();
+        let (mut accepted_blocks, _) = client.process_block(b, Provenance::PRODUCED);
+        let more_accepted_blocks = client.run_catchup().unwrap();
+        accepted_blocks.extend(more_accepted_blocks);
+        for accepted_block in accepted_blocks {
+            client.on_block_accepted(
+                accepted_block.hash,
+                accepted_block.status,
+                accepted_block.provenance,
+            );
+        }
+    }
+}
+
+#[test]
+fn test_process_invalid_tx() {
+    init_test_logger();
+    let store = create_test_store();
+    let network_adapter = Arc::new(MockNetworkAdapter::default());
+    let mut chain_genesis = ChainGenesis::test();
+    chain_genesis.transaction_validity_period = 10;
+    let mut client =
+        setup_client(store, vec![vec!["test1"]], 1, 1, "test1", network_adapter, chain_genesis);
+    let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
+    let tx = SignedTransaction::new(
+        Signature::empty(KeyType::ED25519),
+        Transaction {
+            signer_id: "".to_string(),
+            public_key: signer.public_key(),
+            nonce: 0,
+            receiver_id: "".to_string(),
+            block_hash: client.chain.genesis().hash(),
+            actions: vec![],
+        },
+    );
+    produce_blocks(&mut client, 12);
+    assert_eq!(
+        client.process_tx(tx),
+        NetworkClientResponses::InvalidTx(
+            "Transaction has either expired or from a different fork".to_string()
+        )
+    );
+    let tx2 = SignedTransaction::new(
+        Signature::empty(KeyType::ED25519),
+        Transaction {
+            signer_id: "".to_string(),
+            public_key: signer.public_key(),
+            nonce: 0,
+            receiver_id: "".to_string(),
+            block_hash: CryptoHash::default(),
+            actions: vec![],
+        },
+    );
+    assert_eq!(
+        client.process_tx(tx2),
+        NetworkClientResponses::InvalidTx(
+            "Transaction has either expired or from a different fork".to_string()
+        )
+    );
 }

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -28,7 +28,6 @@ fn test_block() {
                     8, 151, 20, 133, 110, 226, 51, 179, 144, 42, 89, 29, 13, 95, 41, 37
                 ]
             );
-            assert_eq!(res.header.tx_root.0, &[0; 32]);
             assert!(res.header.timestamp > 0);
             assert_eq!(res.header.approval_mask.len(), 0);
             assert_eq!(res.header.approval_sigs.len(), 0);

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -676,7 +676,6 @@ pub struct StateResponseInfo {
     pub chunk: ShardChunk,
     pub chunk_proof: MerklePath,
     pub prev_payload: Vec<u8>,
-    pub block_transactions: Vec<SignedTransaction>,
     pub incoming_receipts_proofs: Vec<ReceiptProofResponse>,
     pub root_proofs: Vec<Vec<RootProof>>,
 }
@@ -719,6 +718,7 @@ pub enum NetworkClientMessages {
 }
 
 // TODO(#1313): Use Box
+#[derive(Eq, PartialEq, Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum NetworkClientResponses {
     /// No response.

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -34,7 +34,6 @@ fn create_transaction() -> SignedTransaction {
 }
 
 fn create_block() -> Block {
-    let transactions = (0..1000).map(|_| create_transaction()).collect::<Vec<_>>();
     let genesis = Block::genesis(vec![MerkleHash::default()], Utc::now(), 1, 1_000, 1_000, 1_000);
     let signer = Arc::new(InMemorySigner::from_random("".to_string(), KeyType::ED25519));
     Block::produce(
@@ -42,7 +41,6 @@ fn create_block() -> Block {
         10,
         vec![genesis.chunks[0].clone()],
         EpochId::default(),
-        transactions,
         HashMap::default(),
         0,
         Some(0),

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -9,7 +9,6 @@ use near_crypto::{EmptySigner, KeyType, PublicKey, Signature, Signer};
 use crate::hash::{hash, CryptoHash};
 use crate::merkle::merklize;
 use crate::sharding::{ChunkHashHeight, ShardChunkHeader};
-use crate::transaction::SignedTransaction;
 use crate::types::{Balance, BlockIndex, EpochId, Gas, MerkleHash, ShardId, ValidatorStake};
 use crate::utils::{from_timestamp, to_timestamp};
 
@@ -24,8 +23,6 @@ pub struct BlockHeaderInner {
     pub prev_hash: CryptoHash,
     /// Root hash of the state at the previous block.
     pub prev_state_root: MerkleHash,
-    /// Root hash of the transactions in the given block.
-    pub tx_root: MerkleHash,
     /// Root hash of the chunk receipts in the given block.
     pub chunk_receipts_root: MerkleHash,
     /// Root hash of the chunk headers in the given block.
@@ -62,7 +59,6 @@ impl BlockHeaderInner {
         epoch_id: EpochId,
         prev_hash: CryptoHash,
         prev_state_root: MerkleHash,
-        tx_root: MerkleHash,
         chunk_receipts_root: MerkleHash,
         chunk_headers_root: MerkleHash,
         chunk_tx_root: MerkleHash,
@@ -83,7 +79,6 @@ impl BlockHeaderInner {
             epoch_id,
             prev_hash,
             prev_state_root,
-            tx_root,
             chunk_receipts_root,
             chunk_headers_root,
             chunk_tx_root,
@@ -125,7 +120,6 @@ impl BlockHeader {
         height: BlockIndex,
         prev_hash: CryptoHash,
         prev_state_root: MerkleHash,
-        tx_root: MerkleHash,
         chunk_receipts_root: MerkleHash,
         chunk_headers_root: MerkleHash,
         chunk_tx_root: MerkleHash,
@@ -148,7 +142,6 @@ impl BlockHeader {
             epoch_id,
             prev_hash,
             prev_state_root,
-            tx_root,
             chunk_receipts_root,
             chunk_headers_root,
             chunk_tx_root,
@@ -183,7 +176,6 @@ impl BlockHeader {
             EpochId::default(),
             CryptoHash::default(),
             state_root,
-            MerkleHash::default(),
             chunk_receipts_root,
             chunk_headers_root,
             chunk_tx_root,
@@ -221,7 +213,6 @@ impl BlockHeader {
 pub struct Block {
     pub header: BlockHeader,
     pub chunks: Vec<ShardChunkHeader>,
-    pub transactions: Vec<SignedTransaction>,
 }
 
 impl Block {
@@ -266,7 +257,6 @@ impl Block {
                 initial_total_supply,
             ),
             chunks,
-            transactions: vec![],
         }
     }
 
@@ -276,7 +266,6 @@ impl Block {
         height: BlockIndex,
         chunks: Vec<ShardChunkHeader>,
         epoch_id: EpochId,
-        transactions: Vec<SignedTransaction>,
         mut approvals: HashMap<usize, Signature>,
         gas_price_adjustment_rate: u8,
         inflation: Option<Balance>,
@@ -328,7 +317,6 @@ impl Block {
                 height,
                 prev.hash(),
                 Block::compute_state_root(&chunks),
-                Block::compute_tx_root(&transactions),
                 Block::compute_chunk_receipts_root(&chunks),
                 Block::compute_chunk_headers_root(&chunks),
                 Block::compute_chunk_tx_root(&chunks),
@@ -348,7 +336,6 @@ impl Block {
                 signer,
             ),
             chunks,
-            transactions,
         }
     }
 
@@ -357,10 +344,6 @@ impl Block {
             &chunks.iter().map(|chunk| chunk.inner.prev_state_root).collect::<Vec<CryptoHash>>(),
         )
         .0
-    }
-
-    pub fn compute_tx_root(transactions: &Vec<SignedTransaction>) -> CryptoHash {
-        merklize(&transactions.iter().map(|tx| tx.get_hash()).collect::<Vec<CryptoHash>>()).0
     }
 
     pub fn compute_chunk_receipts_root(chunks: &Vec<ShardChunkHeader>) -> CryptoHash {

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -161,7 +161,6 @@ impl Block {
             height,
             prev.chunks.clone(),
             epoch_id,
-            vec![],
             approvals,
             0,
             Some(0),

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -278,7 +278,6 @@ pub struct BlockHeaderView {
     pub hash: CryptoHashView,
     pub prev_hash: CryptoHashView,
     pub prev_state_root: CryptoHashView,
-    pub tx_root: CryptoHashView,
     pub chunk_receipts_root: CryptoHashView,
     pub chunk_headers_root: CryptoHashView,
     pub chunk_tx_root: CryptoHashView,
@@ -307,7 +306,6 @@ impl From<BlockHeader> for BlockHeaderView {
             hash: header.hash.into(),
             prev_hash: header.inner.prev_hash.into(),
             prev_state_root: header.inner.prev_state_root.into(),
-            tx_root: header.inner.tx_root.into(),
             chunk_receipts_root: header.inner.chunk_receipts_root.into(),
             chunk_headers_root: header.inner.chunk_headers_root.into(),
             chunk_tx_root: header.inner.chunk_tx_root.into(),
@@ -340,7 +338,6 @@ impl From<BlockHeaderView> for BlockHeader {
                 epoch_id: EpochId(view.epoch_id.into()),
                 prev_hash: view.prev_hash.into(),
                 prev_state_root: view.prev_state_root.into(),
-                tx_root: view.tx_root.into(),
                 chunk_receipts_root: view.chunk_receipts_root.into(),
                 chunk_headers_root: view.chunk_headers_root.into(),
                 chunk_tx_root: view.chunk_tx_root.into(),
@@ -443,7 +440,6 @@ impl From<ChunkHeaderView> for ShardChunkHeader {
 pub struct BlockView {
     pub header: BlockHeaderView,
     pub chunks: Vec<ChunkHeaderView>,
-    pub transactions: Vec<SignedTransactionView>,
 }
 
 impl From<Block> for BlockView {
@@ -451,7 +447,6 @@ impl From<Block> for BlockView {
         BlockView {
             header: block.header.into(),
             chunks: block.chunks.into_iter().map(Into::into).collect(),
-            transactions: block.transactions.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/near/tests/sync_nodes.rs
+++ b/near/tests/sync_nodes.rs
@@ -41,7 +41,6 @@ fn add_blocks(
             prev.header.inner.height + 1,
             blocks[0].chunks.clone(),
             epoch_id,
-            vec![],
             HashMap::default(),
             0,
             Some(0),


### PR DESCRIPTION
Move invalid tx tests into client cargo.
Move run_catchup and process_tx into `Client` as they are operating in non async mode.