### PR TITLE
Remove `@` separator from accounts.

### DIFF
--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -112,10 +112,10 @@ pub fn index_to_bytes(index: u64) -> Vec<u8> {
 lazy_static! {
     /// See NEP#0006
     static ref VALID_ACCOUNT_ID: Regex =
-        Regex::new(r"^(([a-z\d]+[\-_])*[a-z\d]+[\.@])*([a-z\d]+[\-_])*[a-z\d]+$").unwrap();
-    /// Represents a part of an account ID with a suffix of as a separator `.` or `@`.
+        Regex::new(r"^(([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+$").unwrap();
+    /// Represents a part of an account ID with a suffix of as a separator `.`.
     static ref VALID_ACCOUNT_PART_ID_WITH_TAIL_SEPARATOR: Regex =
-        Regex::new(r"^([a-z\d]+[\-_])*[a-z\d]+[\.@]$").unwrap();
+        Regex::new(r"^([a-z\d]+[\-_])*[a-z\d]+\.$").unwrap();
     /// Represents a top level account ID.
     static ref VALID_TOP_LEVEL_ACCOUNT_ID: Regex =
         Regex::new(r"^([a-z\d]+[\-_])*[a-z\d]+$").unwrap();
@@ -269,8 +269,6 @@ mod tests {
             "a.ha",
             "a.b-a.ra",
             "system",
-            "some-complex-address@gmail.com",
-            "sub.buy_d1gitz@atata@b0-rg.c_0_m",
             "over.9000",
             "google.com",
             "illia.cheapaccounts.near",
@@ -314,6 +312,9 @@ mod tests {
             "hello world",
             "abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz",
             "01234567890123456789012345678901234567890123456789012345678901234",
+            // `@` separators are banned now
+            "some-complex-address@gmail.com",
+            "sub.buy_d1gitz@atata@b0-rg.c_0_m",
         ];
         for account_id in bad_account_ids {
             assert!(
@@ -400,14 +401,11 @@ mod tests {
     fn test_is_valid_sub_account_id() {
         let ok_pairs = vec![
             ("test", "a.test"),
-            ("test", "a@test"),
             ("test-me", "abc.test-me"),
-            ("test_me", "abc@test_me"),
-            ("gmail.com", "abc@gmail.com"),
-            ("gmail@com", "abc.gmail@com"),
-            ("gmail.com", "abc-lol@gmail.com"),
-            ("gmail@com", "abc_lol.gmail@com"),
-            ("gmail@com", "bro-abc_lol.gmail@com"),
+            ("gmail.com", "abc.gmail.com"),
+            ("gmail.com", "abc-lol.gmail.com"),
+            ("gmail.com", "abc_lol.gmail.com"),
+            ("gmail.com", "bro-abc_lol.gmail.com"),
             ("g0", "0g.g0"),
             ("1g", "1g.1g"),
             ("5-3", "4_2.5-3"),
@@ -446,6 +444,13 @@ mod tests {
             ("gmail.com", ".abc@gmail.com"),
             ("gmail.com", ".abc@gmail@com"),
             ("gmail.com", "abc@gmail@com"),
+            ("test", "a@test"),
+            ("test_me", "abc@test_me"),
+            ("gmail.com", "abc@gmail.com"),
+            ("gmail@com", "abc.gmail@com"),
+            ("gmail.com", "abc-lol@gmail.com"),
+            ("gmail@com", "abc_lol.gmail@com"),
+            ("gmail@com", "bro-abc_lol.gmail@com"),
             ("gmail.com", "123456789012345678901234567890123456789012345678901234567890@gmail.com"),
             (
                 "123456789012345678901234567890123456789012345678901234567890",

--- a/near/res/testnet.json
+++ b/near/res/testnet.json
@@ -2154,18 +2154,6 @@
           "locked": "0",
           "storage_usage": 182,
           "code_hash": "11111111111111111111111111111111",
-          "amount": "100000000000000000",
-          "storage_paid_at": 0
-        },
-        "account_id": "dion@focus"
-      }
-    },
-    {
-      "Account": {
-        "account": {
-          "locked": "0",
-          "storage_usage": 182,
-          "code_hash": "11111111111111111111111111111111",
           "amount": "10000000000",
           "storage_paid_at": 0
         },
@@ -3328,18 +3316,6 @@
       "Account": {
         "account": {
           "locked": "0",
-          "storage_usage": 264,
-          "code_hash": "11111111111111111111111111111111",
-          "amount": "100000000000000000",
-          "storage_paid_at": 0
-        },
-        "account_id": "jess@near"
-      }
-    },
-    {
-      "Account": {
-        "account": {
-          "locked": "0",
           "storage_usage": 346,
           "code_hash": "11111111111111111111111111111111",
           "amount": "7999999999977794754",
@@ -3538,18 +3514,6 @@
           "storage_paid_at": 0
         },
         "account_id": "karel"
-      }
-    },
-    {
-      "Account": {
-        "account": {
-          "locked": "0",
-          "storage_usage": 264,
-          "code_hash": "11111111111111111111111111111111",
-          "amount": "99999999999980830",
-          "storage_paid_at": 0
-        },
-        "account_id": "kelvinhu9988@gmail.com"
       }
     },
     {
@@ -5818,18 +5782,6 @@
           "storage_paid_at": 0
         },
         "account_id": "marco.test1"
-      }
-    },
-    {
-      "Account": {
-        "account": {
-          "locked": "0",
-          "storage_usage": 428,
-          "code_hash": "11111111111111111111111111111111",
-          "amount": "10000000000000000000",
-          "storage_paid_at": 0
-        },
-        "account_id": "marco@buildlinks"
       }
     },
     {
@@ -27163,16 +27115,6 @@
     {
       "AccessKey": {
         "access_key": {
-          "nonce": 1,
-          "permission": "FullAccess"
-        },
-        "public_key": "ed25519:xzfhfyoKE2BiZXqJrsZny5pDHbwzaz3Yn4kUHyrWMgF",
-        "account_id": "dion@focus"
-      }
-    },
-    {
-      "AccessKey": {
-        "access_key": {
           "nonce": 0,
           "permission": "FullAccess"
         },
@@ -29387,26 +29329,6 @@
     {
       "AccessKey": {
         "access_key": {
-          "nonce": 2,
-          "permission": "FullAccess"
-        },
-        "public_key": "ed25519:DcRYnCyvYqWRPju5RqHTLXLyNPRtj1QBev9rMmQMy3J",
-        "account_id": "jess@near"
-      }
-    },
-    {
-      "AccessKey": {
-        "access_key": {
-          "nonce": 2,
-          "permission": "FullAccess"
-        },
-        "public_key": "ed25519:G4Z5u74WJwJn4oCaCf5qSrqpr6x9wuavAb34KeKGN9kn",
-        "account_id": "jess@near"
-      }
-    },
-    {
-      "AccessKey": {
-        "access_key": {
           "nonce": 4,
           "permission": "FullAccess"
         },
@@ -29812,26 +29734,6 @@
         },
         "public_key": "ed25519:EsjyvmBb2ESGiyjPHMBUnTGCe1P6hPjmxxY2b2hrTBAv",
         "account_id": "karel"
-      }
-    },
-    {
-      "AccessKey": {
-        "access_key": {
-          "nonce": 8,
-          "permission": "FullAccess"
-        },
-        "public_key": "ed25519:D8swymZypy3UQ6H6Jy4URevaBPgZfY4Xo9QBQ6LpSEJM",
-        "account_id": "kelvinhu9988@gmail.com"
-      }
-    },
-    {
-      "AccessKey": {
-        "access_key": {
-          "nonce": 8,
-          "permission": "FullAccess"
-        },
-        "public_key": "ed25519:EsjyvmBb2ESGiyjPHMBUnTGCe1P6hPjmxxY2b2hrTBAv",
-        "account_id": "kelvinhu9988@gmail.com"
       }
     },
     {
@@ -31698,46 +31600,6 @@
         },
         "public_key": "ed25519:BAfDkMsBadjfLBwUqHBC8jVvtJd5Tjs2MfKhf2WQmQBX",
         "account_id": "marco.test1"
-      }
-    },
-    {
-      "AccessKey": {
-        "access_key": {
-          "nonce": 13,
-          "permission": "FullAccess"
-        },
-        "public_key": "ed25519:3mJxkYN62o4cTrS2hb5fKF9jAn35oQn5BaSkiEpZv3L5",
-        "account_id": "marco@buildlinks"
-      }
-    },
-    {
-      "AccessKey": {
-        "access_key": {
-          "nonce": 13,
-          "permission": "FullAccess"
-        },
-        "public_key": "ed25519:8tjVw7A3ySKbJLTivezurnsn4fVyFPbXCkMBhEPoYiaS",
-        "account_id": "marco@buildlinks"
-      }
-    },
-    {
-      "AccessKey": {
-        "access_key": {
-          "nonce": 13,
-          "permission": "FullAccess"
-        },
-        "public_key": "ed25519:D4ZZ1yEafQi4iVznpYHxKUc22XpbcdhtJySMREQg8XVG",
-        "account_id": "marco@buildlinks"
-      }
-    },
-    {
-      "AccessKey": {
-        "access_key": {
-          "nonce": 13,
-          "permission": "FullAccess"
-        },
-        "public_key": "ed25519:GK8TbcYo83XCuEEs6NTYPEN7QN77Rsw9VpmcrfgzWjB8",
-        "account_id": "marco@buildlinks"
       }
     },
     {

--- a/scripts/state/migrate-from-0.3.py
+++ b/scripts/state/migrate-from-0.3.py
@@ -14,10 +14,35 @@ new_records = []
 # TODO: uncomment when we migrate from 0.3 to 0.4
 #q['records'] = q['records'][0]
 
+# The new rule for accounts IDs is excluding `@`
+is_valid_account = re.compile(r"^(([a-z\d]+[\-_])*[a-z\d]+\.)*([a-z\d]+[\-_])*[a-z\d]+$")
+assert(is_valid_account.match("near"))
+
 for value in q['records']:
     if 'Account' in value:
+        account_id = value['Account']['account_id']
+        if not is_valid_account.match(account_id):
+            print("Bad account ID, nuking account %s" % (account_id,))
+            continue
         staked = value['Account']['account'].pop('staked')
         value['Account']['account']['locked'] = staked
+    elif 'AccessKey' in value:
+        account_id = value['AccessKey']['account_id']
+        if not is_valid_account.match(account_id):
+            print("Nuked access key for bad account ID %s" % (account_id,))
+            continue
+    elif 'Contract' in value:
+        account_id = value['Contract']['account_id']
+        if not is_valid_account.match(account_id):
+            print("Nuked contract for bad account ID %s" % (account_id,))
+            continue
+    elif 'Data' in value:
+        key = base64.b64decode(value['Data']['key']).decode('utf-8')
+        account_id = key[1:key.find(',')]
+        if not is_valid_account.match(account_id):
+            print("Nuked data for bad account ID %s" % (account_id,))
+            continue
+
     new_records.append(value)
 
 q['records'] = new_records

--- a/scripts/state/migrate-from-0.3.py
+++ b/scripts/state/migrate-from-0.3.py
@@ -22,7 +22,7 @@ for value in q['records']:
     if 'Account' in value:
         account_id = value['Account']['account_id']
         if not is_valid_account.match(account_id):
-            print("Bad account ID, nuking account %s" % (account_id,))
+            print("Nuked account for bad account ID %s" % (account_id,))
             continue
         staked = value['Account']['account'].pop('staked')
         value['Account']['account']['locked'] = staked


### PR DESCRIPTION
`@` separator is not popular enough and hurts UX in the wallet. We can't prefix every account_id with `@` in the wallet if the `@` is allowed within an account ID.

Discussed with @vgrichina, @jakestutzman and @kcole16 and we've decided to remove this separator completely.  

