### PR TITLE
Fixing chunks retrieval for non-validators

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1659,6 +1659,12 @@ impl Chain {
     pub fn is_orphan(&self, hash: &CryptoHash) -> bool {
         self.orphans.contains(hash)
     }
+
+    /// Check if hash is for a known chunk orphan.
+    #[inline]
+    pub fn is_chunk_orphan(&self, hash: &CryptoHash) -> bool {
+        self.blocks_with_missing_chunks.contains(hash)
+    }
 }
 
 /// Chain update helper, contains information that is needed to process block
@@ -1723,12 +1729,40 @@ impl<'a> ChainUpdate<'a> {
         })
     }
 
+    fn care_about_any_shard_or_part(
+        &mut self,
+        me: &Option<AccountId>,
+        parent_hash: CryptoHash,
+    ) -> Result<bool, Error> {
+        for shard_id in 0..self.runtime_adapter.num_shards() {
+            if self.runtime_adapter.cares_about_shard(me.as_ref(), &parent_hash, shard_id, true)
+                || self.runtime_adapter.will_care_about_shard(
+                    me.as_ref(),
+                    &parent_hash,
+                    shard_id,
+                    true,
+                )
+            {
+                return Ok(true);
+            }
+        }
+        for part_id in 0..self.runtime_adapter.num_total_parts(&parent_hash) {
+            if &Some(self.runtime_adapter.get_part_owner(&parent_hash, part_id as u64)?) == me {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     pub fn ping_missing_chunks(
         &mut self,
         me: &Option<AccountId>,
         parent_hash: CryptoHash,
         block: &Block,
     ) -> Result<(), Error> {
+        if !self.care_about_any_shard_or_part(me, parent_hash)? {
+            return Ok(());
+        }
         let mut missing = vec![];
         let height = block.header.inner.height;
         for (shard_id, chunk_header) in block.chunks.iter().enumerate() {
@@ -1775,7 +1809,14 @@ impl<'a> ChainUpdate<'a> {
         Ok(())
     }
 
-    pub fn save_incoming_receipts_from_block(&mut self, block: &Block) -> Result<(), Error> {
+    pub fn save_incoming_receipts_from_block(
+        &mut self,
+        me: &Option<AccountId>,
+        block: &Block,
+    ) -> Result<(), Error> {
+        if !self.care_about_any_shard_or_part(me, block.header.inner.prev_hash)? {
+            return Ok(());
+        }
         let height = block.header.inner.height;
         let mut receipt_proofs_by_shard_id = HashMap::new();
 
@@ -2102,7 +2143,7 @@ impl<'a> ChainUpdate<'a> {
         let prev_block = self.chain_store_update.get_block(&prev_hash)?.clone();
 
         self.ping_missing_chunks(me, prev_hash, &block)?;
-        self.save_incoming_receipts_from_block(&block)?;
+        self.save_incoming_receipts_from_block(me, &block)?;
 
         // Do basic validation of chunks before applying the transactions
         for (chunk_header, prev_chunk_header) in block.chunks.iter().zip(prev_block.chunks.iter()) {

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -479,21 +479,6 @@ impl Client {
         let blocks_missing_chunks = Arc::new(RwLock::new(vec![]));
         let challenges = Arc::new(RwLock::new(vec![]));
 
-        for chunk_header in block.chunks.iter() {
-            // Process empty partial encoded chunks, to persist those for which no parts/receipts
-            //     are needed
-            let partial_encoded_chunk = PartialEncodedChunk {
-                shard_id: chunk_header.inner.shard_id,
-                chunk_hash: chunk_header.chunk_hash().clone(),
-                header: Some(chunk_header.clone()),
-                receipts: vec![],
-                parts: vec![],
-            };
-            let _ = self
-                .shards_mgr
-                .process_partial_encoded_chunk(partial_encoded_chunk, self.chain.mut_store());
-        }
-
         let result = {
             let me = self
                 .block_producer

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -761,6 +761,7 @@ impl ClientActor {
                 }
                 near_chain::ErrorKind::ChunksMissing(missing_chunks) => {
                     debug!(
+                        target: "client",
                         "Chunks were missing for block {}, I'm {:?}, requesting. Missing: {:?}, ({:?})",
                         hash.clone(),
                         self.client.block_producer.as_ref().map(|bp| bp.account_id.clone()),
@@ -771,7 +772,7 @@ impl ClientActor {
                     NetworkClientResponses::NoResponse
                 }
                 _ => {
-                    debug!("Process block: block {} refused by chain: {}", hash, e.kind());
+                    debug!(target: "client", "Process block: block {} refused by chain: {}", hash, e.kind());
                     NetworkClientResponses::NoResponse
                 }
             },

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -327,7 +327,9 @@ impl BlockSync {
 
         let hashes_to_request = hashes
             .iter()
-            .filter(|x| !chain.get_block(x).is_ok() && !chain.is_orphan(x))
+            .filter(|x| {
+                !chain.get_block(x).is_ok() && !chain.is_orphan(x) && !chain.is_chunk_orphan(x)
+            })
             .take(block_count)
             .collect::<Vec<_>>();
         if hashes_to_request.len() > 0 {

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -244,6 +244,7 @@ impl Peer {
     }
 
     fn ban_peer(&mut self, ctx: &mut Context<Peer>, ban_reason: ReasonForBan) {
+        info!(target: "network", "Banning peer {} for {:?}", self.peer_info, ban_reason);
         self.peer_status = PeerStatus::Banned(ban_reason);
         ctx.stop();
     }

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -275,7 +275,7 @@ impl NearConfig {
                 state_fetch_horizon: 5,
                 block_header_fetch_horizon: 50,
                 catchup_step_period: Duration::from_millis(100),
-                chunk_request_retry_period: Duration::from_millis(100),
+                chunk_request_retry_period: Duration::from_millis(200),
                 tracked_accounts: config.tracked_accounts,
                 tracked_shards: config.tracked_shards,
             },


### PR DESCRIPTION
1. Properly fixing the case when a node is not a validator and doesn't need to request any chunks.
2. Allow fetching chunks that are outside of the cache horizon, and only use the horizon for unknown chunks.