### PR TITLE
Fixing one more issue discovered by `cross_shard_tx`

### DIFF
--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -440,8 +440,8 @@ mod tests {
                 );
             }
 
-            // On X1 it takes ~1m 15s
-            near_network::test_utils::wait_or_panic(120000);
+            // On X1 it takes ~5m 40s
+            near_network::test_utils::wait_or_panic(600000);
         })
         .unwrap();
     }


### PR DESCRIPTION
`catchup_blocks` was removing too many blocks that are stored for the future catchup from the permament storage, which could result in certain blocks never getting caught up, or blocks unblocked too early.