### PR TITLE
Release binary to gcloud

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
     - test
+    - release
 
 variables:
     CACHE_ROOT: "/opt/nearcore"
@@ -87,3 +88,16 @@ test_nearlib_release:
     # the PR is going to merge with. Before fix in bot, keep different version of .gitlab-ci.yml 
     # in staging and master.
     # - master 
+
+release_build:
+    stage: release
+    tags:
+    - shell
+    before_script:
+    - *setup_cache
+    script:
+    - cargo build --release -p near
+    - ./scripts/upload_release.sh
+    only:
+    - staging
+    - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -96,8 +96,10 @@ release_build:
     before_script:
     - *setup_cache
     script:
+    - cargo build -p near
     - cargo build --release -p near
     - ./scripts/upload_release.sh
     only:
     - staging
     - master
+    - release-binary

--- a/scripts/upload_release.sh
+++ b/scripts/upload_release.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ -z "${GITLAB_CI}" ]]; then
+  echo "This script only works in CI"
+  exit 1
+fi
+
+# file name example: near-staging-a449f839907f060e75f4448e8f30c7bf7f7a951b
+near_binary_file=near-$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)-$(git rev-parse HEAD)
+cp target/release/near ${near_binary_file}
+gsutil cp ${near_binary_file} gs://nearprotocol_nearcore_release

--- a/scripts/upload_release.sh
+++ b/scripts/upload_release.sh
@@ -7,5 +7,7 @@ fi
 
 # file name example: near-staging-a449f839907f060e75f4448e8f30c7bf7f7a951b
 near_binary_file=near-$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)-$(git rev-parse HEAD)
-cp target/release/near ${near_binary_file}
-gsutil cp ${near_binary_file} gs://nearprotocol_nearcore_release
+cp target/release/near ${near_binary_file}-release
+cp target/debug/near ${near_binary_file}-debug
+/snap/bin/gsutil cp ${near_binary_file}-release gs://nearprotocol_nearcore_release
+/snap/bin/gsutil cp ${near_binary_file}-debug gs://nearprotocol_nearcore_release

--- a/scripts/upload_release.sh
+++ b/scripts/upload_release.sh
@@ -6,7 +6,7 @@ if [[ -z "${GITLAB_CI}" ]]; then
 fi
 
 # file name example: near-staging-a449f839907f060e75f4448e8f30c7bf7f7a951b
-near_binary_file=near-$(git rev-parse --symbolic-full-name --abbrev-ref HEAD)-$(git rev-parse HEAD)
+near_binary_file=near-${CI_COMMIT_REF_NAME}-$(git rev-parse HEAD)
 cp target/release/near ${near_binary_file}-release
 cp target/debug/near ${near_binary_file}-debug
 /snap/bin/gsutil cp ${near_binary_file}-release gs://nearprotocol_nearcore_release


### PR DESCRIPTION
Each commit into master and staging (This happens after merge any PR into master/staging), will do a release build and upload to gcloud. Will be used in pytest remote node and app layer integration tests.