### PR TITLE
Cargo bug workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,7 +2227,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-fees"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2267,15 +2267,15 @@ dependencies = [
 
 [[package]]
 name = "near-vm-errors"
-version = "0.3.1"
+version = "0.3.2"
 
 [[package]]
 name = "near-vm-logic"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-runtime-fees 0.3.1",
- "near-vm-errors 0.3.1",
+ "near-runtime-fees 0.3.2",
+ "near-vm-errors 0.3.2",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "sodiumoxide 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2283,13 +2283,13 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "assert_matches 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bencher 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "cached 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-errors 0.3.1",
- "near-vm-logic 0.3.1",
+ "near-vm-errors 0.3.2",
+ "near-vm-logic 0.3.2",
  "parity-wasm 0.40.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-utils 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2299,11 +2299,11 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-standalone"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-vm-logic 0.3.1",
- "near-vm-runner 0.3.1",
+ "near-vm-logic 0.3.2",
+ "near-vm-runner 0.3.2",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -2368,11 +2368,11 @@ dependencies = [
  "near-crypto 0.1.0",
  "near-metrics 0.1.0",
  "near-primitives 0.1.0",
- "near-runtime-fees 0.3.1",
+ "near-runtime-fees 0.3.2",
  "near-store 0.1.0",
- "near-vm-errors 0.3.1",
- "near-vm-logic 0.3.1",
- "near-vm-runner 0.3.1",
+ "near-vm-errors 0.3.2",
+ "near-vm-logic 0.3.2",
+ "near-vm-runner 0.3.2",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3518,7 +3518,7 @@ dependencies = [
  "near-jsonrpc-client 0.1.0",
  "near-network 0.1.0",
  "near-primitives 0.1.0",
- "near-runtime-fees 0.3.1",
+ "near-runtime-fees 0.3.2",
  "near-store 0.1.0",
  "node-runtime 0.0.1",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/runtime/near-runtime-fees/Cargo.toml
+++ b/runtime/near-runtime-fees/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-runtime-fees"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-errors/Cargo.toml
+++ b/runtime/near-vm-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-errors"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -14,7 +14,6 @@ This crate implements the specification of the interface that Near blockchain ex
 
 [dependencies]
 bs58 = "0.3"
-sodiumoxide = { version = "0.2.5", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 near-runtime-fees = { path = "../near-runtime-fees", version = "0.3.1" }
 near-vm-errors = { path = "../near-vm-errors", version = "0.3.1" }
@@ -26,39 +25,30 @@ serde_json = {version= "1.0", features= ["preserve_order"]}
 [[test]]
 name = "test_storage_read_write"
 path = "tests/test_storage_read_write.rs"
-required-features = ["mocks"]
 
 [[test]]
 name = "test_context"
 path = "tests/test_context.rs"
-required-features = ["mocks"]
 
 [[test]]
 name = "test_miscs"
 path = "tests/test_miscs.rs"
-required-features = ["mocks"]
 
 [[test]]
 name = "test_registers"
 path = "tests/test_registers.rs"
-required-features = ["mocks"]
 
 [[test]]
 name = "test_storage_usage"
 path = "tests/test_storage_usage.rs"
-required-features = ["mocks"]
 
 [[test]]
 name = "test_promises"
 path = "tests/test_promises.rs"
-required-features = ["mocks"]
 
 [[test]]
 name = "test_iterators"
 path = "tests/test_iterators.rs"
-required-features = ["mocks"]
 
-[features]
-default = []
-# Mocks include some unsafe code to workaround lifetimes and therefore are optional.
-mocks = ["sodiumoxide"]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+sodiumoxide =  "0.2.5"

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-logic"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -15,8 +15,8 @@ This crate implements the specification of the interface that Near blockchain ex
 [dependencies]
 bs58 = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-near-runtime-fees = { path = "../near-runtime-fees", version = "0.3.1" }
-near-vm-errors = { path = "../near-vm-errors", version = "0.3.1" }
+near-runtime-fees = { path = "../near-runtime-fees", version = "0.3.2" }
+near-vm-errors = { path = "../near-vm-errors", version = "0.3.2" }
 
 [dev-dependencies]
 serde_json = {version= "1.0", features= ["preserve_order"]}

--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -3,7 +3,7 @@ mod context;
 mod dependencies;
 mod gas_counter;
 mod logic;
-#[cfg(feature = "mocks")]
+#[cfg(not(target_arch = "wasm32"))]
 pub mod mocks;
 pub mod serde_with;
 

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -21,5 +21,5 @@ to make sure it has expected behavior once deployed to the blockchain.
 [dependencies]
 serde_json = "1.0"
 clap = "2.33.0"
-near-vm-logic = { path = "../near-vm-logic", features = ["mocks"], version = "0.3.1"}
+near-vm-logic = { path = "../near-vm-logic", version = "0.3.1"}
 near-vm-runner = { path = "../near-vm-runner", version = "0.3.1" }

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner-standalone"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,5 +21,5 @@ to make sure it has expected behavior once deployed to the blockchain.
 [dependencies]
 serde_json = "1.0"
 clap = "2.33.0"
-near-vm-logic = { path = "../near-vm-logic", version = "0.3.1"}
-near-vm-runner = { path = "../near-vm-runner", version = "0.3.1" }
+near-vm-logic = { path = "../near-vm-logic", version = "0.3.2"}
+near-vm-runner = { path = "../near-vm-runner", version = "0.3.2" }

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -22,7 +22,6 @@ pwasm-utils = "0.11.0"
 parity-wasm = "0.40.1"
 
 [dev-dependencies]
-near-vm-logic = { path="../near-vm-logic", features=["mocks"], version = "0.3.0"}
 assert_matches = "1.3.0"
 wabt = "0.9"
 bencher = "0.1.5"

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,8 +16,8 @@ This crate implements the specification of the interface that Near blockchain ex
 cached = "0.9.0"
 wasmer-runtime = { version = "0.7.0", features = ["singlepass"] }
 wasmer-runtime-core = { version = "0.7.0"}
-near-vm-logic = { path="../near-vm-logic", version = "0.3.1"}
-near-vm-errors = { path = "../near-vm-errors", version = "0.3.1" }
+near-vm-logic = { path="../near-vm-logic", version = "0.3.2"}
+near-vm-errors = { path = "../near-vm-errors", version = "0.3.2" }
 pwasm-utils = "0.11.0"
 parity-wasm = "0.40.1"
 

--- a/runtime/publish.sh
+++ b/runtime/publish.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -ex
+for p in near-runtime-fees near-vm-errors near-vm-logic near-vm-runner near-vm-runner-standalone
+do
+pushd ./${p}
+cargo publish
+popd
+# Sleep a bit to let the previous package upload to crates.io. Otherwise we fail publishing checks.
+sleep 10
+done


### PR DESCRIPTION
A workaround for this cargo bug https://github.com/rust-lang/cargo/issues/2524 . We need it for making near-bindgen testing nicer.