### PR TITLE
Fixing `chunks_recovered_from_others` flakiness.

### DIFF
--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -1,3 +1,4 @@
+use std::cmp::min;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -163,7 +164,10 @@ impl ClientConfig {
             block_fetch_horizon: 50,
             state_fetch_horizon: 5,
             catchup_step_period: Duration::from_millis(min_block_prod_time / 2),
-            chunk_request_retry_period: Duration::from_millis(min_block_prod_time / 5),
+            chunk_request_retry_period: min(
+                Duration::from_millis(100),
+                Duration::from_millis(min_block_prod_time / 5),
+            ),
             block_header_fetch_horizon: 50,
             tracked_accounts: vec![],
             tracked_shards: vec![],

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, RwLock};
 
 use actix::{Addr, System};
 use futures::{future, Future};
+use log::info;
 
 use near_chain::ChainGenesis;
 use near_client::test_utils::{setup_mock_all_validators, TestEnv};
@@ -40,7 +41,7 @@ fn chunks_produced_and_distributed_one_val_per_shard() {
 #[test]
 fn chunks_recovered_from_others() {
     heavy_test(|| {
-        chunks_produced_and_distributed_common(2, true, 2000);
+        chunks_produced_and_distributed_common(2, true, 1500);
     });
 }
 
@@ -177,11 +178,11 @@ fn chunks_produced_and_distributed_common(
                         request: _,
                     } => {
                         if drop_from_1_to_4 && from_whom == "test4" && to_whom == "test1" {
-                            println!("Dropping Partial Encoded Chunk Request from test4 to test1");
+                            info!("Dropping Partial Encoded Chunk Request from test4 to test1");
                             return (NetworkResponses::NoResponse, false);
                         }
                         if drop_from_1_to_4 && from_whom == "test4" && to_whom == "test2" {
-                            println!("Observed Partial Encoded Chunk Request from test4 to test1");
+                            info!("Observed Partial Encoded Chunk Request from test4 to test2");
                         }
                         partial_chunk_request_msgs += 1;
                     }


### PR DESCRIPTION
Fixes #1705

The problem was that the delay to re-request chunks in the test config was 1/5 of the block production time, and the test might require to request more than 5 times.