### PR TITLE
add autosquash bot

### DIFF
--- a/.github/workflows/autosquash.yml
+++ b/.github/workflows/autosquash.yml
@@ -1,0 +1,37 @@
+name: Autosquash
+on:
+  check_run:
+    types:
+      # Check runs completing successfully can unblock the
+      # corresponding pull requests and make them mergeable.
+      - completed
+  pull_request:
+    types:
+      # A closed pull request makes the checks on the other
+      # pull request on the same base outdated.
+      - closed
+      # Adding the autosquash label to a pull request can
+      # trigger an update or a merge.
+      - labeled
+  pull_request_review:
+    types:
+      # Review approvals can unblock the pull request and
+      # make it mergeable.
+      - submitted
+  # Success statuses can unblock the corresponding
+  # pull requests and make them mergeable.
+  status: {}
+
+jobs:
+  autosquash:
+    runs-on: ubuntu-18.04
+    name: Autosquash
+    steps:
+      - name: Autosquash
+        uses: tibdex/autosquash@master
+        env:
+          # We can't use the built-in secrets.GITHUB_TOKEN yet because of this limitation:
+          # https://github.community/t5/GitHub-Actions/Triggering-a-new-workflow-from-another-workflow/td-p/31676
+          # In the meantime, use a personal access token with repo access.
+          # See https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line
+          GITHUB_TOKEN: ${{ secrets.AUTOSQUASH_TOKEN }}


### PR DESCRIPTION
Usage in short: add `autosquash` label to your PR when you're ready, it's going to:
> updated when new commits land on their base branch, making their status checks outdated.
> squashed and merged once all the branch protections are respected.
