### PR TITLE
Few changes after transaction routing

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -601,6 +601,7 @@ impl Chain {
         match maybe_new_head {
             Ok((head, needs_to_start_fetching_state)) => {
                 chain_update.commit()?;
+
                 if needs_to_start_fetching_state {
                     debug!("Downloading state for block {}", block.hash());
                     self.start_downloading_state(me, &block)?;

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -108,7 +108,7 @@ mod tests {
                 key_pairs.clone(),
                 validator_groups,
                 true,
-                400,
+                1200,
                 false,
                 5,
                 Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -38,11 +38,11 @@ class BaseNode(object):
     def _get_command_line(self, near_root, node_dir, boot_key, boot_node_addr):
         if boot_key is None:
             assert boot_node_addr is None
-            return [os.path.join(near_root, 'near'), "--verbose", "--home", node_dir, "run"]
+            return [os.path.join(near_root, 'near'), "--verbose", "", "--home", node_dir, "run"]
         else:
             assert boot_node_addr is not None
             boot_key = boot_key.split(':')[1]
-            return [os.path.join(near_root, 'near'), "--verbose", "--home", node_dir, "run", '--boot-nodes', "%s@%s:%s" % (boot_key, boot_node_addr[0], boot_node_addr[1])]
+            return [os.path.join(near_root, 'near'), "--verbose", "", "--home", node_dir, "run", '--boot-nodes', "%s@%s:%s" % (boot_key, boot_node_addr[0], boot_node_addr[1])]
 
     def wait_for_rpc(self):
         retry.retry(lambda: self.get_status(), timeout=1)

--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -22,7 +22,7 @@ class TxContext:
             for i in range(self.num_nodes)
         ]
 
-    def send_moar_txs(self, last_block_hash, num):
+    def send_moar_txs(self, last_block_hash, num, use_routing):
         last_balances = [x for x in self.expected_balances]
         for i in range(num):
             from_ = random.randint(0, self.num_nodes - 1)
@@ -33,7 +33,10 @@ class TxContext:
             if self.expected_balances[from_] >= amt:
                 print("Sending a tx from %s to %s for %s" % (from_, to, amt));
                 tx = sign_payment_tx(self.nodes[from_].signer_key, 'test%s' % to, amt, self.next_nonce, base58.b58decode(last_block_hash.encode('utf8')))
-                self.nodes[self.act_to_val[from_]].send_tx(tx)
+                if use_routing:
+                    self.nodes[0].send_tx(tx)
+                else:
+                    self.nodes[self.act_to_val[from_]].send_tx(tx)
                 self.expected_balances[from_] -= amt
                 self.expected_balances[to] += amt
                 self.next_nonce += 1

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -51,12 +51,12 @@ while observed_height < START_AT_BLOCK:
         print("Boot node got to height %s" % new_height);
 
     if mode == 'onetx' and not sent_txs:
-        ctx.send_moar_txs(hash_, 3)
+        ctx.send_moar_txs(hash_, 3, False)
         sent_txs = True
 
     elif mode == 'manytx':
         if ctx.get_balances() == ctx.expected_balances:
-            ctx.send_moar_txs(hash_, 3)
+            ctx.send_moar_txs(hash_, 3, False)
             print("Sending moar txs at height %s" % new_height)
     time.sleep(0.1)
 
@@ -80,7 +80,7 @@ while catch_up_height < observed_height:
 
     if mode == 'manytx':
         if ctx.get_balances() == ctx.expected_balances:
-            ctx.send_moar_txs(hash_, 3)
+            ctx.send_moar_txs(hash_, 3, False)
             print("Sending moar txs at height %s" % boot_height)
     time.sleep(0.1)
 

--- a/pytest/tests/sanity/transactions.py
+++ b/pytest/tests/sanity/transactions.py
@@ -57,7 +57,7 @@ while True:
         # we are done with the sanity test, now let's stress it
         if ctx.get_balances() == ctx.expected_balances:
             print("Balances caught up, took %s blocks, moving on" % (height - sent_height));
-            ctx.send_moar_txs(hash_, 10)
+            ctx.send_moar_txs(hash_, 10, use_routing=True)
             sent_height = height
         else:
             if height > sent_height + 10:


### PR DESCRIPTION
- Chainging the python sanity test to use routing (it passes)
- Changing how the horizon is working
  Before this change it was checking heights (H, H+1, H+2), and
  then routing to H+2. It is both wrong to check H (the chunk at
  H is already produced), and wrong to send to the last height we
  checked, because the recepient with a high chance one block
  behind us, and will redundantly re-forward the transaction.
  Now it looks at (H+1, H+2, H+3), still forwards to H+2.
- The previous change also fixes most of the catchup tests, since
  two blocks horizon was not enough under stress. Shifting horizon
  one block forward fixed most of them.

Some catchup tests still fail due to #1484