### PR TITLE
Setting up parts in Runtime

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1346,23 +1346,17 @@ impl Chain {
             .into());
         }
 
-        // 5. TODO MOO check state_root_node
-        /*if hash(&state_root_node.data.try_to_vec().expect("TODO MOO"))
-            != chunk.header.inner.prev_state_root
+        // 5. Checking that state_root_node is valid
+        if !self
+            .runtime_adapter
+            .validate_state_root_node(state_root_node, &chunk.header.inner.prev_state_root)?
         {
-            println!(
-                "HERE! {:?}, {:?} {:?} {:?}",
-                state_root_node,
-                hash(&state_root_node.try_to_vec().expect("TODO MOO")),
-                hash(&state_root_node.data.try_to_vec().expect("TODO MOO")),
-                chunk.header.inner.prev_state_root
-            );
             byzantine_assert!(false);
             return Err(ErrorKind::Other(
                 "set_shard_state failed: state_root_node is invalid".into(),
             )
             .into());
-        }*/
+        }
 
         // Saving the header data.
         let mut store_update = self.store.owned_store().store_update();

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1400,7 +1400,7 @@ impl Chain {
 
         // Saving the part data.
         let mut store_update = self.store.owned_store().store_update();
-        let key = StatePartKey(part_id, state_root).try_to_vec()?;
+        let key = StatePartKey(shard_id, part_id, state_root).try_to_vec()?;
         store_update.set_ser(COL_STATE_PARTS, &key, data)?;
         store_update.commit()?;
         Ok(())
@@ -1417,7 +1417,7 @@ impl Chain {
         let state_root = shard_state_header.chunk.header.inner.prev_state_root.clone();
         let mut parts = vec![];
         for i in 0..num_parts {
-            let key = StatePartKey(i, state_root.clone()).try_to_vec()?;
+            let key = StatePartKey(shard_id, i, state_root.clone()).try_to_vec()?;
             parts.push(self.store.owned_store().get_ser(COL_STATE_PARTS, &key)?.unwrap());
         }
 
@@ -1471,7 +1471,7 @@ impl Chain {
         let state_root = shard_state_header.chunk.header.inner.prev_state_root.clone();
         let mut store_update = self.store.owned_store().store_update();
         for part_id in 0..num_parts {
-            let key = StatePartKey(part_id, state_root).try_to_vec()?;
+            let key = StatePartKey(shard_id, part_id, state_root).try_to_vec()?;
             store_update.delete(COL_STATE_PARTS, &key);
         }
         Ok(store_update.commit()?)

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1135,7 +1135,7 @@ impl Chain {
         }
 
         let state_root_node =
-            self.runtime_adapter.get_state_root_node(&chunk_header.inner.prev_state_root)?;
+            self.runtime_adapter.get_state_root_node(&chunk_header.inner.prev_state_root);
 
         Ok(ShardStateSyncResponseHeader {
             chunk,
@@ -1178,10 +1178,7 @@ impl Chain {
             )
             .into());
         }
-        let state_part = self
-            .runtime_adapter
-            .obtain_state_part(&state_root, part_id, num_parts)
-            .map_err(|err| ErrorKind::Other(err.to_string()))?;
+        let state_part = self.runtime_adapter.obtain_state_part(&state_root, part_id, num_parts);
 
         Ok(state_part)
     }
@@ -1349,7 +1346,7 @@ impl Chain {
         // 5. Checking that state_root_node is valid
         if !self
             .runtime_adapter
-            .validate_state_root_node(state_root_node, &chunk.header.inner.prev_state_root)?
+            .validate_state_root_node(state_root_node, &chunk.header.inner.prev_state_root)
         {
             byzantine_assert!(false);
             return Err(ErrorKind::Other(
@@ -1393,7 +1390,7 @@ impl Chain {
         let shard_state_header = self.get_received_state_header(shard_id, sync_hash)?;
         let ShardStateSyncResponseHeader { chunk, .. } = shard_state_header;
         let state_root = chunk.header.inner.prev_state_root;
-        if !self.runtime_adapter.validate_state_part(&state_root, part_id, num_parts, data)? {
+        if !self.runtime_adapter.validate_state_part(&state_root, part_id, num_parts, data) {
             byzantine_assert!(false);
             return Err(ErrorKind::Other(
                 "set_state_part failed: validate_state_part failed".into(),

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -26,7 +26,7 @@ use near_primitives::views::{
     ExecutionOutcomeView, ExecutionOutcomeWithIdView, ExecutionStatusView,
     FinalExecutionOutcomeView, FinalExecutionStatus,
 };
-use near_store::{Store, COL_STATE_HEADERS};
+use near_store::{Store, COL_STATE_HEADERS, COL_STATE_PARTS};
 
 use crate::byzantine_assert;
 use crate::error::{Error, ErrorKind};
@@ -36,7 +36,7 @@ use crate::store::{ChainStore, ChainStoreAccess, ChainStoreUpdate, ShardInfo, St
 use crate::types::{
     AcceptedBlock, ApplyTransactionResult, Block, BlockHeader, BlockStatus, Provenance,
     ReceiptList, ReceiptProofResponse, ReceiptResponse, RootProof, RuntimeAdapter,
-    ShardStateSyncResponseHeader, ShardStateSyncResponsePart, StateHeaderKey, Tip,
+    ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey, Tip,
     ValidatorSignatureVerificationResult,
 };
 use crate::validate::{validate_challenge, validate_chunk_proofs, validate_chunk_with_chunk_extra};
@@ -1134,6 +1134,9 @@ impl Chain {
             root_proofs.push(root_proofs_cur);
         }
 
+        let state_root_node =
+            self.runtime_adapter.get_state_root_node(&chunk_header.inner.prev_state_root)?;
+
         Ok(ShardStateSyncResponseHeader {
             chunk,
             chunk_proof,
@@ -1141,6 +1144,7 @@ impl Chain {
             prev_chunk_proof,
             incoming_receipts_proofs,
             root_proofs,
+            state_root_node,
         })
     }
 
@@ -1148,8 +1152,9 @@ impl Chain {
         &mut self,
         shard_id: ShardId,
         part_id: u64,
+        num_parts: u64,
         sync_hash: CryptoHash,
-    ) -> Result<ShardStateSyncResponsePart, Error> {
+    ) -> Result<Vec<u8>, Error> {
         let sync_block = self.get_block(&sync_hash)?;
         let sync_block_header = sync_block.header.clone();
         if shard_id as usize >= sync_block.chunks.len() {
@@ -1167,18 +1172,18 @@ impl Chain {
         }
         let state_root = sync_prev_block.chunks[shard_id as usize].inner.prev_state_root.clone();
 
-        if part_id >= state_root.num_parts {
+        if part_id >= num_parts {
             return Err(ErrorKind::Other(
                 "get_state_response_part fail: part_id out of bound".to_string(),
             )
             .into());
         }
-        let (state_part, proof) = self
+        let state_part = self
             .runtime_adapter
-            .obtain_state_part(shard_id, part_id, &state_root)
+            .obtain_state_part(&state_root, part_id, num_parts)
             .map_err(|err| ErrorKind::Other(err.to_string()))?;
 
-        Ok(ShardStateSyncResponsePart { state_part, proof })
+        Ok(state_part)
     }
 
     pub fn set_state_header(
@@ -1196,6 +1201,7 @@ impl Chain {
             prev_chunk_proof,
             incoming_receipts_proofs,
             root_proofs,
+            state_root_node,
         } = &shard_state_header;
 
         // 1-2. Checking chunk validity
@@ -1340,6 +1346,24 @@ impl Chain {
             .into());
         }
 
+        // 5. TODO MOO check state_root_node
+        /*if hash(&state_root_node.data.try_to_vec().expect("TODO MOO"))
+            != chunk.header.inner.prev_state_root
+        {
+            println!(
+                "HERE! {:?}, {:?} {:?} {:?}",
+                state_root_node,
+                hash(&state_root_node.try_to_vec().expect("TODO MOO")),
+                hash(&state_root_node.data.try_to_vec().expect("TODO MOO")),
+                chunk.header.inner.prev_state_root
+            );
+            byzantine_assert!(false);
+            return Err(ErrorKind::Other(
+                "set_shard_state failed: state_root_node is invalid".into(),
+            )
+            .into());
+        }*/
+
         // Saving the header data.
         let mut store_update = self.store.owned_store().store_update();
         let key = StateHeaderKey(shard_id, sync_hash).try_to_vec()?;
@@ -1368,14 +1392,26 @@ impl Chain {
         &mut self,
         shard_id: ShardId,
         sync_hash: CryptoHash,
-        part: ShardStateSyncResponsePart,
+        part_id: u64,
+        num_parts: u64,
+        data: &Vec<u8>,
     ) -> Result<(), Error> {
         let shard_state_header = self.get_received_state_header(shard_id, sync_hash)?;
         let ShardStateSyncResponseHeader { chunk, .. } = shard_state_header;
-        let state_root = &chunk.header.inner.prev_state_root;
-        self.runtime_adapter
-            .accept_state_part(state_root, &part.state_part, &part.proof)
-            .map_err(|_| ErrorKind::InvalidStatePayload)?;
+        let state_root = chunk.header.inner.prev_state_root;
+        if !self.runtime_adapter.validate_state_part(&state_root, part_id, num_parts, data)? {
+            byzantine_assert!(false);
+            return Err(ErrorKind::Other(
+                "set_state_part failed: validate_state_part failed".into(),
+            )
+            .into());
+        }
+
+        // Saving the part data.
+        let mut store_update = self.store.owned_store().store_update();
+        let key = StatePartKey(part_id, state_root).try_to_vec()?;
+        store_update.set_ser(COL_STATE_PARTS, &key, data)?;
+        store_update.commit()?;
         Ok(())
     }
 
@@ -1383,8 +1419,21 @@ impl Chain {
         &mut self,
         shard_id: ShardId,
         sync_hash: CryptoHash,
+        num_parts: u64,
     ) -> Result<(), Error> {
         let shard_state_header = self.get_received_state_header(shard_id, sync_hash)?;
+        let mut height = shard_state_header.chunk.header.height_included;
+        let state_root = shard_state_header.chunk.header.inner.prev_state_root.clone();
+        let mut parts = vec![];
+        for i in 0..num_parts {
+            let key = StatePartKey(i, state_root.clone()).try_to_vec()?;
+            parts.push(self.store.owned_store().get_ser(COL_STATE_PARTS, &key)?.unwrap());
+        }
+
+        // Confirm that state matches the parts we received
+        self.runtime_adapter.confirm_state(&state_root, &parts)?;
+
+        // Applying the chunk starts here
         let mut chain_update = ChainUpdate::new(
             &mut self.store,
             self.runtime_adapter.clone(),
@@ -1394,7 +1443,6 @@ impl Chain {
             self.epoch_length,
             self.gas_price_adjustment_rate,
         );
-        let mut height = shard_state_header.chunk.header.height_included;
         chain_update.set_state_finalize(shard_id, sync_hash, shard_state_header)?;
         chain_update.commit()?;
 
@@ -1420,6 +1468,22 @@ impl Chain {
             }
         }
         Ok(())
+    }
+
+    pub fn clear_downloaded_parts(
+        &mut self,
+        shard_id: ShardId,
+        sync_hash: CryptoHash,
+        num_parts: u64,
+    ) -> Result<(), Error> {
+        let shard_state_header = self.get_received_state_header(shard_id, sync_hash)?;
+        let state_root = shard_state_header.chunk.header.inner.prev_state_root.clone();
+        let mut store_update = self.store.owned_store().store_update();
+        for part_id in 0..num_parts {
+            let key = StatePartKey(part_id, state_root).try_to_vec()?;
+            store_update.delete(COL_STATE_PARTS, &key);
+        }
+        Ok(store_update.commit()?)
     }
 
     /// Apply transactions in chunks for the next epoch in blocks that were blocked on the state sync
@@ -2681,18 +2745,13 @@ impl<'a> ChainUpdate<'a> {
             prev_chunk_proof: _,
             incoming_receipts_proofs,
             root_proofs: _,
+            state_root_node: _,
         } = shard_state_header;
-        let state_root = &chunk.header.inner.prev_state_root;
 
         let block_header = self
             .chain_store_update
             .get_header_on_chain_by_height(&sync_hash, chunk.header.height_included)?
             .clone();
-
-        // Applying chunk starts here.
-
-        // Confirm that state matches the parts we received.
-        self.runtime_adapter.confirm_state(&state_root)?;
 
         // Getting actual incoming receipts.
         let mut receipt_proof_response: Vec<ReceiptProofResponse> = vec![];

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -118,6 +118,8 @@ impl KeyValueRuntime {
         let mut state_size = HashMap::new();
         let data = kv_state.try_to_vec().unwrap();
         let data_len = data.len() as u64;
+        // StateRoot is actually faked here.
+        // We cannot do any reasonable validations of it in test_utils.
         state.insert(StateRoot::default(), kv_state);
         state_size.insert(StateRoot::default(), data_len);
         KeyValueRuntime {
@@ -743,6 +745,15 @@ impl RuntimeAdapter for KeyValueRuntime {
             data: self.state.read().unwrap().get(&state_root).unwrap().clone().try_to_vec()?,
             memory_usage: self.state_size.read().unwrap().get(&state_root).unwrap().clone(),
         })
+    }
+
+    fn validate_state_root_node(
+        &self,
+        _state_root_node: &StateRootNode,
+        _state_root: &StateRoot,
+    ) -> Result<bool, Error> {
+        // We do not care about deeper validation in test_utils
+        Ok(true)
     }
 
     fn is_next_block_epoch_start(&self, parent_hash: &CryptoHash) -> Result<bool, Error> {

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -20,7 +20,8 @@ use near_primitives::transaction::{
     TransferAction,
 };
 use near_primitives::types::{
-    AccountId, Balance, BlockIndex, EpochId, Gas, Nonce, ShardId, StateRoot, ValidatorStake,
+    AccountId, Balance, BlockIndex, EpochId, Gas, Nonce, ShardId, StateRoot, StateRootNode,
+    ValidatorStake,
 };
 use near_primitives::views::{EpochValidatorInfo, QueryResponse};
 use near_store::test_utils::create_test_store;
@@ -31,8 +32,8 @@ use near_store::{
 use crate::error::{Error, ErrorKind};
 use crate::store::ChainStoreAccess;
 use crate::types::{
-    ApplyTransactionResult, BlockHeader, RuntimeAdapter, StateRootNode,
-    ValidatorSignatureVerificationResult, Weight,
+    ApplyTransactionResult, BlockHeader, RuntimeAdapter, ValidatorSignatureVerificationResult,
+    Weight,
 };
 use crate::{Chain, ChainGenesis, ValidTransaction};
 use near_primitives::block::Approval;

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -13,7 +13,8 @@ use near_primitives::receipt::Receipt;
 use near_primitives::sharding::{ReceiptProof, ShardChunk, ShardChunkHeader};
 use near_primitives::transaction::{ExecutionOutcomeWithId, SignedTransaction};
 use near_primitives::types::{
-    AccountId, Balance, BlockIndex, EpochId, Gas, MerkleHash, ShardId, StateRoot, ValidatorStake,
+    AccountId, Balance, BlockIndex, EpochId, Gas, MerkleHash, ShardId, StateRoot, StateRootNode,
+    ValidatorStake,
 };
 use near_primitives::views::{EpochValidatorInfo, QueryResponse};
 use near_store::{PartialStorage, StoreUpdate, WrappedTrieChanges};
@@ -34,14 +35,6 @@ pub struct StateHeaderKey(pub ShardId, pub CryptoHash);
 
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct StatePartKey(pub ShardId, pub u64 /* PartId */, pub StateRoot);
-
-#[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
-pub struct StateRootNode {
-    /// data is the serialized TrieNodeWithSize
-    pub data: Vec<u8>,
-    /// memory_usage is a field of TrieNodeWithSize
-    pub memory_usage: u64,
-}
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum BlockStatus {
@@ -485,6 +478,12 @@ pub struct ShardStateSyncResponse {
     pub header: Option<ShardStateSyncResponseHeader>,
     pub part_ids: Vec<u64>,
     pub data: Vec<Vec<u8>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Default)]
+pub struct StateRequestParts {
+    pub ids: Vec<u64>,
+    pub num_parts: u64,
 }
 
 #[cfg(test)]

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -385,35 +385,32 @@ pub trait RuntimeAdapter: Send + Sync {
     fn get_validator_info(&self, block_hash: &CryptoHash) -> Result<EpochValidatorInfo, Error>;
 
     /// Get the part of the state from given state root.
-    fn obtain_state_part(
-        &self,
-        state_root: &StateRoot,
-        part_id: u64,
-        num_parts: u64,
-    ) -> Result<Vec<u8>, Error>;
+    fn obtain_state_part(&self, state_root: &StateRoot, part_id: u64, num_parts: u64) -> Vec<u8>;
 
     /// Validate state part that expected to be given state root with provided data.
-    /// Returns error if the resulting part doesn't match the expected one.
+    /// Returns false if the resulting part doesn't match the expected one.
     fn validate_state_part(
         &self,
         state_root: &StateRoot,
         part_id: u64,
         num_parts: u64,
         data: &Vec<u8>,
-    ) -> Result<bool, Error>;
+    ) -> bool;
 
     /// Should be executed after accepting all the parts to set up a new state.
     fn confirm_state(&self, state_root: &StateRoot, parts: &Vec<Vec<u8>>) -> Result<(), Error>;
 
     /// Returns StateRootNode of a state.
-    fn get_state_root_node(&self, state_root: &StateRoot) -> Result<StateRootNode, Error>;
+    /// Panics if requested hash is not in storage.
+    /// Never returns Error
+    fn get_state_root_node(&self, state_root: &StateRoot) -> StateRootNode;
 
     /// Validate StateRootNode of a state.
     fn validate_state_root_node(
         &self,
         state_root_node: &StateRootNode,
         state_root: &StateRoot,
-    ) -> Result<bool, Error>;
+    ) -> bool;
 
     /// Build receipts hashes.
     fn build_receipts_hashes(&self, receipts: &Vec<Receipt>) -> Result<Vec<CryptoHash>, Error> {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -37,7 +37,9 @@ pub struct StatePartKey(pub u64, pub StateRoot);
 
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct StateRootNode {
+    /// data is the serialized TrieNodeWithSize
     pub data: Vec<u8>,
+    /// memory_usage is a field of TrieNodeWithSize
     pub memory_usage: u64,
 }
 
@@ -405,6 +407,13 @@ pub trait RuntimeAdapter: Send + Sync {
 
     /// Returns StateRootNode of a state.
     fn get_state_root_node(&self, state_root: &StateRoot) -> Result<StateRootNode, Error>;
+
+    /// Validate StateRootNode of a state.
+    fn validate_state_root_node(
+        &self,
+        state_root_node: &StateRootNode,
+        state_root: &StateRoot,
+    ) -> Result<bool, Error>;
 
     /// Build receipts hashes.
     fn build_receipts_hashes(&self, receipts: &Vec<Receipt>) -> Result<Vec<CryptoHash>, Error> {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -33,7 +33,7 @@ pub struct RootProof(pub CryptoHash, pub MerklePath);
 pub struct StateHeaderKey(pub ShardId, pub CryptoHash);
 
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
-pub struct StatePartKey(pub u64, pub StateRoot);
+pub struct StatePartKey(pub ShardId, pub u64 /* PartId */, pub StateRoot);
 
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct StateRootNode {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -266,21 +266,15 @@ impl Handler<NetworkClientMessages> for ClientActor {
                     // NetworkClientResponses::Ban { ban_reason: ReasonForBan::BadBlockApproval }
                 }
             }
-            NetworkClientMessages::StateRequest(
-                shard_id,
-                hash,
-                need_header,
-                part_ids,
-                num_parts,
-                route_back,
-            ) => {
+            NetworkClientMessages::StateRequest(shard_id, hash, need_header, parts, route_back) => {
                 let mut data = vec![];
-                for part_id in part_ids.iter() {
-                    match self
-                        .client
-                        .chain
-                        .get_state_response_part(shard_id, *part_id, num_parts, hash)
-                    {
+                for part_id in parts.ids.iter() {
+                    match self.client.chain.get_state_response_part(
+                        shard_id,
+                        *part_id,
+                        parts.num_parts,
+                        hash,
+                    ) {
                         Ok(part) => data.push(part),
                         Err(e) => {
                             error!(target: "sync", "Cannot build sync part (get_state_response_part): {}", e);
@@ -297,7 +291,7 @@ impl Handler<NetworkClientMessages> for ClientActor {
                                     hash,
                                     shard_state: ShardStateSyncResponse {
                                         header: Some(header),
-                                        part_ids,
+                                        part_ids: parts.ids,
                                         data,
                                     },
                                 },
@@ -314,7 +308,11 @@ impl Handler<NetworkClientMessages> for ClientActor {
                         StateResponseInfo {
                             shard_id,
                             hash,
-                            shard_state: ShardStateSyncResponse { header: None, part_ids, data },
+                            shard_state: ShardStateSyncResponse {
+                                header: None,
+                                part_ids: parts.ids,
+                                data,
+                            },
                         },
                         route_back,
                     );

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -384,11 +384,11 @@ impl Handler<NetworkClientMessages> for ClientActor {
                             }
                         }
                         ShardSyncStatus::StateDownloadParts => {
+                            let num_parts = shard_sync_download.downloads.len();
                             for (i, part_id) in shard_state.part_ids.iter().enumerate() {
                                 let part_id = *part_id as usize;
-                                let num_parts = shard_sync_download.downloads.len();
                                 if part_id >= num_parts {
-                                    // TODO MOO ask Alex if continue is enough here
+                                    // This may happen only if we somehow have accepted wrong header
                                     continue;
                                 }
                                 if !shard_sync_download.downloads[part_id].done {

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -6,13 +6,13 @@ use chrono::{DateTime, Duration, Utc};
 use log::{debug, error, info};
 use rand::{thread_rng, Rng};
 
-use near_chain::types::ShardStateSyncResponseHeader;
+use near_chain::types::StateRootNode;
 use near_chain::{Chain, RuntimeAdapter, Tip};
 use near_chunks::NetworkAdapter;
 use near_network::types::{AccountOrPeerIdOrHash, ReasonForBan};
 use near_network::{FullPeerInfo, NetworkRequests};
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::{BlockIndex, Range, ShardId};
+use near_primitives::types::{BlockIndex, ShardId};
 use near_primitives::unwrap_or_return;
 
 use crate::types::{DownloadStatus, ShardSyncDownload, ShardSyncStatus, SyncStatus};
@@ -404,49 +404,6 @@ pub enum StateSyncResult {
     Completed,
 }
 
-pub struct StateSyncStrategy {}
-
-impl StateSyncStrategy {
-    pub fn download_by_one(downloads: &Vec<DownloadStatus>) -> Vec<Vec<Range>> {
-        let mut strategy = vec![];
-        for (i, download) in downloads.iter().enumerate() {
-            if download.run_me {
-                strategy.push(vec![Range(i as u64, i as u64 + 1)]);
-            }
-        }
-        strategy
-    }
-
-    pub fn download_sqrt(downloads: &Vec<DownloadStatus>) -> Vec<Vec<Range>> {
-        let len = downloads.len();
-        let run_count = downloads.iter().filter(|d| d.run_me).count();
-        if run_count * 5 < len {
-            // We downloaded more than 80% of the state.
-            // Let's distribute all small pieces between all nodes.
-            return StateSyncStrategy::download_by_one(downloads);
-        }
-        let mut strategy = vec![];
-        let mut begin = 0;
-        for (i, download) in downloads.iter().enumerate() {
-            if download.run_me {
-                if i - begin >= (len as f64).sqrt() as usize {
-                    strategy.push(vec![Range(begin as u64, i as u64)]);
-                    begin = i;
-                }
-            } else {
-                if begin != i {
-                    strategy.push(vec![Range(begin as u64, i as u64)]);
-                }
-                begin = i + 1;
-            }
-        }
-        if begin != len {
-            strategy.push(vec![Range(begin as u64, len as u64)]);
-        }
-        strategy
-    }
-}
-
 /// Helper to track state sync.
 pub struct StateSync {
     network_adapter: Arc<dyn NetworkAdapter>,
@@ -462,6 +419,12 @@ impl StateSync {
             state_sync_time: Default::default(),
             last_time_block_requested: None,
         }
+    }
+
+    // TODO MOO ask Alex for this
+    pub fn get_num_parts(&self, state_root_node: &StateRootNode) -> u64 {
+        let state_size = state_root_node.memory_usage;
+        state_size / 1000000 + 3
     }
 
     pub fn sync_block_status(
@@ -532,8 +495,8 @@ impl StateSync {
                     if shard_sync_download.downloads[0].done {
                         let shard_state_header =
                             chain.get_received_state_header(shard_id, sync_hash)?;
-                        let ShardStateSyncResponseHeader { chunk, .. } = shard_state_header;
-                        let state_num_parts = chunk.header.inner.prev_state_root.num_parts;
+                        let state_num_parts =
+                            self.get_num_parts(&shard_state_header.state_root_node);
                         *shard_sync_download = ShardSyncDownload {
                             downloads: vec![
                                 DownloadStatus {
@@ -588,7 +551,10 @@ impl StateSync {
                     }
                 }
                 ShardSyncStatus::StateDownloadFinalize => {
-                    match chain.set_state_finalize(shard_id, sync_hash) {
+                    let shard_state_header =
+                        chain.get_received_state_header(shard_id, sync_hash)?;
+                    let state_num_parts = self.get_num_parts(&shard_state_header.state_root_node);
+                    match chain.set_state_finalize(shard_id, sync_hash, state_num_parts) {
                         Ok(_) => {
                             update_sync_status = true;
                             *shard_sync_download = ShardSyncDownload {
@@ -604,6 +570,7 @@ impl StateSync {
                             *shard_sync_download = init_sync_download.clone();
                         }
                     }
+                    chain.clear_downloaded_parts(shard_id, sync_hash, state_num_parts)?;
                 }
                 ShardSyncStatus::StateDownloadComplete => {
                     this_done = true;
@@ -685,7 +652,8 @@ impl StateSync {
                     shard_id,
                     hash,
                     need_header: true,
-                    parts_ranges: vec![],
+                    part_ids: vec![],
+                    num_parts: 0, /* we don't use it here */
                     target: possible_targets[thread_rng().gen_range(0, possible_targets.len())]
                         .clone(),
                 });
@@ -693,16 +661,20 @@ impl StateSync {
                 new_shard_sync_download.downloads[0].run_me = false;
             }
             ShardSyncStatus::StateDownloadParts => {
-                let download_strategy =
-                    StateSyncStrategy::download_sqrt(&shard_sync_download.downloads);
-                self.apply_download_strategy(
-                    shard_id,
-                    hash,
-                    &possible_targets,
-                    download_strategy,
-                    &shard_sync_download,
-                    &mut new_shard_sync_download,
-                )?;
+                for (i, download) in new_shard_sync_download.downloads.iter().enumerate() {
+                    if download.run_me {
+                        self.network_adapter.send(NetworkRequests::StateRequest {
+                            shard_id,
+                            hash,
+                            need_header: false,
+                            part_ids: vec![i as u64],
+                            num_parts: new_shard_sync_download.downloads.len() as u64,
+                            target: possible_targets
+                                [thread_rng().gen_range(0, possible_targets.len())]
+                            .clone(),
+                        });
+                    }
+                }
             }
             _ => {}
         }
@@ -752,35 +724,6 @@ impl StateSync {
         } else {
             StateSyncResult::Unchanged
         })
-    }
-
-    pub fn apply_download_strategy(
-        &mut self,
-        shard_id: ShardId,
-        hash: CryptoHash,
-        possible_targets: &Vec<AccountOrPeerIdOrHash>,
-        download_strategy: Vec<Vec<Range>>,
-        shard_sync_download: &ShardSyncDownload,
-        new_shard_sync_download: &mut ShardSyncDownload,
-    ) -> Result<(), near_chain::Error> {
-        let state_num_parts = shard_sync_download.downloads.len();
-        assert_eq!(state_num_parts, new_shard_sync_download.downloads.len());
-        for parts_ranges in download_strategy {
-            for Range(from, to) in parts_ranges.iter() {
-                for i in *from as usize..*to as usize {
-                    assert!(new_shard_sync_download.downloads[i].run_me);
-                    new_shard_sync_download.downloads[i].run_me = false;
-                }
-            }
-            self.network_adapter.send(NetworkRequests::StateRequest {
-                shard_id,
-                hash,
-                need_header: false,
-                parts_ranges,
-                target: possible_targets[thread_rng().gen_range(0, possible_targets.len())].clone(),
-            });
-        }
-        Ok(())
     }
 }
 

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -568,12 +568,17 @@ impl StateSync {
                             error!(target: "sync", "State sync finalizing error, shard = {}, hash = {}: {:?}", shard_id, sync_hash, e);
                             update_sync_status = true;
                             *shard_sync_download = init_sync_download.clone();
+                            chain.clear_downloaded_parts(shard_id, sync_hash, state_num_parts)?;
                         }
                     }
-                    chain.clear_downloaded_parts(shard_id, sync_hash, state_num_parts)?;
                 }
                 ShardSyncStatus::StateDownloadComplete => {
                     this_done = true;
+                    let shard_state_header =
+                        chain.get_received_state_header(shard_id, sync_hash)?;
+                    let state_num_parts = self.get_num_parts(&shard_state_header.state_root_node);
+                    // TODO MOO ask Alex why uncommenting this fails
+                    //chain.clear_downloaded_parts(shard_id, sync_hash, state_num_parts)?;
                 }
             }
             all_done &= this_done;

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -421,10 +421,12 @@ impl StateSync {
         }
     }
 
-    // TODO MOO ask Alex for this
     pub fn get_num_parts(&self, state_root_node: &StateRootNode) -> u64 {
         let state_size = state_root_node.memory_usage;
-        state_size / 1000000 + 3
+        // We assume that 1 Mb is a good limit for state part size.
+        // On the other side, it's important to divide any state into
+        // several parts to make sure that partitioning always works.
+        state_size / (1024 * 1024) + 3
     }
 
     pub fn sync_block_status(

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -577,8 +577,7 @@ impl StateSync {
                     let shard_state_header =
                         chain.get_received_state_header(shard_id, sync_hash)?;
                     let state_num_parts = self.get_num_parts(&shard_state_header.state_root_node);
-                    // TODO MOO ask Alex why uncommenting this fails
-                    //chain.clear_downloaded_parts(shard_id, sync_hash, state_num_parts)?;
+                    chain.clear_downloaded_parts(shard_id, sync_hash, state_num_parts)?;
                 }
             }
             all_done &= this_done;

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -445,7 +445,8 @@ pub fn setup_mock_all_validators(
                             shard_id,
                             hash,
                             need_header,
-                            parts_ranges,
+                            part_ids,
+                            num_parts,
                             target: target_account_id,
                         } => {
                             let target_account_id = match target_account_id {
@@ -462,7 +463,8 @@ pub fn setup_mock_all_validators(
                                                 *shard_id,
                                                 *hash,
                                                 *need_header,
-                                                parts_ranges.to_vec(),
+                                                part_ids.to_vec(),
+                                                *num_parts,
                                                 my_address,
                                             ))
                                             .then(move |response| {

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -445,8 +445,7 @@ pub fn setup_mock_all_validators(
                             shard_id,
                             hash,
                             need_header,
-                            part_ids,
-                            num_parts,
+                            parts,
                             target: target_account_id,
                         } => {
                             let target_account_id = match target_account_id {
@@ -463,8 +462,7 @@ pub fn setup_mock_all_validators(
                                                 *shard_id,
                                                 *hash,
                                                 *need_header,
-                                                part_ids.to_vec(),
-                                                *num_parts,
+                                                parts.clone(),
                                                 my_address,
                                             ))
                                             .then(move |response| {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -6,7 +6,6 @@ use std::sync::Arc;
 use actix::{Actor, Context, Handler};
 
 use near_chain::{Chain, ChainGenesis, RuntimeAdapter};
-use near_primitives::hash::CryptoHash;
 use near_primitives::types::{AccountId, StateRoot};
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, QueryResponse,
@@ -51,7 +50,7 @@ impl Handler<Query> for ViewClientActor {
         let state_root = {
             if path_parts[0] == "validators" && path_parts.len() == 1 {
                 // for querying validators we don't need state root
-                StateRoot { hash: CryptoHash::default(), num_parts: 0 }
+                StateRoot::default()
             } else {
                 let account_id = AccountId::from(path_parts[1]);
                 let shard_id = self.runtime_adapter.account_id_to_shard_id(&account_id);

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -213,7 +213,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         .shards_mgr
         .create_encoded_shard_chunk(
             last_block.hash(),
-            StateRoot { hash: CryptoHash::default(), num_parts: 1 },
+            StateRoot::default(),
             CryptoHash::default(),
             last_block.header.inner.height + 1,
             0,

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -289,7 +289,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         assert_eq!(prev_merkle_proofs[0], challenge_body.prev_merkle_proof);
         assert_eq!(merkle_proofs[0], challenge_body.merkle_proof);
         assert_eq!(
-            challenge_body.partial_state,
+            challenge_body.partial_state.0,
             vec![
                 vec![
                     1, 7, 0, 227, 6, 86, 139, 125, 37, 242, 104, 89, 182, 115, 113, 193, 120, 119,

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -88,8 +88,7 @@ fn test_chunk_by_hash() {
                     assert_eq!(chunk.header.height_included, 0);
                     assert_eq!(chunk.header.outgoing_receipts_root.as_ref().len(), 32);
                     assert_eq!(chunk.header.prev_block_hash.as_ref().len(), 32);
-                    assert_eq!(chunk.header.prev_state_num_parts, 17);
-                    assert_eq!(chunk.header.prev_state_root_hash.as_ref().len(), 32);
+                    assert_eq!(chunk.header.prev_state_root.as_ref().len(), 32);
                     assert_eq!(chunk.header.rent_paid, 0);
                     assert_eq!(chunk.header.shard_id, 0);
                     assert!(if let Signature::ED25519(_) = chunk.header.signature {

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -323,15 +323,20 @@ impl Peer {
                     RoutedMessageBody::QueryResponse { response, id } => {
                         NetworkClientMessages::QueryResponse { response, id }
                     }
-                    RoutedMessageBody::StateRequest(shard_id, hash, need_header, parts_ranges) => {
-                        NetworkClientMessages::StateRequest(
-                            shard_id,
-                            hash,
-                            need_header,
-                            parts_ranges,
-                            msg_hash.clone().unwrap(),
-                        )
-                    }
+                    RoutedMessageBody::StateRequest(
+                        shard_id,
+                        hash,
+                        need_header,
+                        part_ids,
+                        num_parts,
+                    ) => NetworkClientMessages::StateRequest(
+                        shard_id,
+                        hash,
+                        need_header,
+                        part_ids,
+                        num_parts,
+                        msg_hash.clone().unwrap(),
+                    ),
                     RoutedMessageBody::StateResponse(info) => {
                         NetworkClientMessages::StateResponse(info)
                     }

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -323,20 +323,15 @@ impl Peer {
                     RoutedMessageBody::QueryResponse { response, id } => {
                         NetworkClientMessages::QueryResponse { response, id }
                     }
-                    RoutedMessageBody::StateRequest(
-                        shard_id,
-                        hash,
-                        need_header,
-                        part_ids,
-                        num_parts,
-                    ) => NetworkClientMessages::StateRequest(
-                        shard_id,
-                        hash,
-                        need_header,
-                        part_ids,
-                        num_parts,
-                        msg_hash.clone().unwrap(),
-                    ),
+                    RoutedMessageBody::StateRequest(shard_id, hash, need_header, parts) => {
+                        NetworkClientMessages::StateRequest(
+                            shard_id,
+                            hash,
+                            need_header,
+                            parts,
+                            msg_hash.clone().unwrap(),
+                        )
+                    }
                     RoutedMessageBody::StateResponse(info) => {
                         NetworkClientMessages::StateResponse(info)
                     }

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -729,25 +729,12 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                 }
                 NetworkResponses::NoResponse
             }
-            NetworkRequests::StateRequest {
-                shard_id,
-                hash,
-                need_header,
-                part_ids,
-                num_parts,
-                target,
-            } => {
+            NetworkRequests::StateRequest { shard_id, hash, need_header, parts, target } => {
                 match target {
                     AccountOrPeerIdOrHash::AccountId(account_id) => self.send_message_to_account(
                         ctx,
                         &account_id,
-                        RoutedMessageBody::StateRequest(
-                            shard_id,
-                            hash,
-                            need_header,
-                            part_ids,
-                            num_parts,
-                        ),
+                        RoutedMessageBody::StateRequest(shard_id, hash, need_header, parts),
                     ),
                     peer_or_hash @ AccountOrPeerIdOrHash::PeerId(_)
                     | peer_or_hash @ AccountOrPeerIdOrHash::Hash(_) => self.send_message_to_peer(
@@ -758,8 +745,7 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                                 shard_id,
                                 hash,
                                 need_header,
-                                part_ids,
-                                num_parts,
+                                parts,
                             ),
                         },
                     ),

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -729,12 +729,25 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                 }
                 NetworkResponses::NoResponse
             }
-            NetworkRequests::StateRequest { shard_id, hash, need_header, parts_ranges, target } => {
+            NetworkRequests::StateRequest {
+                shard_id,
+                hash,
+                need_header,
+                part_ids,
+                num_parts,
+                target,
+            } => {
                 match target {
                     AccountOrPeerIdOrHash::AccountId(account_id) => self.send_message_to_account(
                         ctx,
                         &account_id,
-                        RoutedMessageBody::StateRequest(shard_id, hash, need_header, parts_ranges),
+                        RoutedMessageBody::StateRequest(
+                            shard_id,
+                            hash,
+                            need_header,
+                            part_ids,
+                            num_parts,
+                        ),
                     ),
                     peer_or_hash @ AccountOrPeerIdOrHash::PeerId(_)
                     | peer_or_hash @ AccountOrPeerIdOrHash::Hash(_) => self.send_message_to_peer(
@@ -745,7 +758,8 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                                 shard_id,
                                 hash,
                                 need_header,
-                                parts_ranges,
+                                part_ids,
+                                num_parts,
                             ),
                         },
                     ),

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -31,11 +31,7 @@ fn create_transaction() -> SignedTransaction {
 }
 
 fn create_block() -> Block {
-    let genesis_chunks = genesis_chunks(
-        vec![StateRoot { hash: CryptoHash::default(), num_parts: 1 /* TODO MOO */ }],
-        1,
-        1_000,
-    );
+    let genesis_chunks = genesis_chunks(vec![StateRoot::default()], 1, 1_000);
     let genesis = Block::genesis(
         genesis_chunks.into_iter().map(|chunk| chunk.header).collect(),
         Utc::now(),

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -476,10 +476,7 @@ impl Block {
 
     pub fn compute_state_root(chunks: &Vec<ShardChunkHeader>) -> CryptoHash {
         merklize(
-            &chunks
-                .iter()
-                .map(|chunk| chunk.inner.prev_state_root.hash)
-                .collect::<Vec<CryptoHash>>(),
+            &chunks.iter().map(|chunk| chunk.inner.prev_state_root).collect::<Vec<CryptoHash>>(),
         )
         .0
     }

--- a/core/primitives/src/challenge.rs
+++ b/core/primitives/src/challenge.rs
@@ -12,6 +12,10 @@ pub type StateItem = Vec<u8>;
 
 pub type PartialState = Vec<StateItem>;
 
+#[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
+// TODO MOO this is weird
+pub struct PartialStateStruct(pub PartialState);
+
 /// Double signed block.
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]
 pub struct BlockDoubleSign {

--- a/core/primitives/src/challenge.rs
+++ b/core/primitives/src/challenge.rs
@@ -10,11 +10,8 @@ use crate::types::AccountId;
 /// Serialized TrieNodeWithSize
 pub type StateItem = Vec<u8>;
 
-pub type PartialState = Vec<StateItem>;
-
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, Eq, PartialEq)]
-// TODO MOO this is weird
-pub struct PartialStateStruct(pub PartialState);
+pub struct PartialState(pub Vec<StateItem>);
 
 /// Double signed block.
 #[derive(BorshSerialize, BorshDeserialize, PartialEq, Eq, Clone, Debug)]

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -30,12 +30,8 @@ pub type Gas = u64;
 pub type ReceiptIndex = usize;
 pub type PromiseId = Vec<ReceiptIndex>;
 
-/// Hash used by to store state root and the number of parts the state is divided.
-#[derive(Hash, Eq, PartialEq, Clone, Debug, BorshSerialize, BorshDeserialize, Default)]
-pub struct StateRoot {
-    pub hash: CryptoHash,
-    pub num_parts: u64,
-}
+/// Hash used by to store state root.
+pub type StateRoot = CryptoHash;
 
 /// Epoch identifier -- wrapped hash, to make it easier to distinguish.
 #[derive(
@@ -48,9 +44,6 @@ impl AsRef<[u8]> for EpochId {
         self.0.as_ref()
     }
 }
-
-#[derive(Hash, Eq, PartialEq, Clone, Debug, BorshSerialize, BorshDeserialize, Default)]
-pub struct Range(pub u64, pub u64);
 
 /// Stores validator and its stake.
 #[derive(BorshSerialize, BorshDeserialize, Debug, Clone, PartialEq, Eq)]

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -33,6 +33,14 @@ pub type PromiseId = Vec<ReceiptIndex>;
 /// Hash used by to store state root.
 pub type StateRoot = CryptoHash;
 
+#[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
+pub struct StateRootNode {
+    /// in Nightshade, data is the serialized TrieNodeWithSize
+    pub data: Vec<u8>,
+    /// in Nightshade, memory_usage is a field of TrieNodeWithSize
+    pub memory_usage: u64,
+}
+
 /// Epoch identifier -- wrapped hash, to make it easier to distinguish.
 #[derive(
     Hash, Eq, PartialEq, Clone, Debug, BorshSerialize, BorshDeserialize, Default, PartialOrd,

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -360,8 +360,7 @@ pub struct ChunkHeaderView {
     pub chunk_hash: CryptoHash,
     pub prev_block_hash: CryptoHash,
     pub outcome_root: CryptoHash,
-    pub prev_state_root_hash: CryptoHash,
-    pub prev_state_num_parts: u64,
+    pub prev_state_root: StateRoot,
     pub encoded_merkle_root: CryptoHash,
     pub encoded_length: u64,
     pub height_created: BlockIndex,
@@ -387,8 +386,7 @@ impl From<ShardChunkHeader> for ChunkHeaderView {
             chunk_hash: chunk.hash.0,
             prev_block_hash: chunk.inner.prev_block_hash,
             outcome_root: chunk.inner.outcome_root,
-            prev_state_root_hash: chunk.inner.prev_state_root.hash,
-            prev_state_num_parts: chunk.inner.prev_state_root.num_parts,
+            prev_state_root: chunk.inner.prev_state_root,
             encoded_merkle_root: chunk.inner.encoded_merkle_root,
             encoded_length: chunk.inner.encoded_length,
             height_created: chunk.inner.height_created,
@@ -417,10 +415,7 @@ impl From<ChunkHeaderView> for ShardChunkHeader {
         let mut header = ShardChunkHeader {
             inner: ShardChunkHeaderInner {
                 prev_block_hash: view.prev_block_hash,
-                prev_state_root: StateRoot {
-                    hash: view.prev_state_root_hash,
-                    num_parts: view.prev_state_num_parts,
-                },
+                prev_state_root: view.prev_state_root,
                 outcome_root: view.outcome_root,
                 encoded_merkle_root: view.encoded_merkle_root,
                 encoded_length: view.encoded_length,

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -58,7 +58,8 @@ pub const COL_BLOCK_EXTRA: Option<u32> = Some(19);
 pub const COL_BLOCK_PER_HEIGHT: Option<u32> = Some(20);
 pub const COL_LAST_APPROVALS_PER_ACCOUNT: Option<u32> = Some(21);
 pub const COL_MY_LAST_APPROVALS_PER_CHAIN: Option<u32> = Some(22);
-const NUM_COLS: u32 = 23;
+pub const COL_STATE_PARTS: Option<u32> = Some(23);
+const NUM_COLS: u32 = 24;
 
 pub struct Store {
     storage: Arc<dyn KeyValueDB>,

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -543,10 +543,6 @@ impl Trie {
         }
     }
 
-    pub fn get_memory_usage_from_serialized_node(node: &TrieNodeWithSize) -> u64 {
-        node.memory_usage
-    }
-
     #[cfg(test)]
     fn memory_usage_verify(&self, memory: &NodesStorage, handle: NodeHandle) -> u64 {
         if self.storage.as_recording_storage().is_some() {

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -7,7 +7,7 @@ use near_primitives::types::StateRoot;
 
 use crate::trie::iterator::CrumbStatus;
 use crate::trie::nibble_slice::NibbleSlice;
-use crate::trie::{NodeHandle, TrieNode, TrieNodeWithSize, POISONED_LOCK_ERR};
+use crate::trie::{NodeHandle, RawTrieNodeWithSize, TrieNode, TrieNodeWithSize, POISONED_LOCK_ERR};
 use crate::{PartialStorage, StorageError, Trie, TrieChanges, TrieIterator};
 
 impl Trie {
@@ -279,6 +279,15 @@ impl Trie {
             insertions,
             deletions: vec![],
         })
+    }
+
+    pub fn get_memory_usage_from_serialized(bytes: &Vec<u8>) -> Result<u64, StorageError> {
+        match RawTrieNodeWithSize::decode(&bytes) {
+            Ok(value) => Ok(TrieNodeWithSize::from_raw(value).memory_usage),
+            Err(_) => {
+                Err(StorageError::StorageInconsistentState(format!("Failed to decode node",)))
+            }
+        }
     }
 }
 

--- a/core/store/src/trie/state_parts.rs
+++ b/core/store/src/trie/state_parts.rs
@@ -1,6 +1,7 @@
 use std::cmp::min;
 use std::collections::HashMap;
 
+use near_primitives::challenge::PartialStateStruct;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::StateRoot;
 
@@ -21,23 +22,23 @@ impl Trie {
     pub fn get_trie_nodes_for_part(
         &self,
         part_id: u64,
+        num_parts: u64,
         state_root: &StateRoot,
-    ) -> Result<Vec<Vec<u8>>, StorageError> {
-        assert!(part_id < state_root.num_parts);
+    ) -> Result<PartialStateStruct, StorageError> {
+        assert!(part_id < num_parts);
         assert!(self.storage.as_caching_storage().is_some());
-        let root_node = self.retrieve_node(&state_root.hash)?;
-        let num_parts = state_root.num_parts;
+        let root_node = self.retrieve_node(&state_root)?;
         let total_size = root_node.memory_usage;
         let size_start = (total_size + num_parts - 1) / num_parts * part_id;
         let size_end = min((total_size + num_parts - 1) / num_parts * (part_id + 1), total_size);
 
         let with_recording = self.recording_reads();
-        with_recording.visit_nodes_for_size_range(&state_root.hash, size_start, size_end)?;
+        with_recording.visit_nodes_for_size_range(&state_root, size_start, size_end)?;
         let recorded = with_recording.recorded_storage().unwrap();
 
         let trie_nodes = recorded.nodes;
 
-        Ok(trie_nodes)
+        Ok(PartialStateStruct(trie_nodes))
     }
 
     /// Assume we lay out all trie nodes in dfs order visiting children before the parent.
@@ -141,25 +142,26 @@ impl Trie {
     /// Validate state part
     ///
     /// # Panics
-    /// part_id must be in [0..state_root.num_parts)
+    /// part_id must be in [0..num_parts)
     ///
     /// # Errors
     /// StorageError::TrieNodeWithMissing if some nodes are missing
     pub fn validate_trie_nodes_for_part(
         state_root: &StateRoot,
         part_id: u64,
-        trie_nodes: &Vec<Vec<u8>>,
+        num_parts: u64,
+        trie_nodes: &PartialStateStruct,
     ) -> Result<(), StorageError> {
-        assert!(part_id < state_root.num_parts);
+        let trie_nodes = trie_nodes.clone().0;
+        assert!(part_id < num_parts);
         let trie = Trie::from_recorded_storage(PartialStorage { nodes: trie_nodes.to_vec() });
 
-        let root_node = trie.retrieve_node(&state_root.hash)?;
-        let num_parts = state_root.num_parts;
+        let root_node = trie.retrieve_node(&state_root)?;
         let total_size = root_node.memory_usage;
         let size_start = (total_size + num_parts - 1) / num_parts * part_id;
         let size_end = min((total_size + num_parts - 1) / num_parts * (part_id + 1), total_size);
 
-        trie.visit_nodes_for_size_range(&state_root.hash, size_start, size_end)?;
+        trie.visit_nodes_for_size_range(&state_root, size_start, size_end)?;
         let storage = trie.storage.as_partial_storage().unwrap();
 
         if storage.visited_nodes.lock().expect(POISONED_LOCK_ERR).len() != trie_nodes.len() {
@@ -259,7 +261,7 @@ impl Trie {
             .collect::<Vec<_>>();
         let trie = Trie::from_recorded_storage(PartialStorage { nodes });
         let mut insertions = <HashMap<CryptoHash, (Vec<u8>, u32)>>::new();
-        trie.traverse_all_nodes(&state_root.hash, |hash| {
+        trie.traverse_all_nodes(&state_root, |hash| {
             if let Some((_bytes, rc)) = insertions.get_mut(hash) {
                 *rc += 1;
             } else {
@@ -273,7 +275,7 @@ impl Trie {
         insertions.sort();
         Ok(TrieChanges {
             old_root: Default::default(),
-            new_root: state_root.hash,
+            new_root: *state_root,
             insertions,
             deletions: vec![],
         })
@@ -295,7 +297,7 @@ mod tests {
 
     #[test]
     fn test_combine_empty_trie_parts() {
-        let state_root = StateRoot { hash: CryptoHash::default(), num_parts: 0 };
+        let state_root = StateRoot::default();
         let _ = Trie::combine_state_parts(&state_root, &vec![]).unwrap();
     }
 
@@ -306,7 +308,7 @@ mod tests {
             let trie = create_trie();
             let trie_changes = gen_changes(&mut rng, 500);
 
-            let (store_update, root) = trie
+            let (store_update, state_root) = trie
                 .update(&Trie::empty_root(), trie_changes.iter().cloned())
                 .unwrap()
                 .into(trie.clone())
@@ -316,18 +318,19 @@ mod tests {
                 // Test that creating and validating are consistent
                 let num_parts = rng.gen_range(1, 10);
                 let part_id = rng.gen_range(0, num_parts);
-                let state_root = StateRoot { hash: root, num_parts };
-                let trie_nodes = trie.get_trie_nodes_for_part(part_id, &state_root).unwrap();
-                Trie::validate_trie_nodes_for_part(&state_root, part_id, &trie_nodes)
+                let trie_nodes =
+                    trie.get_trie_nodes_for_part(part_id, num_parts, &state_root).unwrap();
+                Trie::validate_trie_nodes_for_part(&state_root, part_id, num_parts, &trie_nodes)
                     .expect("validate ok");
             }
 
             {
                 // Test that combining all parts gets all nodes
                 let num_parts = rng.gen_range(2, 10);
-                let state_root = StateRoot { hash: root, num_parts };
                 let parts = (0..num_parts)
-                    .map(|part_id| trie.get_trie_nodes_for_part(part_id, &state_root).unwrap())
+                    .map(|part_id| {
+                        trie.get_trie_nodes_for_part(part_id, num_parts, &state_root).unwrap().0
+                    })
                     .collect::<Vec<_>>();
 
                 let trie_changes = Trie::combine_state_parts(&state_root, &parts).unwrap();
@@ -346,9 +349,10 @@ mod tests {
                 assert_eq!(all_nodes.len(), trie_changes.insertions.len());
                 let size_of_all = all_nodes.iter().map(|node| node.len()).sum::<usize>();
                 Trie::validate_trie_nodes_for_part(
-                    &StateRoot { hash: root, num_parts: 1 },
+                    &state_root,
                     0,
-                    &all_nodes,
+                    1,
+                    &PartialStateStruct(all_nodes.clone()),
                 )
                 .expect("validate ok");
 

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -116,7 +116,7 @@ impl GenesisBuilder {
             .roots
             .iter()
             .map(|(shard_idx, root)| {
-                (*shard_idx, TrieUpdate::new(self.runtime.trie.clone(), root.hash))
+                (*shard_idx, TrieUpdate::new(self.runtime.trie.clone(), *root))
             })
             .collect();
         self.unflushed_records =
@@ -176,7 +176,7 @@ impl GenesisBuilder {
         let (store_update, root) = state_update.finalize()?.into(trie)?;
         store_update.commit()?;
 
-        self.roots.insert(shard_idx, StateRoot { hash: root, num_parts: 9 /* TODO MOO */ });
+        self.roots.insert(shard_idx, root.clone());
         self.state_updates.insert(shard_idx, TrieUpdate::new(self.runtime.trie.clone(), root));
         Ok(())
     }

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -9,9 +9,7 @@ use borsh::ser::BorshSerialize;
 use borsh::BorshDeserialize;
 use log::debug;
 
-use near_chain::types::{
-    ApplyTransactionResult, StateRootNode, ValidatorSignatureVerificationResult,
-};
+use near_chain::types::{ApplyTransactionResult, ValidatorSignatureVerificationResult};
 use near_chain::{BlockHeader, Error, ErrorKind, RuntimeAdapter, ValidTransaction, Weight};
 use near_crypto::{PublicKey, Signature};
 use near_epoch_manager::{BlockInfo, EpochConfig, EpochManager, RewardCalculator};
@@ -24,7 +22,8 @@ use near_primitives::serialize::from_base64;
 use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
-    AccountId, Balance, BlockIndex, EpochId, Gas, MerkleHash, ShardId, StateRoot, ValidatorStake,
+    AccountId, Balance, BlockIndex, EpochId, Gas, MerkleHash, ShardId, StateRoot, StateRootNode,
+    ValidatorStake,
 };
 use near_primitives::utils::{prefix_for_access_key, ACCOUNT_DATA_SEPARATOR};
 use near_primitives::views::{
@@ -935,9 +934,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     }
 
     fn get_state_root_node(&self, state_root: &StateRoot) -> StateRootNode {
-        let (data, memory_usage) =
-            self.trie.retrieve_root_node(state_root).expect("Failed to get root node");
-        StateRootNode { data, memory_usage }
+        self.trie.retrieve_root_node(state_root).expect("Failed to get root node")
     }
 
     fn validate_state_root_node(

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -1,16 +1,17 @@
 use std::collections::{HashMap, HashSet};
 use std::convert::{TryFrom, TryInto};
 use std::fs::File;
-use std::io::{Cursor, Read, Write};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
+use borsh::ser::BorshSerialize;
 use borsh::BorshDeserialize;
-use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
-use kvdb::DBValue;
 use log::debug;
 
-use near_chain::types::{ApplyTransactionResult, StatePart, ValidatorSignatureVerificationResult};
+use near_chain::types::{
+    ApplyTransactionResult, StateRootNode, ValidatorSignatureVerificationResult,
+};
 use near_chain::{BlockHeader, Error, ErrorKind, RuntimeAdapter, ValidTransaction, Weight};
 use near_crypto::{PublicKey, Signature};
 use near_epoch_manager::{BlockInfo, EpochConfig, EpochManager, RewardCalculator};
@@ -145,7 +146,6 @@ impl NightshadeRuntime {
         file.read_to_end(&mut data).expect("Failed to read genesis roots file.");
         let state_roots: Vec<StateRoot> =
             BorshDeserialize::try_from_slice(&data).expect("Failed to deserialize genesis roots");
-        // TODO MOO read new_state_num_parts
         (store_update, state_roots)
     }
 
@@ -636,7 +636,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         state_root: StateRoot,
         transaction: SignedTransaction,
     ) -> Result<ValidTransaction, RuntimeError> {
-        let mut state_update = TrieUpdate::new(self.trie.clone(), state_root.hash);
+        let mut state_update = TrieUpdate::new(self.trie.clone(), state_root);
         let apply_state = ApplyState {
             block_index,
             epoch_length: self.genesis_config.epoch_length,
@@ -666,7 +666,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         state_root: StateRoot,
         transactions: Vec<SignedTransaction>,
     ) -> Vec<SignedTransaction> {
-        let mut state_update = TrieUpdate::new(self.trie.clone(), state_root.hash);
+        let mut state_update = TrieUpdate::new(self.trie.clone(), state_root);
         let apply_state = ApplyState {
             block_index,
             epoch_length: self.genesis_config.epoch_length,
@@ -749,7 +749,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         };
         match self.process_state_update(
             trie,
-            state_root.hash,
+            *state_root,
             shard_id,
             block_index,
             block_timestamp,
@@ -790,7 +790,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         let trie = Arc::new(Trie::from_recorded_storage(partial_storage));
         self.process_state_update(
             trie.clone(),
-            state_root.hash,
+            *state_root,
             shard_id,
             block_index,
             block_timestamp,
@@ -817,16 +817,14 @@ impl RuntimeAdapter for NightshadeRuntime {
             return Err("Path must contain at least single token".into());
         }
         match path_parts[0] {
-            "account" => {
-                match self.view_account(state_root.hash, &AccountId::from(path_parts[1])) {
-                    Ok(r) => Ok(QueryResponse::ViewAccount(r.into())),
-                    Err(e) => Err(e),
-                }
-            }
+            "account" => match self.view_account(*state_root, &AccountId::from(path_parts[1])) {
+                Ok(r) => Ok(QueryResponse::ViewAccount(r.into())),
+                Err(e) => Err(e),
+            },
             "call" => {
                 let mut logs = vec![];
                 match self.call_function(
-                    state_root.hash,
+                    *state_root,
                     height,
                     block_timestamp,
                     &AccountId::from(path_parts[1]),
@@ -841,7 +839,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 }
             }
             "contract" => {
-                match self.view_state(state_root.hash, &AccountId::from(path_parts[1]), data) {
+                match self.view_state(*state_root, &AccountId::from(path_parts[1]), data) {
                     Ok(result) => Ok(QueryResponse::ViewState(result)),
                     Err(err) => Ok(QueryResponse::Error(QueryError {
                         error: err.to_string(),
@@ -851,21 +849,19 @@ impl RuntimeAdapter for NightshadeRuntime {
             }
             "access_key" => {
                 let result = if path_parts.len() == 2 {
-                    self.view_access_keys(state_root.hash, &AccountId::from(path_parts[1])).map(
-                        |r| {
-                            QueryResponse::AccessKeyList(
-                                r.into_iter()
-                                    .map(|(public_key, access_key)| AccessKeyInfoView {
-                                        public_key,
-                                        access_key: access_key.into(),
-                                    })
-                                    .collect(),
-                            )
-                        },
-                    )
+                    self.view_access_keys(*state_root, &AccountId::from(path_parts[1])).map(|r| {
+                        QueryResponse::AccessKeyList(
+                            r.into_iter()
+                                .map(|(public_key, access_key)| AccessKeyInfoView {
+                                    public_key,
+                                    access_key: access_key.into(),
+                                })
+                                .collect(),
+                        )
+                    })
                 } else {
                     self.view_access_key(
-                        state_root.hash,
+                        *state_root,
                         &AccountId::from(path_parts[1]),
                         &PublicKey::try_from(path_parts[2])?,
                     )
@@ -891,66 +887,72 @@ impl RuntimeAdapter for NightshadeRuntime {
 
     fn obtain_state_part(
         &self,
-        shard_id: ShardId,
-        part_id: u64,
         state_root: &StateRoot,
-    ) -> Result<(StatePart, Vec<u8>), Box<dyn std::error::Error>> {
-        if part_id > 0 {
-            /* TODO MOO */
-            return Ok((StatePart { shard_id, part_id, data: vec![] }, vec![]));
+        part_id: u64,
+        num_parts: u64,
+    ) -> Result<Vec<u8>, Error> {
+        if part_id >= num_parts {
+            return Err("Invalid part_id in obtain_state_part".to_string().into());
         }
-        // TODO(1052): make sure state_root is present in the trie.
-        // create snapshot.
-        let mut result = vec![];
-        let mut cursor = Cursor::new(&mut result);
-        for item in self.trie.iter(&state_root.hash)? {
-            let (key, value) = item?;
-            cursor.write_u32::<LittleEndian>(key.len() as u32)?;
-            cursor.write_all(&key)?;
-            cursor.write_u32::<LittleEndian>(value.len() as u32)?;
-            cursor.write_all(value.as_ref())?;
-        }
-        // TODO(1048): Save on disk an snapshot, split into chunks and compressed. Send chunks instead of single blob.
-        debug!(target: "runtime", "Read state part #{} for shard #{} @ {}, size = {}", part_id, shard_id, state_root.hash, result.len());
-        // TODO add proof in Nightshade Runtime
-        Ok((StatePart { shard_id, part_id, data: result }, vec![]))
+        self
+            .trie
+            .get_trie_nodes_for_part(part_id, num_parts, state_root)
+            .map_err(|e| {
+                format!(
+                    "Cannot run obtain_state_part for part {:?}, num_parts {:?}, state_root {:?}: {:?}",
+                    part_id, num_parts, state_root, e
+                )
+                    .into()
+            })
+            .map(|a| a.try_to_vec().expect("Cannot serialize"))
     }
 
-    fn accept_state_part(
+    fn validate_state_part(
         &self,
         state_root: &StateRoot,
-        part: &StatePart,
-        _proof: &Vec<u8>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        if part.part_id > 0 {
-            /* TODO MOO */
-            return Ok(());
+        part_id: u64,
+        num_parts: u64,
+        data: &Vec<u8>,
+    ) -> Result<bool, Error> {
+        if part_id >= num_parts {
+            return Err("Invalid part_id in validate_state_part".to_string().into());
         }
-        debug!(target: "runtime", "Writing state part #{} for shard #{} @ {}, size = {}", part.part_id, part.shard_id, state_root.hash, part.data.len());
-        // TODO prove that the part is valid
-        let mut state_update = TrieUpdate::new(self.trie.clone(), CryptoHash::default());
-        let state_part_len = part.data.len();
-        let mut cursor = Cursor::new(part.data.clone());
-        while cursor.position() < state_part_len as u64 {
-            let key_len = cursor.read_u32::<LittleEndian>()? as usize;
-            let mut key = vec![0; key_len];
-            cursor.read_exact(&mut key)?;
-            let value_len = cursor.read_u32::<LittleEndian>()? as usize;
-            let mut value = vec![0; value_len];
-            cursor.read_exact(&mut value)?;
-            state_update.set(key, DBValue::from_slice(&value));
+        match BorshDeserialize::try_from_slice(data) {
+            Ok(trie_nodes) => match Trie::validate_trie_nodes_for_part(
+                state_root,
+                part_id,
+                num_parts,
+                &trie_nodes,
+            ) {
+                Ok(_) => Ok(true),
+                // Storage error should not happen
+                Err(_) => Ok(false),
+            },
+            // Deserialization error means we've got the data from malicious peer
+            Err(_) => Ok(false),
         }
-        let (store_update, root) = state_update.finalize()?.into(self.trie.clone())?;
-        if root != state_root.hash {
-            return Err("Invalid state root".into());
-        }
-        store_update.commit()?;
-        Ok(())
     }
 
-    fn confirm_state(&self, _state_root: &StateRoot) -> Result<bool, Error> {
-        // TODO(1457): approve that all parts are here
-        Ok(true)
+    fn confirm_state(&self, state_root: &StateRoot, data: &Vec<Vec<u8>>) -> Result<(), Error> {
+        let mut parts = vec![];
+        for part in data {
+            parts.push(
+                BorshDeserialize::try_from_slice(part)
+                    .expect("Part was already validated earlier, so could never fail here"),
+            );
+        }
+        let trie_changes =
+            Trie::combine_state_parts(&state_root, &parts).expect("Failed to get trie update");
+        // TODO clean old states
+        let trie = self.trie.clone();
+        let (store_update, _) = trie_changes.into(trie).expect("Failed to apply trie update");
+        Ok(store_update.commit()?)
+    }
+
+    fn get_state_root_node(&self, state_root: &StateRoot) -> Result<StateRootNode, Error> {
+        let (data, memory_usage) =
+            self.trie.retrieve_root_node(state_root).expect("Failed to get root node");
+        Ok(StateRootNode { data, memory_usage })
     }
 }
 
@@ -1266,7 +1268,7 @@ mod test {
         pub fn view_account(&self, account_id: &str) -> AccountView {
             let shard_id = self.runtime.account_id_to_shard_id(&account_id.to_string());
             self.runtime
-                .view_account(self.state_roots[shard_id as usize].hash, &account_id.to_string())
+                .view_account(self.state_roots[shard_id as usize], &account_id.to_string())
                 .unwrap()
                 .into()
         }
@@ -1645,7 +1647,7 @@ mod test {
         let staking_transaction = stake(1, &signer, &block_producers[0], TESTING_INIT_STAKE + 1);
         env.step_default(vec![staking_transaction]);
         env.step_default(vec![]);
-        let (state_part, proof) = env.runtime.obtain_state_part(0, 0, &env.state_roots[0]).unwrap();
+        let state_part = env.runtime.obtain_state_part(&env.state_roots[0], 0, 1).unwrap();
         let mut new_env =
             TestEnv::new("test_state_sync", vec![validators.clone()], 2, vec![], vec![]);
         for i in 1..=2 {
@@ -1680,7 +1682,8 @@ mod test {
             new_env.head.prev_block_hash = prev_hash;
             new_env.last_proposals = proposals;
         }
-        new_env.runtime.accept_state_part(&env.state_roots[0], &state_part, &proof).unwrap();
+        new_env.runtime.validate_state_part(&env.state_roots[0], 0, 1, &state_part).unwrap();
+        new_env.runtime.confirm_state(&env.state_roots[0], &vec![state_part]).unwrap();
         new_env.state_roots[0] = env.state_roots[0].clone();
         for _ in 3..=5 {
             new_env.step_default(vec![]);
@@ -1963,7 +1966,7 @@ mod test {
             .runtime
             .apply(
                 env.runtime.trie.clone(),
-                env.state_roots[0].hash,
+                env.state_roots[0],
                 &None,
                 &apply_state,
                 &[],

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -47,7 +47,7 @@ impl RuntimeTestbed {
             BorshDeserialize::try_from_slice(&data).expect("Failed to deserialize genesis roots");
         assert!(state_roots.len() <= 1, "Parameter estimation works with one shard only.");
         assert!(!state_roots.is_empty(), "No state roots found.");
-        let root = state_roots[0].hash;
+        let root = state_roots[0];
 
         let mut runtime_config = RuntimeConfig::default();
         runtime_config.wasm_config.max_log_len = std::u64::MAX;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -1059,8 +1059,9 @@ impl Runtime {
         let key_value_changes = state_update.get_prefix_changes(subscribed_prefixes)?;
 
         let trie_changes = state_update.finalize()?;
+        let state_root = trie_changes.new_root;
         Ok(ApplyResult {
-            state_root: StateRoot { hash: trie_changes.new_root, num_parts: 9 }, /* TODO MOO */
+            state_root,
             trie_changes,
             validator_proposals,
             new_receipts,
@@ -1208,15 +1209,12 @@ impl Runtime {
             set_account(&mut state_update, account_id, &account);
         }
         let trie = state_update.trie.clone();
-        let state_update_state = state_update
+        let (store_update, state_root) = state_update
             .finalize()
             .expect("Genesis state update failed")
             .into(trie)
             .expect("Genesis state update failed");
-        (
-            state_update_state.0,
-            StateRoot { hash: state_update_state.1, num_parts: 9 /* TODO MOO */ },
-        )
+        (store_update, state_root)
     }
 }
 

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -229,7 +229,7 @@ mod tests {
     #[test]
     fn test_view_state() {
         let (_, trie, root) = get_runtime_and_trie();
-        let mut state_update = TrieUpdate::new(trie.clone(), root.hash);
+        let mut state_update = TrieUpdate::new(trie.clone(), root);
         state_update.set(key_for_data(&alice_account(), b"test123"), DBValue::from_slice(b"123"));
         let (db_changes, new_root) = state_update.finalize().unwrap().into(trie.clone()).unwrap();
         db_changes.commit().unwrap();

--- a/runtime/runtime/tests/runtime_group_tools/mod.rs
+++ b/runtime/runtime/tests/runtime_group_tools/mod.rs
@@ -54,7 +54,7 @@ impl StandaloneRuntime {
             gas_limit: None,
         };
 
-        Self { apply_state, runtime, trie, signer, root: root.hash }
+        Self { apply_state, runtime, trie, signer, root: root }
     }
 
     pub fn process_block(

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -323,7 +323,7 @@ fn main() {
             let (runtime, state_roots, height) = load_trie(store, &home_dir, &near_config);
             println!("Storage roots are {:?}, block height is {}", state_roots, height);
             for state_root in state_roots {
-                let trie = TrieIterator::new(&runtime.trie, &state_root.hash).unwrap();
+                let trie = TrieIterator::new(&runtime.trie, &state_root).unwrap();
                 for item in trie {
                     let (key, value) = item.unwrap();
                     print_state_entry(key, value);
@@ -341,7 +341,7 @@ fn main() {
             );
             near_config.genesis_config.records = vec![];
             for state_root in state_roots {
-                let trie = TrieIterator::new(&runtime.trie, &state_root.hash).unwrap();
+                let trie = TrieIterator::new(&runtime.trie, &state_root).unwrap();
                 for item in trie {
                     let (key, value) = item.unwrap();
                     if let Some(sr) = kv_to_state_record(key, value) {

--- a/test-utils/testlib/src/node/runtime_node.rs
+++ b/test-utils/testlib/src/node/runtime_node.rs
@@ -27,7 +27,7 @@ impl RuntimeNode {
         let client = Arc::new(RwLock::new(MockClient {
             runtime,
             trie,
-            state_root: root.hash,
+            state_root: root,
             epoch_length: genesis_config.epoch_length,
         }));
         RuntimeNode { signer, client }

--- a/test-utils/testlib/src/runtime_utils.rs
+++ b/test-utils/testlib/src/runtime_utils.rs
@@ -61,7 +61,7 @@ pub fn get_runtime_and_trie() -> (Runtime, Arc<Trie>, StateRoot) {
 pub fn get_test_trie_viewer() -> (TrieViewer, TrieUpdate) {
     let (_, trie, root) = get_runtime_and_trie();
     let trie_viewer = TrieViewer::new();
-    let state_update = TrieUpdate::new(trie, root.hash);
+    let state_update = TrieUpdate::new(trie, root);
     (trie_viewer, state_update)
 }
 

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -95,7 +95,7 @@ impl RuntimeUser {
                 );
             }
             apply_result.trie_changes.into(client.trie.clone()).unwrap().0.commit().unwrap();
-            client.state_root = apply_result.state_root.hash;
+            client.state_root = apply_result.state_root;
             if apply_result.new_receipts.is_empty() {
                 return Ok(());
             }


### PR DESCRIPTION
Fixes #1523. Fixes #1237.
- state num_parts -> state_size
- download strategy is removed and replaced with simple formula related to
state_size
- download ranges replaced with vector of requested parts
- removed fake StateRoot in Runtime
- confirm_state is commiting
- TrieChanges contains of memory_usage to build StateRoot
- MerkleHash -> CryptoHash where it used incorrectly
- minor changes