### PR TITLE
Finality Gadget respects weights

### DIFF
--- a/chain/chain/src/finality.rs
+++ b/chain/chain/src/finality.rs
@@ -2,7 +2,7 @@ use crate::error::{Error, ErrorKind};
 use crate::{ChainStoreAccess, ChainStoreUpdate};
 use near_primitives::block::{Approval, BlockHeader, BlockHeaderInnerRest, Weight};
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::{AccountId, BlockIndex, EpochId};
+use near_primitives::types::{AccountId, Balance, BlockIndex, EpochId, ValidatorStake};
 use std::collections::{HashMap, HashSet};
 
 // How many blocks back to search for a new reference hash when the chain switches and the block
@@ -178,17 +178,24 @@ impl FinalityGadget {
         mut height: BlockIndex,
         mut approvals: Vec<Approval>,
         chain_store: &mut dyn ChainStoreAccess,
-        total_block_producers: usize,
+        stakes: Vec<ValidatorStake>,
     ) -> Result<FinalityGadgetQuorums, Error> {
         let mut quorum_pre_vote = None;
         let mut quorum_pre_commit = None;
 
         let mut surrounding_approvals = HashSet::new();
+        let mut surrounding_stake = 0 as Balance;
         let mut height_to_accounts_to_remove: HashMap<u64, HashSet<_>> = HashMap::new();
+        let mut height_to_stake: HashMap<u64, Balance> = HashMap::new();
         let mut accounts_to_height_to_remove = HashMap::new();
 
         let mut highest_height_no_quorum = height as i64;
-        let mut accounts_surrounding_no_quroum = 0;
+        let mut stake_surrounding_no_quorum = 0 as Balance;
+
+        let account_id_to_stake =
+            stakes.iter().map(|x| (&x.account_id, x.amount)).collect::<HashMap<_, _>>();
+        assert!(account_id_to_stake.len() == stakes.len());
+        let threshold = account_id_to_stake.values().sum::<u128>() * 2u128 / 3u128;
 
         while quorum_pre_commit.is_none() {
             // If this is genesis, set quorum pre-vote and quorum pre-commit to the default hash
@@ -205,34 +212,35 @@ impl FinalityGadget {
             // Update surrounding approvals
             for approval in approvals {
                 let account_id = approval.account_id.clone();
-
-                let was_surrounding_no_quroum =
-                    if let Some(current_height) = accounts_to_height_to_remove.get(&account_id) {
-                        height_to_accounts_to_remove
-                            .get_mut(current_height)
-                            .unwrap()
-                            .remove(&account_id);
-
-                        *current_height as i64 <= highest_height_no_quorum
-                    } else {
-                        false
-                    };
+                let cur_account_stake = match account_id_to_stake.get(&account_id) {
+                    Some(stake) => *stake,
+                    None => continue,
+                };
 
                 let reference_height =
                     chain_store.get_block_header(&approval.reference_hash)?.inner_lite.height;
 
-                if let Some(old_height) = accounts_to_height_to_remove.get(&account_id) {
+                let was_surrounding_no_quroum = if let Some(old_height) =
+                    accounts_to_height_to_remove.get(&account_id)
+                {
                     if *old_height < reference_height {
                         // If the approval is fully surrounded by the previous known approval from
                         //    the same block producer, disregard it (the existence of two such approvals
                         //    is a slashable behavior, and we can safely ignore either or both here)
                         continue;
                     }
-                }
+
+                    height_to_accounts_to_remove.get_mut(old_height).unwrap().remove(&account_id);
+                    *height_to_stake.get_mut(old_height).unwrap() -= cur_account_stake;
+
+                    *old_height as i64 <= highest_height_no_quorum
+                } else {
+                    false
+                };
 
                 if reference_height as i64 <= highest_height_no_quorum && !was_surrounding_no_quroum
                 {
-                    accounts_surrounding_no_quroum += 1;
+                    stake_surrounding_no_quorum += cur_account_stake;
                 }
 
                 height_to_accounts_to_remove
@@ -240,14 +248,23 @@ impl FinalityGadget {
                     .or_insert_with(|| HashSet::new())
                     .insert(account_id.clone());
 
+                *height_to_stake.entry(reference_height).or_insert_with(|| 0 as Balance) +=
+                    cur_account_stake;
+
                 accounts_to_height_to_remove.insert(account_id.clone(), reference_height);
 
-                surrounding_approvals.insert(account_id);
+                if !surrounding_approvals.contains(&account_id) {
+                    surrounding_stake += cur_account_stake;
+                    surrounding_approvals.insert(account_id);
+                }
             }
 
             if let Some(remove_accounts) = height_to_accounts_to_remove.get(&height) {
                 for account_id in remove_accounts {
-                    surrounding_approvals.remove(account_id);
+                    if surrounding_approvals.contains(account_id) {
+                        surrounding_stake -= *account_id_to_stake.get(account_id).unwrap();
+                        surrounding_approvals.remove(account_id);
+                    }
                     accounts_to_height_to_remove.remove(account_id);
                 }
             }
@@ -275,16 +292,14 @@ impl FinalityGadget {
             }
 
             // Move `highest_height_no_quorum` if needed
-            while accounts_surrounding_no_quroum > total_block_producers * 2 / 3 {
-                accounts_surrounding_no_quroum -= height_to_accounts_to_remove
-                    .get(&(highest_height_no_quorum as u64))
-                    .map(|v| v.len())
-                    .unwrap_or(0);
+            while stake_surrounding_no_quorum > threshold {
+                stake_surrounding_no_quorum -=
+                    *height_to_stake.get(&(highest_height_no_quorum as u64)).unwrap_or(&0);
 
                 highest_height_no_quorum -= 1;
             }
 
-            if surrounding_approvals.len() > total_block_producers * 2 / 3 {
+            if surrounding_stake > threshold {
                 if quorum_pre_vote.is_none() {
                     quorum_pre_vote = Some(last_block_header.hash())
                 }

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -305,9 +305,9 @@ impl RuntimeAdapter for KeyValueRuntime {
         &self,
         epoch_id: &EpochId,
         _last_known_block_hash: &CryptoHash,
-    ) -> Result<Vec<(AccountId, bool)>, Error> {
+    ) -> Result<Vec<(ValidatorStake, bool)>, Error> {
         let validators = &self.validators[self.get_valset_for_epoch(epoch_id)?];
-        Ok(validators.iter().map(|x| (x.account_id.clone(), false)).collect())
+        Ok(validators.iter().map(|x| (x.clone(), false)).collect())
     }
 
     fn get_block_producer(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -186,7 +186,7 @@ pub trait RuntimeAdapter: Send + Sync {
         &self,
         epoch_id: &EpochId,
         last_known_block_hash: &CryptoHash,
-    ) -> Result<Vec<(AccountId, bool)>, Error>;
+    ) -> Result<Vec<(ValidatorStake, bool)>, Error>;
 
     /// Block producers for given height for the main block. Return error if outside of known boundaries.
     fn get_block_producer(

--- a/chain/chain/tests/finality.rs
+++ b/chain/chain/tests/finality.rs
@@ -1,10 +1,10 @@
 use near_chain::test_utils::setup;
 use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 use near_chain::{FinalityGadget, FinalityGadgetQuorums};
-use near_crypto::{Signature, Signer};
+use near_crypto::{KeyType, PublicKey, Signature, Signer};
 use near_primitives::block::{Approval, Block};
 use near_primitives::hash::CryptoHash;
-use near_primitives::types::{AccountId, BlockIndex, EpochId};
+use near_primitives::types::{AccountId, Balance, BlockIndex, EpochId, ValidatorStake};
 use near_store::test_utils::create_test_store;
 use rand::seq::SliceRandom;
 use rand::Rng;
@@ -14,7 +14,7 @@ fn compute_quorums_slow(
     mut prev_hash: CryptoHash,
     approvals: Vec<Approval>,
     chain_store: &mut dyn ChainStoreAccess,
-    total_block_producers: usize,
+    stakes: Vec<ValidatorStake>,
 ) -> FinalityGadgetQuorums {
     let mut all_approvals = approvals;
 
@@ -22,6 +22,11 @@ fn compute_quorums_slow(
     let mut quorum_pre_commit = CryptoHash::default();
 
     let mut all_heights_and_hashes = vec![];
+
+    let account_id_to_stake =
+        stakes.iter().map(|x| (&x.account_id, x.amount)).collect::<HashMap<_, _>>();
+    assert!(account_id_to_stake.len() == stakes.len());
+    let threshold = account_id_to_stake.values().sum::<u128>() * 2u128 / 3u128;
 
     while prev_hash != CryptoHash::default() {
         let block_header = chain_store.get_block_header(&prev_hash).unwrap();
@@ -48,13 +53,17 @@ fn compute_quorums_slow(
 
     for (hash, height) in all_heights_and_hashes.iter().rev() {
         let mut surrounding = HashSet::new();
+        let mut surrounding_stake = 0 as Balance;
         for approval in all_approvals.iter() {
             if approval.1 <= *height && approval.2 >= *height {
-                surrounding.insert(approval.0.clone());
+                if !surrounding.contains(&approval.0) {
+                    surrounding_stake += *account_id_to_stake.get(&approval.0).unwrap();
+                    surrounding.insert(approval.0.clone());
+                }
             }
         }
 
-        if surrounding.len() > total_block_producers * 2 / 3 {
+        if surrounding_stake > threshold {
             quorum_pre_vote = hash.clone();
         }
 
@@ -62,23 +71,29 @@ fn compute_quorums_slow(
             if other_height > height {
                 let mut surrounding_both = HashSet::new();
                 let mut surrounding_left = HashSet::new();
+                let mut surrounding_both_stake = 0 as Balance;
+                let mut surrounding_left_stake = 0 as Balance;
                 for approval in all_approvals.iter() {
                     if approval.1 <= *height
                         && approval.2 >= *height
                         && approval.1 <= *other_height
                         && approval.2 >= *other_height
+                        && !surrounding_both.contains(&approval.0)
                     {
+                        surrounding_both_stake += *account_id_to_stake.get(&approval.0).unwrap();
                         surrounding_both.insert(approval.0.clone());
                     }
-                    if approval.1 <= *height && approval.2 >= *height && approval.2 < *other_height
+                    if approval.1 <= *height
+                        && approval.2 >= *height
+                        && approval.2 < *other_height
+                        && !surrounding_left.contains(&approval.0)
                     {
+                        surrounding_left_stake += *account_id_to_stake.get(&approval.0).unwrap();
                         surrounding_left.insert(approval.0.clone());
                     }
                 }
 
-                if surrounding_both.len() > total_block_producers * 2 / 3
-                    && surrounding_left.len() > total_block_producers * 2 / 3
-                {
+                if surrounding_both_stake > threshold && surrounding_left_stake > threshold {
                     quorum_pre_commit = hash.clone();
                 }
             }
@@ -97,7 +112,7 @@ fn create_block(
     chain_store: &mut ChainStore,
     signer: &dyn Signer,
     approvals: Vec<Approval>,
-    total_block_producers: usize,
+    stakes: Vec<ValidatorStake>,
 ) -> Block {
     let mut block = Block::empty(prev, signer);
     block.header.inner_rest.approvals = approvals.clone();
@@ -112,15 +127,14 @@ fn create_block(
     );*/
 
     let slow_quorums =
-        compute_quorums_slow(prev.hash(), approvals.clone(), chain_store, total_block_producers)
-            .clone();
+        compute_quorums_slow(prev.hash(), approvals.clone(), chain_store, stakes.clone()).clone();
     let fast_quorums = FinalityGadget::compute_quorums(
         prev.hash(),
         EpochId(CryptoHash::default()),
         height,
         approvals.clone(),
         chain_store,
-        total_block_producers,
+        stakes.clone(),
     )
     .unwrap()
     .clone();
@@ -154,19 +168,31 @@ fn apr(account_id: AccountId, reference_hash: CryptoHash, parent_hash: CryptoHas
     Approval { account_id, reference_hash, parent_hash, signature: Signature::default() }
 }
 
+fn gen_stakes(n: usize) -> Vec<ValidatorStake> {
+    (0..n)
+        .map(|x| {
+            ValidatorStake::new(format!("test{}", x + 1), PublicKey::empty(KeyType::ED25519), 1)
+        })
+        .collect()
+}
+
 #[test]
 fn test_finality_genesis() {
     let store = create_test_store();
     let mut chain_store = ChainStore::new(store);
+
+    let stakes = gen_stakes(10);
 
     let expected_quorums = FinalityGadgetQuorums {
         last_quorum_pre_vote: CryptoHash::default(),
         last_quorum_pre_commit: CryptoHash::default(),
     };
     let slow_quorums =
-        compute_quorums_slow(CryptoHash::default(), vec![], &mut chain_store, 10).clone();
+        compute_quorums_slow(CryptoHash::default(), vec![], &mut chain_store, stakes.clone())
+            .clone();
     let fast_quorums =
-        compute_quorums_slow(CryptoHash::default(), vec![], &mut chain_store, 10).clone();
+        compute_quorums_slow(CryptoHash::default(), vec![], &mut chain_store, stakes.clone())
+            .clone();
 
     assert_eq!(expected_quorums, slow_quorums);
     assert_eq!(expected_quorums, fast_quorums);
@@ -175,7 +201,7 @@ fn test_finality_genesis() {
 #[test]
 fn test_finality_genesis2() {
     let (mut chain, _, signer) = setup();
-    let total_block_producers = 4;
+    let stakes = gen_stakes(4);
 
     let genesis_block = chain.get_block(&chain.genesis().hash()).unwrap().clone();
 
@@ -189,7 +215,7 @@ fn test_finality_genesis2() {
             apr("test2".to_string(), genesis_block.hash(), genesis_block.hash()),
             apr("test3".to_string(), genesis_block.hash(), genesis_block.hash()),
         ],
-        total_block_producers,
+        stakes.clone(),
     );
 
     let expected_quorums = FinalityGadgetQuorums {
@@ -198,15 +224,14 @@ fn test_finality_genesis2() {
     };
 
     let slow_quorums =
-        compute_quorums_slow(block1.hash(), vec![], chain.mut_store(), total_block_producers)
-            .clone();
+        compute_quorums_slow(block1.hash(), vec![], chain.mut_store(), stakes.clone()).clone();
     let fast_quorums = FinalityGadget::compute_quorums(
         block1.hash(),
         EpochId(CryptoHash::default()),
         2,
         vec![],
         chain.mut_store(),
-        total_block_producers,
+        stakes.clone(),
     )
     .unwrap()
     .clone();
@@ -218,12 +243,12 @@ fn test_finality_genesis2() {
 #[test]
 fn test_finality_basic() {
     let (mut chain, _, signer) = setup();
-    let total_block_producers = 4;
+    let stakes = gen_stakes(4);
 
     let genesis_block = chain.get_block(&chain.genesis().hash()).unwrap().clone();
 
     let block1 =
-        create_block(&genesis_block, 1, chain.mut_store(), &*signer, vec![], total_block_producers);
+        create_block(&genesis_block, 1, chain.mut_store(), &*signer, vec![], stakes.clone());
     let block2 = create_block(
         &block1,
         2,
@@ -234,7 +259,7 @@ fn test_finality_basic() {
             apr("test2".to_string(), block1.hash(), block1.hash()),
             apr("test3".to_string(), block1.hash(), block1.hash()),
         ],
-        total_block_producers,
+        stakes.clone(),
     );
     let block3 = create_block(
         &block2,
@@ -246,7 +271,7 @@ fn test_finality_basic() {
             apr("test2".to_string(), block1.hash(), block2.hash()),
             apr("test3".to_string(), block1.hash(), block2.hash()),
         ],
-        total_block_producers,
+        stakes.clone(),
     );
 
     let expected_quorums = FinalityGadgetQuorums {
@@ -255,15 +280,63 @@ fn test_finality_basic() {
     };
 
     let slow_quorums =
-        compute_quorums_slow(block3.hash(), vec![], chain.mut_store(), total_block_producers)
-            .clone();
+        compute_quorums_slow(block3.hash(), vec![], chain.mut_store(), stakes.clone()).clone();
     let fast_quorums = FinalityGadget::compute_quorums(
         block3.hash(),
         EpochId(CryptoHash::default()),
         4,
         vec![],
         chain.mut_store(),
-        total_block_producers,
+        stakes.clone(),
+    )
+    .unwrap()
+    .clone();
+
+    assert_eq!(expected_quorums, slow_quorums);
+    assert_eq!(expected_quorums, fast_quorums);
+}
+
+#[test]
+fn test_finality_weight() {
+    let (mut chain, _, signer) = setup();
+    let mut stakes = gen_stakes(4);
+    stakes[0].amount = 8;
+
+    let genesis_block = chain.get_block(&chain.genesis().hash()).unwrap().clone();
+
+    let block1 =
+        create_block(&genesis_block, 1, chain.mut_store(), &*signer, vec![], stakes.clone());
+    let block2 = create_block(
+        &block1,
+        2,
+        chain.mut_store(),
+        &*signer,
+        vec![apr("test1".to_string(), block1.hash(), block1.hash())],
+        stakes.clone(),
+    );
+    let block3 = create_block(
+        &block2,
+        3,
+        chain.mut_store(),
+        &*signer,
+        vec![apr("test1".to_string(), block1.hash(), block2.hash())],
+        stakes.clone(),
+    );
+
+    let expected_quorums = FinalityGadgetQuorums {
+        last_quorum_pre_vote: block2.hash(),
+        last_quorum_pre_commit: block1.hash(),
+    };
+
+    let slow_quorums =
+        compute_quorums_slow(block3.hash(), vec![], chain.mut_store(), stakes.clone()).clone();
+    let fast_quorums = FinalityGadget::compute_quorums(
+        block3.hash(),
+        EpochId(CryptoHash::default()),
+        4,
+        vec![],
+        chain.mut_store(),
+        stakes.clone(),
     )
     .unwrap()
     .clone();
@@ -275,12 +348,12 @@ fn test_finality_basic() {
 #[test]
 fn test_finality_fewer_approvals_per_block() {
     let (mut chain, _, signer) = setup();
-    let total_block_producers = 4;
+    let stakes = gen_stakes(4);
 
     let genesis_block = chain.get_block(&chain.genesis().hash()).unwrap().clone();
 
     let block1 =
-        create_block(&genesis_block, 1, chain.mut_store(), &*signer, vec![], total_block_producers);
+        create_block(&genesis_block, 1, chain.mut_store(), &*signer, vec![], stakes.clone());
     let block2 = create_block(
         &block1,
         2,
@@ -290,7 +363,7 @@ fn test_finality_fewer_approvals_per_block() {
             apr("test1".to_string(), block1.hash(), block1.hash()),
             apr("test2".to_string(), block1.hash(), block1.hash()),
         ],
-        total_block_producers,
+        stakes.clone(),
     );
     let block3 = create_block(
         &block2,
@@ -301,7 +374,7 @@ fn test_finality_fewer_approvals_per_block() {
             apr("test1".to_string(), block1.hash(), block2.hash()),
             apr("test3".to_string(), block1.hash(), block2.hash()),
         ],
-        total_block_producers,
+        stakes.clone(),
     );
     let block4 = create_block(
         &block3,
@@ -312,7 +385,7 @@ fn test_finality_fewer_approvals_per_block() {
             apr("test1".to_string(), block1.hash(), block3.hash()),
             apr("test2".to_string(), block1.hash(), block3.hash()),
         ],
-        total_block_producers,
+        stakes.clone(),
     );
     let block5 = create_block(
         &block4,
@@ -323,7 +396,7 @@ fn test_finality_fewer_approvals_per_block() {
             apr("test1".to_string(), block1.hash(), block4.hash()),
             apr("test3".to_string(), block1.hash(), block4.hash()),
         ],
-        total_block_producers,
+        stakes.clone(),
     );
 
     let expected_quorums = FinalityGadgetQuorums {
@@ -332,15 +405,14 @@ fn test_finality_fewer_approvals_per_block() {
     };
 
     let slow_quorums =
-        compute_quorums_slow(block5.hash(), vec![], chain.mut_store(), total_block_producers)
-            .clone();
+        compute_quorums_slow(block5.hash(), vec![], chain.mut_store(), stakes.clone()).clone();
     let fast_quorums = FinalityGadget::compute_quorums(
         block5.hash(),
         EpochId(CryptoHash::default()),
         6,
         vec![],
         chain.mut_store(),
-        total_block_producers,
+        stakes.clone(),
     )
     .unwrap()
     .clone();
@@ -353,20 +425,13 @@ fn test_finality_fewer_approvals_per_block() {
 fn test_finality_quorum_precommit_cases() {
     for target in 0..=1 {
         let (mut chain, _, signer) = setup();
-        let total_block_producers = 4;
+        let stakes = gen_stakes(4);
 
         let genesis_block = chain.get_block(&chain.genesis().hash()).unwrap().clone();
 
-        let block1 = create_block(
-            &genesis_block,
-            1,
-            chain.mut_store(),
-            &*signer,
-            vec![],
-            total_block_producers,
-        );
-        let block2 =
-            create_block(&block1, 2, chain.mut_store(), &*signer, vec![], total_block_producers);
+        let block1 =
+            create_block(&genesis_block, 1, chain.mut_store(), &*signer, vec![], stakes.clone());
+        let block2 = create_block(&block1, 2, chain.mut_store(), &*signer, vec![], stakes.clone());
 
         let block3 = create_block(
             &block2,
@@ -378,7 +443,7 @@ fn test_finality_quorum_precommit_cases() {
                 apr("test2".to_string(), block1.hash(), block2.hash()),
                 apr("test3".to_string(), block1.hash(), block2.hash()),
             ],
-            total_block_producers,
+            stakes.clone(),
         );
 
         let target_hash = if target == 0 { block1.hash() } else { block3.hash() };
@@ -393,7 +458,7 @@ fn test_finality_quorum_precommit_cases() {
                 apr("test2".to_string(), target_hash, block3.hash()),
                 apr("test3".to_string(), target_hash, block3.hash()),
             ],
-            total_block_producers,
+            stakes.clone(),
         );
 
         let expected_quorums = FinalityGadgetQuorums {
@@ -402,15 +467,14 @@ fn test_finality_quorum_precommit_cases() {
         };
 
         let slow_quorums =
-            compute_quorums_slow(block4.hash(), vec![], chain.mut_store(), total_block_producers)
-                .clone();
+            compute_quorums_slow(block4.hash(), vec![], chain.mut_store(), stakes.clone()).clone();
         let fast_quorums = FinalityGadget::compute_quorums(
             block4.hash(),
             EpochId(CryptoHash::default()),
             5,
             vec![],
             chain.mut_store(),
-            total_block_producers,
+            stakes.clone(),
         )
         .unwrap()
         .clone();
@@ -423,29 +487,21 @@ fn test_finality_quorum_precommit_cases() {
 #[test]
 fn test_my_approvals() {
     let (mut chain, _, signer) = setup();
-    let total_block_producers = 4;
-    let account_id = "test".to_string();
+    let stakes = gen_stakes(4);
+    let account_id = "test1".to_string();
 
     let genesis_block = chain.get_block(&chain.genesis().hash()).unwrap().clone();
 
     let block1 =
-        create_block(&genesis_block, 1, chain.mut_store(), &*signer, vec![], total_block_producers);
-    let block2 =
-        create_block(&block1, 2, chain.mut_store(), &*signer, vec![], total_block_producers);
-    let block3 =
-        create_block(&block2, 3, chain.mut_store(), &*signer, vec![], total_block_producers);
-    let block4 =
-        create_block(&block3, 4, chain.mut_store(), &*signer, vec![], total_block_producers);
-    let block5 =
-        create_block(&block1, 5, chain.mut_store(), &*signer, vec![], total_block_producers);
-    let block6 =
-        create_block(&block4, 6, chain.mut_store(), &*signer, vec![], total_block_producers);
-    let block7 =
-        create_block(&block6, 7, chain.mut_store(), &*signer, vec![], total_block_producers);
-    let block8 =
-        create_block(&block6, 8, chain.mut_store(), &*signer, vec![], total_block_producers);
-    let block9 =
-        create_block(&block7, 9, chain.mut_store(), &*signer, vec![], total_block_producers);
+        create_block(&genesis_block, 1, chain.mut_store(), &*signer, vec![], stakes.clone());
+    let block2 = create_block(&block1, 2, chain.mut_store(), &*signer, vec![], stakes.clone());
+    let block3 = create_block(&block2, 3, chain.mut_store(), &*signer, vec![], stakes.clone());
+    let block4 = create_block(&block3, 4, chain.mut_store(), &*signer, vec![], stakes.clone());
+    let block5 = create_block(&block1, 5, chain.mut_store(), &*signer, vec![], stakes.clone());
+    let block6 = create_block(&block4, 6, chain.mut_store(), &*signer, vec![], stakes.clone());
+    let block7 = create_block(&block6, 7, chain.mut_store(), &*signer, vec![], stakes.clone());
+    let block8 = create_block(&block6, 8, chain.mut_store(), &*signer, vec![], stakes.clone());
+    let block9 = create_block(&block7, 9, chain.mut_store(), &*signer, vec![], stakes.clone());
 
     // Intentionally skipping block8 in both expeted and in the loop below, block8 is processed
     //     separately at the end
@@ -495,7 +551,7 @@ fn test_fuzzy_finality() {
 
     let block_producers =
         vec!["test1".to_string(), "test2".to_string(), "test3".to_string(), "test4".to_string()];
-    let total_block_producers = block_producers.len();
+    let stakes = gen_stakes(block_producers.len());
 
     for complexity in 1..=num_complexities {
         for iter in 0..num_iters {
@@ -554,7 +610,7 @@ fn test_fuzzy_finality() {
                     chain.mut_store(),
                     &*signer,
                     approvals,
-                    total_block_producers,
+                    stakes.clone(),
                 );
 
                 last_approvals.insert(new_block.hash().clone(), last_approvals_entry);

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -309,18 +309,18 @@ impl ShardsManager {
     ) -> Result<AccountId, Error> {
         let mut block_producers = vec![];
         let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(parent_hash).unwrap();
-        for (block_producer, is_slashed) in
+        for (validator_stake, is_slashed) in
             self.runtime_adapter.get_epoch_block_producers(&epoch_id, parent_hash)?
         {
             if !is_slashed
                 && self.cares_about_shard_this_or_next_epoch(
-                    Some(&block_producer),
+                    Some(&validator_stake.account_id),
                     &parent_hash,
                     shard_id,
                     false,
                 )
             {
-                block_producers.push(block_producer);
+                block_producers.push(validator_stake.account_id);
             }
         }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -292,7 +292,6 @@ impl Client {
             epoch_id.clone(),
             next_height,
             approvals.clone(),
-            total_block_producers,
             &*self.runtime_adapter,
             self.chain.mut_store(),
         )?
@@ -814,7 +813,7 @@ impl Client {
                 .get_epoch_block_producers(&block_header.inner_lite.epoch_id, &block_header.hash())
             {
                 if let Some((_, is_slashed)) =
-                    validators.into_iter().find(|v| v.0 == block_producer.account_id)
+                    validators.into_iter().find(|v| v.0.account_id == block_producer.account_id)
                 {
                     if !is_slashed {
                         let reference_hash =
@@ -875,7 +874,7 @@ impl Client {
             .get_epoch_block_producers(&header.inner_lite.epoch_id, &parent_hash)
         {
             Ok(validators) => {
-                let position = validators.iter().position(|x| &(x.0) == account_id);
+                let position = validators.iter().position(|x| &(x.0.account_id) == account_id);
                 if let Some(idx) = position {
                     if !validators[idx].1 {
                         idx

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -494,7 +494,10 @@ impl Handler<Status> for ClientActor {
             .get_epoch_block_producers(&head.epoch_id, &head.last_block_hash)
             .map_err(|err| err.to_string())?
             .into_iter()
-            .map(|(account_id, is_slashed)| ValidatorInfo { account_id, is_slashed })
+            .map(|(validator_stake, is_slashed)| ValidatorInfo {
+                account_id: validator_stake.account_id,
+                is_slashed,
+            })
             .collect();
         Ok(StatusResponse {
             version: self.client.config.version.clone(),
@@ -598,7 +601,9 @@ impl ClientActor {
         if let Ok(validators) =
             self.client.runtime_adapter.get_epoch_block_producers(&next_epoch_id, &prev_block_hash)
         {
-            if validators.iter().any(|(account_id, _)| (account_id == &block_producer.account_id)) {
+            if validators.iter().any(|(validator_stake, _)| {
+                (validator_stake.account_id == block_producer.account_id)
+            }) {
                 debug!(target: "client", "Sending announce account for {}", block_producer.account_id);
                 self.last_validator_announce_height = Some(epoch_start_height);
                 self.last_validator_announce_time = Some(now);
@@ -1191,7 +1196,7 @@ impl ClientActor {
             let num_validators = validators.len();
             let is_validator = if let Some(block_producer) = &act.client.block_producer {
                 if let Some((_, is_slashed)) =
-                    validators.into_iter().find(|x| x.0 == block_producer.account_id)
+                    validators.into_iter().find(|x| x.0.account_id == block_producer.account_id)
                 {
                     !is_slashed
                 } else {

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -623,14 +623,14 @@ impl StateSync {
             Ok(shard_sync_download)
         )
         .iter()
-        .filter_map(|(account_id, _slashed)| {
+        .filter_map(|(validator_stake, _slashed)| {
             if runtime_adapter.cares_about_shard(
-                Some(account_id),
+                Some(&validator_stake.account_id),
                 &prev_block_hash,
                 shard_id,
                 false,
             ) {
-                Some(AccountOrPeerIdOrHash::AccountId(account_id.clone()))
+                Some(AccountOrPeerIdOrHash::AccountId(validator_stake.account_id.clone()))
             } else {
                 None
             }

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -439,11 +439,11 @@ impl EpochManager {
         &mut self,
         epoch_id: &EpochId,
         last_known_block_hash: &CryptoHash,
-    ) -> Result<Vec<(AccountId, bool)>, EpochError> {
+    ) -> Result<Vec<(ValidatorStake, bool)>, EpochError> {
         Ok(self
             .get_all_block_producer_info(epoch_id, last_known_block_hash)?
             .into_iter()
-            .map(|(v, is_slashed)| (v.account_id, is_slashed))
+            .map(|(v, is_slashed)| (v, is_slashed))
             .collect())
     }
 
@@ -1027,7 +1027,12 @@ mod tests {
 
         let epoch1 = epoch_manager.get_epoch_id(&h[1]).unwrap();
         assert_eq!(
-            epoch_manager.get_all_block_producers(&epoch1, &h[1]).unwrap(),
+            epoch_manager
+                .get_all_block_producers(&epoch1, &h[1])
+                .unwrap()
+                .iter()
+                .map(|x| (x.0.account_id.clone(), x.1))
+                .collect::<Vec<_>>(),
             vec![
                 ("test3".to_string(), false),
                 ("test2".to_string(), false),
@@ -1037,13 +1042,23 @@ mod tests {
 
         let epoch2_1 = epoch_manager.get_epoch_id(&h[13]).unwrap();
         assert_eq!(
-            epoch_manager.get_all_block_producers(&epoch2_1, &h[1]).unwrap(),
+            epoch_manager
+                .get_all_block_producers(&epoch2_1, &h[1])
+                .unwrap()
+                .iter()
+                .map(|x| (x.0.account_id.clone(), x.1))
+                .collect::<Vec<_>>(),
             vec![("test2".to_string(), false), ("test4".to_string(), false)]
         );
 
         let epoch2_2 = epoch_manager.get_epoch_id(&h[11]).unwrap();
         assert_eq!(
-            epoch_manager.get_all_block_producers(&epoch2_2, &h[1]).unwrap(),
+            epoch_manager
+                .get_all_block_producers(&epoch2_2, &h[1])
+                .unwrap()
+                .iter()
+                .map(|x| (x.0.account_id.clone(), x.1))
+                .collect::<Vec<_>>(),
             vec![("test1".to_string(), false), ("test3".to_string(), false),]
         );
 
@@ -1231,7 +1246,12 @@ mod tests {
 
         let epoch_id = epoch_manager.get_epoch_id(&h[1]).unwrap();
         assert_eq!(
-            epoch_manager.get_all_block_producers(&epoch_id, &h[1]).unwrap(),
+            epoch_manager
+                .get_all_block_producers(&epoch_id, &h[1])
+                .unwrap()
+                .iter()
+                .map(|x| (x.0.account_id.clone(), x.1))
+                .collect::<Vec<_>>(),
             vec![("test2".to_string(), false), ("test1".to_string(), true)]
         );
 

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -8,9 +8,9 @@ pytest sanity/staking1.py
 pytest --timeout=800 sanity/staking2.py
 pytest --timeout=800 sanity/staking_repro1.py
 pytest --timeout=800 sanity/staking_repro2.py
-pytest sanity/state_sync.py manytx 50
+pytest sanity/state_sync.py manytx 30
 pytest --timeout=600 sanity/state_sync.py manytx 250
-pytest sanity/state_sync.py onetx 50
+pytest sanity/state_sync.py onetx 30
 pytest --timeout=600 sanity/state_sync.py onetx 250
 pytest sanity/rpc_tx_forwarding.py
 pytest --timeout=240 sanity/skip_epoch.py
@@ -43,7 +43,7 @@ expensive --timeout=1500 near-client cross_shard_tx tests::test_cross_shard_tx_d
 expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation
 
 # finality gadget safety fuzzy test
-expensive --timeout=600 near-epoch-manager finality tests::test_fuzzy_safety
+expensive --timeout=900 near-epoch-manager finality tests::test_fuzzy_safety
 
 # state sync tests
 expensive near sync_state_nodes sync_state_nodes_multishard

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -127,8 +127,10 @@ class LocalNode(BaseNode):
         env = os.environ.copy()
         env["RUST_BACKTRACE"] = "1"
 
-        self.stdout = open(os.path.join(self.node_dir, 'stdout'), 'a')
-        self.stderr = open(os.path.join(self.node_dir, 'stderr'), 'a')
+        self.stdout_name = os.path.join(self.node_dir, 'stdout')
+        self.stderr_name = os.path.join(self.node_dir, 'stderr')
+        self.stdout = open(self.stdout_name, 'a')
+        self.stderr = open(self.stderr_name, 'a')
         cmd = self._get_command_line(
             self.near_root, self.node_dir, boot_key, boot_node_addr)
         self.pid.value = subprocess.Popen(

--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -44,3 +44,20 @@ class TxContext:
                 self.expected_balances[to] += amt
                 self.next_nonce += 1
 
+
+# opens up a log file, scrolls to the end. then allows to check if
+# a particular line appeared (or didn't) between the last time it was
+# checked and now
+class LogTracker:
+    def __init__(self, node):
+        self.fname = node.stderr_name
+        with open(self.fname) as f:
+            f.seek(0, 2)
+            self.offset = f.tell()
+
+    def check(self, s):
+        with open(self.fname) as f:
+            f.seek(self.offset)
+            ret = s in f.read()
+            self.offset = f.tell()
+        return ret


### PR DESCRIPTION
- Making the Finality Gadget respect weights
   - Both `compute_quorums` and `compute_quorums_slow` in the test infra now take stakes
     as parameter. Both functions are changed to respect the stakes.

- Also (unrelated to the finality gadget) added LogTracker into python test utilities that
  allows to track if a particular substring appears in the logs between two interactions
  with the log tracker
   - Added check to `state_sync.py` test to check if "State 0" appears in the logs when the
     sync height is > 100, and that it doesn't appear when it is < 30, runs with both heights
     passed

Test Plan for the Finality Gadget change:
- Added a sanity test `test_finality_weight` with a simple case to test that weights are
  actually respected
- `test_fuzzy_safety` now on each iteration with 50% chance uses unequal weights.