### PR TITLE
Add chunk validator kickout threshold

### DIFF
--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -110,7 +110,7 @@ pub enum ErrorKind {
     #[fail(display = "Invalid Approvals")]
     InvalidApprovals,
     /// Validator error.
-    #[fail(display = "Validator Error")]
+    #[fail(display = "Validator Error: {}", _0)]
     ValidatorError(String),
     /// Epoch out of bounds. Usually if received block is too far in the future or alternative fork.
     #[fail(display = "Epoch Out Of Bounds")]

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -241,17 +241,16 @@ impl Client {
         let total_approvals =
             total_block_producers - min(if prev_same_bp { 1 } else { 2 }, total_block_producers);
         let num_approvals = self.approvals.cache_get(&prev_hash).map(|h| h.len()).unwrap_or(0);
+        let new_chunks = self.shards_mgr.prepare_chunks(prev_hash);
         if head.height > 0
-            && num_approvals < total_approvals
+            && num_approvals < min(total_approvals, 2 * total_block_producers / 3)
+            && (new_chunks.len() as ShardId) < self.runtime_adapter.num_shards()
             && elapsed_since_last_block < self.config.max_block_production_delay
         {
             // Will retry after a `block_production_tracking_delay`.
             debug!(target: "client", "Produce block: approvals {}, expected: {}", num_approvals, total_approvals);
             return Ok(None);
         }
-
-        // If we are not producing empty blocks, skip this and call handle scheduling for the next block.
-        let new_chunks = self.shards_mgr.prepare_chunks(prev_hash);
 
         // If we are producing empty blocks and there are no transactions.
         if !self.config.produce_empty_blocks && new_chunks.is_empty() {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -626,11 +626,15 @@ impl ClientActor {
                 }
             }
         } else {
-            let num_blocks_missing = self.client.runtime_adapter.get_num_missing_blocks(
-                &head.epoch_id,
-                &head.last_block_hash,
-                &next_block_producer_account,
-            )?;
+            let num_blocks_missing = if head.epoch_id == epoch_id {
+                self.client.runtime_adapter.get_num_missing_blocks(
+                    &head.epoch_id,
+                    &head.last_block_hash,
+                    &next_block_producer_account,
+                )?
+            } else {
+                0
+            };
             // Given next block producer already missed `num_blocks_missing`, we back off the time we are waiting for them.
             if elapsed
                 < std::cmp::max(

--- a/chain/epoch_manager/src/proposals.rs
+++ b/chain/epoch_manager/src/proposals.rs
@@ -177,7 +177,7 @@ mod tests {
     fn test_proposals_to_assignments() {
         assert_eq!(
             proposals_to_epoch_info(
-                &epoch_config(2, 2, 1, 1, 90),
+                &epoch_config(2, 2, 1, 1, 90, 60),
                 [0; 32],
                 &EpochInfo::default(),
                 vec![stake("test1", 1_000_000)],
@@ -204,7 +204,8 @@ mod tests {
                     num_block_producers: 6,
                     block_producers_per_shard: vec![6, 2, 2, 2, 2],
                     avg_fisherman_per_shard: vec![6, 2, 2, 2, 2],
-                    validator_kickout_threshold: 90,
+                    block_producer_kickout_threshold: 90,
+                    chunk_producer_kickout_threshold: 60
                 },
                 [0; 32],
                 &EpochInfo::default(),

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -68,7 +68,8 @@ pub fn epoch_config(
     num_shards: ShardId,
     num_block_producers: usize,
     num_fisherman: usize,
-    validator_kickout_threshold: u8,
+    block_producer_kickout_threshold: u8,
+    chunk_producer_kickout_threshold: u8,
 ) -> EpochConfig {
     EpochConfig {
         epoch_length,
@@ -79,7 +80,8 @@ pub fn epoch_config(
             num_block_producers,
         ),
         avg_fisherman_per_shard: (0..num_shards).map(|_| num_fisherman).collect(),
-        validator_kickout_threshold,
+        block_producer_kickout_threshold,
+        chunk_producer_kickout_threshold,
     }
 }
 
@@ -128,12 +130,19 @@ pub fn setup_epoch_manager(
     num_shards: ShardId,
     num_seats: usize,
     num_fisherman: usize,
-    kickout_threshold: u8,
+    block_producer_kickout_threshold: u8,
+    chunk_producer_kickout_threshold: u8,
     reward_calculator: RewardCalculator,
 ) -> EpochManager {
     let store = create_test_store();
-    let config =
-        epoch_config(epoch_length, num_shards, num_seats, num_fisherman, kickout_threshold);
+    let config = epoch_config(
+        epoch_length,
+        num_shards,
+        num_seats,
+        num_fisherman,
+        block_producer_kickout_threshold,
+        chunk_producer_kickout_threshold,
+    );
     EpochManager::new(
         store,
         config,
@@ -149,7 +158,8 @@ pub fn setup_default_epoch_manager(
     num_shards: ShardId,
     num_seats: usize,
     num_fisherman: usize,
-    kickout_threshold: u8,
+    block_producer_kickout_threshold: u8,
+    chunk_producer_kickout_threshold: u8,
 ) -> EpochManager {
     setup_epoch_manager(
         validators,
@@ -157,7 +167,8 @@ pub fn setup_default_epoch_manager(
         num_shards,
         num_seats,
         num_fisherman,
-        kickout_threshold,
+        block_producer_kickout_threshold,
+        chunk_producer_kickout_threshold,
         default_reward_calculator(),
     )
 }

--- a/chain/epoch_manager/src/types.rs
+++ b/chain/epoch_manager/src/types.rs
@@ -24,8 +24,10 @@ pub struct EpochConfig {
     pub block_producers_per_shard: Vec<ValidatorId>,
     /// Expected number of fisherman per each shard.
     pub avg_fisherman_per_shard: Vec<ValidatorId>,
-    /// Criterion for kicking out validators
-    pub validator_kickout_threshold: u8,
+    /// Criterion for kicking out block producers
+    pub block_producer_kickout_threshold: u8,
+    /// Criterion for kicking out chunk producers
+    pub chunk_producer_kickout_threshold: u8,
 }
 
 #[derive(Default, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
@@ -50,6 +52,7 @@ pub struct EpochInfo {
     pub validator_reward: HashMap<AccountId, Balance>,
     /// Total inflation in the epoch
     pub inflation: Balance,
+    /// Validators who are kicked out in this epoch
     pub validator_kickout: HashSet<AccountId>,
 }
 

--- a/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_to_json_configs.rs
@@ -2,10 +2,11 @@ use std::fs::File;
 use std::path::Path;
 
 use near::config::{
-    get_initial_supply, Config, CONFIG_FILENAME, DEVELOPER_PERCENT, EXPECTED_EPOCH_LENGTH,
-    GAS_PRICE_ADJUSTMENT_RATE, GENESIS_CONFIG_FILENAME, INITIAL_GAS_LIMIT, INITIAL_GAS_PRICE,
-    MAX_INFLATION_RATE, NODE_KEY_FILE, NUM_BLOCKS_PER_YEAR, NUM_BLOCK_PRODUCERS, PROTOCOL_PERCENT,
-    TRANSACTION_VALIDITY_PERIOD, VALIDATOR_KEY_FILE, VALIDATOR_KICKOUT_THRESHOLD,
+    get_initial_supply, Config, BLOCK_PRODUCER_KICKOUT_THRESHOLD, CHUNK_PRODUCER_KICKOUT_THRESHOLD,
+    CONFIG_FILENAME, DEVELOPER_PERCENT, EXPECTED_EPOCH_LENGTH, GAS_PRICE_ADJUSTMENT_RATE,
+    GENESIS_CONFIG_FILENAME, INITIAL_GAS_LIMIT, INITIAL_GAS_PRICE, MAX_INFLATION_RATE,
+    NODE_KEY_FILE, NUM_BLOCKS_PER_YEAR, NUM_BLOCK_PRODUCERS, PROTOCOL_PERCENT,
+    TRANSACTION_VALIDITY_PERIOD, VALIDATOR_KEY_FILE,
 };
 use near::{GenesisConfig, NEAR_BASE};
 use near_network::types::PROTOCOL_VERSION;
@@ -63,7 +64,7 @@ pub fn csv_to_json_configs(home: &Path, chain_id: String) {
         gas_limit: INITIAL_GAS_LIMIT,
         gas_price: INITIAL_GAS_PRICE,
         gas_price_adjustment_rate: GAS_PRICE_ADJUSTMENT_RATE,
-        validator_kickout_threshold: VALIDATOR_KICKOUT_THRESHOLD,
+        block_producer_kickout_threshold: BLOCK_PRODUCER_KICKOUT_THRESHOLD,
         runtime_config: Default::default(),
         validators,
         transaction_validity_period: TRANSACTION_VALIDITY_PERIOD,
@@ -74,6 +75,7 @@ pub fn csv_to_json_configs(home: &Path, chain_id: String) {
         total_supply,
         num_blocks_per_year: NUM_BLOCKS_PER_YEAR,
         protocol_treasury_account: treasury,
+        chunk_producer_kickout_threshold: CHUNK_PRODUCER_KICKOUT_THRESHOLD,
     };
 
     // Write all configs to files.

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -63,8 +63,11 @@ const REDUCE_DELAY_FOR_MISSING_BLOCKS: u64 = 1_000;
 /// Expected epoch length.
 pub const EXPECTED_EPOCH_LENGTH: BlockIndex = (5 * 60) / MIN_BLOCK_PRODUCTION_DELAY;
 
-/// Criterion for kicking out validators.
-pub const VALIDATOR_KICKOUT_THRESHOLD: u8 = 90;
+/// Criterion for kicking out block producers.
+pub const BLOCK_PRODUCER_KICKOUT_THRESHOLD: u8 = 90;
+
+/// Criterion for kicking out chunk producers.
+pub const CHUNK_PRODUCER_KICKOUT_THRESHOLD: u8 = 60;
 
 /// Fast mode constants for testing/developing.
 pub const FAST_MIN_BLOCK_PRODUCTION_DELAY: u64 = 200;
@@ -383,8 +386,10 @@ pub struct GenesisConfig {
     pub gas_limit: Gas,
     /// Initial gas price.
     pub gas_price: Balance,
-    /// Criterion for kicking out validators (this is a number between 0 and 100)
-    pub validator_kickout_threshold: u8,
+    /// Criterion for kicking out block producers (this is a number between 0 and 100)
+    pub block_producer_kickout_threshold: u8,
+    /// Criterion for kicking out chunk producers (this is a number between 0 and 100)
+    pub chunk_producer_kickout_threshold: u8,
     /// Gas price adjustment rate
     pub gas_price_adjustment_rate: u8,
     /// Runtime configuration (mostly economics constants).
@@ -499,7 +504,7 @@ impl GenesisConfig {
             gas_limit: INITIAL_GAS_LIMIT,
             gas_price: INITIAL_GAS_PRICE,
             gas_price_adjustment_rate: GAS_PRICE_ADJUSTMENT_RATE,
-            validator_kickout_threshold: VALIDATOR_KICKOUT_THRESHOLD,
+            block_producer_kickout_threshold: BLOCK_PRODUCER_KICKOUT_THRESHOLD,
             runtime_config: Default::default(),
             validators,
             records,
@@ -510,6 +515,7 @@ impl GenesisConfig {
             num_blocks_per_year: NUM_BLOCKS_PER_YEAR,
             protocol_treasury_account: PROTOCOL_TREASURY_ACCOUNT.to_string(),
             transaction_validity_period: TRANSACTION_VALIDITY_PERIOD,
+            chunk_producer_kickout_threshold: CHUNK_PRODUCER_KICKOUT_THRESHOLD,
         }
     }
 
@@ -713,7 +719,7 @@ pub fn init_configs(
                 gas_limit: INITIAL_GAS_LIMIT,
                 gas_price: INITIAL_GAS_PRICE,
                 gas_price_adjustment_rate: GAS_PRICE_ADJUSTMENT_RATE,
-                validator_kickout_threshold: VALIDATOR_KICKOUT_THRESHOLD,
+                block_producer_kickout_threshold: BLOCK_PRODUCER_KICKOUT_THRESHOLD,
                 runtime_config: Default::default(),
                 validators: vec![AccountInfo {
                     account_id: account_id.clone(),
@@ -728,6 +734,7 @@ pub fn init_configs(
                 total_supply,
                 num_blocks_per_year: NUM_BLOCKS_PER_YEAR,
                 protocol_treasury_account: account_id,
+                chunk_producer_kickout_threshold: CHUNK_PRODUCER_KICKOUT_THRESHOLD,
             };
             genesis_config.write_to_file(&dir.join(config.genesis_file));
             info!(target: "near", "Generated node key, validator key, genesis file in {}", dir.to_str().unwrap());

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -79,7 +79,8 @@ impl NightshadeRuntime {
             num_block_producers: genesis_config.num_block_producers,
             block_producers_per_shard: genesis_config.block_producers_per_shard.clone(),
             avg_fisherman_per_shard: genesis_config.avg_fisherman_per_shard.clone(),
-            validator_kickout_threshold: genesis_config.validator_kickout_threshold,
+            block_producer_kickout_threshold: genesis_config.block_producer_kickout_threshold,
+            chunk_producer_kickout_threshold: genesis_config.chunk_producer_kickout_threshold,
         };
         let reward_calculator = RewardCalculator {
             max_inflation_rate: genesis_config.max_inflation_rate,

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -1135,6 +1135,8 @@ mod test {
             // No fees mode.
             genesis_config.runtime_config = RuntimeConfig::free();
             genesis_config.epoch_length = epoch_length;
+            genesis_config.chunk_producer_kickout_threshold =
+                genesis_config.block_producer_kickout_threshold;
             let runtime = NightshadeRuntime::new(
                 dir.path(),
                 store,

--- a/near/src/shard_tracker.rs
+++ b/near/src/shard_tracker.rs
@@ -247,7 +247,8 @@ mod tests {
             num_block_producers: 1,
             block_producers_per_shard: vec![1],
             avg_fisherman_per_shard: vec![],
-            validator_kickout_threshold: 90,
+            block_producer_kickout_threshold: 90,
+            chunk_producer_kickout_threshold: 60,
         };
         let reward_calculator = RewardCalculator {
             max_inflation_rate: 0,

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -45,6 +45,7 @@ fn init_test_staking(
     genesis_config.epoch_length = epoch_length;
     genesis_config.num_block_producers = num_nodes;
     genesis_config.block_producer_kickout_threshold = 20;
+    genesis_config.chunk_producer_kickout_threshold = 20;
     if !enable_rewards {
         genesis_config.max_inflation_rate = 0;
         genesis_config.gas_price = 0;

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -44,7 +44,7 @@ fn init_test_staking(
         GenesisConfig::test(seeds.iter().map(|s| s.as_str()).collect(), num_validators);
     genesis_config.epoch_length = epoch_length;
     genesis_config.num_block_producers = num_nodes;
-    genesis_config.validator_kickout_threshold = 20;
+    genesis_config.block_producer_kickout_threshold = 20;
     if !enable_rewards {
         genesis_config.max_inflation_rate = 0;
         genesis_config.gas_price = 0;

--- a/near/tests/sync_nodes.rs
+++ b/near/tests/sync_nodes.rs
@@ -187,7 +187,7 @@ fn sync_state_stake_change() {
 
         let mut genesis_config = GenesisConfig::test(vec!["test1"], 1);
         genesis_config.epoch_length = 5;
-        genesis_config.validator_kickout_threshold = 80;
+        genesis_config.block_producer_kickout_threshold = 80;
 
         let (port1, port2) = (open_port(), open_port());
         let mut near1 = load_test_config("test1", port1, &genesis_config);


### PR DESCRIPTION
Add a separate threshold for chunk validator kickout. Also now block producer will wait for chunks to arrive, in addition to block approvals.