### PR TITLE
RE: client tx limiting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,6 +1912,7 @@ dependencies = [
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "near-crypto 0.1.0",
  "near-metrics 0.1.0",
+ "near-pool 0.1.0",
  "near-primitives 0.1.0",
  "near-store 0.1.0",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2104,11 +2105,6 @@ dependencies = [
 name = "near-pool"
 version = "0.1.0"
 dependencies = [
- "chrono 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near-chain 0.1.0",
  "near-crypto 0.1.0",
  "near-primitives 0.1.0",
  "rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2283,7 +2279,7 @@ dependencies = [
  "kvdb 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "near 0.4.4",
+ "near 0.4.5",
  "near-crypto 0.1.0",
  "near-metrics 0.1.0",
  "near-primitives 0.1.0",

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -22,7 +22,7 @@ near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store" }
 near-metrics = { path = "../../core/metrics" }
-
+near-pool = { path = "../pool" }
 
 [features]
 # if enabled, we assert in most situations that are impossible unless some byzantine behavior is observed.

--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -6,8 +6,7 @@ pub use error::{Error, ErrorKind};
 pub use finality::{FinalityGadget, FinalityGadgetQuorums};
 pub use store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 pub use types::{
-    Block, BlockHeader, BlockStatus, Provenance, ReceiptResult, RuntimeAdapter, Tip,
-    ValidTransaction, Weight,
+    Block, BlockHeader, BlockStatus, Provenance, ReceiptResult, RuntimeAdapter, Tip, Weight,
 };
 
 pub mod chain;

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -6,7 +6,6 @@ use near_crypto::Signature;
 use near_primitives::block::{Approval, WeightAndScore};
 pub use near_primitives::block::{Block, BlockHeader, Weight};
 use near_primitives::challenge::ChallengesResult;
-use near_primitives::errors::RuntimeError;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{merklize, MerklePath};
 use near_primitives::receipt::Receipt;
@@ -20,6 +19,8 @@ use near_primitives::views::{EpochValidatorInfo, QueryResponse};
 use near_store::{PartialStorage, StoreUpdate, WrappedTrieChanges};
 
 use crate::error::Error;
+use near_pool::types::PoolIterator;
+use near_primitives::errors::InvalidTxError;
 
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
 pub struct ReceiptResponse(pub CryptoHash, pub Vec<Receipt>);
@@ -74,12 +75,6 @@ pub struct AcceptedBlock {
     pub hash: CryptoHash,
     pub status: BlockStatus,
     pub provenance: Provenance,
-}
-
-/// Information about valid transaction that was processed by chain + runtime.
-#[derive(Debug)]
-pub struct ValidTransaction {
-    pub transaction: SignedTransaction,
 }
 
 /// Map of shard to list of receipts to send to it.
@@ -139,27 +134,38 @@ pub trait RuntimeAdapter: Send + Sync {
         header: &BlockHeader,
     ) -> Result<Weight, Error>;
 
-    /// Validate transaction and return transaction information relevant to ordering it in the mempool.
+    /// Validates a given signed transaction on top of the given state root.
+    /// Returns an option of `InvalidTxError`, it contains `Some(InvalidTxError)` if there is
+    /// a validation error, or `None` in case the transaction succeeded.
+    /// Throws an `Error` with `ErrorKind::StorageError` in case the runtime throws
+    /// `RuntimeError::StorageError`.
     fn validate_tx(
         &self,
         block_index: BlockIndex,
         block_timestamp: u64,
         gas_price: Balance,
         state_root: StateRoot,
-        transaction: SignedTransaction,
-    ) -> Result<ValidTransaction, RuntimeError>;
+        transaction: &SignedTransaction,
+    ) -> Result<Option<InvalidTxError>, Error>;
 
-    /// Filter transactions by verifying each one by one in the given order. Every successful
-    /// verification stores the updated account balances to be used by next transactions.
-    fn filter_transactions(
+    /// Returns an ordered list of valid transactions from the pool up the given limits.
+    /// Pulls transactions from the given pool iterators one by one. Validates each transaction
+    /// against the given `chain_validate` closure and runtime's transaction verifier.
+    /// If the transaction is valid for both, it's added to the result and the temporary state
+    /// update is preserved for validation of next transactions.
+    /// Throws an `Error` with `ErrorKind::StorageError` in case the runtime throws
+    /// `RuntimeError::StorageError`.
+    fn prepare_transactions(
         &self,
         block_index: BlockIndex,
         block_timestamp: u64,
         gas_price: Balance,
         gas_limit: Gas,
         state_root: StateRoot,
-        transactions: Vec<SignedTransaction>,
-    ) -> Vec<SignedTransaction>;
+        max_number_of_transactions: usize,
+        pool_iterator: &mut dyn PoolIterator,
+        chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
+    ) -> Result<Vec<SignedTransaction>, Error>;
 
     /// Verify validator signature for the given epoch.
     /// Note: doesnt't account for slashed accounts within given epoch. USE WITH CAUTION.

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -11,12 +11,12 @@ use rand::seq::SliceRandom;
 use near_chain::validate::validate_chunk_proofs;
 use near_chain::{
     byzantine_assert, collect_receipts, ChainStore, ChainStoreAccess, ChainStoreUpdate, ErrorKind,
-    RuntimeAdapter, ValidTransaction,
+    RuntimeAdapter,
 };
 use near_crypto::Signer;
 use near_network::types::PartialEncodedChunkRequestMsg;
 use near_network::NetworkRequests;
-use near_pool::TransactionPool;
+use near_pool::{PoolIteratorWrapper, TransactionPool};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, verify_path, MerklePath};
 use near_primitives::receipt::Receipt;
@@ -190,16 +190,8 @@ impl ShardsManager {
         );
     }
 
-    pub fn prepare_transactions(
-        &mut self,
-        shard_id: ShardId,
-        expected_weight: u32,
-    ) -> Result<Vec<SignedTransaction>, Error> {
-        if let Some(tx_pool) = self.tx_pools.get_mut(&shard_id) {
-            tx_pool.prepare_transactions(expected_weight).map_err(|err| err.into())
-        } else {
-            Ok(vec![])
-        }
+    pub fn get_pool_iterator(&mut self, shard_id: ShardId) -> Option<PoolIteratorWrapper> {
+        self.tx_pools.get_mut(&shard_id).map(|pool| pool.pool_iterator())
     }
 
     pub fn cares_about_shard_this_or_next_epoch(
@@ -424,7 +416,7 @@ impl ShardsManager {
         self.block_hash_to_chunk_headers.remove(&prev_block_hash).unwrap_or_else(|| vec![])
     }
 
-    pub fn insert_transaction(&mut self, shard_id: ShardId, tx: ValidTransaction) {
+    pub fn insert_transaction(&mut self, shard_id: ShardId, tx: SignedTransaction) {
         self.tx_pools
             .entry(shard_id)
             .or_insert_with(TransactionPool::default)
@@ -449,7 +441,7 @@ impl ShardsManager {
         self.tx_pools
             .entry(shard_id)
             .or_insert_with(TransactionPool::default)
-            .reintroduce_transactions(transactions);
+            .reintroduce_transactions(transactions.clone());
     }
 
     pub fn receipts_recipient_filter(
@@ -834,7 +826,7 @@ impl ShardsManager {
         validator_reward: Balance,
         balance_burnt: Balance,
         validator_proposals: Vec<ValidatorStake>,
-        transactions: &Vec<SignedTransaction>,
+        transactions: Vec<SignedTransaction>,
         outgoing_receipts: &Vec<Receipt>,
         outgoing_receipts_root: CryptoHash,
         tx_root: CryptoHash,

--- a/chain/chunks/src/types.rs
+++ b/chain/chunks/src/types.rs
@@ -11,7 +11,6 @@ pub enum Error {
     KnownPart,
     ChainError(near_chain::Error),
     IOError(std::io::Error),
-    PoolError(near_pool::Error),
 }
 
 impl std::fmt::Display for Error {
@@ -29,11 +28,5 @@ impl From<std::io::Error> for Error {
 impl From<near_chain::Error> for Error {
     fn from(err: near_chain::Error) -> Self {
         Error::ChainError(err)
-    }
-}
-
-impl From<near_pool::Error> for Error {
-    fn from(err: near_pool::Error) -> Self {
-        Error::PoolError(err)
     }
 }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -21,13 +21,12 @@ use near_network::types::{PeerId, ReasonForBan};
 use near_network::{FullPeerInfo, NetworkClientResponses, NetworkRequests};
 use near_primitives::block::{Approval, ApprovalMessage, Block, BlockHeader};
 use near_primitives::challenge::{Challenge, ChallengeBody};
-use near_primitives::errors::RuntimeError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, MerklePath};
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::{EncodedShardChunk, PartialEncodedChunk, ShardChunkHeader};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockIndex, EpochId, ShardId};
+use near_primitives::types::{AccountId, BlockIndex, ChunkExtra, EpochId, ShardId};
 use near_primitives::unwrap_or_return;
 use near_primitives::utils::to_timestamp;
 use near_primitives::views::{FinalExecutionOutcomeView, QueryResponse};
@@ -406,38 +405,21 @@ impl Client {
             .clone();
 
         let prev_block_header = self.chain.get_block_header(&prev_block_hash)?.clone();
-        let transaction_validity_period = self.chain.transaction_validity_period;
-        let transactions: Vec<_> = self
-            .shards_mgr
-            .prepare_transactions(shard_id, self.config.block_expected_weight)?
-            .into_iter()
-            .filter(|t| {
-                self.chain
-                    .mut_store()
-                    .check_blocks_on_same_chain(
-                        &prev_block_header,
-                        &t.transaction.block_hash,
-                        transaction_validity_period,
-                    )
-                    .is_ok()
-            })
-            .collect();
-        let block_header = self.chain.get_block_header(&prev_block_hash)?;
-        let transactions_len = transactions.len();
-        let filtered_transactions = self.runtime_adapter.filter_transactions(
+
+        let transactions = self.prepare_transactions(
             next_height,
             prev_block_timestamp,
-            block_header.inner.gas_price,
-            chunk_extra.gas_limit,
-            chunk_extra.state_root.clone(),
-            transactions,
+            shard_id,
+            &chunk_extra,
+            &prev_block_header,
         );
-        let (tx_root, _) = merklize(&filtered_transactions);
+
+        let num_filtered_transactions = transactions.len();
+
+        let (tx_root, _) = merklize(&transactions);
         debug!(
-            "Creating a chunk with {} filtered transactions from {} total transactions for shard {}",
-            filtered_transactions.len(),
-            transactions_len,
-            shard_id
+            "Creating a chunk with {} filtered transactions for shard {}",
+            num_filtered_transactions, shard_id
         );
 
         let ReceiptResponse(_, outgoing_receipts) = self.chain.get_outgoing_receipts_for_shard(
@@ -474,7 +456,7 @@ impl Client {
             chunk_extra.validator_reward,
             chunk_extra.balance_burnt,
             chunk_extra.validator_proposals.clone(),
-            &filtered_transactions,
+            transactions,
             &outgoing_receipts,
             outgoing_receipts_root,
             tx_root,
@@ -486,7 +468,7 @@ impl Client {
             "Produced chunk at height {} for shard {} with {} txs and {} receipts, I'm {}, chunk_hash: {}",
             next_height,
             shard_id,
-            filtered_transactions.len(),
+            num_filtered_transactions,
             outgoing_receipts.len(),
             block_producer.account_id,
             encoded_chunk.chunk_hash().0,
@@ -494,6 +476,44 @@ impl Client {
 
         near_metrics::inc_counter(&metrics::BLOCK_PRODUCED_TOTAL);
         Ok(Some((encoded_chunk, merkle_paths, outgoing_receipts)))
+    }
+
+    /// Prepares an ordered list of valid transactions from the pool up the limits.
+    fn prepare_transactions(
+        &mut self,
+        next_height: u64,
+        prev_block_timestamp: u64,
+        shard_id: u64,
+        chunk_extra: &ChunkExtra,
+        prev_block_header: &BlockHeader,
+    ) -> Vec<SignedTransaction> {
+        let Self { chain, shards_mgr, config, runtime_adapter, .. } = self;
+        if let Some(mut iter) = shards_mgr.get_pool_iterator(shard_id) {
+            let transaction_validity_period = chain.transaction_validity_period;
+            runtime_adapter
+                .prepare_transactions(
+                    next_height,
+                    prev_block_timestamp,
+                    prev_block_header.inner.gas_price,
+                    chunk_extra.gas_limit,
+                    chunk_extra.state_root.clone(),
+                    config.block_expected_weight as usize,
+                    &mut iter,
+                    &mut |tx: &SignedTransaction| -> bool {
+                        chain
+                            .mut_store()
+                            .check_blocks_on_same_chain(
+                                &prev_block_header,
+                                &tx.transaction.block_hash,
+                                transaction_validity_period,
+                            )
+                            .is_ok()
+                    },
+                )
+                .expect("no StorageError please")
+        } else {
+            vec![]
+        }
     }
 
     pub fn send_challenges(&mut self, challenges: Arc<RwLock<Vec<ChallengeBody>>>) -> () {
@@ -1063,40 +1083,37 @@ impl Client {
                     return self.forward_tx(tx);
                 }
             };
-            match self.runtime_adapter.validate_tx(
-                head.height + 1,
-                cur_block_header.inner.timestamp,
-                gas_price,
-                state_root,
-                tx,
-            ) {
-                Ok(valid_transaction) => {
-                    let active_validator = unwrap_or_return!(self.active_validator(shard_id), {
-                        warn!(target: "client", "I'm: {:?} Dropping tx: {:?}", me, valid_transaction);
-                        NetworkClientResponses::NoResponse
-                    });
+            if let Some(err) = self
+                .runtime_adapter
+                .validate_tx(
+                    head.height + 1,
+                    cur_block_header.inner.timestamp,
+                    gas_price,
+                    state_root,
+                    &tx,
+                )
+                .expect("no storage errors")
+            {
+                debug!(target: "client", "Invalid tx: {:?}", err);
+                NetworkClientResponses::InvalidTx(err)
+            } else {
+                let active_validator = unwrap_or_return!(self.active_validator(shard_id), {
+                    warn!(target: "client", "I'm: {:?} Dropping tx: {:?}", me, tx);
+                    NetworkClientResponses::NoResponse
+                });
 
-                    // If I'm not an active validator I should forward tx to next validators.
-                    if active_validator {
-                        debug!(
-                            target: "client",
-                            "Recording a transaction. I'm {:?}, {}",
-                            me,
-                            shard_id
-                        );
-                        self.shards_mgr.insert_transaction(shard_id, valid_transaction);
-                        NetworkClientResponses::ValidTx
-                    } else {
-                        self.forward_tx(valid_transaction.transaction)
-                    }
-                }
-                Err(RuntimeError::InvalidTxError(err)) => {
-                    debug!(target: "client", "Invalid tx: {:?}", err);
-                    NetworkClientResponses::InvalidTx(err)
-                }
-                Err(RuntimeError::StorageError(err)) => panic!("{}", err),
-                Err(RuntimeError::BalanceMismatch(err)) => {
-                    unreachable!("Unexpected BalanceMismatch error in validate_tx: {}", err)
+                // If I'm not an active validator I should forward tx to next validators.
+                if active_validator {
+                    debug!(
+                        target: "client",
+                        "Recording a transaction. I'm {:?}, {}",
+                        me,
+                        shard_id
+                    );
+                    self.shards_mgr.insert_transaction(shard_id, tx);
+                    NetworkClientResponses::ValidTx
+                } else {
+                    self.forward_tx(tx)
                 }
             }
         } else {

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -21,7 +21,6 @@ pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 #[derive(Debug)]
 pub enum Error {
     Chain(near_chain::Error),
-    Pool(near_pool::Error),
     Chunk(near_chunks::Error),
     BlockProducer(String),
     ChunkProducer(String),
@@ -32,7 +31,6 @@ impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Error::Chain(err) => write!(f, "Chain: {}", err),
-            Error::Pool(err) => write!(f, "Pool: {}", err),
             Error::Chunk(err) => write!(f, "Chunk: {}", err),
             Error::BlockProducer(err) => write!(f, "Block Producer: {}", err),
             Error::ChunkProducer(err) => write!(f, "Chunk Producer: {}", err),
@@ -53,12 +51,6 @@ impl From<near_chain::ErrorKind> for Error {
     fn from(e: near_chain::ErrorKind) -> Self {
         let error: near_chain::Error = e.into();
         Error::Chain(error)
-    }
-}
-
-impl From<near_pool::Error> for Error {
-    fn from(e: near_pool::Error) -> Self {
-        Error::Pool(e)
     }
 }
 

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -223,7 +223,7 @@ fn test_verify_chunk_invalid_state_challenge() {
             0,
             0,
             vec![],
-            &vec![],
+            vec![],
             &vec![],
             last_block.chunks[0].inner.outgoing_receipts_root,
             CryptoHash::default(),

--- a/chain/pool/Cargo.toml
+++ b/chain/pool/Cargo.toml
@@ -5,14 +5,8 @@ authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 
 [dependencies]
-log = "0.4"
-chrono = "0.4.4"
-failure = "0.1"
-failure_derive = "0.1"
-
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }
-near-chain = { path = "../chain" }
 
 [dev-dependencies]
 rand = "0.7"

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -1,127 +1,382 @@
-use std::collections::btree_map::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 
-use near_chain::ValidTransaction;
+use crate::types::{AccountPK, PoolIterator, TransactionGroup};
+use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, Nonce};
-
-pub use crate::types::Error;
 
 pub mod types;
 
 /// Transaction pool: keeps track of transactions that were not yet accepted into the block chain.
 #[derive(Default)]
 pub struct TransactionPool {
-    num_transactions: usize,
-    /// Transactions grouped by account and ordered by nonce.
-    pub transactions: HashMap<AccountId, BTreeMap<Nonce, SignedTransaction>>,
+    /// Transactions are grouped by a pair of (account ID, signer public key).
+    /// NOTE: It's more efficient on average to keep transactions unsorted and with potentially
+    /// conflicting nonce than to create a BTreeMap for every transaction.
+    pub transactions: HashMap<AccountPK, Vec<SignedTransaction>>,
+    /// Set of all hashes to quickly check if the given transaction is in the pool.
+    pub unique_transactions: HashSet<CryptoHash>,
 }
 
 impl TransactionPool {
-    /// Insert a valid transaction into the pool that passed validation.
-    pub fn insert_transaction(&mut self, valid_transaction: ValidTransaction) {
-        let signer_id = valid_transaction.transaction.transaction.signer_id.clone();
-        let nonce = valid_transaction.transaction.transaction.nonce;
-        self.num_transactions += 1;
+    /// Insert a signed transaction into the pool that passed validation.
+    pub fn insert_transaction(&mut self, signed_transaction: SignedTransaction) {
+        if self.unique_transactions.contains(&signed_transaction.get_hash()) {
+            return;
+        }
+        self.unique_transactions.insert(signed_transaction.get_hash());
+        let signer_id = signed_transaction.transaction.signer_id.clone();
+        let signer_public_key = signed_transaction.transaction.public_key.clone();
         self.transactions
-            .entry(signer_id)
-            .or_insert_with(BTreeMap::new)
-            .insert(nonce, valid_transaction.transaction);
+            .entry((signer_id, signer_public_key))
+            .or_insert_with(Vec::new)
+            .push(signed_transaction);
     }
 
-    /// Take transactions from the pool, in the appropriate order to be put in a new block.
-    /// Ensure that on average they will fit into expected weight.
-    pub fn prepare_transactions(
-        &mut self,
-        expected_weight: u32,
-    ) -> Result<Vec<SignedTransaction>, Error> {
-        // TODO: pack transactions better.
-        let result = self
-            .transactions
-            .values()
-            .flat_map(BTreeMap::values)
-            .take(expected_weight as usize)
-            .cloned()
-            .collect();
-        Ok(result)
+    /// Returns a pool iterator wrapper that implements an iterator like trait to iterate over
+    /// transaction groups in the proper order defined by the protocol.
+    /// When the iterator is dropped, all remaining groups are inserted back into the pool.
+    pub fn pool_iterator(&mut self) -> PoolIteratorWrapper {
+        PoolIteratorWrapper::new(self)
     }
 
     /// Quick reconciliation step - evict all transactions that already in the block
     /// or became invalid after it.
-    pub fn remove_transactions(&mut self, transactions: &Vec<SignedTransaction>) {
-        for transaction in transactions.iter() {
-            let signer_id = &transaction.transaction.signer_id;
-            let nonce = transaction.transaction.nonce;
-            let mut remove_map = false;
-            if let Some(map) = self.transactions.get_mut(signer_id) {
-                map.remove(&nonce);
-                remove_map = map.is_empty();
+    pub fn remove_transactions(&mut self, transactions: &[SignedTransaction]) {
+        let mut grouped_transactions = HashMap::new();
+        for tx in transactions {
+            if self.unique_transactions.contains(&tx.get_hash()) {
+                let signer_id = &tx.transaction.signer_id;
+                let signer_public_key = &tx.transaction.public_key;
+                grouped_transactions
+                    .entry((signer_id, signer_public_key))
+                    .or_insert_with(HashSet::new)
+                    .insert(tx.get_hash());
             }
-            if remove_map {
-                self.num_transactions -= 1;
-                self.transactions.remove(signer_id);
+        }
+        for (key, hashes) in grouped_transactions {
+            let key = (key.0.clone(), key.1.clone());
+            let mut remove_entry = false;
+            if let Some(v) = self.transactions.get_mut(&key) {
+                v.retain(|tx| !hashes.contains(&tx.get_hash()));
+                remove_entry = v.is_empty();
+            }
+            if remove_entry {
+                self.transactions.remove(&key);
+            }
+            for hash in hashes {
+                self.unique_transactions.remove(&hash);
             }
         }
     }
 
-    /// Reintroduce transactions back during the reorg
-    pub fn reintroduce_transactions(&mut self, transactions: &Vec<SignedTransaction>) {
-        for transaction in transactions.iter() {
-            let transaction = transaction.clone();
-            self.insert_transaction(ValidTransaction { transaction });
+    /// Reintroduce transactions back during the chain reorg
+    pub fn reintroduce_transactions(&mut self, transactions: Vec<SignedTransaction>) {
+        for tx in transactions {
+            self.insert_transaction(tx);
         }
     }
 
     pub fn len(&self) -> usize {
-        self.num_transactions
+        self.unique_transactions.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.num_transactions == 0
+        self.unique_transactions.is_empty()
+    }
+}
+
+/// PoolIterator is a structure to pull transactions from the pool.
+/// It implements `PoolIterator` trait that iterates over transaction groups one by one.
+/// When the wrapper is dropped the remaining transactions are returned back to the pool.
+pub struct PoolIteratorWrapper<'a> {
+    /// Mutable reference to the pool, to avoid exposing it while the iterator exists.
+    pool: &'a mut TransactionPool,
+
+    /// Queue of transaction groups. Each group there is sorted by nonce.
+    sorted_groups: VecDeque<TransactionGroup>,
+}
+
+impl<'a> PoolIteratorWrapper<'a> {
+    pub fn new(pool: &'a mut TransactionPool) -> Self {
+        Self { pool, sorted_groups: Default::default() }
+    }
+}
+
+/// The iterator works with the following algorithm:
+/// On next(), the iterator tries to get a transaction group from the pool, sorts transactions in
+/// it, and add it to the back of the sorted groups queue.
+///
+/// If the pool is empty, the iterator gets the group from the front of the sorted groups queue.
+///
+/// If this group is empty (no transactions left inside), then the iterator discards it and
+/// updates `unique_transactions` in the pool. Then gets the next one.
+///
+/// Once a non-empty group is found, this group is pushed to the back of the sorted groups queue
+/// and the iterator returns a mutable reference to this group.
+///
+/// If the sorted groups queue is empty, the iterator returns None.
+///
+/// When the iterator is dropped, `unique_transactions` in the pool is updated for every group.
+/// And all non-empty group from the sorted groups queue are inserted back into the pool.
+impl<'a> PoolIterator for PoolIteratorWrapper<'a> {
+    fn next(&mut self) -> Option<&mut TransactionGroup> {
+        let key = self.pool.transactions.keys().next().cloned();
+        match key {
+            Some(key) => {
+                let mut transactions =
+                    self.pool.transactions.remove(&key.clone()).expect("just checked existence");
+                transactions.sort_by_key(|st| std::cmp::Reverse(st.transaction.nonce));
+                self.sorted_groups.push_back(TransactionGroup {
+                    key,
+                    transactions,
+                    removed_transaction_hashes: vec![],
+                });
+                Some(self.sorted_groups.back_mut().expect("just pushed"))
+            }
+            None => {
+                while let Some(sorted_group) = self.sorted_groups.pop_front() {
+                    if sorted_group.transactions.is_empty() {
+                        for hash in sorted_group.removed_transaction_hashes {
+                            self.pool.unique_transactions.remove(&hash);
+                        }
+                    } else {
+                        self.sorted_groups.push_back(sorted_group);
+                        return Some(self.sorted_groups.back_mut().expect("just pushed"));
+                    }
+                }
+                None
+            }
+        }
+    }
+}
+
+/// When a pool iterator is dropped, all remaining non empty transaction groups from the sorted
+/// groups queue are inserted back into the pool. And removed transactions hashes from groups are
+/// removed from the pool's unique_transactions.
+impl<'a> Drop for PoolIteratorWrapper<'a> {
+    fn drop(&mut self) {
+        for group in self.sorted_groups.drain(..) {
+            for hash in group.removed_transaction_hashes {
+                self.pool.unique_transactions.remove(&hash);
+            }
+            if !group.transactions.is_empty() {
+                self.pool.transactions.insert(group.key, group.transactions);
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::sync::Arc;
 
     use rand::seq::SliceRandom;
     use rand::thread_rng;
 
-    use near_chain::ValidTransaction;
     use near_crypto::{InMemorySigner, KeyType};
-    use near_primitives::transaction::SignedTransaction;
 
-    use crate::TransactionPool;
     use near_primitives::hash::CryptoHash;
     use near_primitives::types::Balance;
 
-    /// Add transactions of nonce from 1..10 in random order. Check that mempool
-    /// orders them correctly.
-    #[test]
-    fn test_order_nonce() {
+    fn generate_transactions(
+        signer_id: &str,
+        signer_seed: &str,
+        starting_nonce: u64,
+        end_nonce: u64,
+    ) -> Vec<SignedTransaction> {
         let signer =
-            Arc::new(InMemorySigner::from_seed("alice.near", KeyType::ED25519, "alice.near"));
-        let mut transactions: Vec<_> = (1..10)
+            Arc::new(InMemorySigner::from_seed(signer_seed, KeyType::ED25519, signer_seed));
+        (starting_nonce..=end_nonce)
             .map(|i| {
                 SignedTransaction::send_money(
                     i,
-                    "alice.near".to_string(),
+                    signer_id.to_string(),
                     "bob.near".to_string(),
                     &*signer,
                     i as Balance,
                     CryptoHash::default(),
                 )
             })
-            .collect();
+            .collect()
+    }
+
+    fn process_txs_to_nonces(
+        mut transactions: Vec<SignedTransaction>,
+        expected_weight: u32,
+    ) -> (Vec<u64>, TransactionPool) {
         let mut pool = TransactionPool::default();
         let mut rng = thread_rng();
         transactions.shuffle(&mut rng);
         for tx in transactions {
-            pool.insert_transaction(ValidTransaction { transaction: tx });
+            pool.insert_transaction(tx);
         }
-        let transactions = pool.prepare_transactions(10).unwrap();
-        let nonces: Vec<u64> = transactions.iter().map(|tx| tx.transaction.nonce).collect();
-        assert_eq!(nonces, (1..10).collect::<Vec<u64>>())
+        (
+            prepare_transactions(&mut pool, expected_weight)
+                .iter()
+                .map(|tx| tx.transaction.nonce)
+                .collect(),
+            pool,
+        )
+    }
+
+    fn sort_pairs(a: &mut [u64]) {
+        for c in a.chunks_exact_mut(2) {
+            if c[0] > c[1] {
+                c.swap(0, 1);
+            }
+        }
+    }
+
+    fn prepare_transactions(
+        pool: &mut TransactionPool,
+        max_number_of_transactions: u32,
+    ) -> Vec<SignedTransaction> {
+        let mut res = vec![];
+        let mut pool_iter = pool.pool_iterator();
+        while res.len() < max_number_of_transactions as usize {
+            if let Some(iter) = pool_iter.next() {
+                if let Some(tx) = iter.next() {
+                    res.push(tx);
+                }
+            } else {
+                break;
+            }
+        }
+        res
+    }
+
+    /// Add transactions of nonce from 1..10 in random order. Check that mempool
+    /// orders them correctly.
+    #[test]
+    fn test_order_nonce() {
+        let transactions = generate_transactions("alice.near", "alice.near", 1, 10);
+        let (nonces, _) = process_txs_to_nonces(transactions, 10);
+        assert_eq!(nonces, (1..=10).collect::<Vec<u64>>());
+    }
+
+    /// Add transactions of nonce from 1..10 in random order from 2 signers. Check that mempool
+    /// orders them correctly.
+    #[test]
+    fn test_order_nonce_two_signers() {
+        let mut transactions = generate_transactions("alice.near", "alice.near", 1, 10);
+        transactions.extend(generate_transactions("bob.near", "bob.near", 1, 10));
+
+        let (nonces, _) = process_txs_to_nonces(transactions, 10);
+        assert_eq!(nonces, (1..=5).map(|a| vec![a; 2]).flatten().collect::<Vec<u64>>());
+    }
+
+    /// Add transactions of nonce from 1..10 in random order from the same account but with
+    /// different public keys.
+    #[test]
+    fn test_order_nonce_same_account_two_access_keys_variable_nonces() {
+        let mut transactions = generate_transactions("alice.near", "alice.near", 1, 10);
+        transactions.extend(generate_transactions("alice.near", "bob.near", 21, 30));
+
+        let (mut nonces, _) = process_txs_to_nonces(transactions, 10);
+        sort_pairs(&mut nonces[..]);
+        assert_eq!(nonces, (1..=5).map(|a| vec![a, a + 20]).flatten().collect::<Vec<u64>>());
+    }
+
+    /// Add transactions of nonce from 1..=3 and transactions with nonce 21..=31. Pull 10.
+    /// Then try to get another 10.
+    #[test]
+    fn test_retain() {
+        let mut transactions = generate_transactions("alice.near", "alice.near", 1, 3);
+        transactions.extend(generate_transactions("alice.near", "bob.near", 21, 31));
+
+        let (mut nonces, mut pool) = process_txs_to_nonces(transactions, 10);
+        sort_pairs(&mut nonces[..6]);
+        assert_eq!(nonces, vec![1, 21, 2, 22, 3, 23, 24, 25, 26, 27]);
+        let nonces: Vec<u64> =
+            prepare_transactions(&mut pool, 10).iter().map(|tx| tx.transaction.nonce).collect();
+        assert_eq!(nonces, vec![28, 29, 30, 31]);
+    }
+
+    #[test]
+    fn test_remove_transactions() {
+        let n = 100;
+        let mut transactions = (1..=n)
+            .map(|i| {
+                let signer_seed = format!("user_{}", i % 3);
+                let signer = Arc::new(InMemorySigner::from_seed(
+                    &signer_seed,
+                    KeyType::ED25519,
+                    &signer_seed,
+                ));
+                let signer_id = format!("user_{}", i % 5);
+                SignedTransaction::send_money(
+                    i,
+                    signer_id.to_string(),
+                    "bob.near".to_string(),
+                    &*signer,
+                    i as Balance,
+                    CryptoHash::default(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut pool = TransactionPool::default();
+        let mut rng = thread_rng();
+        transactions.shuffle(&mut rng);
+        for tx in transactions.clone() {
+            println!("{:?}", tx);
+            pool.insert_transaction(tx);
+        }
+        assert_eq!(pool.len(), n as usize);
+
+        transactions.shuffle(&mut rng);
+        let (txs_to_remove, txs_to_check) = transactions.split_at(transactions.len() / 2);
+        pool.remove_transactions(txs_to_remove);
+
+        assert_eq!(pool.len(), txs_to_check.len());
+
+        let mut pool_txs = prepare_transactions(&mut pool, txs_to_check.len() as u32);
+        pool_txs.sort_by_key(|tx| tx.transaction.nonce);
+        let mut expected_txs = txs_to_check.to_vec();
+        expected_txs.sort_by_key(|tx| tx.transaction.nonce);
+
+        assert_eq!(pool_txs, expected_txs);
+    }
+
+    /// Add transactions of nonce from 1..=3 and transactions with nonce 21..=31. Pull 10.
+    /// Then try to get another 10.
+    #[test]
+    fn test_pool_iterator() {
+        let mut transactions = generate_transactions("alice.near", "alice.near", 1, 3);
+        transactions.extend(generate_transactions("alice.near", "bob.near", 21, 31));
+
+        let (nonces, mut pool) = process_txs_to_nonces(transactions, 0);
+        assert!(nonces.is_empty());
+        let mut res = vec![];
+        let mut pool_iter = pool.pool_iterator();
+        while let Some(iter) = pool_iter.next() {
+            while let Some(tx) = iter.next() {
+                if tx.transaction.nonce & 1 == 1 {
+                    res.push(tx);
+                    break;
+                }
+            }
+        }
+        let mut nonces: Vec<_> = res.into_iter().map(|tx| tx.transaction.nonce).collect();
+        sort_pairs(&mut nonces[..4]);
+        assert_eq!(nonces, vec![1, 21, 3, 23, 25, 27, 29, 31]);
+    }
+
+    /// Test pool iterator updates unique transactions.
+    #[test]
+    fn test_pool_iterator_removes_unique() {
+        let transactions = generate_transactions("alice.near", "alice.near", 1, 10);
+
+        let (nonces, mut pool) = process_txs_to_nonces(transactions.clone(), 5);
+        assert_eq!(nonces.len(), 5);
+        assert_eq!(pool.len(), 5);
+
+        for tx in transactions {
+            pool.insert_transaction(tx);
+        }
+        assert_eq!(pool.len(), 10);
+        let txs = prepare_transactions(&mut pool, 10);
+        assert_eq!(txs.len(), 10);
     }
 }

--- a/chain/pool/src/types.rs
+++ b/chain/pool/src/types.rs
@@ -1,23 +1,39 @@
-use failure::Fail;
+use near_crypto::PublicKey;
+use near_primitives::hash::CryptoHash;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::AccountId;
 
-use near_chain::ValidTransaction;
-
-/// Possible errors whe interacting with transaction pool.
-#[derive(Debug, Fail)]
-pub enum Error {
-    /// An invalid pool entry caused by underlying tx validation error
-    #[fail(display = "Invalid Tx {}", _0)]
-    InvalidTx(String),
-    /// Other kinds of error (not yet pulled out into meaningful errors).
-    #[fail(display = "General pool error {}", _0)]
-    Other(String),
+/// Trait acts like an iterator. It iterates over transactions groups by returning mutable
+/// references to them. Each transaction group implements a draining iterator to pull transactions.
+/// The order of the transaction groups is round robin scheduling.
+/// When this iterator is dropped the remaining transactions are returned back to the pool.
+pub trait PoolIterator {
+    fn next(&mut self) -> Option<&mut TransactionGroup>;
 }
 
-pub type ValidateTxCallback = fn(&[u8]) -> Result<ValidTransaction, Error>;
+/// A key that is used for grouping transactions together.
+/// It consists of the signer's account ID and signer's public key.
+pub(crate) type AccountPK = (AccountId, PublicKey);
 
-// Interface that the transaction pool requires from a blockchain implementation.
-//pub trait ChainAdapter {
-//    /// Verify transaction validity.
-//    // TODO: possible return values: deserialized transaction, it's expected "weight", nonce and account id for grouping.
-//    fn validate_tx(&self, tx: &[u8]) -> Result<ValidTransaction, Error>;
-//}
+/// Represents a group of transactions with the same key.
+pub struct TransactionGroup {
+    /// The key of the group.
+    pub(crate) key: AccountPK,
+    /// Ordered transactions by nonce in non-increasing order (e.g. 3, 2, 2).
+    pub(crate) transactions: Vec<SignedTransaction>,
+    /// Hashes of the transactions that were pulled from the group using `.next()`.
+    pub(crate) removed_transaction_hashes: Vec<CryptoHash>,
+}
+
+impl TransactionGroup {
+    /// Returns the next transaction with the smallest nonce and removes it from the group.
+    /// It also stores all hashes of returned transactions.
+    pub fn next(&mut self) -> Option<SignedTransaction> {
+        if let Some(tx) = self.transactions.pop() {
+            self.removed_transaction_hashes.push(tx.get_hash());
+            Some(tx)
+        } else {
+            None
+        }
+    }
+}

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -9,6 +9,7 @@ use rand::SeedableRng;
 use serde_derive::{Deserialize, Serialize};
 
 use lazy_static::lazy_static;
+use std::hash::{Hash, Hasher};
 
 lazy_static! {
     pub static ref SECP256K1: secp256k1::Secp256k1 = secp256k1::Secp256k1::new();
@@ -117,6 +118,21 @@ impl PublicKey {
         match self {
             PublicKey::ED25519(_) => KeyType::ED25519,
             PublicKey::SECP256K1(_) => KeyType::SECP256K1,
+        }
+    }
+}
+
+impl Hash for PublicKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            PublicKey::ED25519(public_key) => {
+                state.write_u8(0u8);
+                state.write(&public_key.0);
+            }
+            PublicKey::SECP256K1(public_key) => {
+                state.write_u8(1u8);
+                state.write(&public_key.0);
+            }
         }
     }
 }

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -327,7 +327,7 @@ pub fn genesis_chunks(
                 0,
                 CryptoHash::default(),
                 vec![],
-                &vec![],
+                vec![],
                 &vec![],
                 CryptoHash::default(),
                 &EmptySigner {},

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -225,13 +225,12 @@ impl EncodedShardChunk {
 
         tx_root: CryptoHash,
         validator_proposals: Vec<ValidatorStake>,
-        transactions: &Vec<SignedTransaction>,
+        transactions: Vec<SignedTransaction>,
         outgoing_receipts: &Vec<Receipt>,
         outgoing_receipts_root: CryptoHash,
         signer: &dyn Signer,
     ) -> Result<(EncodedShardChunk, Vec<MerklePath>), std::io::Error> {
-        let mut bytes =
-            TransactionReceipt(transactions.to_vec(), outgoing_receipts.to_vec()).try_to_vec()?;
+        let mut bytes = TransactionReceipt(transactions, outgoing_receipts.clone()).try_to_vec()?;
         let parity_parts = total_parts - data_parts;
 
         let mut parts = vec![];

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -9,13 +9,17 @@ use borsh::ser::BorshSerialize;
 use borsh::BorshDeserialize;
 use log::debug;
 
+use crate::config::GenesisConfig;
+use crate::shard_tracker::{account_id_to_shard_id, ShardTracker};
 use near_chain::types::{ApplyTransactionResult, ValidatorSignatureVerificationResult};
-use near_chain::{BlockHeader, Error, ErrorKind, RuntimeAdapter, ValidTransaction, Weight};
+use near_chain::{BlockHeader, Error, ErrorKind, RuntimeAdapter, Weight};
 use near_crypto::{PublicKey, Signature};
 use near_epoch_manager::{BlockInfo, EpochConfig, EpochManager, RewardCalculator};
+use near_pool::types::PoolIterator;
 use near_primitives::account::{AccessKey, Account};
+use near_primitives::block::Approval;
 use near_primitives::challenge::ChallengesResult;
-use near_primitives::errors::RuntimeError;
+use near_primitives::errors::{InvalidTxError, RuntimeError};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::Receipt;
 use near_primitives::serialize::from_base64;
@@ -36,10 +40,6 @@ use near_store::{
 use node_runtime::adapter::ViewRuntimeAdapter;
 use node_runtime::state_viewer::TrieViewer;
 use node_runtime::{ApplyState, Runtime, StateRecord, ValidatorAccountsUpdate};
-
-use crate::config::GenesisConfig;
-use crate::shard_tracker::{account_id_to_shard_id, ShardTracker};
-use near_primitives::block::Approval;
 
 const POISONED_LOCK_ERR: &str = "The lock was poisoned.";
 const STATE_DUMP_FILE: &str = "state_dump";
@@ -633,8 +633,8 @@ impl RuntimeAdapter for NightshadeRuntime {
         block_timestamp: u64,
         gas_price: Balance,
         state_root: StateRoot,
-        transaction: SignedTransaction,
-    ) -> Result<ValidTransaction, RuntimeError> {
+        transaction: &SignedTransaction,
+    ) -> Result<Option<InvalidTxError>, Error> {
         let mut state_update = TrieUpdate::new(self.trie.clone(), state_root);
         let apply_state = ApplyState {
             block_index,
@@ -645,26 +645,32 @@ impl RuntimeAdapter for NightshadeRuntime {
             gas_limit: None,
         };
 
-        if let Err(err) = self.runtime.verify_and_charge_transaction(
+        match self.runtime.verify_and_charge_transaction(
             &mut state_update,
             &apply_state,
             &transaction,
         ) {
-            debug!(target: "runtime", "Tx {:?} validation failed: {:?}", transaction, err);
-            return Err(err);
+            Ok(_) => Ok(None),
+            Err(RuntimeError::InvalidTxError(err)) => {
+                debug!(target: "runtime", "Tx {:?} validation failed: {:?}", transaction, err);
+                Ok(Some(err))
+            }
+            Err(RuntimeError::StorageError(_err)) => Err(Error::from(ErrorKind::StorageError)),
+            Err(err) => unreachable!("Unexpected RuntimeError error {:?}", err),
         }
-        Ok(ValidTransaction { transaction })
     }
 
-    fn filter_transactions(
+    fn prepare_transactions(
         &self,
         block_index: BlockIndex,
         block_timestamp: u64,
         gas_price: Balance,
         gas_limit: Gas,
         state_root: StateRoot,
-        transactions: Vec<SignedTransaction>,
-    ) -> Vec<SignedTransaction> {
+        max_number_of_transactions: usize,
+        pool_iterator: &mut dyn PoolIterator,
+        chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
+    ) -> Result<Vec<SignedTransaction>, Error> {
         let mut state_update = TrieUpdate::new(self.trie.clone(), state_root);
         let apply_state = ApplyState {
             block_index,
@@ -673,14 +679,50 @@ impl RuntimeAdapter for NightshadeRuntime {
             block_timestamp,
             gas_limit: Some(gas_limit),
         };
-        transactions
-            .into_iter()
-            .filter(|transaction| {
-                self.runtime
-                    .verify_and_charge_transaction(&mut state_update, &apply_state, transaction)
-                    .is_ok()
-            })
-            .collect()
+
+        // Total amount of gas burnt for converting transactions towards receipts.
+        let mut total_gas_burnt = 0;
+        // TODO: Update gas limit for transactions
+        let transactions_gas_limit = gas_limit / 2;
+        let mut transactions = vec![];
+        let mut num_checked_transactions = 0;
+
+        while transactions.len() < max_number_of_transactions
+            && total_gas_burnt < transactions_gas_limit
+        {
+            if let Some(iter) = pool_iterator.next() {
+                while let Some(tx) = iter.next() {
+                    num_checked_transactions += 1;
+                    // Verifying the transaction is on the same chain and hasn't expired yet.
+                    if chain_validate(&tx) {
+                        // Verifying the validity of the transaction based on the current state.
+                        match self.runtime.verify_and_charge_transaction(
+                            &mut state_update,
+                            &apply_state,
+                            &tx,
+                        ) {
+                            Ok(verification_result) => {
+                                state_update.commit();
+                                transactions.push(tx);
+                                total_gas_burnt += verification_result.gas_burnt;
+                                break;
+                            }
+                            Err(RuntimeError::InvalidTxError(_err)) => {
+                                state_update.rollback();
+                            }
+                            Err(RuntimeError::StorageError(_err)) => {
+                                return Err(Error::from(ErrorKind::StorageError))
+                            }
+                            Err(err) => unreachable!("Unexpected RuntimeError error {:?}", err),
+                        }
+                    }
+                }
+            } else {
+                break;
+            }
+        }
+        debug!(target: "runtime", "Transaction filtering results {} valid out of {} pulled from the pool", transactions.len(), num_checked_transactions);
+        Ok(transactions)
     }
 
     fn add_validator_proposals(


### PR DESCRIPTION
Reverting the revert https://github.com/nearprotocol/nearcore/commit/bbeed123db9a3fda06943c6d17556a889c8e4901

And reintroducing transactions back into the pool after filtering at chunk production. It removes invalid transactions from the pool during filtering while keeping valid transactions until the chunk is included in the block.