### PR TITLE
use x86-64 arch to avoid illegal inst in older cpus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /near
 COPY . .
 
 ENV CARGO_TARGET_DIR=/tmp/target
+ENV RUSTC_FLAGS='-C target-cpu=x86-64'
 RUN --mount=type=cache,target=/tmp/target \
     --mount=type=cache,target=/usr/local/cargo/git \
     --mount=type=cache,target=/usr/local/cargo/registry \


### PR DESCRIPTION
@hoekevin I just pushed this build to `ailisp/nearcore` docker image, can you try if this build works for you? Thanks