### PR TITLE
Transaction propagation fixed. Added test that showcases it. Test als…

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -464,6 +464,7 @@ pub fn setup_mock_all_validators(
                             }
                         }
                         NetworkRequests::BlockHeaderAnnounce { header: _, approval: None } => {}
+                        NetworkRequests::ForwardTx(_, _) => {}
                         NetworkRequests::Sync(_) => {}
                         NetworkRequests::FetchRoutingTable => {}
                         NetworkRequests::BanPeer { .. } => {}

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -19,10 +19,10 @@ use crate::codec::{bytes_to_peer_message, peer_message_to_bytes, Codec};
 use crate::rate_counter::RateCounter;
 use crate::routing::{Edge, EdgeInfo};
 use crate::types::{
-    AccountOrPeerId, Ban, Consolidate, ConsolidateResponse, Handshake, HandshakeFailureReason,
+    Ban, Consolidate, ConsolidateResponse, Handshake, HandshakeFailureReason,
     NetworkClientMessages, PeerChainInfo, PeerInfo, PeerManagerRequest, PeerMessage,
     PeerStatsResult, PeerStatus, PeerType, PeersRequest, PeersResponse, QueryPeerStats,
-    RawRoutedMessage, ReasonForBan, RoutedMessageBody, SendMessage, Unregister, PROTOCOL_VERSION,
+    ReasonForBan, RoutedMessageBody, SendMessage, Unregister, PROTOCOL_VERSION,
 };
 use crate::{NetworkClientResponses, NetworkRequests, PeerManagerActor};
 
@@ -309,12 +309,6 @@ impl Peer {
             .then(|res, act, ctx| {
                 // Ban peer if client thinks received data is bad.
                 match res {
-                    Ok(NetworkClientResponses::ForwardTx(account_id, tx)) => {
-                        act.peer_manager_addr.do_send(RawRoutedMessage {
-                            target: AccountOrPeerId::AccountId(account_id),
-                            body: RoutedMessageBody::ForwardTx(tx)
-                        })
-                    }
                     Ok(NetworkClientResponses::InvalidTx(err)) => {
                         warn!(target: "network", "Received invalid tx from peer {}: {}", act.peer_info, err);
                         // TODO: count as malicious behaviour?

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -641,6 +641,10 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                 );
                 NetworkResponses::NoResponse
             }
+            NetworkRequests::ForwardTx(account_id, tx) => {
+                self.send_message_to_account(ctx, &account_id, RoutedMessageBody::ForwardTx(tx));
+                NetworkResponses::NoResponse
+            }
             NetworkRequests::FetchRoutingTable => {
                 NetworkResponses::RoutingTableInfo(self.routing_table.info())
             }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -649,25 +649,14 @@ pub enum NetworkRequests {
     /// Fetch information from the network.
     FetchInfo,
     /// Sends block, either when block was just produced or when requested.
-    Block {
-        block: Block,
-    },
+    Block { block: Block },
     /// Sends block header announcement, with possibly attaching approval for this block if
     /// participating in this epoch.
-    BlockHeaderAnnounce {
-        header: BlockHeader,
-        approval: Option<BlockApproval>,
-    },
+    BlockHeaderAnnounce { header: BlockHeader, approval: Option<BlockApproval> },
     /// Request block with given hash from given peer.
-    BlockRequest {
-        hash: CryptoHash,
-        peer_id: PeerId,
-    },
+    BlockRequest { hash: CryptoHash, peer_id: PeerId },
     /// Request given block headers.
-    BlockHeadersRequest {
-        hashes: Vec<CryptoHash>,
-        peer_id: PeerId,
-    },
+    BlockHeadersRequest { hashes: Vec<CryptoHash>, peer_id: PeerId },
     /// Request state for given shard at given state root.
     StateRequest {
         shard_id: ShardId,
@@ -677,43 +666,28 @@ pub enum NetworkRequests {
         account_id: AccountId,
     },
     /// Ban given peer.
-    BanPeer {
-        peer_id: PeerId,
-        ban_reason: ReasonForBan,
-    },
+    BanPeer { peer_id: PeerId, ban_reason: ReasonForBan },
     /// Announce account
     AnnounceAccount(AnnounceAccount),
 
     /// Request chunk part
-    ChunkPartRequest {
-        account_id: AccountId,
-        part_request: ChunkPartRequestMsg,
-    },
+    ChunkPartRequest { account_id: AccountId, part_request: ChunkPartRequestMsg },
     /// Request chunk part and receipts
-    ChunkOnePartRequest {
-        account_id: AccountId,
-        one_part_request: ChunkOnePartRequestMsg,
-    },
+    ChunkOnePartRequest { account_id: AccountId, one_part_request: ChunkOnePartRequestMsg },
     /// Response to a peer with chunk part and receipts.
-    ChunkOnePartResponse {
-        peer_id: PeerId,
-        header_and_part: ChunkOnePart,
-    },
+    ChunkOnePartResponse { peer_id: PeerId, header_and_part: ChunkOnePart },
     /// A chunk header and one part for another validator.
-    ChunkOnePartMessage {
-        account_id: AccountId,
-        header_and_part: ChunkOnePart,
-    },
+    ChunkOnePartMessage { account_id: AccountId, header_and_part: ChunkOnePart },
     /// A chunk part
-    ChunkPart {
-        peer_id: PeerId,
-        part: ChunkPartMsg,
-    },
+    ChunkPart { peer_id: PeerId, part: ChunkPartMsg },
 
-    // The following types of requests are used to trigger actions in the Peer Manager for testing.
-    // Fetch current routing table
+    /// Valid transaction but since we are not validators we send this transaction to current validators.
+    ForwardTx(AccountId, SignedTransaction),
+
+    /// The following types of requests are used to trigger actions in the Peer Manager for testing.
+    /// Fetch current routing table.
     FetchRoutingTable,
-    // Data to sync routing table from active peer.
+    /// Data to sync routing table from active peer.
     Sync(SyncData),
 }
 
@@ -820,8 +794,6 @@ pub enum NetworkClientResponses {
     ValidTx,
     /// Invalid transaction inserted into mempool as response to Transaction.
     InvalidTx(InvalidTxError),
-    /// Valid transaction but since we are not validators we send this transaction to current validators.
-    ForwardTx(AccountId, SignedTransaction),
     /// Ban peer for malicious behaviour.
     Ban { ban_reason: ReasonForBan },
     /// Chain information.

--- a/near/tests/run_nodes.rs
+++ b/near/tests/run_nodes.rs
@@ -21,7 +21,7 @@ fn run_nodes(
             TempDir::new(&format!("run_nodes_{}_{}_{}", num_nodes, num_validators, i)).unwrap()
         })
         .collect::<Vec<_>>();
-    let (_, clients) = start_nodes(num_shards, &dirs, num_validators, 0, epoch_length);
+    let (_, _, clients) = start_nodes(num_shards, &dirs, num_validators, 0, epoch_length);
     let view_client = clients[clients.len() - 1].1.clone();
     WaitOrTimeout::new(
         Box::new(move |_ctx| {

--- a/near/tests/run_nodes.rs
+++ b/near/tests/run_nodes.rs
@@ -21,7 +21,7 @@ fn run_nodes(
             TempDir::new(&format!("run_nodes_{}_{}_{}", num_nodes, num_validators, i)).unwrap()
         })
         .collect::<Vec<_>>();
-    let clients = start_nodes(num_shards, &dirs, num_validators, epoch_length);
+    let (_, clients) = start_nodes(num_shards, &dirs, num_validators, 0, epoch_length);
     let view_client = clients[clients.len() - 1].1.clone();
     WaitOrTimeout::new(
         Box::new(move |_ctx| {

--- a/near/tests/track_shards.rs
+++ b/near/tests/track_shards.rs
@@ -19,7 +19,7 @@ fn track_shards() {
         let dirs = (0..num_nodes)
             .map(|i| TempDir::new(&format!("track_shards_{}", i)).unwrap())
             .collect::<Vec<_>>();
-        let clients = start_nodes(4, &dirs, 2, 10);
+        let (_, clients) = start_nodes(4, &dirs, 2, 0, 10);
         let view_client = clients[clients.len() - 1].1.clone();
         let last_block_hash: Arc<RwLock<Option<CryptoHash>>> = Arc::new(RwLock::new(None));
         WaitOrTimeout::new(

--- a/near/tests/track_shards.rs
+++ b/near/tests/track_shards.rs
@@ -19,7 +19,7 @@ fn track_shards() {
         let dirs = (0..num_nodes)
             .map(|i| TempDir::new(&format!("track_shards_{}", i)).unwrap())
             .collect::<Vec<_>>();
-        let (_, clients) = start_nodes(4, &dirs, 2, 0, 10);
+        let (_, _, clients) = start_nodes(4, &dirs, 2, 0, 10);
         let view_client = clients[clients.len() - 1].1.clone();
         let last_block_hash: Arc<RwLock<Option<CryptoHash>>> = Arc::new(RwLock::new(None));
         WaitOrTimeout::new(

--- a/near/tests/tx_propagation.rs
+++ b/near/tests/tx_propagation.rs
@@ -1,0 +1,84 @@
+use actix::{Actor, System};
+use borsh::BorshSerialize;
+use futures::future::Future;
+use tempdir::TempDir;
+
+use near_client::{GetBlock, TxStatus};
+use near_crypto::{InMemorySigner, KeyType};
+use near_jsonrpc::client::new_client;
+use near_network::test_utils::WaitOrTimeout;
+use near_primitives::serialize::to_base64;
+use near_primitives::test_utils::{heavy_test, init_integration_logger};
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::views::FinalExecutionStatus;
+use testlib::{genesis_block, start_nodes};
+
+/// Starts 2 validators and 2 light clients (not tracking anything).
+/// Sends tx to first light client and checks that a node can return tx status.
+/// TODO: here the other light client should be able to return result via RPC forwarding.
+#[test]
+fn tx_propagation() {
+    init_integration_logger();
+    heavy_test(|| {
+        let system = System::new("NEAR");
+        let num_nodes = 4;
+        let dirs = (0..num_nodes)
+            .map(|i| TempDir::new(&format!("tx_propagation{}", i)).unwrap())
+            .collect::<Vec<_>>();
+        let (genesis_config, rpc_addrs, clients) = start_nodes(4, &dirs, 2, 2, 10);
+        let view_client = clients[0].1.clone();
+
+        let genesis_hash = genesis_block(genesis_config).hash();
+        let signer = InMemorySigner::from_seed("near.1", KeyType::ED25519, "near.1");
+        let transaction = SignedTransaction::send_money(
+            1,
+            "near.1".to_string(),
+            "near.2".to_string(),
+            &signer,
+            10000,
+            genesis_hash,
+        );
+        let tx_hash = transaction.get_hash();
+
+        WaitOrTimeout::new(
+            Box::new(move |_ctx| {
+                let rpc_addrs_copy = rpc_addrs.clone();
+                let transaction_copy = transaction.clone();
+                let tx_hash_clone = tx_hash.clone();
+                // We are sending this tx unstop, just to get over the warm up period.
+                // Probably make sense to stop after 1 time though.
+                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
+                    if res.unwrap().unwrap().header.height > 1 {
+                        let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                        let bytes = transaction_copy.try_to_vec().unwrap();
+                        actix::spawn(
+                            client
+                                .broadcast_tx_async(to_base64(&bytes))
+                                .map_err(|err| panic!(err))
+                                .map(move |result| {
+                                    assert_eq!(String::from(&tx_hash_clone), result)
+                                }),
+                        );
+                    }
+                    futures::future::ok(())
+                }));
+                actix::spawn(view_client.send(TxStatus { tx_hash }).then(move |res| {
+                    match &res {
+                        Ok(Ok(feo))
+                            if feo.status == FinalExecutionStatus::SuccessValue("".to_string()) =>
+                        {
+                            System::current().stop();
+                        }
+                        _ => return futures::future::err(()),
+                    };
+                    futures::future::ok(())
+                }));
+            }),
+            100,
+            20000,
+        )
+        .start();
+
+        system.run().unwrap();
+    });
+}

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -70,11 +70,13 @@ pub fn start_nodes(
     num_shards: usize,
     dirs: &[TempDir],
     num_validators: usize,
+    num_lightclient: usize,
     epoch_length: BlockIndex,
-) -> Vec<(Addr<ClientActor>, Addr<ViewClientActor>)> {
+) -> (GenesisConfig, Vec<String>, Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>) {
     init_integration_logger();
 
     let num_nodes = dirs.len();
+    let num_tracking_nodes = dirs.len() - num_lightclient;
     let seeds = (0..num_nodes).map(|i| format!("near.{}", i)).collect::<Vec<_>>();
     let mut genesis_config = GenesisConfig::test_sharded(
         seeds.iter().map(|s| s.as_str()).collect(),
@@ -86,20 +88,22 @@ pub fn start_nodes(
     let validators = (0..num_validators).map(|i| format!("near.{}", i)).collect::<Vec<_>>();
     let mut near_configs = vec![];
     let first_node = open_port();
+    let mut rpc_addrs = vec![];
     for i in 0..num_nodes {
         let mut near_config = load_test_config(
             if i < num_validators { &validators[i] } else { "" },
             if i == 0 { first_node } else { open_port() },
             &genesis_config,
         );
+        rpc_addrs.push(near_config.rpc_config.addr.clone());
         near_config.client_config.min_num_peers = num_nodes - 1;
         if i > 0 {
             near_config.network_config.boot_nodes =
                 convert_boot_nodes(vec![("near.0", first_node)]);
         }
         // if non validator, add some shards to track.
-        if i >= num_validators {
-            let shards_per_node = num_shards / (num_nodes - num_validators);
+        if i >= num_validators && i < num_tracking_nodes {
+            let shards_per_node = num_shards / (num_tracking_nodes - num_validators);
             let (from, to) = (
                 ((i - num_validators) * shards_per_node) as ShardId,
                 ((i - num_validators + 1) * shards_per_node) as ShardId,
@@ -114,5 +118,5 @@ pub fn start_nodes(
         let (client, view_client) = start_with_config(dirs[i].path(), near_config);
         res.push((client, view_client))
     }
-    res
+    (genesis_config, rpc_addrs, res)
 }


### PR DESCRIPTION
Previously Tx propagation didn't work for two reasons:
 - RPC calling to Client wasn't actually handling response for forwarding tx
 - If node wasn't tracking shard that this tx is originating - it would just return invalid tx.

Fixed both issues with test that showcases it.
 + Setup this test to also check RPC forwarding by having a light client that must be queriable (but not right now)