### PR TITLE
Finalizing the Finality Gadget

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1956,6 +1956,7 @@ dependencies = [
  "near-primitives 0.1.0",
  "near-store 0.1.0",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -189,7 +189,6 @@ pub struct Chain {
     orphans: OrphanBlockPool,
     blocks_with_missing_chunks: OrphanBlockPool,
     genesis: BlockHeader,
-    pub finality_gadget: FinalityGadget,
     pub transaction_validity_period: BlockIndex,
     pub epoch_length: BlockIndex,
 }
@@ -257,6 +256,7 @@ impl Chain {
                         CryptoHash::default(),
                         genesis.hash(),
                         genesis.header.inner.height,
+                        0,
                         vec![],
                         vec![],
                         vec![],
@@ -302,7 +302,7 @@ impl Chain {
         }
         store_update.commit()?;
 
-        info!(target: "chain", "Init: head: {} @ {} [{}]", head.total_weight.to_num(), head.height, head.last_block_hash);
+        info!(target: "chain", "Init: head: weight: {}, score: {} @ {} [{}]", head.weight_and_score.weight.to_num(), head.weight_and_score.score.to_num(), head.height, head.last_block_hash);
 
         Ok(Chain {
             store,
@@ -310,7 +310,6 @@ impl Chain {
             orphans: OrphanBlockPool::new(),
             blocks_with_missing_chunks: OrphanBlockPool::new(),
             genesis: genesis.header,
-            finality_gadget: FinalityGadget {},
             transaction_validity_period: chain_genesis.transaction_validity_period,
             epoch_length: chain_genesis.epoch_length,
         })
@@ -322,7 +321,7 @@ impl Chain {
         approval: &Approval,
     ) -> Result<(), Error> {
         let mut chain_store_update = ChainStoreUpdate::new(&mut self.store);
-        self.finality_gadget.process_approval(me, approval, &mut chain_store_update)?;
+        FinalityGadget::process_approval(me, approval, &mut chain_store_update)?;
         chain_store_update.commit()?;
         Ok(())
     }
@@ -331,27 +330,33 @@ impl Chain {
         &mut self,
         approval: &Approval,
     ) -> Result<(), ApprovalVerificationError> {
-        self.finality_gadget.verify_approval_conditions(approval, &mut self.store)
+        FinalityGadget::verify_approval_conditions(approval, &mut self.store)
     }
 
     pub fn get_my_approval_reference_hash(&mut self, last_hash: CryptoHash) -> Option<CryptoHash> {
-        self.finality_gadget.get_my_approval_reference_hash(last_hash, &mut self.store)
+        FinalityGadget::get_my_approval_reference_hash(last_hash, &mut self.store)
     }
 
     pub fn compute_quorums(
-        &mut self,
         prev_hash: CryptoHash,
+        epoch_id: EpochId,
         height: BlockIndex,
         approvals: Vec<Approval>,
         total_block_producers: usize,
+        runtime_adapter: &dyn RuntimeAdapter,
+        chain_store: &mut dyn ChainStoreAccess,
     ) -> Result<FinalityGadgetQuorums, Error> {
-        self.finality_gadget.compute_quorums(
+        let mut ret = FinalityGadget::compute_quorums(
             prev_hash,
+            epoch_id,
             height,
             approvals,
-            &mut self.store,
+            chain_store,
             total_block_producers,
-        )
+        )?;
+        ret.last_quorum_pre_commit = runtime_adapter
+            .push_final_block_back_if_needed(prev_hash, ret.last_quorum_pre_commit)?;
+        Ok(ret)
     }
 
     /// Reset "sync" head to current header head.
@@ -541,6 +546,7 @@ impl Chain {
                     header.inner.prev_hash,
                     header.hash(),
                     header.inner.height,
+                    self.store.get_block_height(&header.inner.last_quorum_pre_commit)?,
                     header.inner.validator_proposals.clone(),
                     vec![],
                     header.inner.chunk_mask.clone(),
@@ -579,7 +585,7 @@ impl Chain {
         let header_head = self.header_head()?;
         let mut hashes = vec![];
 
-        if block_head.total_weight >= header_head.total_weight {
+        if block_head.weight_and_score >= header_head.weight_and_score {
             return Ok((false, hashes));
         }
 
@@ -2236,8 +2242,7 @@ impl<'a> ChainUpdate<'a> {
         self.process_header_for_block(&block.header, provenance, on_challenge)?;
 
         for approval in block.header.inner.approvals.iter() {
-            let fg = FinalityGadget {};
-            fg.process_approval(me, approval, &mut self.chain_store_update)?;
+            FinalityGadget::process_approval(me, approval, &mut self.chain_store_update)?;
         }
 
         // We need to know the last approval on the previous block to later compute the reference
@@ -2297,10 +2302,17 @@ impl<'a> ChainUpdate<'a> {
         }
 
         // If block checks out, record validator proposals for given block.
+        let last_quorum_pre_commit = &block.header.inner.last_quorum_pre_commit;
+        let last_finalized_height = if last_quorum_pre_commit == &CryptoHash::default() {
+            0
+        } else {
+            self.chain_store_update.get_block_header(last_quorum_pre_commit)?.inner.height
+        };
         self.runtime_adapter.add_validator_proposals(
             block.header.inner.prev_hash,
             block.hash(),
             block.header.inner.height,
+            last_finalized_height,
             block.header.inner.validator_proposals.clone(),
             block.header.inner.challenges_result.clone(),
             block.header.inner.chunk_mask.clone(),
@@ -2433,6 +2445,24 @@ impl<'a> ChainUpdate<'a> {
             if weight != header.inner.total_weight {
                 return Err(ErrorKind::InvalidBlockWeight.into());
             }
+
+            let quorums = Chain::compute_quorums(
+                header.inner.prev_hash,
+                header.inner.epoch_id.clone(),
+                header.inner.height,
+                header.inner.approvals.clone(),
+                self.runtime_adapter
+                    .get_epoch_block_producers(&header.inner.epoch_id, &header.inner.prev_hash)?
+                    .len(),
+                &*self.runtime_adapter,
+                &mut self.chain_store_update,
+            )?;
+
+            if header.inner.last_quorum_pre_commit != quorums.last_quorum_pre_commit
+                || header.inner.last_quorum_pre_vote != quorums.last_quorum_pre_vote
+            {
+                return Err(ErrorKind::InvalidFinalityInfo.into());
+            }
         }
 
         Ok(())
@@ -2444,7 +2474,7 @@ impl<'a> ChainUpdate<'a> {
         header: &BlockHeader,
     ) -> Result<Option<Tip>, Error> {
         let header_head = self.chain_store_update.header_head()?;
-        if header.inner.total_weight > header_head.total_weight {
+        if header.inner.weight_and_score() > header_head.weight_and_score {
             let tip = Tip::from_header(header);
             self.chain_store_update.save_header_head_if_not_challenged(&tip)?;
             debug!(target: "chain", "Header head updated to {} at {}", tip.last_block_hash, tip.height);
@@ -2462,7 +2492,7 @@ impl<'a> ChainUpdate<'a> {
         // if we made a fork with more weight than the head (which should also be true
         // when extending the head), update it
         let head = self.chain_store_update.head()?;
-        if block.header.inner.total_weight > head.total_weight {
+        if block.header.inner.weight_and_score() > head.weight_and_score {
             let tip = Tip::from_header(&block.header);
 
             self.chain_store_update.save_body_head(&tip)?;

--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -100,6 +100,9 @@ pub enum ErrorKind {
     /// Invalid epoch hash
     #[fail(display = "Invalid Epoch Hash")]
     InvalidEpochHash,
+    /// Invalid quorum_pre_vote or quorum_pre_commit
+    #[fail(display = "Invalid Finality Info")]
+    InvalidFinalityInfo,
     /// Invalid validator proposals in the block.
     #[fail(display = "Invalid Validator Proposals")]
     InvalidValidatorProposals,
@@ -199,6 +202,7 @@ impl Error {
             | ErrorKind::MaliciousChallenge
             | ErrorKind::IncorrectNumberOfChunkHeaders
             | ErrorKind::InvalidEpochHash
+            | ErrorKind::InvalidFinalityInfo
             | ErrorKind::InvalidValidatorProposals
             | ErrorKind::InvalidSignature
             | ErrorKind::InvalidApprovals => true,

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -465,6 +465,14 @@ impl ChainStore {
         }
         Err(InvalidTxError::Expired)
     }
+
+    pub fn get_block_height(&mut self, hash: &CryptoHash) -> Result<BlockIndex, Error> {
+        if hash == &CryptoHash::default() {
+            Ok(0)
+        } else {
+            Ok(self.get_block_header(hash)?.inner.height)
+        }
+    }
 }
 
 impl ChainStoreAccess for ChainStore {

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -468,6 +468,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         _parent_hash: CryptoHash,
         _current_hash: CryptoHash,
         _block_index: u64,
+        _last_finalized_height: u64,
         _proposals: Vec<ValidatorStake>,
         _slashed_validators: Vec<AccountId>,
         _validator_mask: Vec<bool>,
@@ -806,6 +807,14 @@ impl RuntimeAdapter for KeyValueRuntime {
 
     fn get_epoch_inflation(&self, _epoch_id: &EpochId) -> Result<u128, Error> {
         Ok(0)
+    }
+
+    fn push_final_block_back_if_needed(
+        &self,
+        _prev_block: CryptoHash,
+        last_final: CryptoHash,
+    ) -> Result<CryptoHash, Error> {
+        Ok(last_final)
     }
 }
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use borsh::{BorshDeserialize, BorshSerialize};
 
 use near_crypto::Signature;
-use near_primitives::block::Approval;
+use near_primitives::block::{Approval, WeightAndScore};
 pub use near_primitives::block::{Block, BlockHeader, Weight};
 use near_primitives::challenge::ChallengesResult;
 use near_primitives::errors::RuntimeError;
@@ -282,12 +282,19 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Get inflation for a certain epoch
     fn get_epoch_inflation(&self, epoch_id: &EpochId) -> Result<Balance, Error>;
 
+    fn push_final_block_back_if_needed(
+        &self,
+        parent_hash: CryptoHash,
+        last_final_hash: CryptoHash,
+    ) -> Result<CryptoHash, Error>;
+
     /// Add proposals for validators.
     fn add_validator_proposals(
         &self,
         parent_hash: CryptoHash,
         current_hash: CryptoHash,
         block_index: BlockIndex,
+        last_finalized_height: BlockIndex,
         proposals: Vec<ValidatorStake>,
         slashed_validators: Vec<AccountId>,
         validator_mask: Vec<bool>,
@@ -434,7 +441,7 @@ pub struct Tip {
     /// Previous block
     pub prev_block_hash: CryptoHash,
     /// Total weight on that fork
-    pub total_weight: Weight,
+    pub weight_and_score: WeightAndScore,
     /// Previous epoch id. Used for getting validator info.
     pub epoch_id: EpochId,
 }
@@ -446,7 +453,7 @@ impl Tip {
             height: header.inner.height,
             last_block_hash: header.hash(),
             prev_block_hash: header.inner.prev_hash,
-            total_weight: header.inner.total_weight,
+            weight_and_score: header.inner.weight_and_score(),
             epoch_id: header.inner.epoch_id.clone(),
         }
     }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -278,10 +278,27 @@ impl Client {
             }
         }
 
-        let quorums = self
-            .chain
-            .compute_quorums(prev_hash, next_height, approvals.clone(), total_block_producers)?
-            .clone();
+        // At this point, the previous epoch hash must be available
+        let epoch_id = self
+            .runtime_adapter
+            .get_epoch_id_from_prev_block(&head.last_block_hash)
+            .expect("Epoch hash should exist at this point");
+
+        // Here `total_block_producers` is the number of block producers in the epoch of the previous
+        // block. It would be more correct to pass the number of block producers in the current epoch.
+        // However, in the case when the epochs differ the `compute_quorums` will exit on the very
+        // first iteration without using `total_block_producers`, thus it doesn't affect the
+        // correctness of the computation.
+        let quorums = Chain::compute_quorums(
+            prev_hash,
+            epoch_id.clone(),
+            next_height,
+            approvals.clone(),
+            total_block_producers,
+            &*self.runtime_adapter,
+            self.chain.mut_store(),
+        )?
+        .clone();
 
         let score = if quorums.last_quorum_pre_vote == CryptoHash::default() {
             0.into()
@@ -294,8 +311,7 @@ impl Client {
         let prev_block = self.chain.get_block(&head.last_block_hash)?;
         let mut chunks = prev_block.chunks.clone();
 
-        // TODO (#1675): this assert can currently trigger due to epoch switches not handled properly
-        //assert!(score >= prev_block.header.inner.score);
+        assert!(score >= prev_block.header.inner.score);
 
         // Collect new chunks.
         for (shard_id, mut chunk_header) in new_chunks {
@@ -304,12 +320,6 @@ impl Client {
         }
 
         let prev_header = &prev_block.header;
-
-        // At this point, the previous epoch hash must be available
-        let epoch_id = self
-            .runtime_adapter
-            .get_epoch_id_from_prev_block(&head.last_block_hash)
-            .expect("Epoch hash should exist at this point");
 
         let inflation = if self.runtime_adapter.is_next_block_epoch_start(&head.last_block_hash)? {
             let next_epoch_id =

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -104,7 +104,7 @@ impl HeaderSync {
             let header_head = chain.header_head()?;
             self.syncing_peer = None;
             if let Some(peer) = most_weight_peer(&most_weight_peers) {
-                if peer.chain_info.total_weight > header_head.total_weight {
+                if peer.chain_info.weight_and_score > header_head.weight_and_score {
                     self.syncing_peer = self.request_headers(chain, peer);
                 }
             }
@@ -150,8 +150,8 @@ impl HeaderSync {
                                 if now > *stalling_ts + Duration::seconds(120)
                                     && *highest_height == peer.chain_info.height
                                 {
-                                    info!(target: "sync", "Sync: ban a fraudulent peer: {}, claimed height: {}, total weight: {}",
-                                        peer.peer_info, peer.chain_info.height, peer.chain_info.total_weight);
+                                    info!(target: "sync", "Sync: ban a fraudulent peer: {}, claimed height: {}, total weight: {}, score: {}",
+                                        peer.peer_info, peer.chain_info.height, peer.chain_info.weight_and_score.weight, peer.chain_info.weight_and_score.score);
                                     self.network_adapter.send(NetworkRequests::BanPeer {
                                         peer_id: peer.peer_info.id.clone(),
                                         ban_reason: ReasonForBan::HeightFraud,
@@ -847,7 +847,7 @@ mod test {
                     hash: chain.genesis().hash(),
                 },
                 height: chain2.head().unwrap().height,
-                total_weight: chain2.head().unwrap().total_weight,
+                weight_and_score: chain2.head().unwrap().weight_and_score,
                 tracked_shards: vec![],
             },
             edge_info: EdgeInfo::default(),

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -1,5 +1,5 @@
 use std::cmp::max;
-use std::collections::{HashSet, VecDeque};
+use std::collections::{BTreeSet, HashMap, HashSet, VecDeque};
 use std::ops::DerefMut;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -21,7 +21,7 @@ use near_network::{
     FullPeerInfo, NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses,
     PeerInfo, PeerManagerActor,
 };
-use near_primitives::block::{Block, GenesisId, Weight};
+use near_primitives::block::{Block, GenesisId, WeightAndScore};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockIndex, ShardId, ValidatorId};
 use near_store::test_utils::create_test_store;
@@ -29,7 +29,8 @@ use near_store::Store;
 use near_telemetry::TelemetryActor;
 
 use crate::{BlockProducer, Client, ClientActor, ClientConfig, ViewClientActor};
-use near_primitives::hash::hash;
+use near_primitives::hash::{hash, CryptoHash};
+use std::ops::Bound::{Excluded, Included, Unbounded};
 
 pub type NetworkMock = Mocker<PeerManagerActor>;
 
@@ -58,7 +59,8 @@ pub fn setup(
     epoch_length: u64,
     account_id: &str,
     skip_sync_wait: bool,
-    block_prod_time: u64,
+    min_block_prod_time: u64,
+    max_block_prod_time: u64,
     recipient: Recipient<NetworkRequests>,
     tx_validity_period: BlockIndex,
     genesis_time: DateTime<Utc>,
@@ -88,7 +90,12 @@ pub fn setup(
     let signer = Arc::new(InMemorySigner::from_seed(account_id, KeyType::ED25519, account_id));
     let telemetry = TelemetryActor::default().start();
     let view_client = ViewClientActor::new(store.clone(), &chain_genesis, runtime.clone()).unwrap();
-    let config = ClientConfig::test(skip_sync_wait, block_prod_time, num_validators);
+    let config = ClientConfig::test(
+        skip_sync_wait,
+        min_block_prod_time,
+        max_block_prod_time,
+        num_validators,
+    );
     let client = ClientActor::new(
         config,
         store,
@@ -150,6 +157,7 @@ pub fn setup_mock_with_validity_period(
             account_id,
             skip_sync_wait,
             100,
+            200,
             pm.recipient(),
             validity_period,
             Utc::now(),
@@ -165,6 +173,36 @@ fn sample_binary(n: u64, k: u64) -> bool {
 }
 
 /// Sets up ClientActor and ViewClientActor with mock PeerManager.
+///
+/// # Arguments
+/// * `validators` - a vector or vector of validator names. Each vector is a set of validators for a
+///                 particular epoch. E.g. if `validators` has three elements, then the each epoch
+///                 with id % 3 == 0 will have the first set of validators, with id % 3 == 1 will
+///                 have the second set of validators, and with id % 3 == 2 will have the third
+/// * `key_pairs` - a flattened list of key pairs for the `validators`
+/// * `validator_groups` - how many groups to split validators into. E.g. say there are four shards,
+///                 and four validators in a particular epoch. If `validator_groups == 1`, all vals
+///                 will validate all shards. If `validator_groups == 2`, shards 0 and 1 will have
+///                 two validators validating them, and shards 2 and 3 will have the remaining two.
+///                 If `validator_groups == 4`, each validator will validate a single shard
+/// `skip_sync_wait`
+/// `block_prod_time` - Minimum block production time, assuming there is enough approvals. The
+///                 maximum block production time depends on the value of `tamper_with_fg`, and is
+///                 equal to `block_prod_time` if `tamper_with_fg` is `true`, otherwise it is
+///                 `block_prod_time * 2`
+/// `drop_chunks` - if set to true, 10% of all the chunk messages / requests will be dropped
+/// `tamper_with_fg` - if set to true, will split the heights into groups of 100. For some groups
+///                 all the approvals will be dropped (thus completely disabling the finality gadget
+///                 and introducing severe forkfulness if `block_prod_time` is sufficiently small),
+///                 for some groups will keep all the approvals (and test the fg invariants), and
+///                 for some will drop 50% of the approvals.
+/// `epoch_length` - approximate number of heights per epoch
+/// `network_mock` - the callback that is called for each message sent. The `mock` is called before
+///                 the default processing. `mock` returns `(response, perform_default)`. If
+///                 `perform_default` is false, then the message is not processed or broadcasted
+///                 further and `response` is returned to the requester immediately. Otherwise
+///                 the default action is performed, that might (and likely will) overwrite the
+///                 `response` before it is sent back to the requester.
 pub fn setup_mock_all_validators(
     validators: Vec<Vec<&'static str>>,
     key_pairs: Vec<PeerInfo>,
@@ -172,6 +210,7 @@ pub fn setup_mock_all_validators(
     skip_sync_wait: bool,
     block_prod_time: u64,
     drop_chunks: bool,
+    tamper_with_fg: bool,
     epoch_length: u64,
     network_mock: Arc<RwLock<dyn FnMut(String, &NetworkRequests) -> (NetworkResponses, bool)>>,
 ) -> (Block, Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>) {
@@ -193,7 +232,11 @@ pub fn setup_mock_all_validators(
     let genesis_block = Arc::new(RwLock::new(None));
     let num_shards = validators.iter().map(|x| x.len()).min().unwrap() as ShardId;
 
-    let last_height_weight = Arc::new(RwLock::new(vec![(0, Weight::from(0)); key_pairs.len()]));
+    let last_height_weight =
+        Arc::new(RwLock::new(vec![(0, WeightAndScore::from_ints(0, 0)); key_pairs.len()]));
+    let hash_to_score = Arc::new(RwLock::new(HashMap::new()));
+    let approval_intervals: Arc<RwLock<Vec<BTreeSet<(WeightAndScore, WeightAndScore)>>>> =
+        Arc::new(RwLock::new(key_pairs.iter().map(|_| BTreeSet::new()).collect()));
 
     for account_id in validators.iter().flatten().cloned() {
         let view_client_addr = Arc::new(RwLock::new(None));
@@ -207,6 +250,8 @@ pub fn setup_mock_all_validators(
         let network_mock1 = network_mock.clone();
         let announced_accounts1 = announced_accounts.clone();
         let last_height_weight1 = last_height_weight.clone();
+        let hash_to_score1 = hash_to_score.clone();
+        let approval_intervals1 = approval_intervals.clone();
         let client_addr = ClientActor::create(move |ctx| {
             let _client_addr = ctx.address();
             let pm = NetworkMock::mock(Box::new(move |msg, _ctx| {
@@ -246,7 +291,7 @@ pub fn setup_mock_all_validators(
                                             hash: Default::default(),
                                         },
                                         height: last_height_weight1[i].0,
-                                        total_weight: last_height_weight1[i].1,
+                                        weight_and_score: last_height_weight1[i].1,
                                         tracked_shards: vec![],
                                     },
                                     edge_info: EdgeInfo::default(),
@@ -278,7 +323,12 @@ pub fn setup_mock_all_validators(
 
                             my_height_weight.0 = max(my_height_weight.0, block.header.inner.height);
                             my_height_weight.1 =
-                                max(my_height_weight.1, block.header.inner.total_weight);
+                                max(my_height_weight.1, block.header.inner.weight_and_score());
+
+                            hash_to_score1
+                                .write()
+                                .unwrap()
+                                .insert(block.header.hash(), block.header.inner.weight_and_score());
                         }
                         NetworkRequests::PartialEncodedChunkRequest {
                             account_id: their_account_id,
@@ -455,18 +505,72 @@ pub fn setup_mock_all_validators(
                             }
                         }
                         NetworkRequests::BlockHeaderAnnounce {
-                            header: _,
+                            header,
                             approval_message: Some(approval_message),
                         } => {
-                            for (i, name) in validators_clone2.iter().flatten().enumerate() {
-                                if name == &approval_message.target {
-                                    connectors1.read().unwrap()[i].0.do_send(
-                                        NetworkClientMessages::BlockApproval(
-                                            approval_message.approval.clone(),
-                                            my_key_pair.id.clone(),
-                                        ),
-                                    );
+                            let height_mod = header.inner.height % 300;
+
+                            let do_propagate = if tamper_with_fg {
+                                if height_mod < 100 {
+                                    false
+                                } else if height_mod < 200 {
+                                    let mut rng = rand::thread_rng();
+                                    rng.gen()
+                                } else {
+                                    true
                                 }
+                            } else {
+                                true
+                            };
+
+                            let approval = approval_message.approval.clone();
+
+                            if do_propagate {
+                                for (i, name) in validators_clone2.iter().flatten().enumerate() {
+                                    if name == &approval_message.target {
+                                        connectors1.read().unwrap()[i].0.do_send(
+                                            NetworkClientMessages::BlockApproval(
+                                                approval.clone(),
+                                                my_key_pair.id.clone(),
+                                            ),
+                                        );
+                                    }
+                                }
+                            }
+
+                            // Ensure the finality gadget invariant that no two approvals intersect
+                            //     is maintained
+                            let hh = hash_to_score1.read().unwrap();
+                            let arange =
+                                (hh.get(&approval.reference_hash), hh.get(&approval.parent_hash));
+                            if let (Some(left), Some(right)) = arange {
+                                let arange = (*left, *right);
+                                assert!(arange.0 <= arange.1);
+
+                                let approval_intervals =
+                                    &mut approval_intervals1.write().unwrap()[my_ord];
+                                let prev = approval_intervals
+                                    .range((Unbounded, Excluded((arange.0, arange.0))))
+                                    .next_back();
+                                let mut next_weight_and_score = arange.0;
+                                next_weight_and_score.weight =
+                                    (next_weight_and_score.weight.to_num() + 1).into();
+                                let next = approval_intervals
+                                    .range((
+                                        Included((next_weight_and_score, next_weight_and_score)),
+                                        Unbounded,
+                                    ))
+                                    .next();
+
+                                if let Some(prev) = prev {
+                                    assert!(prev.1 < arange.0);
+                                }
+
+                                if let Some(next) = next {
+                                    assert!(next.0 > arange.1);
+                                }
+
+                                approval_intervals.insert(arange);
                             }
                         }
                         NetworkRequests::ForwardTx(_, _)
@@ -494,6 +598,13 @@ pub fn setup_mock_all_validators(
                 account_id,
                 skip_sync_wait,
                 block_prod_time,
+                // When we tamper with fg, some blocks will have enough approvals, some will not,
+                //     and the `block_prod_timeout` is carefully chosen to get enough forkfulness,
+                //     but not to break the synchrony assumption, so we can't allow the timeout to
+                //     be too different for blocks with and without enough approvals.
+                // When not tampering with fg, make the relationship between constants closer to the
+                //     actual relationship.
+                if tamper_with_fg { block_prod_time } else { block_prod_time * 2 },
                 pm.recipient(),
                 10000,
                 genesis_time,
@@ -504,6 +615,11 @@ pub fn setup_mock_all_validators(
         });
         ret.push((client_addr, view_client_addr.clone().read().unwrap().clone().unwrap()));
     }
+    hash_to_score.write().unwrap().insert(CryptoHash::default(), WeightAndScore::from_ints(0, 0));
+    hash_to_score.write().unwrap().insert(
+        genesis_block.read().unwrap().as_ref().unwrap().header.clone().hash(),
+        WeightAndScore::from_ints(0, 0),
+    );
     *locked_connectors = ret.clone();
     let value = genesis_block.read().unwrap();
     (value.clone().unwrap(), ret)
@@ -560,7 +676,7 @@ pub fn setup_client_with_runtime(
 ) -> Client {
     let block_producer =
         account_id.map(|x| Arc::new(InMemorySigner::from_seed(x, KeyType::ED25519, x)).into());
-    let mut config = ClientConfig::test(true, 10, num_validators);
+    let mut config = ClientConfig::test(true, 10, 20, num_validators);
     config.epoch_length = chain_genesis.epoch_length;
     Client::new(config, store, chain_genesis, runtime_adapter, network_adapter, block_producer)
         .unwrap()

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -136,7 +136,8 @@ pub struct ClientConfig {
 impl ClientConfig {
     pub fn test(
         skip_sync_wait: bool,
-        block_prod_time: u64,
+        min_block_prod_time: u64,
+        max_block_prod_time: u64,
         num_block_producers: ValidatorId,
     ) -> Self {
         ClientConfig {
@@ -145,11 +146,11 @@ impl ClientConfig {
             rpc_addr: "0.0.0.0:3030".to_string(),
             block_production_tracking_delay: Duration::from_millis(std::cmp::max(
                 10,
-                block_prod_time / 5,
+                min_block_prod_time / 5,
             )),
-            min_block_production_delay: Duration::from_millis(block_prod_time),
-            max_block_production_delay: Duration::from_millis(2 * block_prod_time),
-            max_block_wait_delay: Duration::from_millis(3 * block_prod_time),
+            min_block_production_delay: Duration::from_millis(min_block_prod_time),
+            max_block_production_delay: Duration::from_millis(max_block_prod_time),
+            max_block_wait_delay: Duration::from_millis(3 * min_block_prod_time),
             reduce_wait_for_missing_block: Duration::from_millis(0),
             block_expected_weight: 1000,
             skip_sync_wait,
@@ -167,8 +168,8 @@ impl ClientConfig {
             ttl_account_id_router: Duration::from_secs(60 * 60),
             block_fetch_horizon: 50,
             state_fetch_horizon: 5,
-            catchup_step_period: Duration::from_millis(block_prod_time / 2),
-            chunk_request_retry_period: Duration::from_millis(block_prod_time / 5),
+            catchup_step_period: Duration::from_millis(min_block_prod_time / 2),
+            chunk_request_retry_period: Duration::from_millis(min_block_prod_time / 5),
             block_header_fetch_horizon: 50,
             tracked_accounts: vec![],
             tracked_shards: vec![],

--- a/chain/client/tests/bug_repros.rs
+++ b/chain/client/tests/bug_repros.rs
@@ -41,6 +41,7 @@ fn repro_1183() {
             true,
             200,
             false,
+            false,
             5,
             Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {
                 if let NetworkRequests::Block { block } = msg {

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -110,6 +110,7 @@ mod tests {
                 true,
                 1200,
                 false,
+                false,
                 5,
                 Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {
                     let account_from = "test3.3".to_string();
@@ -344,6 +345,7 @@ mod tests {
                 true,
                 1500,
                 false,
+                false,
                 5,
                 Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {
                     let mut seen_heights_same_block = seen_heights_same_block.write().unwrap();
@@ -552,6 +554,7 @@ mod tests {
                 validator_groups,
                 true,
                 400,
+                false,
                 false,
                 5,
                 Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -145,7 +145,7 @@ fn create_invalid_proofs_chunk(
         vec![],
         &*client.block_producer.as_ref().unwrap().signer,
         0.into(),
-        CryptoHash::default(),
+        last_block.header.inner.prev_hash,
         CryptoHash::default(),
     );
     (chunk, merkle_paths, receipts, block)
@@ -207,6 +207,8 @@ fn test_verify_chunk_invalid_state_challenge() {
     // Invalid chunk & block.
     let last_block_hash = env.clients[0].chain.head().unwrap().last_block_hash;
     let last_block = env.clients[0].chain.get_block(&last_block_hash).unwrap().clone();
+    let prev_to_last_block =
+        env.clients[0].chain.get_block(&last_block.header.inner.prev_hash).unwrap().clone();
     let (mut invalid_chunk, merkle_paths) = env.clients[0]
         .shards_mgr
         .create_encoded_shard_chunk(
@@ -255,8 +257,8 @@ fn test_verify_chunk_invalid_state_challenge() {
         vec![],
         &signer,
         0.into(),
-        CryptoHash::default(),
-        CryptoHash::default(),
+        last_block.header.inner.prev_hash,
+        prev_to_last_block.header.inner.prev_hash,
     );
 
     let challenge_body = {

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -40,7 +40,7 @@ fn chunks_produced_and_distributed_one_val_per_shard() {
 #[test]
 fn chunks_recovered_from_others() {
     heavy_test(|| {
-        chunks_produced_and_distributed_common(2, true, 1000);
+        chunks_produced_and_distributed_common(2, true, 2000);
     });
 }
 
@@ -48,7 +48,7 @@ fn chunks_recovered_from_others() {
 #[should_panic]
 fn chunks_recovered_from_full_timeout_too_short() {
     heavy_test(|| {
-        chunks_produced_and_distributed_common(4, true, 1000);
+        chunks_produced_and_distributed_common(4, true, 1500);
     });
 }
 
@@ -100,6 +100,7 @@ fn chunks_produced_and_distributed_common(
             true,
             block_timeout,
             false,
+            false,
             5,
             Arc::new(RwLock::new(move |from_whom: String, msg: &NetworkRequests| {
                 match msg {
@@ -122,11 +123,13 @@ fn chunks_produced_and_distributed_common(
                             block.header.inner.last_quorum_pre_commit,
                         );
 
-                        if block.header.inner.height > 1 {
-                            assert_eq!(block.header.inner.last_quorum_pre_vote, *height_to_hash.get(&(block.header.inner.height - 1)).unwrap());
+                        // Make sure blocks are finalized. 6 is the epoch boundary.
+                        let h = block.header.inner.height;
+                        if h > 1 && h != 6 {
+                            assert_eq!(block.header.inner.last_quorum_pre_vote, *height_to_hash.get(&(h - 1)).unwrap());
                         }
-                        if block.header.inner.height > 2 {
-                            assert_eq!(block.header.inner.last_quorum_pre_commit, *height_to_hash.get(&(block.header.inner.height - 2)).unwrap());
+                        if h > 2 && (h != 6 && h != 7) {
+                            assert_eq!(block.header.inner.last_quorum_pre_commit, *height_to_hash.get(&(h - 2)).unwrap());
                         }
 
                         if block.header.inner.height > 1 {
@@ -143,7 +146,7 @@ fn chunks_produced_and_distributed_common(
                             }
                         }
 
-                        if block.header.inner.height >= 6 {
+                        if block.header.inner.height >= 8 {
                             println!("PREV BLOCK HASH: {}", block.header.inner.prev_hash);
                             println!(
                                 "STATS: responses: {} requests: {}",

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -32,6 +32,7 @@ fn test_keyvalue_runtime_balances() {
             true,
             100,
             false,
+            false,
             5,
             Arc::new(RwLock::new(move |_account_id: String, _msg: &NetworkRequests| {
                 (NetworkResponses::NoResponse, true)
@@ -117,7 +118,8 @@ mod tests {
                 )))
                 .then(move |x| {
                     match x.unwrap() {
-                        NetworkClientResponses::NoResponse => {
+                        NetworkClientResponses::NoResponse
+                        | NetworkClientResponses::RequestRouted => {
                             assert_eq!(num_validators, 24);
                             send_tx(
                                 num_validators,
@@ -136,7 +138,13 @@ mod tests {
                                 connector_ordinal
                             );
                         }
-                        _ => assert!(false),
+                        other @ _ => {
+                            println!(
+                                "Transaction was rejected with an unexpected outcome: {:?}",
+                                other
+                            );
+                            assert!(false)
+                        }
                     }
                     future::result(Ok(()))
                 }),
@@ -388,8 +396,9 @@ mod tests {
                 key_pairs.clone(),
                 validator_groups,
                 true,
-                if drop_chunks || rotate_validators { 300 } else { 200 },
+                if drop_chunks || rotate_validators { 150 } else { 75 },
                 drop_chunks,
+                true,
                 20,
                 Arc::new(RwLock::new(move |_account_id: String, _msg: &NetworkRequests| {
                     (NetworkResponses::NoResponse, true)

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -17,7 +17,7 @@ use near_network::types::{FullPeerInfo, NetworkInfo, PeerChainInfo};
 use near_network::{
     NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses, PeerInfo,
 };
-use near_primitives::block::{Approval, BlockHeader};
+use near_primitives::block::{Approval, BlockHeader, WeightAndScore};
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::merklize;
@@ -420,7 +420,7 @@ fn client_sync_headers() {
                         chain_info: PeerChainInfo {
                             genesis_id: Default::default(),
                             height: 5,
-                            total_weight: 100.into(),
+                            weight_and_score: WeightAndScore::from_ints(100, 100),
                             tracked_shards: vec![],
                         },
                         edge_info: EdgeInfo::default(),
@@ -432,7 +432,7 @@ fn client_sync_headers() {
                         chain_info: PeerChainInfo {
                             genesis_id: Default::default(),
                             height: 5,
-                            total_weight: 100.into(),
+                            weight_and_score: WeightAndScore::from_ints(100, 100),
                             tracked_shards: vec![],
                         },
                         edge_info: EdgeInfo::default(),

--- a/chain/epoch_manager/Cargo.toml
+++ b/chain/epoch_manager/Cargo.toml
@@ -10,6 +10,7 @@ protocol_defining_rand = { package = "rand", version = "0.6.5" }
 log = "0.4"
 cached = "0.9.0"
 borsh = "0.2.9"
+rand = "0.7"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
@@ -17,5 +18,8 @@ serde_json = "1.0"
 
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }
-near-store = { path = "../../core/store" }
 near-chain = { path = "../chain" }
+near-store = { path = "../../core/store" }
+
+[features]
+expensive_tests = []

--- a/chain/epoch_manager/src/test_utils.rs
+++ b/chain/epoch_manager/src/test_utils.rs
@@ -185,6 +185,7 @@ pub fn record_block(
             &cur_h,
             BlockInfo::new(
                 index,
+                0,
                 prev_h,
                 proposals,
                 vec![],

--- a/chain/epoch_manager/src/types.rs
+++ b/chain/epoch_manager/src/types.rs
@@ -60,6 +60,7 @@ pub struct EpochInfo {
 #[derive(Default, BorshSerialize, BorshDeserialize, Clone, Debug)]
 pub struct BlockInfo {
     pub index: BlockIndex,
+    pub last_finalized_height: BlockIndex,
     pub prev_hash: CryptoHash,
     pub epoch_first_block: CryptoHash,
     pub epoch_id: EpochId,
@@ -80,6 +81,7 @@ pub struct BlockInfo {
 impl BlockInfo {
     pub fn new(
         index: BlockIndex,
+        last_finalized_height: BlockIndex,
         prev_hash: CryptoHash,
         proposals: Vec<ValidatorStake>,
         validator_mask: Vec<bool>,
@@ -90,6 +92,7 @@ impl BlockInfo {
     ) -> Self {
         Self {
             index,
+            last_finalized_height,
             prev_hash,
             proposals,
             chunk_mask: validator_mask,

--- a/chain/epoch_manager/tests/finality.rs
+++ b/chain/epoch_manager/tests/finality.rs
@@ -1,0 +1,390 @@
+#[cfg(test)]
+#[cfg(feature = "expensive_tests")]
+mod tests {
+    use near_chain::test_utils::setup;
+    use near_chain::FinalityGadget;
+    use near_chain::{Chain, ChainStore, ChainStoreAccess, ChainStoreUpdate};
+    use near_crypto::{Signature, Signer};
+    use near_epoch_manager::test_utils::{record_block, setup_default_epoch_manager};
+    use near_epoch_manager::EpochManager;
+    use near_primitives::block::{Approval, Block, Weight};
+    use near_primitives::hash::CryptoHash;
+    use near_primitives::types::{AccountId, BlockIndex, EpochId};
+    use rand::seq::SliceRandom;
+    use rand::Rng;
+    use std::collections::{HashMap, HashSet};
+
+    fn create_block(
+        em: &mut EpochManager,
+        prev: &Block,
+        height: BlockIndex,
+        chain_store: &mut ChainStore,
+        signer: &dyn Signer,
+        approvals: Vec<Approval>,
+        total_block_producers: usize,
+    ) -> Block {
+        let is_this_block_epoch_start = em.is_next_block_epoch_start(&prev.hash()).unwrap();
+
+        let epoch_id = if is_this_block_epoch_start {
+            // This is a bit weird way to define an epoch, but replicating the exact way we use today is
+            // unnecessarily complex. Using last `pre_commit` is sufficient to ensure that the `epoch_id`
+            // of the next epoch will be the same for as long as the last committed block in the prev
+            // epoch was the same.
+            EpochId(prev.header.inner.last_quorum_pre_commit)
+        } else {
+            prev.header.inner.epoch_id.clone()
+        };
+
+        let mut block = Block::empty(prev, signer);
+        block.header.inner.approvals = approvals.clone();
+        block.header.inner.height = height;
+        block.header.inner.total_weight = (height as u128).into();
+        block.header.inner.epoch_id = epoch_id.clone();
+
+        let quorums = FinalityGadget::compute_quorums(
+            prev.hash(),
+            epoch_id,
+            height,
+            approvals.clone(),
+            chain_store,
+            total_block_producers,
+        )
+        .unwrap()
+        .clone();
+
+        block.header.inner.last_quorum_pre_vote = quorums.last_quorum_pre_vote;
+        block.header.inner.last_quorum_pre_commit = em
+            .push_final_block_back_if_needed(prev.hash(), quorums.last_quorum_pre_commit)
+            .unwrap();
+
+        block.header.inner.score = if quorums.last_quorum_pre_vote == CryptoHash::default() {
+            0.into()
+        } else {
+            chain_store.get_block_header(&quorums.last_quorum_pre_vote).unwrap().inner.total_weight
+        };
+
+        block.header.init();
+
+        let mut chain_store_update = ChainStoreUpdate::new(chain_store);
+        chain_store_update.save_block_header(block.header.clone());
+        chain_store_update.commit().unwrap();
+
+        record_block(
+            em,
+            block.header.inner.prev_hash,
+            block.hash(),
+            block.header.inner.height,
+            vec![],
+        );
+
+        block
+    }
+
+    fn apr(account_id: AccountId, reference_hash: CryptoHash, parent_hash: CryptoHash) -> Approval {
+        Approval { account_id, reference_hash, parent_hash, signature: Signature::default() }
+    }
+
+    fn print_chain(chain: &mut Chain, mut hash: CryptoHash) {
+        while hash != CryptoHash::default() {
+            let header = chain.get_block_header(&hash).unwrap();
+            println!(
+                "    {}: {} (epoch: {}, qv: {}, qc: {}), approvals: {:?}",
+                header.inner.height,
+                header.hash(),
+                header.inner.epoch_id.0,
+                header.inner.last_quorum_pre_vote,
+                header.inner.last_quorum_pre_commit,
+                header.inner.approvals
+            );
+            hash = header.inner.prev_hash;
+        }
+    }
+
+    fn check_safety(
+        chain: &mut Chain,
+        new_final_hash: CryptoHash,
+        old_final_height: BlockIndex,
+        old_final_hash: CryptoHash,
+    ) {
+        let on_chain_hash =
+            chain.get_header_on_chain_by_height(&new_final_hash, old_final_height).unwrap().hash();
+        let ok = on_chain_hash == old_final_hash;
+
+        if !ok {
+            println!(
+                "New hash: {:?}, new height: {:?}, on_chain_hash: {:?}",
+                new_final_hash,
+                chain.mut_store().get_block_height(&new_final_hash),
+                on_chain_hash
+            );
+            print_chain(chain, new_final_hash);
+            println!("Old hash: {:?}, old height: {:?}", old_final_hash, old_final_height,);
+            print_chain(chain, old_final_hash);
+            assert!(false);
+        }
+    }
+
+    /// Tests safety with epoch switches
+    ///
+    /// Runs many iterations with the following parameters:
+    ///  - complexity: number of blocks created during the iterations
+    ///  - likelihood_random: how likely is a block to be built on top of random prev block
+    ///  - likelihood_heavy: how likely is a block to be built on top of one of the blocks with the highest score
+    ///  - likelihood_last: how likely is a block to be built on top of last built block
+    ///  - adversaries: are there nodes that behave adversarially (if `true` then 2 out of 7 bps create approvals
+    ///       randomly instead of following the protocol)
+    ///
+    /// Uses the same utility to perform epoch switches that the actual epoch manager uses, thus testing
+    /// the actual live conditions. Uses two block producer sets that switch randomly between epochs.
+    /// Makes sure that all the finalized blocks are on the same chain.
+    ///
+    #[test]
+    fn test_fuzzy_safety() {
+        for (complexity, num_iters) in vec![
+            (30, 2000),
+            //(20, 2000),
+            (50, 100),
+            (100, 50),
+            (200, 50),
+            (500, 20),
+            (1000, 10),
+            (2000, 10),
+            (2000, 10),
+        ] {
+            for adversaries in vec![false, true] {
+                let mut good_iters = 0;
+
+                let block_producers1 = vec![
+                    "test1.1".to_string(),
+                    "test1.2".to_string(),
+                    "test1.3".to_string(),
+                    "test1.4".to_string(),
+                    "test1.5".to_string(),
+                    "test1.6".to_string(),
+                    "test1.7".to_string(),
+                ];
+                let block_producers2 = vec![
+                    "test2.1".to_string(),
+                    "test2.2".to_string(),
+                    "test2.3".to_string(),
+                    "test2.4".to_string(),
+                    "test2.5".to_string(),
+                    "test2.6".to_string(),
+                    "test2.7".to_string(),
+                ];
+                let total_block_producers = block_producers1.len();
+
+                let mut epoch_to_bps = HashMap::new();
+
+                for iter in 0..num_iters {
+                    let likelihood_random = rand::thread_rng().gen_range(1, 3);
+                    let likelihood_heavy = rand::thread_rng().gen_range(1, 11);
+                    let likelihood_last = rand::thread_rng().gen_range(1, 11);
+
+                    println!(
+                        "Starting iteration {} at complexity {} and likelihoods {}, {}, {}",
+                        iter, complexity, likelihood_random, likelihood_heavy, likelihood_last
+                    );
+                    let (mut chain, _, signer) = setup();
+                    let mut em = setup_default_epoch_manager(
+                        block_producers1.iter().map(|_| ("test", 1000000)).collect(),
+                        10,
+                        4,
+                        7,
+                        0,
+                        50,
+                        50,
+                    );
+
+                    let genesis_block = chain.get_block(&chain.genesis().hash()).unwrap().clone();
+
+                    let mut last_final_block_hash = CryptoHash::default();
+                    let mut last_final_block_height = 0;
+                    let mut largest_height = 0;
+                    let mut finalized_hashes = HashSet::new();
+                    let mut largest_weight: HashMap<AccountId, Weight> = HashMap::new();
+                    let mut largest_score: HashMap<AccountId, Weight> = HashMap::new();
+                    let mut last_approvals: HashMap<CryptoHash, HashMap<AccountId, Approval>> =
+                        HashMap::new();
+
+                    let mut all_blocks = vec![genesis_block.clone()];
+                    record_block(
+                        &mut em,
+                        genesis_block.header.inner.prev_hash,
+                        genesis_block.hash(),
+                        genesis_block.header.inner.height,
+                        vec![],
+                    );
+                    for _i in 0..complexity {
+                        let max_score =
+                            all_blocks.iter().map(|block| block.header.inner.score).max().unwrap();
+                        let random_max_score_block = all_blocks
+                            .iter()
+                            .filter(|block| block.header.inner.score == max_score)
+                            .collect::<Vec<_>>()
+                            .choose(&mut rand::thread_rng())
+                            .unwrap()
+                            .clone()
+                            .clone();
+                        let last_block = all_blocks.last().unwrap().clone();
+                        let prev_block = (0..likelihood_random)
+                            .map(|_| all_blocks.choose(&mut rand::thread_rng()).unwrap())
+                            .chain((0..likelihood_heavy).map(|_| &random_max_score_block))
+                            .chain((0..likelihood_last).map(|_| &last_block))
+                            .collect::<Vec<_>>()
+                            .choose(&mut rand::thread_rng())
+                            .unwrap()
+                            .clone();
+                        let mut last_approvals_entry = last_approvals
+                            .get(&prev_block.hash())
+                            .unwrap_or(&HashMap::new())
+                            .clone();
+                        let mut approvals = vec![];
+
+                        let block_producers = epoch_to_bps
+                            .entry(prev_block.header.inner.epoch_id.0)
+                            .or_insert_with(|| {
+                                vec![block_producers1.clone(), block_producers2.clone()]
+                                    .choose(&mut rand::thread_rng())
+                                    .unwrap()
+                                    .clone()
+                            });
+
+                        for (i, block_producer) in block_producers.iter().enumerate() {
+                            if rand::thread_rng().gen::<bool>() {
+                                continue;
+                            }
+
+                            let reference_hash = if i < 2 && adversaries {
+                                // malicious
+                                let prev_reference = if let Some(prev_approval) =
+                                    last_approvals_entry.get(block_producer)
+                                {
+                                    prev_approval.reference_hash
+                                } else {
+                                    genesis_block.hash().clone()
+                                };
+
+                                let mut possible_references = vec![prev_reference];
+                                {
+                                    let mut prev_block_hash = prev_block.hash();
+                                    for _j in 0..10 {
+                                        if prev_block_hash == prev_reference {
+                                            break;
+                                        }
+                                        possible_references.push(prev_block_hash);
+                                        prev_block_hash = chain
+                                            .mut_store()
+                                            .get_block_header(&prev_block_hash)
+                                            .unwrap()
+                                            .inner
+                                            .prev_hash;
+                                    }
+                                }
+
+                                possible_references.choose(&mut rand::thread_rng()).unwrap().clone()
+                            } else {
+                                // honest
+                                let old_largest_weight =
+                                    *largest_weight.get(block_producer).unwrap_or(&0u128.into());
+                                let old_largest_score =
+                                    *largest_score.get(block_producer).unwrap_or(&0u128.into());
+
+                                match FinalityGadget::get_my_approval_reference_hash_inner(
+                                    prev_block.hash(),
+                                    last_approvals_entry.get(block_producer).cloned(),
+                                    old_largest_weight,
+                                    old_largest_score,
+                                    chain.mut_store(),
+                                ) {
+                                    Some(hash) => hash,
+                                    None => continue,
+                                }
+                            };
+
+                            let approval = apr(
+                                block_producer.clone(),
+                                reference_hash.clone(),
+                                prev_block.hash(),
+                            );
+                            approvals.push(approval.clone());
+                            last_approvals_entry.insert(block_producer.clone(), approval);
+                            largest_weight.insert(
+                                block_producer.clone(),
+                                prev_block.header.inner.total_weight,
+                            );
+                            largest_score
+                                .insert(block_producer.clone(), prev_block.header.inner.score);
+                        }
+
+                        let new_block = create_block(
+                            &mut em,
+                            &prev_block,
+                            prev_block.header.inner.height + 1,
+                            chain.mut_store(),
+                            &*signer,
+                            approvals,
+                            total_block_producers,
+                        );
+
+                        let final_block = new_block.header.inner.last_quorum_pre_commit;
+                        if final_block != CryptoHash::default() {
+                            let new_final_block_height =
+                                chain.get_block_header(&final_block).unwrap().inner.height;
+                            if last_final_block_height != 0 {
+                                if new_final_block_height > last_final_block_height {
+                                    check_safety(
+                                        &mut chain,
+                                        final_block,
+                                        last_final_block_height,
+                                        last_final_block_hash,
+                                    );
+                                } else if new_final_block_height < last_final_block_height {
+                                    check_safety(
+                                        &mut chain,
+                                        last_final_block_hash,
+                                        new_final_block_height,
+                                        final_block,
+                                    );
+                                } else {
+                                    if final_block != last_final_block_hash {
+                                        print_chain(&mut chain, final_block);
+                                        print_chain(&mut chain, last_final_block_hash);
+                                        assert_eq!(final_block, last_final_block_hash);
+                                    }
+                                }
+                            }
+
+                            finalized_hashes.insert(final_block);
+
+                            if new_final_block_height >= last_final_block_height {
+                                last_final_block_hash = final_block;
+                                last_final_block_height = new_final_block_height;
+                            }
+                        }
+
+                        if new_block.header.inner.height > largest_height {
+                            largest_height = new_block.header.inner.height;
+                        }
+
+                        last_approvals.insert(new_block.hash().clone(), last_approvals_entry);
+
+                        all_blocks.push(new_block);
+                    }
+                    println!("Finished iteration {}, largest finalized height: {}, largest height: {}, final blocks: {}", iter, last_final_block_height, largest_height, finalized_hashes.len());
+                    if last_final_block_height > 0 {
+                        good_iters += 1;
+                    }
+                }
+                println!("Good iterations: {}/{}", good_iters, num_iters);
+                if complexity < 100 {
+                    assert!(good_iters >= num_iters / 4);
+                } else if complexity < 500 {
+                    assert!(good_iters >= num_iters / 2);
+                } else {
+                    assert_eq!(good_iters, num_iters);
+                }
+            }
+        }
+    }
+}

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -78,7 +78,7 @@ mod test {
     };
 
     use super::*;
-    use near_primitives::block::Approval;
+    use near_primitives::block::{Approval, WeightAndScore};
 
     fn test_codec(msg: PeerMessage) {
         let mut codec = Codec::new();
@@ -98,7 +98,7 @@ mod test {
             chain_info: PeerChainInfo {
                 genesis_id: Default::default(),
                 height: 0,
-                total_weight: 0.into(),
+                weight_and_score: WeightAndScore::from_ints(0, 0),
                 tracked_shards: vec![],
             },
             edge_info: EdgeInfo::default(),

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -227,13 +227,18 @@ impl Peer {
                 Ok(NetworkClientResponses::ChainInfo {
                     genesis_id,
                     height,
-                    total_weight,
+                    weight_and_score,
                     tracked_shards,
                 }) => {
                     let handshake = Handshake::new(
                         act.node_info.id.clone(),
                         act.node_info.addr_port(),
-                        PeerChainInfo { genesis_id, height, total_weight, tracked_shards },
+                        PeerChainInfo {
+                            genesis_id,
+                            height,
+                            weight_and_score: weight_and_score,
+                            tracked_shards,
+                        },
                         act.edge_info.as_ref().unwrap().clone(),
                     );
                     act.send_message(PeerMessage::Handshake(handshake));
@@ -272,16 +277,16 @@ impl Peer {
                 let block_hash = block.hash();
                 self.tracker.push_received(block_hash);
                 self.chain_info.height = max(self.chain_info.height, block.header.inner.height);
-                self.chain_info.total_weight =
-                    max(self.chain_info.total_weight, block.header.inner.total_weight);
+                self.chain_info.weight_and_score =
+                    max(self.chain_info.weight_and_score, block.header.inner.weight_and_score());
                 NetworkClientMessages::Block(block, peer_id, self.tracker.has_request(block_hash))
             }
             PeerMessage::BlockHeaderAnnounce(header) => {
                 let block_hash = header.hash();
                 self.tracker.push_received(block_hash);
                 self.chain_info.height = max(self.chain_info.height, header.inner.height);
-                self.chain_info.total_weight =
-                    max(self.chain_info.total_weight, header.inner.total_weight);
+                self.chain_info.weight_and_score =
+                    max(self.chain_info.weight_and_score, header.inner.weight_and_score());
                 NetworkClientMessages::BlockHeader(header, peer_id)
             }
             PeerMessage::Transaction(transaction) => {

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -274,7 +274,7 @@ impl PeerManagerActor {
             .values()
             .map(|active_peers| {
                 (
-                    active_peers.full_peer_info.chain_info.total_weight,
+                    active_peers.full_peer_info.chain_info.weight_and_score,
                     active_peers.full_peer_info.chain_info.height,
                 )
             })

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -15,10 +15,10 @@ use serde_derive::{Deserialize, Serialize};
 use tokio::net::TcpStream;
 
 use near_chain::types::ShardStateSyncResponse;
-use near_chain::{Block, BlockHeader, Weight};
+use near_chain::{Block, BlockHeader};
 use near_crypto::{PublicKey, SecretKey, Signature};
 use near_metrics;
-use near_primitives::block::{Approval, ApprovalMessage, GenesisId};
+use near_primitives::block::{Approval, ApprovalMessage, GenesisId, WeightAndScore};
 use near_primitives::challenge::Challenge;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::{hash, CryptoHash};
@@ -173,8 +173,8 @@ pub struct PeerChainInfo {
     pub genesis_id: GenesisId,
     /// Last known chain height of the peer.
     pub height: BlockIndex,
-    /// Last known chain weight of the peer.
-    pub total_weight: Weight,
+    /// Last known chain weight/score of the peer.
+    pub weight_and_score: WeightAndScore,
     /// Shards that the peer is tracking
     pub tracked_shards: Vec<ShardId>,
 }
@@ -1099,7 +1099,7 @@ pub enum NetworkClientResponses {
     ChainInfo {
         genesis_id: GenesisId,
         height: BlockIndex,
-        total_weight: Weight,
+        weight_and_score: WeightAndScore,
         tracked_shards: Vec<ShardId>,
     },
     /// Block response.

--- a/chain/network/tests/announce_account.rs
+++ b/chain/network/tests/announce_account.rs
@@ -17,7 +17,7 @@ use near_network::{
     NetworkClientMessages, NetworkClientResponses, NetworkConfig, NetworkRequests,
     NetworkResponses, PeerManagerActor,
 };
-use near_primitives::block::{GenesisId, Weight};
+use near_primitives::block::{GenesisId, WeightAndScore};
 use near_primitives::hash::hash;
 use near_primitives::test_utils::init_integration_logger;
 use near_primitives::types::EpochId;
@@ -63,7 +63,7 @@ pub fn setup_network_node(
 
     let peer_manager = PeerManagerActor::create(move |ctx| {
         let client_actor = ClientActor::new(
-            ClientConfig::test(false, 100, num_validators),
+            ClientConfig::test(false, 100, 200, num_validators),
             store.clone(),
             chain_genesis,
             runtime,
@@ -186,7 +186,7 @@ pub fn make_peer_manager(
                 Box::new(Some(NetworkClientResponses::ChainInfo {
                     genesis_id: GenesisId::default(),
                     height: 1,
-                    total_weight: Weight::default(),
+                    weight_and_score: WeightAndScore::from_ints(0, 0),
                     tracked_shards: vec![],
                 }))
             }

--- a/chain/network/tests/peer_handshake.rs
+++ b/chain/network/tests/peer_handshake.rs
@@ -14,6 +14,7 @@ use near_network::{
     NetworkClientMessages, NetworkClientResponses, NetworkConfig, NetworkRequests,
     NetworkResponses, PeerManagerActor,
 };
+use near_primitives::block::WeightAndScore;
 use near_primitives::test_utils::init_test_logger;
 use near_store::test_utils::create_test_store;
 
@@ -36,7 +37,7 @@ fn make_peer_manager(
                 Box::new(Some(NetworkClientResponses::ChainInfo {
                     genesis_id: Default::default(),
                     height: 1,
-                    total_weight: 1.into(),
+                    weight_and_score: WeightAndScore::from_ints(1, 0),
                     tracked_shards: vec![],
                 }))
             }

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -60,7 +60,7 @@ pub fn setup_network_node(
         ChainGenesis::new(genesis_time, 1_000_000, 100, 1_000_000_000, 0, 0, 1000, 5);
 
     let peer_manager = PeerManagerActor::create(move |ctx| {
-        let mut client_config = ClientConfig::test(false, 100, num_validators);
+        let mut client_config = ClientConfig::test(false, 100, 200, num_validators);
         client_config.ttl_account_id_router = ttl_account_id_router;
         let client_actor = ClientActor::new(
             client_config,

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -203,6 +203,7 @@ impl GenesisBuilder {
                 CryptoHash::default(),
                 genesis.hash(),
                 genesis.header.inner.height,
+                0,
                 vec![],
                 vec![],
                 vec![],

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -621,6 +621,15 @@ impl RuntimeAdapter for NightshadeRuntime {
         Ok(epoch_manager.get_epoch_inflation(epoch_id)?)
     }
 
+    fn push_final_block_back_if_needed(
+        &self,
+        parent_hash: CryptoHash,
+        last_final_hash: CryptoHash,
+    ) -> Result<CryptoHash, Error> {
+        let mut epoch_manager = self.epoch_manager.write().expect(POISONED_LOCK_ERR);
+        Ok(epoch_manager.push_final_block_back_if_needed(parent_hash, last_final_hash)?)
+    }
+
     fn validate_tx(
         &self,
         block_index: BlockIndex,
@@ -678,6 +687,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         parent_hash: CryptoHash,
         current_hash: CryptoHash,
         block_index: BlockIndex,
+        last_finalized_height: BlockIndex,
         proposals: Vec<ValidatorStake>,
         slashed_validators: Vec<AccountId>,
         chunk_mask: Vec<bool>,
@@ -696,6 +706,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         }
         let block_info = BlockInfo::new(
             block_index,
+            last_finalized_height,
             parent_hash,
             proposals,
             chunk_mask,
@@ -1025,7 +1036,7 @@ mod test {
     use near_chain::{ReceiptResult, RuntimeAdapter, Tip};
     use near_client::BlockProducer;
     use near_crypto::{InMemorySigner, KeyType, Signer};
-    use near_primitives::block::Weight;
+    use near_primitives::block::WeightAndScore;
     use near_primitives::challenge::ChallengesResult;
     use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::receipt::Receipt;
@@ -1152,6 +1163,7 @@ mod test {
                     CryptoHash::default(),
                     genesis_hash,
                     0,
+                    0,
                     vec![],
                     vec![],
                     vec![],
@@ -1167,7 +1179,7 @@ mod test {
                     prev_block_hash: CryptoHash::default(),
                     height: 0,
                     epoch_id: EpochId::default(),
-                    total_weight: Weight::default(),
+                    weight_and_score: WeightAndScore::from_ints(0, 0),
                 },
                 state_roots,
                 last_receipts: HashMap::default(),
@@ -1217,6 +1229,7 @@ mod test {
                     self.head.last_block_hash,
                     new_hash,
                     self.head.height + 1,
+                    self.head.height.saturating_sub(1),
                     self.last_proposals.clone(),
                     challenges_result,
                     chunk_mask,
@@ -1232,7 +1245,10 @@ mod test {
                 prev_block_hash: self.head.last_block_hash,
                 height: self.head.height + 1,
                 epoch_id: self.runtime.get_epoch_id_from_prev_block(&new_hash).unwrap(),
-                total_weight: Weight::from(self.head.total_weight.to_num() + 1),
+                weight_and_score: WeightAndScore::from_ints(
+                    self.head.weight_and_score.weight.to_num() + 1,
+                    self.head.weight_and_score.score.to_num(),
+                ),
             };
         }
 
@@ -1644,6 +1660,7 @@ mod test {
                     prev_hash,
                     cur_hash,
                     i,
+                    i.saturating_sub(2),
                     new_env.last_proposals.clone(),
                     vec![],
                     vec![true],

--- a/near/src/shard_tracker.rs
+++ b/near/src/shard_tracker.rs
@@ -285,6 +285,7 @@ mod tests {
                 &cur_h,
                 BlockInfo::new(
                     index,
+                    0,
                     prev_h,
                     proposals,
                     vec![],

--- a/pytest/tests/sanity/block_production.py
+++ b/pytest/tests/sanity/block_production.py
@@ -13,14 +13,14 @@ TIMEOUT = 150
 BLOCKS = 50
 
 # Local:
-nodes = start_cluster(4, 0, 4, {'local': True, 'near_root': '../target/debug/'}, [["epoch_length", 10], ["validator_kickout_threshold", 80]], {})
+nodes = start_cluster(4, 0, 4, {'local': True, 'near_root': '../target/debug/'}, [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
 
 # Remote:
 # nodes = start_cluster(4, 0, 4, {'local': False, 'near_root': '../target/debug/',
 #     'remote': {
 #         'instance_name': 'near-pytest',
 #     }
-# }, [["epoch_length", 10], ["validator_kickout_threshold", 80]], {})
+# }, [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
 
 started = time.time()
 

--- a/pytest/tests/sanity/restart.py
+++ b/pytest/tests/sanity/restart.py
@@ -13,7 +13,7 @@ TIMEOUT = 150
 BLOCKS1 = 20
 BLOCKS2 = 40
 
-nodes = start_cluster(2, 0, 2, {'local': True, 'near_root': '../target/debug/'}, [["epoch_length", 10], ["validator_kickout_threshold", 80]], {})
+nodes = start_cluster(2, 0, 2, {'local': True, 'near_root': '../target/debug/'}, [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
 
 started = time.time()
 

--- a/pytest/tests/sanity/rpc_tx_forwarding.py
+++ b/pytest/tests/sanity/rpc_tx_forwarding.py
@@ -12,7 +12,7 @@ from cluster import start_cluster
 from utils import TxContext
 from transaction import sign_payment_tx
 
-nodes = start_cluster(2, 2, 4, {'local': True, 'near_root': '../target/debug/'}, [["epoch_length", 10], ["validator_kickout_threshold", 70]], {3: {"tracked_shards": [0, 1, 2, 3]}})
+nodes = start_cluster(2, 2, 4, {'local': True, 'near_root': '../target/debug/'}, [["epoch_length", 10], ["block_producer_kickout_threshold", 70]], {3: {"tracked_shards": [0, 1, 2, 3]}})
 
 started = time.time()
 

--- a/pytest/tests/sanity/skip_epoch.py
+++ b/pytest/tests/sanity/skip_epoch.py
@@ -15,7 +15,7 @@ TIMEOUT = 300
 TWENTY_FIVE = 25
 
 config = {'local': True, 'near_root': '../target/debug/'}
-near_root, node_dirs = init_cluster(2, 1, 2, config, [["max_inflation_rate", 0], ["epoch_length", 7], ["validator_kickout_threshold", 80]], {2: {"tracked_shards": [0, 1]}})
+near_root, node_dirs = init_cluster(2, 1, 2, config, [["max_inflation_rate", 0], ["epoch_length", 7], ["block_producer_kickout_threshold", 80]], {2: {"tracked_shards": [0, 1]}})
 
 started = time.time()
 

--- a/pytest/tests/sanity/staking1.py
+++ b/pytest/tests/sanity/staking1.py
@@ -12,7 +12,7 @@ from transaction import sign_staking_tx
 TIMEOUT = 150
 
 config = {'local': True, 'near_root': '../target/debug/'}
-nodes = start_cluster(2, 1, 1, config, [["epoch_length", 5], ["validator_kickout_threshold", 40]], {2: {"tracked_shards": [0]}})
+nodes = start_cluster(2, 1, 1, config, [["epoch_length", 5], ["block_producer_kickout_threshold", 40]], {2: {"tracked_shards": [0]}})
 
 started = time.time()
 

--- a/pytest/tests/sanity/staking2.py
+++ b/pytest/tests/sanity/staking2.py
@@ -65,7 +65,7 @@ def doit(seq = []):
     sequence = seq
 
     config = {'local': True, 'near_root': '../target/debug/'}
-    nodes = start_cluster(2, 1, 1, config, [["epoch_length", EPOCH_LENGTH], ["validator_kickout_threshold", 40]], {2: {"tracked_shards": [0]}})
+    nodes = start_cluster(2, 1, 1, config, [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 40]], {2: {"tracked_shards": [0]}})
 
     started = time.time()
     last_iter = started

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -26,7 +26,7 @@ START_AT_BLOCK = int(sys.argv[2])
 TIMEOUT = 150 + START_AT_BLOCK * 10
 
 config = {'local': True, 'near_root': '../target/debug/'}
-near_root, node_dirs = init_cluster(2, 1, 1, config, [["epoch_length", 10], ["validator_kickout_threshold", 80]], {2: {"tracked_shards": [0]}})
+near_root, node_dirs = init_cluster(2, 1, 1, config, [["max_inflation_rate", 0], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {2: {"tracked_shards": [0]}})
 
 started = time.time()
 

--- a/pytest/tests/sanity/transactions.py
+++ b/pytest/tests/sanity/transactions.py
@@ -15,7 +15,7 @@ from transaction import sign_payment_tx
 
 TIMEOUT = 240
 
-nodes = start_cluster(4, 0, 4, {'local': True, 'near_root': '../target/debug/'}, [["epoch_length", 10], ["validator_kickout_threshold", 70]], {})
+nodes = start_cluster(4, 0, 4, {'local': True, 'near_root': '../target/debug/'}, [["max_inflation_rate", 0], ["epoch_length", 10], ["block_producer_kickout_threshold", 70]], {})
 
 started = time.time()
 

--- a/pytest/tests/stress/stress.py
+++ b/pytest/tests/stress/stress.py
@@ -403,7 +403,7 @@ def doit(s, n, N, k, monkeys, timeout):
         # make all the observers track all the shards
         local_config_changes[i] = {"tracked_shards": list(range(s))}
 
-    near_root, node_dirs = init_cluster(N, s, k + 1, config, [["max_inflation_rate", 0], ["epoch_length", EPOCH_LENGTH], ["validator_kickout_threshold", 75]], local_config_changes)
+    near_root, node_dirs = init_cluster(N, s, k + 1, config, [["max_inflation_rate", 0], ["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 75]], local_config_changes)
 
     started = time.time()
 

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -233,6 +233,7 @@ fn replay_chain(
                     header.inner.prev_hash,
                     header.hash(),
                     header.inner.height,
+                    chain_store.get_block_height(&header.inner.last_quorum_pre_commit).unwrap(),
                     header.inner.validator_proposals,
                     vec![],
                     header.inner.chunk_mask,


### PR DESCRIPTION
As of after this change, the finality gadget is fully implemented and fully integrated.

1. The QV search now stops at the epoch boundaries (since the participants set changes at the epoch boundary, and the NFG relies on the participants set being constant)
2. Actually changing the fork choice rule to use `score + total_weight` instead of just `total_weight`.
3. Delaying the epoch switch until a block at height or later `first_epoch_block_height + epoch_length - 3` is finalied.

Test plan
---------
1. `cross_shard_tx` now collects all the approvals and makes sure the finality gadget invariant holds.  Also, since `cross_shard_tx` is designed to test under high forkfulness, and the finality gadget removes the forkfulness, making approvals get lost during some long periods of time in `cross_shard_tx` so that the low level fork choice rule kicks in again. For this purpose also making `cross_shard_tx` have the same timeout for block production with or without approvals.
2. `test_fuzzy_sanity` tests that no two blocks ever get finalized on two different chains with epoch switches and adversarial behavior. The chains construction has several parameters that change between iterations. The test catches any small deviation from the protocol that can be introduced, such as a) not waiting for a final block on epoch switches and b) allowing equal weights when creating an approval

Also many tests in epoch manager only launch a single client, and thus do not accumulate approvals. Those always have < 4 validators, and finality with < 4 validators is not very meaningful anyway, so I specialcased it in the epoch manager, and ignore the last finalized block if the number of block producers < 4.