### PR TITLE
Remove OldBlock error

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2677,17 +2677,7 @@ impl<'a> ChainUpdate<'a> {
     /// Check if this block is in the store already.
     fn check_known_store(&self, header: &BlockHeader) -> Result<(), Error> {
         match self.chain_store_update.block_exists(&header.hash()) {
-            Ok(true) => {
-                let head = self.chain_store_update.head()?;
-                if head.height > 50 && header.inner.height < head.height - 50 {
-                    // We flag this as an "abusive peer" but only in the case
-                    // where we have the full block in our store.
-                    // So this is not a particularly exhaustive check.
-                    Err(ErrorKind::OldBlock.into())
-                } else {
-                    Err(ErrorKind::Unfit("already known in store".to_string()).into())
-                }
-            }
+            Ok(true) => Err(ErrorKind::Unfit("already known in store".to_string()).into()),
             Ok(false) => {
                 // Not yet processed this block, we can proceed.
                 Ok(())

--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -25,9 +25,6 @@ pub enum ErrorKind {
     /// Chunks missing with header info.
     #[fail(display = "Chunks Missing: {:?}", _0)]
     ChunksMissing(Vec<(ShardChunkHeader)>),
-    /// Peer abusively sending us an old block we already have
-    #[fail(display = "Old Block")]
-    OldBlock,
     /// Block time is before parent block time.
     #[fail(display = "Invalid Block Time: block time {} before previous {}", _1, _0)]
     InvalidBlockPastTime(DateTime<Utc>, DateTime<Utc>),
@@ -199,7 +196,6 @@ impl Error {
             ErrorKind::InvalidBlockPastTime(_, _)
             | ErrorKind::InvalidBlockFutureTime(_)
             | ErrorKind::InvalidBlockHeight
-            | ErrorKind::OldBlock
             | ErrorKind::InvalidBlockProposer
             | ErrorKind::InvalidBlockConfirmation
             | ErrorKind::InvalidBlockWeight

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -657,15 +657,11 @@ impl ClientActor {
             // Given next block producer already missed `num_blocks_missing`, we back off the time we are waiting for them.
             if elapsed
                 < std::cmp::max(
-                    self.client
-                        .config
-                        .max_block_wait_delay
-                        .checked_sub(
-                            self.client.config.reduce_wait_for_missing_block
-                                * num_blocks_missing as u32,
-                        )
-                        .unwrap_or(self.client.config.min_block_production_delay),
-                    self.client.config.min_block_production_delay,
+                    self.client.config.max_block_wait_delay.saturating_sub(
+                        self.client.config.reduce_wait_for_missing_block
+                            * num_blocks_missing as u32,
+                    ),
+                    self.client.config.max_block_production_delay,
                 )
             {
                 // Next block producer is not this client, so just go for another loop iteration.

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -657,10 +657,14 @@ impl ClientActor {
             // Given next block producer already missed `num_blocks_missing`, we back off the time we are waiting for them.
             if elapsed
                 < std::cmp::max(
-                    self.client.config.max_block_wait_delay.saturating_sub(
-                        self.client.config.reduce_wait_for_missing_block
-                            * num_blocks_missing as u32,
-                    ),
+                    self.client
+                        .config
+                        .max_block_wait_delay
+                        .checked_sub(
+                            self.client.config.reduce_wait_for_missing_block
+                                * num_blocks_missing as u32,
+                        )
+                        .unwrap_or(self.client.config.max_block_production_delay),
                     self.client.config.max_block_production_delay,
                 )
             {

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -58,7 +58,7 @@ pub const MAX_BLOCK_PRODUCTION_DELAY: u64 = 2_000;
 pub const MAX_BLOCK_WAIT_DELAY: u64 = 6_000;
 
 /// Reduce wait time for every missing block in ms.
-const REDUCE_DELAY_FOR_MISSING_BLOCKS: u64 = 1_000;
+const REDUCE_DELAY_FOR_MISSING_BLOCKS: u64 = 100;
 
 /// Expected epoch length.
 pub const EXPECTED_EPOCH_LENGTH: BlockIndex = (5 * 60 * 1000) / MIN_BLOCK_PRODUCTION_DELAY;


### PR DESCRIPTION
Also adjust the adaptive waiting time for skipped blocks to be at least `max_block_production_delay` to reduce forkfulness.