### PR TITLE
Fix some issues with block timestamps

### DIFF
--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -28,9 +28,6 @@ pub enum ErrorKind {
     /// Block time is before parent block time.
     #[fail(display = "Invalid Block Time: block time {} before previous {}", _1, _0)]
     InvalidBlockPastTime(DateTime<Utc>, DateTime<Utc>),
-    /// Block time is from too much in the future.
-    #[fail(display = "Invalid Block Time: Too far in the future: {}", _0)]
-    InvalidBlockFutureTime(DateTime<Utc>),
     /// Block height is invalid (not previous + 1).
     #[fail(display = "Invalid Block Height")]
     InvalidBlockHeight,
@@ -194,7 +191,6 @@ impl Error {
             | ErrorKind::StorageError
             | ErrorKind::DBNotFoundErr(_) => false,
             ErrorKind::InvalidBlockPastTime(_, _)
-            | ErrorKind::InvalidBlockFutureTime(_)
             | ErrorKind::InvalidBlockHeight
             | ErrorKind::InvalidBlockProposer
             | ErrorKind::InvalidBlockConfirmation

--- a/chain/chain/tests/challenges.rs
+++ b/chain/chain/tests/challenges.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use near_chain::test_utils::setup;
 use near_chain::{Block, ErrorKind, Provenance};
 use near_primitives::test_utils::init_test_logger;
@@ -21,11 +22,16 @@ fn challenges_new_head_prev() {
     assert_eq!(chain.head().unwrap().height, 5);
 
     // The block to be added below after we invalidated fourth block.
-    let last_block = Block::empty(&chain.get_block(&hashes[3]).unwrap(), &*signer);
+    let last_block = Block::empty_with_timestamp(
+        &chain.get_block(&hashes[3]).unwrap(),
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(4),
+    );
     assert_eq!(last_block.header.inner_lite.height, 5);
 
     let prev = chain.get_block(&hashes[1]).unwrap();
-    let challenger_block = Block::empty(&prev, &*signer);
+    let challenger_block =
+        Block::empty_with_timestamp(&prev, &*signer, Utc::now() + chrono::Duration::seconds(2));
     let challenger_hash = challenger_block.hash();
 
     let _ = chain
@@ -57,13 +63,18 @@ fn challenges_new_head_prev() {
     assert_eq!(chain.head_header().unwrap().hash(), hashes[2]);
 
     // Add two more blocks
-    let b3 = Block::empty(&chain.get_block(&hashes[2]).unwrap().clone(), &*signer);
+    let b3 = Block::empty_with_timestamp(
+        &chain.get_block(&hashes[2]).unwrap().clone(),
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(2),
+    );
+
     let _ = chain
         .process_block(&None, b3.clone(), Provenance::PRODUCED, |_| {}, |_| {}, |_| {})
         .unwrap()
         .unwrap();
 
-    let b4 = Block::empty(&b3, &*signer);
+    let b4 = Block::empty_with_timestamp(&b3, &*signer, Utc::now() + chrono::Duration::seconds(3));
     let new_head = chain
         .process_block(&None, b4.clone(), Provenance::PRODUCED, |_| {}, |_| {}, |_| {})
         .unwrap()
@@ -73,12 +84,16 @@ fn challenges_new_head_prev() {
     assert_eq!(chain.head_header().unwrap().hash(), new_head);
 
     // Add two more blocks on an alternative chain
-    let b3 = Block::empty(&chain.get_block(&hashes[2]).unwrap().clone(), &*signer);
+    let b3 = Block::empty_with_timestamp(
+        &chain.get_block(&hashes[2]).unwrap().clone(),
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(2),
+    );
     let _ = chain
         .process_block(&None, b3.clone(), Provenance::PRODUCED, |_| {}, |_| {}, |_| {})
         .unwrap();
 
-    let b4 = Block::empty(&b3, &*signer);
+    let b4 = Block::empty_with_timestamp(&b3, &*signer, Utc::now() + chrono::Duration::seconds(3));
     let _ = chain
         .process_block(&None, b4.clone(), Provenance::PRODUCED, |_| {}, |_| {}, |_| {})
         .unwrap();

--- a/chain/chain/tests/simple_chain.rs
+++ b/chain/chain/tests/simple_chain.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use near_chain::test_utils::setup;
 use near_chain::{Block, ErrorKind, Provenance};
 use near_crypto::Signer;
@@ -138,20 +139,61 @@ fn blocks_at_height() {
     init_test_logger();
     let (mut chain, _, signer) = setup();
     let genesis = chain.get_block_by_height(0).unwrap();
-    let b_1 = Block::empty_with_height(genesis, 1, &*signer);
-    let b_2 = Block::empty_with_height(&b_1, 2, &*signer);
-    let b_3 = Block::empty_with_height(&b_2, 3, &*signer);
+    let b_1 = Block::empty_with_timestamp(
+        genesis,
+        &*signer,
+        Utc::now() + chrono::Duration::milliseconds(500),
+    );
+    let b_2 =
+        Block::empty_with_timestamp(&b_1, &*signer, Utc::now() + chrono::Duration::seconds(1));
+    let b_3 =
+        Block::empty_with_timestamp(&b_2, &*signer, Utc::now() + chrono::Duration::seconds(2));
 
-    let c_1 = Block::empty_with_height(&genesis, 1, &*signer);
-    let c_3 = Block::empty_with_height(&c_1, 3, &*signer);
-    let c_4 = Block::empty_with_height(&c_3, 4, &*signer);
-    let c_5 = Block::empty_with_height(&c_4, 5, &*signer);
+    let c_1 = Block::empty(&genesis, &*signer);
+    let c_3 = Block::empty_with_height_and_timestamp(
+        &c_1,
+        3,
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(1),
+    );
+    let c_4 = Block::empty_with_height_and_timestamp(
+        &c_3,
+        4,
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(2),
+    );
+    let c_5 = Block::empty_with_height_and_timestamp(
+        &c_4,
+        5,
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(3),
+    );
 
-    let d_3 = Block::empty_with_height(&b_2, 3, &*signer);
-    let d_4 = Block::empty_with_height(&d_3, 4, &*signer);
-    let d_5 = Block::empty_with_height(&d_4, 5, &*signer);
+    let d_3 = Block::empty_with_height_and_timestamp(
+        &b_2,
+        3,
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(3),
+    );
+    let d_4 = Block::empty_with_height_and_timestamp(
+        &d_3,
+        4,
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(4),
+    );
+    let d_5 = Block::empty_with_height_and_timestamp(
+        &d_4,
+        5,
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(5),
+    );
 
-    let mut e_2 = Block::empty_with_height(&b_1, 2, &*signer);
+    let mut e_2 = Block::empty_with_height_and_timestamp(
+        &b_1,
+        2,
+        &*signer,
+        Utc::now() + chrono::Duration::seconds(1),
+    );
     e_2.header.inner_rest.total_weight = (10 * e_2.header.inner_rest.total_weight.to_num()).into();
     e_2.header.init();
     e_2.header.signature = signer.sign(e_2.header.hash().as_ref());

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -331,6 +331,8 @@ fn invalid_blocks() {
                 CryptoHash::default(),
             );
             block.header.inner_lite.prev_state_root = hash(&[1]);
+            block.header.init();
+            block.header.signature = signer.sign(block.header.hash.as_ref());
             client.do_send(NetworkClientMessages::Block(
                 block.clone(),
                 PeerInfo::random().id,

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -662,11 +662,8 @@ fn test_block_time_in_the_future() {
 
     let (_, result) = env.clients[0].process_block(b1.clone(), Provenance::NONE);
     match result {
-        Err(e) => match e.kind() {
-            ErrorKind::Orphan => {}
-            _ => assert!(false, "wrong error: {}", e),
-        },
-        _ => panic!("Block should be orphaned"),
+        Err(e) if e.kind() == ErrorKind::Orphan => {}
+        _ => assert!(false, "wrong result: {:?}", result),
     }
 
     std::thread::sleep(Duration::from_secs(2));

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -13,6 +13,8 @@ use crate::transaction::{
     TransferAction,
 };
 use crate::types::{AccountId, Balance, BlockIndex, EpochId, Nonce};
+use crate::utils::to_timestamp;
+use chrono::{DateTime, Utc};
 
 lazy_static! {
     static ref HEAVY_TESTS_LOCK: Mutex<()> = Mutex::new(());
@@ -144,6 +146,32 @@ impl Block {
 
     pub fn empty(prev: &Block, signer: &dyn Signer) -> Self {
         Self::empty_with_height(prev, prev.header.inner_lite.height + 1, signer)
+    }
+
+    pub fn empty_with_timestamp(
+        prev: &Block,
+        signer: &dyn Signer,
+        timestamp: DateTime<Utc>,
+    ) -> Self {
+        Self::empty_with_height_and_timestamp(
+            prev,
+            prev.header.inner_lite.height + 1,
+            signer,
+            timestamp,
+        )
+    }
+
+    pub fn empty_with_height_and_timestamp(
+        prev: &Block,
+        height: BlockIndex,
+        signer: &dyn Signer,
+        timestamp: DateTime<Utc>,
+    ) -> Self {
+        let mut block = Self::empty_with_height(prev, height, signer);
+        block.header.inner_lite.timestamp = to_timestamp(timestamp);
+        block.header.init();
+        block.header.signature = signer.sign(block.header.hash.as_ref());
+        block
     }
 
     /// This is not suppose to be used outside of chain tests, because this doesn't refer to correct chunks.


### PR DESCRIPTION
* If a block has timestamp that's too far in the future we should orphan it instead of rejecting it directly. Fixes #1753 
* A block has timestamp that's smaller than last block timestamp plus some delta, it should be considered as invalid so that adversaries cannot produce a long fork very quickly.