### PR TITLE
Adding a test to monitor network structure sizes

### DIFF
--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1164,3 +1164,71 @@ pub struct PartialEncodedChunkRequestMsg {
 
 #[derive(Message)]
 pub struct StopSignal {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem::size_of;
+
+    const ALLOWED_SIZE: usize = 1 << 20;
+
+    macro_rules! assert_size {
+        ($type:ident) => {
+            let struct_size = size_of::<$type>();
+            println!("The size of {} is {}", stringify!($type), struct_size);
+            assert!(struct_size <= ALLOWED_SIZE);
+        };
+    }
+
+    #[test]
+    fn test_enum_size() {
+        assert_size!(PeerType);
+        assert_size!(PeerStatus);
+        assert_size!(HandshakeFailureReason);
+        assert_size!(RoutedMessageBody);
+        assert_size!(PeerIdOrHash);
+        assert_size!(KnownPeerStatus);
+        assert_size!(ConsolidateResponse);
+        assert_size!(PeerRequest);
+        assert_size!(PeerResponse);
+        assert_size!(ReasonForBan);
+        assert_size!(NetworkRequests);
+        assert_size!(PeerManagerRequest);
+        assert_size!(NetworkResponses);
+        assert_size!(NetworkClientMessages);
+        assert_size!(NetworkClientResponses);
+    }
+
+    #[test]
+    fn test_struct_size() {
+        assert_size!(PeerInfo);
+        assert_size!(PeerChainInfo);
+        assert_size!(Handshake);
+        assert_size!(AnnounceAccountRoute);
+        assert_size!(AnnounceAccount);
+        assert_size!(Ping);
+        assert_size!(Pong);
+        assert_size!(RawRoutedMessage);
+        assert_size!(RoutedMessageNoSignature);
+        assert_size!(RoutedMessage);
+        assert_size!(RoutedMessageFrom);
+        assert_size!(SyncData);
+        assert_size!(NetworkConfig);
+        assert_size!(KnownPeerState);
+        assert_size!(InboundTcpConnect);
+        assert_size!(OutboundTcpConnect);
+        assert_size!(SendMessage);
+        assert_size!(Consolidate);
+        assert_size!(Unregister);
+        assert_size!(PeerList);
+        assert_size!(PeersRequest);
+        assert_size!(PeersResponse);
+        assert_size!(Ban);
+        assert_size!(FullPeerInfo);
+        assert_size!(NetworkInfo);
+        assert_size!(StateResponseInfo);
+        assert_size!(QueryPeerStats);
+        assert_size!(PartialEncodedChunkRequestMsg);
+        assert_size!(StopSignal);
+    }
+}

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1171,11 +1171,14 @@ mod tests {
     use std::mem::size_of;
 
     const ALLOWED_SIZE: usize = 1 << 20;
+    const NOTIFY_SIZE: usize = 1024;
 
     macro_rules! assert_size {
         ($type:ident) => {
             let struct_size = size_of::<$type>();
-            println!("The size of {} is {}", stringify!($type), struct_size);
+            if struct_size >= NOTIFY_SIZE {
+                println!("The size of {} is {}", stringify!($type), struct_size);
+            }
             assert!(struct_size <= ALLOWED_SIZE);
         };
     }


### PR DESCRIPTION
Currently, the test is configured just for info, but some messages are above 1024.

```
Enums: 

The size of RoutedMessageBody is 1096
The size of PeerRequest is 1136
The size of NetworkRequests is 1192
The size of NetworkClientMessages is 1192
The size of NetworkClientResponses is 1128

Structs:

The size of RawRoutedMessage is 1168
The size of RoutedMessageNoSignature is 1232
The size of RoutedMessage is 1296
The size of RoutedMessageFrom is 1368
The size of SendMessage is 1304
The size of StateResponseInfo is 1088
```

ref #1313 