### PR TITLE
Network route back.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2237,6 +2237,7 @@ dependencies = [
  "borsh 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -389,20 +389,23 @@ impl Handler<NetworkClientMessages> for ClientActor {
                 }
                 NetworkClientResponses::NoResponse
             }
-            NetworkClientMessages::AnnounceAccount(announce_account) => {
-                match self.check_signature_account_announce(&announce_account) {
-                    AccountAnnounceVerificationResult::Valid => {
-                        self.network_adapter
-                            .send(NetworkRequests::AnnounceAccount(announce_account));
-                        NetworkClientResponses::NoResponse
-                    }
-                    AccountAnnounceVerificationResult::Invalid(ban_reason) => {
-                        NetworkClientResponses::Ban { ban_reason }
-                    }
-                    AccountAnnounceVerificationResult::UnknownEpoch => {
-                        NetworkClientResponses::NoResponse
+            NetworkClientMessages::AnnounceAccount(announce_accounts) => {
+                let mut filtered_announce_accounts = Vec::new();
+
+                for announce_account in announce_accounts.into_iter() {
+                    match self.check_signature_account_announce(&announce_account) {
+                        AccountAnnounceVerificationResult::Invalid(ban_reason) => {
+                            return NetworkClientResponses::Ban { ban_reason };
+                        }
+                        AccountAnnounceVerificationResult::Valid => {
+                            filtered_announce_accounts.push(announce_account);
+                        }
+                        // Filter this account
+                        AccountAnnounceVerificationResult::UnknownEpoch => {}
                     }
                 }
+
+                NetworkClientResponses::AnnounceAccount(filtered_announce_accounts)
             }
         }
     }
@@ -760,12 +763,8 @@ impl ClientActor {
     fn request_block_by_hash(&mut self, hash: CryptoHash, peer_id: PeerId) {
         match self.client.chain.block_exists(&hash) {
             Ok(false) => self.network_adapter.send(NetworkRequests::BlockRequest { hash, peer_id }),
-            Ok(true) => {
-                debug!(target: "client", "send_block_request_to_peer: block {} already known", hash)
-            }
-            Err(e) => {
-                error!(target: "client", "send_block_request_to_peer: failed to check block exists: {:?}", e)
-            }
+            Ok(true) => debug!(target: "client", "send_block_request_to_peer: block {} already known", hash),
+            Err(e) => error!(target: "client", "send_block_request_to_peer: failed to check block exists: {:?}", e),
         }
     }
 
@@ -862,9 +861,7 @@ impl ClientActor {
             Ok(accepted_blocks) => {
                 self.process_accepted_blocks(accepted_blocks);
             }
-            Err(err) => {
-                error!(target: "client", "{:?} Error occurred during catchup for the next epoch: {:?}", self.client.block_producer.as_ref().map(|bp| bp.account_id.clone()), err)
-            }
+            Err(err) => error!(target: "client", "{:?} Error occurred during catchup for the next epoch: {:?}", self.client.block_producer.as_ref().map(|bp| bp.account_id.clone()), err),
         }
 
         ctx.run_later(self.client.config.catchup_step_period, move |act, ctx| {
@@ -1035,13 +1032,11 @@ impl ClientActor {
                     act.network_info = network_info;
                     actix::fut::ok(())
                 }
-                Ok(NetworkResponses::RoutingTableInfo(_))
-                | Ok(NetworkResponses::NoResponse)
-                | Ok(NetworkResponses::PingPongInfo { .. }) => actix::fut::ok(()),
                 Err(e) => {
                     error!(target: "client", "Sync: received error or incorrect result: {}", e);
                     actix::fut::err(())
                 }
+                _ => actix::fut::ok(()),
             })
             .wait(ctx);
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1035,9 +1035,9 @@ impl ClientActor {
                     act.network_info = network_info;
                     actix::fut::ok(())
                 }
-                Ok(NetworkResponses::RoutingTableInfo(_)) | Ok(NetworkResponses::NoResponse) => {
-                    actix::fut::ok(())
-                }
+                Ok(NetworkResponses::RoutingTableInfo(_))
+                | Ok(NetworkResponses::NoResponse)
+                | Ok(NetworkResponses::PingPongInfo { .. }) => actix::fut::ok(()),
                 Err(e) => {
                     error!(target: "client", "Sync: received error or incorrect result: {}", e);
                     actix::fut::err(())

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -440,9 +440,9 @@ pub fn setup_mock_all_validators(
                             if aa.get(&key).is_none() {
                                 aa.insert(key);
                                 for (client, _) in connectors1.read().unwrap().iter() {
-                                    client.do_send(NetworkClientMessages::AnnounceAccount(
+                                    client.do_send(NetworkClientMessages::AnnounceAccount(vec![
                                         announce_account.clone(),
-                                    ))
+                                    ]))
                                 }
                             }
                         }
@@ -464,7 +464,7 @@ pub fn setup_mock_all_validators(
                             }
                         }
                         NetworkRequests::ForwardTx(_, _)
-                        | NetworkRequests::Sync(_)
+                        | NetworkRequests::Sync { .. }
                         | NetworkRequests::FetchRoutingTable
                         | NetworkRequests::PingTo(_, _)
                         | NetworkRequests::FetchPingPongInfo

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -463,11 +463,13 @@ pub fn setup_mock_all_validators(
                                 }
                             }
                         }
-                        NetworkRequests::BlockHeaderAnnounce { header: _, approval: None } => {}
-                        NetworkRequests::ForwardTx(_, _) => {}
-                        NetworkRequests::Sync(_) => {}
-                        NetworkRequests::FetchRoutingTable => {}
-                        NetworkRequests::BanPeer { .. } => {}
+                        NetworkRequests::ForwardTx(_, _)
+                        | NetworkRequests::Sync(_)
+                        | NetworkRequests::FetchRoutingTable
+                        | NetworkRequests::PingTo(_, _)
+                        | NetworkRequests::FetchPingPongInfo
+                        | NetworkRequests::BanPeer { .. }
+                        | NetworkRequests::BlockHeaderAnnounce { .. } => {}
                     };
                 }
                 Box::new(Some(resp))

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -19,6 +19,7 @@ byteorder = "1.2"
 lazy_static = "1.4"
 
 borsh = "0.2.5"
+cached = "0.9.0"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -73,7 +73,8 @@ mod test {
 
     use crate::routing::EdgeInfo;
     use crate::types::{
-        AnnounceAccount, Handshake, PeerChainInfo, PeerInfo, RoutedMessage, RoutedMessageBody,
+        AnnounceAccount, Handshake, PeerChainInfo, PeerIdOrHash, PeerInfo, RoutedMessage,
+        RoutedMessageBody,
     };
 
     use super::*;
@@ -136,7 +137,7 @@ mod test {
         let bls_signature = bls_sk.sign(hash.as_ref());
 
         let msg = PeerMessage::Routed(RoutedMessage {
-            target: sk.public_key().into(),
+            target: PeerIdOrHash::PeerId(sk.public_key().into()),
             author: sk.public_key().into(),
             signature: signature.clone(),
             body: RoutedMessageBody::BlockApproval(

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -74,7 +74,7 @@ mod test {
     use crate::routing::EdgeInfo;
     use crate::types::{
         AnnounceAccount, Handshake, PeerChainInfo, PeerIdOrHash, PeerInfo, RoutedMessage,
-        RoutedMessageBody,
+        RoutedMessageBody, SyncData,
     };
 
     use super::*;
@@ -118,11 +118,14 @@ mod test {
         let sk = SecretKey::from_random(KeyType::ED25519);
         let network_sk = SecretKey::from_random(KeyType::ED25519);
         let signature = sk.sign(vec![].as_slice());
-        let msg = PeerMessage::AnnounceAccount(AnnounceAccount {
-            account_id: "test1".to_string(),
-            peer_id: network_sk.public_key().into(),
-            epoch_id: EpochId::default(),
-            signature,
+        let msg = PeerMessage::Sync(SyncData {
+            edges: Vec::new(),
+            accounts: vec![AnnounceAccount {
+                account_id: "test1".to_string(),
+                peer_id: network_sk.public_key().into(),
+                epoch_id: EpochId::default(),
+                signature,
+            }],
         });
         test_codec(msg);
     }

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -15,5 +15,6 @@ pub mod peer_store;
 mod rate_counter;
 pub mod routing;
 pub mod types;
+mod utils;
 
 pub mod test_utils;

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -571,8 +571,13 @@ impl StreamHandler<Vec<u8>, io::Error> for Peer {
             (_, PeerStatus::Ready, PeerMessage::Routed(routed_message)) => {
                 debug!(target: "network", "Received routed message from {} to {}.", self.peer_info, routed_message.target);
 
+                if let RoutedMessageBody::Ping(_) = &routed_message.body {
+                    println!("ASD PEER LEVEL RECEIVED PING: {:?}", routed_message);
+                }
+
                 // Receive invalid routed message from peer.
                 if !routed_message.verify() {
+                    println!("ASD BANNING PEER!");
                     self.ban_peer(ctx, ReasonForBan::InvalidSignature);
                 } else {
                     self.peer_manager_addr

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -268,9 +268,6 @@ impl Peer {
                 NetworkClientMessages::StateRequest(shard_id, hash, need_header, parts_ranges)
             }
             PeerMessage::StateResponse(info) => NetworkClientMessages::StateResponse(info),
-            PeerMessage::AnnounceAccount(announce_account) => {
-                NetworkClientMessages::AnnounceAccount(announce_account)
-            }
             // All Routed messages received at this point are for us.
             PeerMessage::Routed(routed_message) => match routed_message.body {
                 RoutedMessageBody::BlockApproval(account_id, hash, signature) => {
@@ -566,9 +563,11 @@ impl StreamHandler<Vec<u8>, io::Error> for Peer {
                 debug!(target: "network", "Received peers from {}: {} peers.", self.peer_info, peers.len());
                 self.peer_manager_addr.do_send(PeersResponse { peers });
             }
-            (_, PeerStatus::Ready, PeerMessage::Sync(sync)) => {
-                // TODO(MarX, #1466): Verify received data before accept it. Check all edges and accounts are valid.
-                self.peer_manager_addr.do_send(NetworkRequests::Sync(sync));
+            (_, PeerStatus::Ready, PeerMessage::Sync(sync_data)) => {
+                self.peer_manager_addr.do_send(NetworkRequests::Sync {
+                    peer_id: self.peer_info.as_ref().as_ref().unwrap().id.clone(),
+                    sync_data,
+                });
             }
             (_, PeerStatus::Ready, PeerMessage::Routed(routed_message)) => {
                 debug!(target: "network", "Received routed message from {} to {:?}.", self.peer_info, routed_message.target);

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -1,17 +1,16 @@
-use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use byteorder::WriteBytesExt;
 use bytes::LittleEndian;
+use cached::{Cached, SizedCache};
 use log::debug;
 
-use cached::{Cached, SizedCache};
 use near_crypto::{SecretKey, Signature};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::types::AccountId;
 
-use crate::types::{PeerId, PeerIdOrHash, Ping, Pong};
+use crate::types::{AnnounceAccount, PeerId, PeerIdOrHash, Ping, Pong};
 use crate::utils::CloneNone;
 
 const ROUTE_BACK_CACHE_SIZE: usize = 10000;
@@ -194,7 +193,7 @@ pub struct RoutingTable {
     // TODO(MarX, #1363): Use cache and file storing to keep this information.
     // TODO(MarX): Add proof that this account belongs to this peer.
     /// PeerId associated for every known account id.
-    pub account_peers: HashMap<AccountId, PeerId>,
+    pub account_peers: HashMap<AccountId, AnnounceAccount>,
     /// Active PeerId that are part of the shortest path to each PeerId.
     pub peer_forwarding: HashMap<PeerId, HashSet<PeerId>>,
     /// Store last update for known edges.
@@ -256,20 +255,26 @@ impl RoutingTable {
 
     /// Find peer that owns this AccountId.
     pub fn account_owner(&self, account_id: &AccountId) -> Result<PeerId, FindRouteError> {
-        self.account_peers.get(account_id).cloned().ok_or_else(|| FindRouteError::AccountNotFound)
+        self.account_peers
+            .get(account_id)
+            .map(|announce_account| announce_account.peer_id.clone())
+            .ok_or_else(|| FindRouteError::AccountNotFound)
     }
 
     /// Add (account id, peer id) to routing table.
     /// Returns a bool indicating whether this is a new entry or not.
     /// Note: There is at most on peer id per account id.
-    pub fn add_account(&mut self, account_id: AccountId, peer_id: PeerId) -> bool {
-        match self.account_peers.entry(account_id) {
-            Entry::Occupied(_) => false,
-            Entry::Vacant(entry) => {
-                entry.insert(peer_id);
-                true
-            }
-        }
+    pub fn add_account(&mut self, announce_account: AnnounceAccount) -> bool {
+        let account_id = announce_account.account_id.clone();
+        self.account_peers
+            .insert(account_id, announce_account.clone())
+            .map_or(true, |old_announce_account| old_announce_account == announce_account)
+    }
+
+    pub fn contains_account(&self, announce_account: AnnounceAccount) -> bool {
+        self.account_peers
+            .get(&announce_account.account_id)
+            .map_or(false, |cur_announce_account| *cur_announce_account == announce_account)
     }
 
     /// Add this edge to the current view of the network.
@@ -314,6 +319,10 @@ impl RoutingTable {
         self.edges_info.iter().map(|(_, edge)| edge.clone()).collect()
     }
 
+    pub fn get_accounts(&self) -> Vec<AnnounceAccount> {
+        self.account_peers.iter().map(|(_key, value)| value.clone()).collect()
+    }
+
     pub fn add_route_back(&mut self, hash: CryptoHash, peer_id: PeerId) {
         self.route_back.value().cache_set(hash, peer_id);
     }
@@ -354,8 +363,14 @@ impl RoutingTable {
     }
 
     pub fn info(&self) -> RoutingTableInfo {
+        let account_peers = self
+            .account_peers
+            .iter()
+            .map(|(key, value)| (key.clone(), value.peer_id.clone()))
+            .collect();
+
         RoutingTableInfo {
-            account_peers: self.account_peers.clone(),
+            account_peers: account_peers,
             peer_forwarding: self.peer_forwarding.clone(),
         }
     }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -245,12 +245,14 @@ pub enum HandshakeFailureReason {
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub struct Ping {
-    nonce: usize,
+    pub nonce: usize,
+    pub source: PeerId,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub struct Pong {
-    nonce: usize,
+    pub nonce: usize,
+    pub source: PeerId,
 }
 
 // TODO(#1313): Use Box
@@ -263,7 +265,7 @@ pub enum RoutedMessageBody {
     ChunkPartRequest(ChunkPartRequestMsg),
     ChunkOnePartRequest(ChunkOnePartRequestMsg),
     ChunkOnePart(ChunkOnePart),
-    /// Ping and Pong are used for testing networking and routing
+    /// Ping and Pong are used for testing networking and routing.
     Ping(Ping),
     Pong(Pong),
 }
@@ -692,6 +694,11 @@ pub enum NetworkRequests {
     FetchRoutingTable,
     /// Data to sync routing table from active peer.
     Sync(SyncData),
+
+    // Start ping to `PeerId` with `nonce`.
+    PingTo(usize, PeerId),
+    // Fetch all received ping and pong so far.
+    FetchPingPongInfo,
 }
 
 /// Messages from PeerManager to Peer
@@ -725,6 +732,7 @@ pub enum NetworkResponses {
     NoResponse,
     Info(NetworkInfo),
     RoutingTableInfo(RoutingTableInfo),
+    PingPongInfo { pings: HashMap<usize, Ping>, pongs: HashMap<usize, Pong> },
 }
 
 impl<A, M> MessageResponse<A, M> for NetworkResponses

--- a/chain/network/src/utils.rs
+++ b/chain/network/src/utils.rs
@@ -1,0 +1,21 @@
+/// Allow to clone an object that don't implement the Clone trait as an emtpy object.
+pub struct CloneNone<U> {
+    value: Option<U>,
+}
+
+impl<U> CloneNone<U> {
+    pub fn new(value: U) -> Self {
+        Self { value: Some(value) }
+    }
+
+    /// This method will panic if called after clone.
+    pub fn value(&mut self) -> &mut U {
+        self.value.as_mut().unwrap()
+    }
+}
+
+impl<U> Clone for CloneNone<U> {
+    fn clone(&self) -> Self {
+        Self { value: None }
+    }
+}

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -84,6 +84,10 @@ enum Action {
     AddEdge(usize, usize),
     CheckRoutingTable(usize, Vec<(usize, Vec<usize>)>),
     CheckAccountId(usize, Vec<usize>),
+    // Send ping from `source` with `nonce` to `target`
+    PingTo(usize, usize, usize),
+    // Check for `source` received pings and pongs.
+    CheckPingPong(usize, Vec<(usize, usize)>, Vec<(usize, usize)>),
 }
 
 #[derive(Clone)]
@@ -181,6 +185,59 @@ impl StateMachine {
                                         flag.store(true, Ordering::Relaxed);
                                     }
                                 }
+                                future::ok(())
+                            }),
+                    );
+                }));
+            }
+            Action::PingTo(source, nonce, target) => {
+                self.actions.push(Box::new(move |info: RunningInfo, flag: Arc<AtomicBool>| {
+                    let target = info.peers_info[target].id.clone();
+                    let _ = info.pm_addr[source].do_send(NetworkRequests::PingTo(nonce, target));
+                    flag.store(true, Ordering::Relaxed);
+                }));
+            }
+            Action::CheckPingPong(source, pings, pongs) => {
+                self.actions.push(Box::new(move |info: RunningInfo, flag: Arc<AtomicBool>| {
+                    let pings_expected: Vec<_> = pings
+                        .clone()
+                        .into_iter()
+                        .map(|(nonce, source)| (nonce, info.peers_info[source].id.clone()))
+                        .collect();
+
+                    let pongs_expected: Vec<_> = pongs
+                        .clone()
+                        .into_iter()
+                        .map(|(nonce, source)| (nonce, info.peers_info[source].id.clone()))
+                        .collect();
+
+                    actix::spawn(
+                        info.pm_addr
+                            .get(source)
+                            .unwrap()
+                            .send(NetworkRequests::FetchPingPongInfo)
+                            .map_err(|_| ())
+                            .and_then(move |res| {
+                                if let NetworkResponses::PingPongInfo { pings, pongs } = res {
+                                    let ping_ok =
+                                        pings_expected.into_iter().all(|(nonce, source)| {
+                                            pings
+                                                .get(&nonce)
+                                                .map_or(false, |ping| ping.source == source)
+                                        });
+
+                                    let pong_ok =
+                                        pongs_expected.into_iter().all(|(nonce, source)| {
+                                            pongs
+                                                .get(&nonce)
+                                                .map_or(false, |pong| pong.source == source)
+                                        });
+
+                                    if ping_ok && pong_ok {
+                                        flag.store(true, Ordering::Relaxed);
+                                    }
+                                }
+
                                 future::ok(())
                             }),
                     );
@@ -364,6 +421,41 @@ fn account_propagation() {
         runner.push(Action::CheckAccountId(1, vec![0, 1]));
         runner.push(Action::AddEdge(0, 2));
         runner.push(Action::CheckAccountId(2, vec![0, 1]));
+        runner.run();
+    })
+    .unwrap();
+}
+
+#[test]
+fn ping_simple() {
+    init_test_logger();
+
+    System::run(|| {
+        let mut runner = Runner::new(2, 2);
+
+        runner.push(Action::AddEdge(0, 1));
+        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
+        runner.push(Action::PingTo(0, 0, 1));
+        runner.push(Action::CheckPingPong(1, vec![(0, 0)], vec![]));
+        runner.push(Action::CheckPingPong(0, vec![], vec![(0, 1)]));
+
+        runner.run();
+    })
+    .unwrap();
+}
+
+#[test]
+fn ping_jump() {
+    init_test_logger();
+
+    System::run(|| {
+        let mut runner = Runner::new(3, 2);
+
+        runner.push(Action::AddEdge(1, 2));
+        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
+        runner.push(Action::PingTo(0, 0, 2));
+        runner.push(Action::CheckPingPong(2, vec![(0, 0)], vec![]));
+        runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2)]));
 
         runner.run();
     })

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -148,9 +148,6 @@ impl StateMachine {
                             .map_err(|_| ())
                             .and_then(move |res| {
                                 if let NetworkResponses::RoutingTableInfo(routing_table) = res {
-                                    // println!("\nROUTING TABLE: {:?}\n", routing_table);
-                                    // println!("\nEXPECTED: {:?}\n", expected1);
-
                                     if expected_routing_tables(
                                         routing_table.peer_forwarding,
                                         expected,

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -421,6 +421,7 @@ fn account_propagation() {
         runner.push(Action::CheckAccountId(1, vec![0, 1]));
         runner.push(Action::AddEdge(0, 2));
         runner.push(Action::CheckAccountId(2, vec![0, 1]));
+
         runner.run();
     })
     .unwrap();
@@ -451,6 +452,7 @@ fn ping_jump() {
     System::run(|| {
         let mut runner = Runner::new(3, 2);
 
+        runner.push(Action::AddEdge(0, 1));
         runner.push(Action::AddEdge(1, 2));
         runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
         runner.push(Action::PingTo(0, 0, 2));


### PR DESCRIPTION
It is possible to route back messages now without having explicit route to the author of the original message. Add ping/pong for easy testing networking.