### PR TITLE
Fix some issues in rpc routing

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -23,7 +23,7 @@ use near_primitives::transaction::{
 use near_primitives::types::{
     AccountId, Balance, BlockIndex, EpochId, MerkleHash, Nonce, ShardId, StateRoot, ValidatorStake,
 };
-use near_primitives::views::QueryResponse;
+use near_primitives::views::{EpochValidatorInfo, QueryResponse};
 use near_store::test_utils::create_test_store;
 use near_store::{
     PartialStorage, Store, StoreUpdate, Trie, TrieChanges, WrappedTrieChanges, COL_BLOCK_HEADER,
@@ -806,6 +806,14 @@ impl RuntimeAdapter for KeyValueRuntime {
 
     fn get_epoch_inflation(&self, _epoch_id: &EpochId) -> Result<u128, Error> {
         Ok(0)
+    }
+
+    fn get_validator_info(&self, _block_hash: &CryptoHash) -> Result<EpochValidatorInfo, Error> {
+        Ok(EpochValidatorInfo {
+            current_validators: vec![],
+            next_validators: vec![],
+            current_proposals: vec![],
+        })
     }
 }
 

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -15,7 +15,7 @@ use near_primitives::transaction::{ExecutionOutcomeWithId, SignedTransaction};
 use near_primitives::types::{
     AccountId, Balance, BlockIndex, EpochId, Gas, MerkleHash, ShardId, StateRoot, ValidatorStake,
 };
-use near_primitives::views::QueryResponse;
+use near_primitives::views::{EpochValidatorInfo, QueryResponse};
 use near_store::{PartialStorage, StoreUpdate, WrappedTrieChanges};
 
 use crate::error::Error;
@@ -370,6 +370,8 @@ pub trait RuntimeAdapter: Send + Sync {
         path_parts: Vec<&str>,
         data: &[u8],
     ) -> Result<QueryResponse, Box<dyn std::error::Error>>;
+
+    fn get_validator_info(&self, block_hash: &CryptoHash) -> Result<EpochValidatorInfo, Error>;
 
     /// Get the part of the state from given state root + proof.
     fn obtain_state_part(

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -4,8 +4,8 @@ extern crate lazy_static;
 pub use crate::client::Client;
 pub use crate::client_actor::ClientActor;
 pub use crate::types::{
-    BlockProducer, ClientConfig, Error, GetBlock, GetChunk, GetNetworkInfo, Query, Status,
-    StatusResponse, SyncStatus, TxStatus,
+    BlockProducer, ClientConfig, Error, GetBlock, GetChunk, GetNetworkInfo, GetValidatorInfo,
+    Query, Status, StatusResponse, SyncStatus, TxStatus,
 };
 pub use crate::view_client::ViewClientActor;
 

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -11,7 +11,9 @@ use near_network::PeerInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{AccountId, BlockIndex, ShardId, ValidatorId, Version};
-use near_primitives::views::{BlockView, ChunkView, FinalExecutionOutcomeView, QueryResponse};
+use near_primitives::views::{
+    BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, QueryResponse,
+};
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 
 /// Combines errors coming from chain, tx pool and block producer.
@@ -305,4 +307,12 @@ pub struct TxStatus {
 
 impl Message for TxStatus {
     type Result = Result<FinalExecutionOutcomeView, String>;
+}
+
+pub struct GetValidatorInfo {
+    pub last_block_hash: CryptoHash,
+}
+
+impl Message for GetValidatorInfo {
+    type Result = Result<EpochValidatorInfo, String>;
 }

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -8,11 +8,13 @@ use actix::{Actor, Context, Handler};
 use near_chain::{Chain, ChainGenesis, RuntimeAdapter};
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{AccountId, StateRoot};
-use near_primitives::views::{BlockView, ChunkView, FinalExecutionOutcomeView, QueryResponse};
+use near_primitives::views::{
+    BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, QueryResponse,
+};
 use near_store::Store;
 
 use crate::types::{Error, GetBlock, Query, TxStatus};
-use crate::GetChunk;
+use crate::{GetChunk, GetValidatorInfo};
 
 /// View client provides currently committed (to the storage) view of the current chain and state.
 pub struct ViewClientActor {
@@ -123,5 +125,13 @@ impl Handler<TxStatus> for ViewClientActor {
 
     fn handle(&mut self, msg: TxStatus, _: &mut Context<Self>) -> Self::Result {
         self.chain.get_final_transaction_result(&msg.tx_hash)
+    }
+}
+
+impl Handler<GetValidatorInfo> for ViewClientActor {
+    type Result = Result<EpochValidatorInfo, String>;
+
+    fn handle(&mut self, msg: GetValidatorInfo, _: &mut Context<Self>) -> Self::Result {
+        self.runtime_adapter.get_validator_info(&msg.last_block_hash).map_err(|e| e.to_string())
     }
 }

--- a/chain/epoch_manager/src/types.rs
+++ b/chain/epoch_manager/src/types.rs
@@ -63,7 +63,6 @@ pub struct BlockInfo {
     pub prev_hash: CryptoHash,
     pub epoch_first_block: CryptoHash,
     pub epoch_id: EpochId,
-
     pub proposals: Vec<ValidatorStake>,
     pub chunk_mask: Vec<bool>,
     pub slashed: HashSet<AccountId>,
@@ -75,6 +74,8 @@ pub struct BlockInfo {
     pub total_supply: Balance,
     /// Map from validator index to (num_blocks_produced, num_blocks_expected) so far in the given epoch.
     pub block_tracker: HashMap<ValidatorId, (BlockIndex, BlockIndex)>,
+    /// All proposals in this epoch up to this block
+    pub all_proposals: Vec<ValidatorStake>,
 }
 
 impl BlockInfo {
@@ -101,6 +102,7 @@ impl BlockInfo {
             epoch_first_block: CryptoHash::default(),
             epoch_id: EpochId::default(),
             block_tracker: HashMap::default(),
+            all_proposals: vec![],
         }
     }
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -8,7 +8,8 @@ use serde::Serialize;
 use near_primitives::hash::CryptoHash;
 use near_primitives::types::{BlockIndex, ShardId};
 use near_primitives::views::{
-    BlockView, ChunkView, FinalExecutionOutcomeView, QueryResponse, StatusResponse,
+    BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, QueryResponse,
+    StatusResponse,
 };
 
 use crate::message::{from_slice, Message};
@@ -187,6 +188,7 @@ jsonrpc_client!(pub struct JsonRpcClient {
     pub fn tx(&mut self, hash: String, account_id: String) -> RpcRequest<FinalExecutionOutcomeView>;
     pub fn block(&mut self, id: BlockId) -> RpcRequest<BlockView>;
     pub fn chunk(&mut self, id: ChunkId) -> RpcRequest<ChunkView>;
+    pub fn validators(&mut self, block_hash: String) -> RpcRequest<EpochValidatorInfo>;
 });
 
 fn create_client() -> Client {

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -17,7 +17,10 @@ use serde_json::Value;
 use async_utils::{delay, timeout};
 use message::Message;
 use message::{Request, RpcError};
-use near_client::{ClientActor, GetBlock, GetChunk, GetNetworkInfo, Status, TxStatus, ViewClientActor, GetValidatorInfo};
+use near_client::{
+    ClientActor, GetBlock, GetChunk, GetNetworkInfo, GetValidatorInfo, Status, TxStatus,
+    ViewClientActor,
+};
 pub use near_jsonrpc_client as client;
 use near_jsonrpc_client::{message, BlockId, ChunkId};
 use near_metrics::{Encoder, TextEncoder};
@@ -395,7 +398,12 @@ impl JsonRpcHandler {
 
     async fn validators(&self, params: Option<Value>) -> Result<Value, RpcError> {
         let block_hash = parse_hash(params)?;
-        jsonify(self.view_client_addr.send(GetValidatorInfo { last_block_hash: block_hash }).compat().await)
+        jsonify(
+            self.view_client_addr
+                .send(GetValidatorInfo { last_block_hash: block_hash })
+                .compat()
+                .await,
+        )
     }
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -976,9 +976,18 @@ impl TryFrom<ReceiptView> for Receipt {
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct EpochValidatorInfo {
     /// Validators for the current epoch
-    pub current_validators: Vec<ValidatorStakeView>,
+    pub current_validators: Vec<CurrentEpochValidatorInfo>,
     /// Validators for the next epoch
     pub next_validators: Vec<ValidatorStakeView>,
     /// Proposals in the current epoch
     pub current_proposals: Vec<ValidatorStakeView>,
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct CurrentEpochValidatorInfo {
+    pub account_id: AccountId,
+    pub is_slashed: bool,
+    #[serde(with = "u128_dec_format")]
+    pub stake: Balance,
+    pub num_missing_blocks: BlockIndex,
 }

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -27,7 +27,7 @@ use near_primitives::types::{
 };
 use near_primitives::utils::{prefix_for_access_key, ACCOUNT_DATA_SEPARATOR};
 use near_primitives::views::{
-    AccessKeyInfoView, CallResult, QueryError, QueryResponse, ViewStateResult,
+    AccessKeyInfoView, CallResult, EpochValidatorInfo, QueryError, QueryResponse, ViewStateResult,
 };
 use near_store::{
     get_access_key_raw, PartialStorage, Store, StoreUpdate, Trie, TrieUpdate, WrappedTrieChanges,
@@ -792,7 +792,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         state_root: &StateRoot,
         height: BlockIndex,
         block_timestamp: u64,
-        block_hash: &CryptoHash,
+        _block_hash: &CryptoHash,
         path_parts: Vec<&str>,
         data: &[u8],
     ) -> Result<QueryResponse, Box<dyn std::error::Error>> {
@@ -862,17 +862,14 @@ impl RuntimeAdapter for NightshadeRuntime {
                     })),
                 }
             }
-            "validators" => {
-                let mut epoch_manager = self.epoch_manager.write().expect(POISONED_LOCK_ERR);
-                match epoch_manager.get_validator_info(block_hash) {
-                    Ok(info) => Ok(QueryResponse::Validators(info)),
-                    Err(e) => {
-                        Ok(QueryResponse::Error(QueryError { error: e.to_string(), logs: vec![] }))
-                    }
-                }
-            }
             _ => Err(format!("Unknown path {}", path_parts[0]).into()),
         }
+    }
+
+    fn get_validator_info(&self, block_hash: &CryptoHash) -> Result<EpochValidatorInfo, Error> {
+        println!("get validator info");
+        let mut epoch_manager = self.epoch_manager.write().expect(POISONED_LOCK_ERR);
+        epoch_manager.get_validator_info(block_hash).map_err(|e| e.into())
     }
 
     fn obtain_state_part(
@@ -1036,7 +1033,7 @@ mod test {
     use near_primitives::types::{
         AccountId, Balance, BlockIndex, EpochId, Nonce, ShardId, StateRoot, ValidatorStake,
     };
-    use near_primitives::views::{AccountView, EpochValidatorInfo, QueryResponse};
+    use near_primitives::views::{AccountView, EpochValidatorInfo};
     use near_store::create_store;
     use node_runtime::adapter::ViewRuntimeAdapter;
     use node_runtime::config::RuntimeConfig;
@@ -1761,57 +1758,39 @@ mod test {
             .unwrap()
             .validators
             .clone();
-        let response = env
-            .runtime
-            .query(&env.state_roots[0], 2, 0, &env.head.last_block_hash, vec!["validators"], &[])
-            .unwrap();
-        match response {
-            QueryResponse::Validators(info) => assert_eq!(
-                info,
-                EpochValidatorInfo {
-                    current_validators: current_validators
-                        .clone()
-                        .into_iter()
-                        .map(Into::into)
-                        .collect(),
-                    next_validators: current_validators
-                        .clone()
-                        .into_iter()
-                        .map(Into::into)
-                        .collect(),
-                    current_proposals: vec![ValidatorStake {
-                        account_id: "test1".to_string(),
-                        public_key: block_producers[0].signer.public_key(),
-                        amount: 0
-                    }
-                    .into()]
+        let response = env.runtime.get_validator_info(&env.head.last_block_hash).unwrap();
+        assert_eq!(
+            response,
+            EpochValidatorInfo {
+                current_validators: current_validators
+                    .clone()
+                    .into_iter()
+                    .map(Into::into)
+                    .collect(),
+                next_validators: current_validators.clone().into_iter().map(Into::into).collect(),
+                current_proposals: vec![ValidatorStake {
+                    account_id: "test1".to_string(),
+                    public_key: block_producers[0].signer.public_key(),
+                    amount: 0
                 }
-            ),
-            _ => panic!("wrong response"),
-        }
-        env.step_default(vec![]);
-        let response = env
-            .runtime
-            .query(&env.state_roots[0], 3, 0, &env.head.last_block_hash, vec!["validators"], &[])
-            .unwrap();
-        match response {
-            QueryResponse::Validators(info) => {
-                let v: Vec<ValidatorStake> =
-                    info.current_validators.clone().into_iter().map(Into::into).collect();
-                assert_eq!(v, current_validators);
-                assert_eq!(
-                    info.next_validators,
-                    vec![ValidatorStake {
-                        account_id: "test2".to_string(),
-                        public_key: block_producers[1].signer.public_key(),
-                        amount: TESTING_INIT_STAKE + per_epoch_per_validator_reward
-                    }
-                    .into()]
-                );
-                assert!(info.current_proposals.is_empty());
+                .into()]
             }
-            _ => panic!("wrong response"),
-        }
+        );
+        env.step_default(vec![]);
+        let response = env.runtime.get_validator_info(&env.head.last_block_hash).unwrap();
+        let v: Vec<ValidatorStake> =
+            response.current_validators.clone().into_iter().map(Into::into).collect();
+        assert_eq!(v, current_validators);
+        assert_eq!(
+            response.next_validators,
+            vec![ValidatorStake {
+                account_id: "test2".to_string(),
+                public_key: block_producers[1].signer.public_key(),
+                amount: TESTING_INIT_STAKE + per_epoch_per_validator_reward
+            }
+            .into()]
+        );
+        assert!(response.current_proposals.is_empty());
     }
 
     #[test]

--- a/near/tests/rpc_nodes.rs
+++ b/near/tests/rpc_nodes.rs
@@ -8,7 +8,7 @@ use near_client::{GetBlock, TxStatus};
 use near_crypto::{InMemorySigner, KeyType};
 use near_jsonrpc::client::new_client;
 use near_network::test_utils::WaitOrTimeout;
-use near_primitives::serialize::to_base64;
+use near_primitives::serialize::{to_base, to_base64};
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::views::{FinalExecutionStatus, QueryResponse};
@@ -243,6 +243,54 @@ fn test_rpc_routing() {
                                         System::current().stop();
                                     }
                                     _ => panic!("wrong query response"),
+                                }),
+                        );
+                    }
+                    futures::future::ok(())
+                }));
+            }),
+            100,
+            20000,
+        )
+        .start();
+
+        system.run().unwrap();
+    });
+}
+
+#[test]
+fn test_get_validator_info_rpc() {
+    init_integration_logger();
+    heavy_test(|| {
+        let system = System::new("NEAR");
+        let num_nodes = 1;
+        let dirs = (0..num_nodes)
+            .map(|i| TempDir::new(&format!("tx_propagation{}", i)).unwrap())
+            .collect::<Vec<_>>();
+        let (_, rpc_addrs, clients) = start_nodes(1, &dirs, 1, 0, 10);
+        let view_client = clients[0].1.clone();
+
+        WaitOrTimeout::new(
+            Box::new(move |_ctx| {
+                let rpc_addrs_copy = rpc_addrs.clone();
+                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
+                    let res = res.unwrap().unwrap();
+                    if res.header.height > 1 {
+                        let mut client = new_client(&format!("http://{}", rpc_addrs_copy[0]));
+                        let block_hash = res.header.hash;
+                        actix::spawn(
+                            client
+                                .validators(to_base(&block_hash))
+                                .map_err(|err| {
+                                    panic!(format!("error: {:?}", err));
+                                })
+                                .map(move |result| {
+                                    assert_eq!(result.current_validators.len(), 1);
+                                    assert!(result
+                                        .current_validators
+                                        .iter()
+                                        .any(|r| r.account_id == "near.0".to_string()));
+                                    System::current().stop();
                                 }),
                         );
                     }


### PR DESCRIPTION
* Fix a bug in rpc routing where previous we do not route the query if the query at current node is not successful
* Refactor validator query to be its own rpc instead of being part of query rpc
* Add number of missing blocks to validator query result. Fixes #1637 