### PR TITLE
Epoch manager fixes

### DIFF
--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -39,6 +39,10 @@ pub fn epoch_info(
         acc.insert(x.0.to_string(), i);
         acc
     });
+    let validator_kickout = stake_change
+        .iter()
+        .filter_map(|(account, balance)| if *balance == 0 { Some(account.clone()) } else { None })
+        .collect();
     EpochInfo {
         validators: accounts
             .into_iter()
@@ -55,6 +59,7 @@ pub fn epoch_info(
         stake_change,
         validator_reward,
         inflation,
+        validator_kickout,
     }
 }
 

--- a/chain/epoch_manager/src/types.rs
+++ b/chain/epoch_manager/src/types.rs
@@ -50,6 +50,7 @@ pub struct EpochInfo {
     pub validator_reward: HashMap<AccountId, Balance>,
     /// Total inflation in the epoch
     pub inflation: Balance,
+    pub validator_kickout: HashSet<AccountId>,
 }
 
 /// Information per each block.


### PR DESCRIPTION
Fixes two bugs in epoch manager:
* When we kickout validators, we need to make sure that the union of kickout set for current epoch  and last epoch is not the whole validator set for the current epoch. Otherwise everyone gets kicked out.
* When we calculate expected number of blocks we need to go to `max(epoch_last_block_index, last_epoch_last_block_index + self.config.epoch_length)` instead of just `last_epoch_last_block_index + self.config.epoch_length` to handle the situation where the epoch ends later than expected.