### PR TITLE
Fixing an issue that was causing blocks being produced without chunks

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -409,6 +409,13 @@ impl ShardsManager {
         Ok(())
     }
 
+    pub fn num_chunks_for_block(&mut self, prev_block_hash: CryptoHash) -> ShardId {
+        self.block_hash_to_chunk_headers
+            .get(&prev_block_hash)
+            .map(|x| x.len() as ShardId)
+            .unwrap_or_else(|| 0)
+    }
+
     pub fn prepare_chunks(
         &mut self,
         prev_block_hash: CryptoHash,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -240,10 +240,10 @@ impl Client {
         let total_approvals =
             total_block_producers - min(if prev_same_bp { 1 } else { 2 }, total_block_producers);
         let num_approvals = self.approvals.cache_get(&prev_hash).map(|h| h.len()).unwrap_or(0);
-        let new_chunks = self.shards_mgr.prepare_chunks(prev_hash);
+        let num_chunks = self.shards_mgr.num_chunks_for_block(prev_hash);
         if head.height > 0
             && num_approvals < min(total_approvals, 2 * total_block_producers / 3)
-            && (new_chunks.len() as ShardId) < self.runtime_adapter.num_shards()
+            && num_chunks < self.runtime_adapter.num_shards()
             && elapsed_since_last_block < self.config.max_block_production_delay
         {
             // Will retry after a `block_production_tracking_delay`.
@@ -251,6 +251,7 @@ impl Client {
             return Ok(None);
         }
 
+        let new_chunks = self.shards_mgr.prepare_chunks(prev_hash);
         // If we are producing empty blocks and there are no transactions.
         if !self.config.produce_empty_blocks && new_chunks.is_empty() {
             debug!(target: "client", "Empty blocks, skipping block production");

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -13,8 +13,9 @@ pytest --timeout=600 sanity/state_sync.py manytx 250
 pytest sanity/state_sync.py onetx 50
 pytest --timeout=600 sanity/state_sync.py onetx 250
 pytest sanity/rpc_tx_forwarding.py
-pytest sanity/skip_epoch.py
-pytest sanity/fork_sync.py
+pytest --timeout=240 sanity/skip_epoch.py
+pytest --timeout=600 sanity/fork_sync.py
+pytest --timeout=240 sanity/one_val.py
 
 # python stress tests
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network

--- a/pytest/tests/sanity/fork_sync.py
+++ b/pytest/tests/sanity/fork_sync.py
@@ -80,7 +80,7 @@ while cur_height < TIMEOUT:
         exit(0)
     time.sleep(0.5)
 
-assert(False, "timed out waiting for forks to resolve")
+assert False, "timed out waiting for forks to resolve"
 
 
 

--- a/pytest/tests/sanity/one_val.py
+++ b/pytest/tests/sanity/one_val.py
@@ -1,0 +1,55 @@
+# Creates a genesis config with two block producers, and kills one right away after
+# launch. Makes sure that the other block producer can produce blocks with chunks and
+# process transactions. Makes large-ish number of block producers per shard to minimize
+# the chance of the second block producer occupying all the seats in one of the shards
+
+import sys, time, base58, random
+
+sys.path.append('lib')
+
+
+from cluster import start_cluster
+from utils import TxContext
+from transaction import sign_payment_tx
+
+TIMEOUT = 240
+
+nodes = start_cluster(2, 1, 8, {'local': True, 'near_root': '../target/debug/'}, [["num_block_producers", 199], ["block_producers_per_shard", [24, 25, 25, 25, 25, 25, 25, 25]], ["gas_price", 0], ["max_inflation_rate", 0], ["epoch_length", 10], ["block_producer_kickout_threshold", 70]], {})
+nodes[1].kill()
+
+started = time.time()
+
+act_to_val = [0, 0, 0]
+ctx = TxContext(act_to_val, nodes)
+
+last_balances = [x for x in ctx.expected_balances]
+
+max_height = 0
+sent_height = -1
+caught_up_times = 0
+
+while True:
+    assert time.time() - started < TIMEOUT
+    status = nodes[0].get_status()
+
+    height = status['sync_info']['latest_block_height']
+    hash_ = status['sync_info']['latest_block_hash']
+
+    if height > max_height:
+        print("Got to height", height)
+        max_height = height
+
+    if ctx.get_balances() == ctx.expected_balances:
+        print("Balances caught up, took %s blocks, moving on" % (height - sent_height));
+        ctx.send_moar_txs(hash_, 10, use_routing=True)
+        sent_height = height
+        caught_up_times += 1
+    else:
+        if height > sent_height + 30:
+            assert False, "Balances before: %s\nExpected balances: %s\nCurrent balances: %s\nSent at height: %s\n" % (last_balances, ctx.expected_balances, ctx.get_balances(), sent_height)
+        time.sleep(0.2)
+
+    if caught_up_times == 3:
+        break
+
+


### PR DESCRIPTION
Problem: the call to `prepare_chunks` was moved in `produce_blocks` before the check
for sufficient number of approvals. `prepare_chunks` removes the chunks info from the
`shards_mgr`, so if we then didn't have enough approvals or enough chunks and were
delaying the block production, the next time around `prepare_chunks` returned an empty
set

Test Plan: new pytest `one_val.py` that reproduces the issue without this change