### PR TITLE
Do not accept blocks with unreasonable height

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -154,6 +154,7 @@ pub struct ChainGenesis {
     pub max_inflation_rate: u8,
     pub gas_price_adjustment_rate: u8,
     pub transaction_validity_period: BlockIndex,
+    pub epoch_length: BlockIndex,
 }
 
 impl ChainGenesis {
@@ -165,6 +166,7 @@ impl ChainGenesis {
         max_inflation_rate: u8,
         gas_price_adjustment_rate: u8,
         transaction_validity_period: BlockIndex,
+        epoch_length: BlockIndex,
     ) -> Self {
         Self {
             time,
@@ -174,6 +176,7 @@ impl ChainGenesis {
             max_inflation_rate,
             gas_price_adjustment_rate,
             transaction_validity_period,
+            epoch_length,
         }
     }
 }
@@ -188,6 +191,7 @@ pub struct Chain {
     genesis: BlockHeader,
     pub finality_gadget: FinalityGadget,
     pub transaction_validity_period: BlockIndex,
+    pub epoch_length: BlockIndex,
 }
 
 impl Chain {
@@ -308,6 +312,7 @@ impl Chain {
             genesis: genesis.header,
             finality_gadget: FinalityGadget {},
             transaction_validity_period: chain_genesis.transaction_validity_period,
+            epoch_length: chain_genesis.epoch_length,
         })
     }
 
@@ -389,6 +394,7 @@ impl Chain {
             &self.orphans,
             &self.blocks_with_missing_chunks,
             self.transaction_validity_period,
+            self.epoch_length,
         );
         chain_update.process_block_header(header, on_challenge)?;
         Ok(())
@@ -405,6 +411,7 @@ impl Chain {
             &self.orphans,
             &self.blocks_with_missing_chunks,
             self.transaction_validity_period,
+            self.epoch_length,
         );
         chain_update.mark_block_as_challenged(block_hash, Some(challenger_hash))?;
         chain_update.commit()?;
@@ -464,6 +471,7 @@ impl Chain {
             &self.orphans,
             &self.blocks_with_missing_chunks,
             self.transaction_validity_period,
+            self.epoch_length,
         );
         match chain_update.verify_challenges(
             &vec![challenge.clone()],
@@ -513,6 +521,7 @@ impl Chain {
                     &self.orphans,
                     &self.blocks_with_missing_chunks,
                     self.transaction_validity_period,
+                    self.epoch_length,
                 );
 
                 match chain_update.check_header_known(header) {
@@ -548,6 +557,7 @@ impl Chain {
             &self.orphans,
             &self.blocks_with_missing_chunks,
             self.transaction_validity_period,
+            self.epoch_length,
         );
 
         if let Some(header) = headers.last() {
@@ -730,6 +740,7 @@ impl Chain {
             &self.orphans,
             &self.blocks_with_missing_chunks,
             self.transaction_validity_period,
+            self.epoch_length,
         );
         let maybe_new_head = chain_update.process_block(me, &block, &provenance, on_challenge);
 
@@ -1337,6 +1348,7 @@ impl Chain {
             &self.orphans,
             &self.blocks_with_missing_chunks,
             self.transaction_validity_period,
+            self.epoch_length,
         );
         let mut height = shard_state_header.chunk.header.height_included;
         chain_update.set_state_finalize(shard_id, sync_hash, shard_state_header)?;
@@ -1352,6 +1364,7 @@ impl Chain {
                 &self.orphans,
                 &self.blocks_with_missing_chunks,
                 self.transaction_validity_period,
+                self.epoch_length,
             );
             // Result of successful execution of set_state_finalize_on_height is bool,
             // should we commit and continue or stop.
@@ -1392,6 +1405,7 @@ impl Chain {
             &self.orphans,
             &self.blocks_with_missing_chunks,
             self.transaction_validity_period,
+            self.epoch_length,
         );
         chain_update.apply_chunks(me, &block, &prev_block, ApplyChunksMode::NextEpoch)?;
         chain_update.commit()?;
@@ -1421,6 +1435,7 @@ impl Chain {
                     &self.orphans,
                     &self.blocks_with_missing_chunks,
                     self.transaction_validity_period,
+                    self.epoch_length,
                 );
 
                 chain_update.apply_chunks(me, &block, &prev_block, ApplyChunksMode::NextEpoch)?;
@@ -1719,6 +1734,7 @@ pub struct ChainUpdate<'a> {
     orphans: &'a OrphanBlockPool,
     blocks_with_missing_chunks: &'a OrphanBlockPool,
     transaction_validity_period: BlockIndex,
+    epoch_length: BlockIndex,
 }
 
 impl<'a> ChainUpdate<'a> {
@@ -1728,14 +1744,16 @@ impl<'a> ChainUpdate<'a> {
         orphans: &'a OrphanBlockPool,
         blocks_with_missing_chunks: &'a OrphanBlockPool,
         transaction_validity_period: BlockIndex,
+        epoch_length: BlockIndex,
     ) -> Self {
-        let chain_store_update = store.store_update();
+        let chain_store_update: ChainStoreUpdate = store.store_update();
         ChainUpdate {
             runtime_adapter,
             chain_store_update,
             orphans,
             blocks_with_missing_chunks,
             transaction_validity_period,
+            epoch_length,
         }
     }
 
@@ -2154,6 +2172,10 @@ impl<'a> ChainUpdate<'a> {
         // Block is an orphan if we do not know about the previous full block.
         if !is_next && !self.chain_store_update.block_exists(&prev_hash)? {
             return Err(ErrorKind::Orphan.into());
+        }
+
+        if block.header.inner.height > head.height + self.epoch_length {
+            return Err(ErrorKind::InvalidBlockHeight.into());
         }
 
         let (is_caught_up, needs_to_start_fetching_state) =

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -812,7 +812,7 @@ pub fn setup_with_tx_validity_period(
     let chain = Chain::new(
         store,
         runtime.clone(),
-        &ChainGenesis::new(Utc::now(), 1_000_000, 100, 1_000_000_000, 0, 0, validity),
+        &ChainGenesis::new(Utc::now(), 1_000_000, 100, 1_000_000_000, 0, 0, validity, 10),
     )
     .unwrap();
     let signer = Arc::new(InMemorySigner::from_seed("test", KeyType::ED25519, "test"));
@@ -929,6 +929,7 @@ impl ChainGenesis {
             max_inflation_rate: 0,
             gas_price_adjustment_rate: 0,
             transaction_validity_period: 100,
+            epoch_length: 5,
         }
     }
 }

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -72,8 +72,16 @@ pub fn setup(
         num_shards,
         epoch_length,
     ));
-    let chain_genesis =
-        ChainGenesis::new(genesis_time, 1_000_000, 100, 1_000_000_000, 0, 0, tx_validity_period);
+    let chain_genesis = ChainGenesis::new(
+        genesis_time,
+        1_000_000,
+        100,
+        1_000_000_000,
+        0,
+        0,
+        tx_validity_period,
+        epoch_length,
+    );
     let mut chain = Chain::new(store.clone(), runtime.clone(), &chain_genesis).unwrap();
     let genesis_block = chain.get_block(&chain.genesis().hash()).unwrap().clone();
 
@@ -544,12 +552,11 @@ pub fn setup_client_with_runtime(
     network_adapter: Arc<dyn NetworkAdapter>,
     chain_genesis: ChainGenesis,
     runtime_adapter: Arc<dyn RuntimeAdapter>,
-    epoch_length: u64,
 ) -> Client {
     let block_producer =
         account_id.map(|x| Arc::new(InMemorySigner::from_seed(x, KeyType::ED25519, x)).into());
     let mut config = ClientConfig::test(true, 10, num_validators);
-    config.epoch_length = epoch_length;
+    config.epoch_length = chain_genesis.epoch_length;
     Client::new(config, store, chain_genesis, runtime_adapter, network_adapter, block_producer)
         .unwrap()
 }
@@ -562,7 +569,6 @@ pub fn setup_client(
     account_id: Option<&str>,
     network_adapter: Arc<dyn NetworkAdapter>,
     chain_genesis: ChainGenesis,
-    epoch_length: u64,
 ) -> Client {
     let num_validators = validators.iter().map(|x| x.len()).sum();
     let runtime_adapter = Arc::new(KeyValueRuntime::new_with_validators(
@@ -570,7 +576,7 @@ pub fn setup_client(
         validators.into_iter().map(|inner| inner.into_iter().map(Into::into).collect()).collect(),
         validator_groups,
         num_shards,
-        epoch_length,
+        chain_genesis.epoch_length,
     ));
     setup_client_with_runtime(
         store,
@@ -579,7 +585,6 @@ pub fn setup_client(
         network_adapter,
         chain_genesis,
         runtime_adapter,
-        epoch_length,
     )
 }
 
@@ -588,16 +593,10 @@ pub struct TestEnv {
     validators: Vec<AccountId>,
     pub network_adapters: Vec<Arc<MockNetworkAdapter>>,
     pub clients: Vec<Client>,
-    epoch_length: u64,
 }
 
 impl TestEnv {
-    pub fn new(
-        chain_genesis: ChainGenesis,
-        num_clients: usize,
-        num_validators: usize,
-        epoch_length: u64,
-    ) -> Self {
+    pub fn new(chain_genesis: ChainGenesis, num_clients: usize, num_validators: usize) -> Self {
         let validators: Vec<AccountId> =
             (0..num_validators).map(|i| format!("test{}", i)).collect();
         let network_adapters =
@@ -613,11 +612,10 @@ impl TestEnv {
                     Some(&format!("test{}", i)),
                     network_adapters[i].clone(),
                     chain_genesis.clone(),
-                    epoch_length,
                 )
             })
             .collect();
-        TestEnv { chain_genesis, validators, network_adapters, clients, epoch_length }
+        TestEnv { chain_genesis, validators, network_adapters, clients }
     }
 
     pub fn new_with_runtime(
@@ -625,7 +623,6 @@ impl TestEnv {
         num_clients: usize,
         num_validators: usize,
         runtime_adapters: Vec<Arc<dyn RuntimeAdapter>>,
-        epoch_length: u64,
     ) -> Self {
         let network_adapters: Vec<Arc<MockNetworkAdapter>> =
             (0..num_clients).map(|_| Arc::new(MockNetworkAdapter::default())).collect();
@@ -635,7 +632,6 @@ impl TestEnv {
             num_validators,
             runtime_adapters,
             network_adapters,
-            epoch_length,
         )
     }
 
@@ -645,7 +641,6 @@ impl TestEnv {
         num_validators: usize,
         runtime_adapters: Vec<Arc<dyn RuntimeAdapter>>,
         network_adapters: Vec<Arc<MockNetworkAdapter>>,
-        epoch_length: u64,
     ) -> Self {
         let validators: Vec<AccountId> =
             (0..num_validators).map(|i| format!("test{}", i)).collect();
@@ -659,11 +654,10 @@ impl TestEnv {
                     network_adapters[i].clone(),
                     chain_genesis.clone(),
                     runtime_adapters[i].clone(),
-                    epoch_length,
                 )
             })
             .collect();
-        TestEnv { chain_genesis, validators, network_adapters, clients, epoch_length }
+        TestEnv { chain_genesis, validators, network_adapters, clients }
     }
 
     pub fn process_block(&mut self, id: usize, block: Block, provenance: Provenance) {
@@ -708,7 +702,6 @@ impl TestEnv {
             Some(&format!("test{}", id)),
             self.network_adapters[id].clone(),
             self.chain_genesis.clone(),
-            self.epoch_length,
         )
     }
 }

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -25,7 +25,7 @@ use near_store::test_utils::create_test_store;
 
 #[test]
 fn test_verify_block_double_sign_challenge() {
-    let mut env = TestEnv::new(ChainGenesis::test(), 2, 1, 5);
+    let mut env = TestEnv::new(ChainGenesis::test(), 2, 1);
     env.produce_block(0, 1);
     let genesis = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
     let b1 = env.clients[0].produce_block(2, Duration::from_millis(10)).unwrap().unwrap();
@@ -153,7 +153,7 @@ fn create_invalid_proofs_chunk(
 
 #[test]
 fn test_verify_chunk_invalid_proofs_challenge() {
-    let mut env = TestEnv::new(ChainGenesis::test(), 1, 1, 5);
+    let mut env = TestEnv::new(ChainGenesis::test(), 1, 1);
     env.produce_block(0, 1);
     let (chunk, _merkle_paths, _receipts, block) = create_invalid_proofs_chunk(&mut env.clients[0]);
 
@@ -190,7 +190,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         vec![],
         vec![],
     ))];
-    let mut env = TestEnv::new_with_runtime(ChainGenesis::test(), 1, 1, runtimes, 5);
+    let mut env = TestEnv::new_with_runtime(ChainGenesis::test(), 1, 1, runtimes);
     let signer = InMemorySigner::from_seed("test0", KeyType::ED25519, "test0");
     let genesis_hash = env.clients[0].chain.genesis().hash();
     env.produce_block(0, 1);
@@ -264,6 +264,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         let chain = &mut client.chain;
         let adapter = chain.runtime_adapter.clone();
         let validity_period = chain.transaction_validity_period;
+        let epoch_length = chain.epoch_length;
         let empty_block_pool = OrphanBlockPool::new();
 
         let mut chain_update = ChainUpdate::new(
@@ -272,6 +273,7 @@ fn test_verify_chunk_invalid_state_challenge() {
             &empty_block_pool,
             &empty_block_pool,
             validity_period,
+            epoch_length,
         );
 
         chain_update
@@ -322,7 +324,7 @@ fn test_verify_chunk_invalid_state_challenge() {
 #[test]
 fn test_receive_invalid_chunk_as_chunk_producer() {
     init_test_logger();
-    let mut env = TestEnv::new(ChainGenesis::test(), 2, 1, 5);
+    let mut env = TestEnv::new(ChainGenesis::test(), 2, 1);
     env.produce_block(0, 1);
     let block1 = env.clients[0].chain.get_block_by_height(1).unwrap().clone();
     env.process_block(1, block1, Provenance::NONE);
@@ -397,7 +399,7 @@ fn test_receive_two_blocks_from_one_producer() {}
 #[test]
 fn test_block_challenge() {
     init_test_logger();
-    let mut env = TestEnv::new(ChainGenesis::test(), 1, 1, 5);
+    let mut env = TestEnv::new(ChainGenesis::test(), 1, 1);
     env.produce_block(0, 1);
     let (chunk, _merkle_paths, _receipts, block) = create_invalid_proofs_chunk(&mut env.clients[0]);
 
@@ -442,14 +444,10 @@ fn test_challenge_in_different_epoch() {
     ));
     let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![runtime1, runtime2];
     let networks = vec![network_adapter.clone(), network_adapter.clone()];
-    let mut env = TestEnv::new_with_runtime_and_network_adapter(
-        ChainGenesis::test(),
-        2,
-        2,
-        runtimes,
-        networks,
-        2,
-    );
+    let mut chain_genesis = ChainGenesis::test();
+    chain_genesis.epoch_length = 2;
+    let mut env =
+        TestEnv::new_with_runtime_and_network_adapter(chain_genesis, 2, 2, runtimes, networks);
     let mut fork_blocks = vec![];
     for i in 1..5 {
         let block1 =

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -212,7 +212,7 @@ fn chunks_produced_and_distributed_common(
 #[test]
 fn test_request_chunk_restart() {
     init_integration_logger();
-    let mut env = TestEnv::new(ChainGenesis::test(), 1, 1, 5);
+    let mut env = TestEnv::new(ChainGenesis::test(), 1, 1);
     for i in 1..4 {
         env.produce_block(0, i);
         env.network_adapters[0].pop();

--- a/chain/network/tests/announce_account.rs
+++ b/chain/network/tests/announce_account.rs
@@ -50,7 +50,8 @@ pub fn setup_network_node(
     ));
     let block_producer = BlockProducer::from(signer.clone());
     let telemetry_actor = TelemetryActor::new(TelemetryConfig::default()).start();
-    let chain_genesis = ChainGenesis::new(genesis_time, 1_000_000, 100, 1_000_000_000, 0, 0, 1000);
+    let chain_genesis =
+        ChainGenesis::new(genesis_time, 1_000_000, 100, 1_000_000_000, 0, 0, 1000, 5);
 
     let peer_manager = PeerManagerActor::create(move |ctx| {
         let client_actor = ClientActor::new(

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -56,7 +56,8 @@ pub fn setup_network_node(
     ));
     let block_producer = BlockProducer::from(signer.clone());
     let telemetry_actor = TelemetryActor::new(TelemetryConfig::default()).start();
-    let chain_genesis = ChainGenesis::new(genesis_time, 1_000_000, 100, 1_000_000_000, 0, 0, 1000);
+    let chain_genesis =
+        ChainGenesis::new(genesis_time, 1_000_000, 100, 1_000_000_000, 0, 0, 1000, 5);
 
     let peer_manager = PeerManagerActor::create(move |ctx| {
         let mut client_config = ClientConfig::test(false, 100, num_validators);

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -416,6 +416,7 @@ impl From<GenesisConfig> for ChainGenesis {
             genesis_config.max_inflation_rate,
             genesis_config.gas_price_adjustment_rate,
             genesis_config.transaction_validity_period,
+            genesis_config.epoch_length,
         )
     }
 }

--- a/near/src/lib.rs
+++ b/near/src/lib.rs
@@ -70,6 +70,7 @@ pub fn start_with_config(
         config.genesis_config.max_inflation_rate,
         config.genesis_config.gas_price_adjustment_rate,
         config.genesis_config.transaction_validity_period,
+        config.genesis_config.epoch_length,
     );
 
     let view_client =

--- a/test-utils/testlib/src/lib.rs
+++ b/test-utils/testlib/src/lib.rs
@@ -46,6 +46,7 @@ pub fn genesis_header(genesis_config: &GenesisConfig) -> BlockHeader {
         genesis_config.max_inflation_rate,
         genesis_config.gas_price_adjustment_rate,
         genesis_config.transaction_validity_period,
+        genesis_config.epoch_length,
     );
     let chain = Chain::new(store, runtime, &chain_genesis).unwrap();
     chain.genesis().clone()


### PR DESCRIPTION
We should not accept blocks that are more than `cur_height + epoch_length` as validators should not skip their slots when producing blocks.