### PR TITLE
Replace state_root with sync_hash in StatePartKey

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1400,7 +1400,7 @@ impl Chain {
 
         // Saving the part data.
         let mut store_update = self.store.owned_store().store_update();
-        let key = StatePartKey(shard_id, part_id, state_root).try_to_vec()?;
+        let key = StatePartKey(sync_hash, shard_id, part_id).try_to_vec()?;
         store_update.set_ser(COL_STATE_PARTS, &key, data)?;
         store_update.commit()?;
         Ok(())
@@ -1416,8 +1416,8 @@ impl Chain {
         let mut height = shard_state_header.chunk.header.height_included;
         let state_root = shard_state_header.chunk.header.inner.prev_state_root.clone();
         let mut parts = vec![];
-        for i in 0..num_parts {
-            let key = StatePartKey(shard_id, i, state_root.clone()).try_to_vec()?;
+        for part_id in 0..num_parts {
+            let key = StatePartKey(sync_hash, shard_id, part_id).try_to_vec()?;
             parts.push(self.store.owned_store().get_ser(COL_STATE_PARTS, &key)?.unwrap());
         }
 
@@ -1467,11 +1467,9 @@ impl Chain {
         sync_hash: CryptoHash,
         num_parts: u64,
     ) -> Result<(), Error> {
-        let shard_state_header = self.get_received_state_header(shard_id, sync_hash)?;
-        let state_root = shard_state_header.chunk.header.inner.prev_state_root.clone();
         let mut store_update = self.store.owned_store().store_update();
         for part_id in 0..num_parts {
-            let key = StatePartKey(shard_id, part_id, state_root).try_to_vec()?;
+            let key = StatePartKey(sync_hash, shard_id, part_id).try_to_vec()?;
             store_update.delete(COL_STATE_PARTS, &key);
         }
         Ok(store_update.commit()?)

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -35,7 +35,7 @@ pub struct RootProof(pub CryptoHash, pub MerklePath);
 pub struct StateHeaderKey(pub ShardId, pub CryptoHash);
 
 #[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize)]
-pub struct StatePartKey(pub ShardId, pub u64 /* PartId */, pub StateRoot);
+pub struct StatePartKey(pub CryptoHash, pub ShardId, pub u64 /* PartId */);
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum BlockStatus {


### PR DESCRIPTION
It's possible to have multiple sync_hash with the same state_root,
which would lead to one of them deleting shared data while the other
is still running.