### PR TITLE
working coredump for docker

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,9 +1,5 @@
 FROM phusion/baseimage:0.11
 
-RUN apt-get update -qq && apt-get install -y \
-    systemd-coredump \
-    && rm -rf /var/lib/apt/lists/*
-
 EXPOSE 3030 24567
 
 COPY scripts/run_docker.sh /usr/local/bin/run.sh

--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ docker-nearcore:
 	mkdir -p docker-build
 	docker run -v ${PWD}/docker-build:/opt/mount --rm --entrypoint cp nearcore-dev /usr/local/bin/near /opt/mount/near
 	docker build -t nearcore -f Dockerfile.prod .
-	rm -rf docker-build
+	sudo rm -rf docker-build

--- a/scripts/nodelib.py
+++ b/scripts/nodelib.py
@@ -129,6 +129,8 @@ def run_docker(image, home_dir, boot_nodes, verbose):
         envs.extend(['-e', 'VERBOSE=1'])
     subprocess.check_output(['docker', 'run',
                     '-d', '-p', rpc_port, '-p', network_port, '-v', '%s:/srv/near' % home_dir,
+                    '-v', '/tmp:/tmp',
+                    '--ulimit', 'core=-1',
                     '--name', 'nearcore', '--restart', 'unless-stopped'] + 
                     envs + [image])
     # Start Watchtower that will automatically update the nearcore container when new version appears.


### PR DESCRIPTION
systemd-coredump needs to be installed in host machine instead of docker. Remove it in docker to minimize image size. Besides these, docker is kind of a special "process" in host machine, a configuration change in host needed to make coredump works. On linux it's:
```
echo '/tmp/core.%t.%e.%p' | sudo tee /proc/sys/kernel/core_pattern
```
Docker use content host's core_pattern as path to store core dump, but store that in the container fs instead of host fs, so the change in nodelib.py is for bring the core dump into host (/tmp)

To test this by making a segment fault, easiest way is adding this to main():
```
    let r1 = 0 as *const i32;

    unsafe {
        println!("r1 is: {}", *r1);
    }
```