### PR TITLE
Exposed block height at which given query RPC was performed

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -677,7 +677,7 @@ impl RuntimeAdapter for KeyValueRuntime {
         let account_id = path[1].to_string();
         let account_id2 = account_id.clone();
         Ok(QueryResponse {
-            response: QueryResponseKind::ViewAccount(
+            kind: QueryResponseKind::ViewAccount(
                 Account {
                     amount: self
                         .state

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -18,7 +18,7 @@ mod tests {
     use near_primitives::test_utils::{init_integration_logger, init_test_logger};
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::types::BlockIndex;
-    use near_primitives::views::QueryResponse::ViewAccount;
+    use near_primitives::views::QueryResponseKind::ViewAccount;
     use std::collections::hash_map::Entry;
     use std::collections::{HashMap, HashSet};
     use std::sync::{Arc, RwLock};
@@ -295,7 +295,7 @@ mod tests {
                                                     let res_inner = res.unwrap();
                                                     if let Ok(Some(query_response)) = res_inner {
                                                         if let ViewAccount(view_account_result) =
-                                                            query_response
+                                                            query_response.kind
                                                         {
                                                             assert_eq!(
                                                                 view_account_result.amount,
@@ -488,7 +488,7 @@ mod tests {
                                                         {
                                                             if let ViewAccount(
                                                                 view_account_result,
-                                                            ) = query_response
+                                                            ) = query_response.kind
                                                             {
                                                                 check_amount(
                                                                     amounts1,

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -9,7 +9,7 @@ use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, Query, ViewClientActor};
 use near_network::{NetworkRequests, NetworkResponses, PeerInfo};
 use near_primitives::test_utils::init_test_logger;
-use near_primitives::views::QueryResponse::ViewAccount;
+use near_primitives::views::QueryResponseKind::ViewAccount;
 
 /// Tests that the KeyValueRuntime properly sets balances in genesis and makes them queriable
 #[test]
@@ -52,7 +52,7 @@ fn test_keyvalue_runtime_balances() {
                     .send(Query::new("account/".to_string() + flat_validators[i], vec![]))
                     .then(move |res| {
                         let query_responce = res.unwrap().unwrap().unwrap();
-                        if let ViewAccount(view_account_result) = query_responce {
+                        if let ViewAccount(view_account_result) = query_response.kind {
                             assert_eq!(view_account_result.amount, expected);
                             successful_queries2.fetch_add(1, Ordering::Relaxed);
                             if successful_queries2.load(Ordering::Relaxed) >= 4 {
@@ -91,7 +91,7 @@ mod tests {
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::types::AccountId;
     use near_primitives::views::QueryResponse;
-    use near_primitives::views::QueryResponse::ViewAccount;
+    use near_primitives::views::QueryResponseKind::ViewAccount;
 
     fn send_tx(
         num_validators: usize,
@@ -211,7 +211,7 @@ mod tests {
             }
         };
 
-        if let ViewAccount(view_account_result) = query_response {
+        if let ViewAccount(view_account_result) = query_response.kind {
             let mut expected = 0;
             for i in 0..8 {
                 if validators[i] == account_id {

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -51,7 +51,7 @@ fn test_keyvalue_runtime_balances() {
                     .1
                     .send(Query::new("account/".to_string() + flat_validators[i], vec![]))
                     .then(move |res| {
-                        let query_responce = res.unwrap().unwrap().unwrap();
+                        let query_response = res.unwrap().unwrap().unwrap();
                         if let ViewAccount(view_account_result) = query_response.kind {
                             assert_eq!(view_account_result.amount, expected);
                             successful_queries2.fetch_add(1, Ordering::Relaxed);

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -5,7 +5,7 @@ use futures::future::Future;
 use near_client::test_utils::setup_no_network;
 use near_client::Query;
 use near_primitives::test_utils::init_test_logger;
-use near_primitives::views::QueryResponse;
+use near_primitives::views::QueryResponseKind;
 
 /// Query account from view client
 #[test]
@@ -15,8 +15,8 @@ fn query_client() {
         let (_, view_client) = setup_no_network(vec!["test"], "other", true);
         actix::spawn(view_client.send(Query::new("account/test".to_string(), vec![])).then(
             |res| {
-                match res {
-                    Ok(Ok(Some(QueryResponse::ViewAccount(_)))) => (),
+                match res.unwrap().unwrap().unwrap().kind {
+                    QueryResponseKind::ViewAccount(_) => (),
                     _ => panic!("Invalid response"),
                 }
                 System::current().stop();

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -129,12 +129,12 @@ fn test_query() {
                 let query_response = query_response.unwrap();
                 assert_eq!(query_response.block_height, 0);
                 let account_info =
-                    if let QueryResponseKind::ViewAccount(account) = query_response.response {
+                    if let QueryResponseKind::ViewAccount(account) = query_response.kind {
                         account
                     } else {
                         panic!(
                             "queried account, but received something else: {:?}",
-                            query_response.response
+                            query_response.kind
                         );
                     };
                 assert_eq!(account_info.amount, 0);

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -4,11 +4,12 @@ use actix::{Actor, System};
 use futures::future;
 use futures::future::Future;
 
-use near_crypto::Signature;
+use near_crypto::{KeyType, PublicKey, Signature};
 use near_jsonrpc::client::new_client;
 use near_jsonrpc::test_utils::start_all;
 use near_jsonrpc_client::{BlockId, ChunkId};
 use near_network::test_utils::WaitOrTimeout;
+use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::hash::CryptoHash;
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::types::ShardId;
@@ -172,6 +173,9 @@ fn test_query_access_keys() {
                             query_response.kind
                         );
                     };
+                assert_eq!(access_keys.keys.len(), 1);
+                assert_eq!(access_keys.keys[0].access_key, AccessKey::full_access().into());
+                assert_eq!(access_keys.keys[0].public_key, PublicKey::empty(KeyType::ED25519));
                 System::current().stop();
                 future::result(Ok(()))
             },
@@ -193,7 +197,7 @@ fn test_query_access_key() {
             |query_response| {
                 let query_response = query_response.unwrap();
                 assert_eq!(query_response.block_height, 0);
-                let access_keys =
+                let access_key =
                     if let QueryResponseKind::AccessKey(access_keys) = query_response.kind {
                         access_keys
                     } else {
@@ -202,6 +206,8 @@ fn test_query_access_key() {
                             query_response.kind
                         );
                     };
+                assert_eq!(access_key.nonce, 0);
+                assert_eq!(access_key.permission, AccessKeyPermission::FullAccess.into());
                 System::current().stop();
                 future::result(Ok(()))
             },

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -115,9 +115,9 @@ fn test_chunk_by_hash() {
     .unwrap();
 }
 
-/// Connect to json rpc and query the client.
+/// Connect to json rpc and query account info.
 #[test]
-fn test_query() {
+fn test_query_account() {
     init_test_logger();
 
     System::run(|| {
@@ -142,6 +142,66 @@ fn test_query() {
                 assert_eq!(account_info.locked, 0);
                 assert_eq!(account_info.storage_paid_at, 0);
                 assert_eq!(account_info.storage_usage, 0);
+                System::current().stop();
+                future::result(Ok(()))
+            },
+        ));
+    })
+    .unwrap();
+}
+
+/// Connect to json rpc and query account info.
+#[test]
+fn test_query_access_keys() {
+    init_test_logger();
+
+    System::run(|| {
+        let (_view_client_addr, addr) = start_all(false);
+
+        let mut client = new_client(&format!("http://{}", addr));
+        actix::spawn(client.query("access_key/test".to_string(), "".to_string()).then(
+            |query_response| {
+                let query_response = query_response.unwrap();
+                assert_eq!(query_response.block_height, 0);
+                let access_keys =
+                    if let QueryResponseKind::AccessKeyList(access_keys) = query_response.kind {
+                        access_keys
+                    } else {
+                        panic!(
+                            "queried access keys, but received something else: {:?}",
+                            query_response.kind
+                        );
+                    };
+                System::current().stop();
+                future::result(Ok(()))
+            },
+        ));
+    })
+    .unwrap();
+}
+
+/// Connect to json rpc and query account info.
+#[test]
+fn test_query_access_key() {
+    init_test_logger();
+
+    System::run(|| {
+        let (_view_client_addr, addr) = start_all(false);
+
+        let mut client = new_client(&format!("http://{}", addr));
+        actix::spawn(client.query("access_key/test/xxx".to_string(), "".to_string()).then(
+            |query_response| {
+                let query_response = query_response.unwrap();
+                assert_eq!(query_response.block_height, 0);
+                let access_keys =
+                    if let QueryResponseKind::AccessKey(access_keys) = query_response.kind {
+                        access_keys
+                    } else {
+                        panic!(
+                            "queried access keys, but received something else: {:?}",
+                            query_response.kind
+                        );
+                    };
                 System::current().stop();
                 future::result(Ok(()))
             },

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -146,14 +146,25 @@ pub struct AccessKeyInfoView {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct AccessKeyList {
+    pub keys: Vec<AccessKeyInfoView>,
+}
+
+impl std::iter::FromIterator<AccessKeyInfoView> for AccessKeyList {
+    fn from_iter<I: IntoIterator<Item = AccessKeyInfoView>>(iter: I) -> Self {
+        Self { keys: iter.into_iter().collect() }
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(untagged)]
 pub enum QueryResponseKind {
     ViewAccount(AccountView),
     ViewState(ViewStateResult),
     CallResult(CallResult),
     Error(QueryError),
-    AccessKey(Option<AccessKeyView>),
-    AccessKeyList(Vec<AccessKeyInfoView>),
+    AccessKey(AccessKeyView),
+    AccessKeyList(AccessKeyList),
     Validators(EpochValidatorInfo),
 }
 
@@ -217,7 +228,7 @@ impl TryFrom<QueryResponse> for ViewStateResult {
     }
 }
 
-impl TryFrom<QueryResponse> for Option<AccessKeyView> {
+impl TryFrom<QueryResponse> for AccessKeyView {
     type Error = String;
 
     fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -147,7 +147,7 @@ pub struct AccessKeyInfoView {
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(untagged)]
-pub enum QueryResponse {
+pub enum QueryResponseKind {
     ViewAccount(AccountView),
     ViewState(ViewStateResult),
     CallResult(CallResult),
@@ -155,6 +155,13 @@ pub enum QueryResponse {
     AccessKey(Option<AccessKeyView>),
     AccessKeyList(Vec<AccessKeyInfoView>),
     Validators(EpochValidatorInfo),
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+pub struct QueryResponse {
+    #[serde(flatten)]
+    pub response: QueryResponseKind,
+    pub block_height: BlockIndex,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -192,8 +199,8 @@ impl TryFrom<QueryResponse> for AccountView {
     type Error = String;
 
     fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response {
-            QueryResponse::ViewAccount(acc) => Ok(acc),
+        match query_response.response {
+            QueryResponseKind::ViewAccount(acc) => Ok(acc),
             _ => Err("Invalid type of response".into()),
         }
     }
@@ -203,8 +210,8 @@ impl TryFrom<QueryResponse> for ViewStateResult {
     type Error = String;
 
     fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response {
-            QueryResponse::ViewState(vs) => Ok(vs),
+        match query_response.response {
+            QueryResponseKind::ViewState(vs) => Ok(vs),
             _ => Err("Invalid type of response".into()),
         }
     }
@@ -214,8 +221,8 @@ impl TryFrom<QueryResponse> for Option<AccessKeyView> {
     type Error = String;
 
     fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response {
-            QueryResponse::AccessKey(access_key) => Ok(access_key),
+        match query_response.response {
+            QueryResponseKind::AccessKey(access_key) => Ok(access_key),
             _ => Err("Invalid type of response".into()),
         }
     }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -160,7 +160,7 @@ pub enum QueryResponseKind {
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct QueryResponse {
     #[serde(flatten)]
-    pub response: QueryResponseKind,
+    pub kind: QueryResponseKind,
     pub block_height: BlockIndex,
 }
 
@@ -199,7 +199,7 @@ impl TryFrom<QueryResponse> for AccountView {
     type Error = String;
 
     fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response.response {
+        match query_response.kind {
             QueryResponseKind::ViewAccount(acc) => Ok(acc),
             _ => Err("Invalid type of response".into()),
         }
@@ -210,7 +210,7 @@ impl TryFrom<QueryResponse> for ViewStateResult {
     type Error = String;
 
     fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response.response {
+        match query_response.kind {
             QueryResponseKind::ViewState(vs) => Ok(vs),
             _ => Err("Invalid type of response".into()),
         }
@@ -221,7 +221,7 @@ impl TryFrom<QueryResponse> for Option<AccessKeyView> {
     type Error = String;
 
     fn try_from(query_response: QueryResponse) -> Result<Self, Self::Error> {
-        match query_response.response {
+        match query_response.kind {
             QueryResponseKind::AccessKey(access_key) => Ok(access_key),
             _ => Err("Invalid type of response".into()),
         }

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -960,8 +960,8 @@ impl RuntimeAdapter for NightshadeRuntime {
                         &AccountId::from(path_parts[1]),
                         &PublicKey::try_from(path_parts[2])?,
                     )
-                    .map(|r| QueryResponse {
-                        kind: QueryResponseKind::AccessKey(r.map(|access_key| access_key.into())),
+                    .map(|access_key| QueryResponse {
+                        kind: QueryResponseKind::AccessKey(access_key.into()),
                         block_height,
                     })
                 };
@@ -1110,7 +1110,7 @@ impl node_runtime::adapter::ViewRuntimeAdapter for NightshadeRuntime {
         state_root: MerkleHash,
         account_id: &AccountId,
         public_key: &PublicKey,
-    ) -> Result<Option<AccessKey>, Box<dyn std::error::Error>> {
+    ) -> Result<AccessKey, Box<dyn std::error::Error>> {
         let state_update = TrieUpdate::new(self.trie.clone(), state_root);
         self.trie_viewer.view_access_key(&state_update, account_id, public_key)
     }

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -30,7 +30,8 @@ use near_primitives::types::{
 };
 use near_primitives::utils::{prefix_for_access_key, ACCOUNT_DATA_SEPARATOR};
 use near_primitives::views::{
-    AccessKeyInfoView, CallResult, EpochValidatorInfo, QueryError, QueryResponse, ViewStateResult,
+    AccessKeyInfoView, CallResult, EpochValidatorInfo, QueryError, QueryResponse,
+    QueryResponseKind, ViewStateResult,
 };
 use near_store::{
     get_access_key_raw, ColState, PartialStorage, Store, StoreUpdate, Trie, TrieUpdate,
@@ -889,7 +890,7 @@ impl RuntimeAdapter for NightshadeRuntime {
     fn query(
         &self,
         state_root: &StateRoot,
-        height: BlockIndex,
+        block_height: BlockIndex,
         block_timestamp: u64,
         _block_hash: &CryptoHash,
         path_parts: Vec<&str>,
@@ -900,46 +901,65 @@ impl RuntimeAdapter for NightshadeRuntime {
         }
         match path_parts[0] {
             "account" => match self.view_account(*state_root, &AccountId::from(path_parts[1])) {
-                Ok(r) => Ok(QueryResponse::ViewAccount(r.into())),
+                Ok(r) => Ok(QueryResponse {
+                    response: QueryResponseKind::ViewAccount(r.into()),
+                    block_height,
+                }),
                 Err(e) => Err(e),
             },
             "call" => {
                 let mut logs = vec![];
                 match self.call_function(
                     *state_root,
-                    height,
+                    block_height,
                     block_timestamp,
                     &AccountId::from(path_parts[1]),
                     path_parts[2],
                     &data,
                     &mut logs,
                 ) {
-                    Ok(result) => Ok(QueryResponse::CallResult(CallResult { result, logs })),
-                    Err(err) => {
-                        Ok(QueryResponse::Error(QueryError { error: err.to_string(), logs }))
-                    }
+                    Ok(result) => Ok(QueryResponse {
+                        response: QueryResponseKind::CallResult(CallResult { result, logs }),
+                        block_height,
+                    }),
+                    Err(err) => Ok(QueryResponse {
+                        response: QueryResponseKind::Error(QueryError {
+                            error: err.to_string(),
+                            logs,
+                        }),
+                        block_height,
+                    }),
                 }
             }
             "contract" => {
                 match self.view_state(*state_root, &AccountId::from(path_parts[1]), data) {
-                    Ok(result) => Ok(QueryResponse::ViewState(result)),
-                    Err(err) => Ok(QueryResponse::Error(QueryError {
-                        error: err.to_string(),
-                        logs: vec![],
-                    })),
+                    Ok(result) => Ok(QueryResponse {
+                        response: QueryResponseKind::ViewState(result),
+                        block_height,
+                    }),
+                    Err(err) => Ok(QueryResponse {
+                        response: QueryResponseKind::Error(QueryError {
+                            error: err.to_string(),
+                            logs: vec![],
+                        }),
+                        block_height,
+                    }),
                 }
             }
             "access_key" => {
                 let result = if path_parts.len() == 2 {
                     self.view_access_keys(*state_root, &AccountId::from(path_parts[1])).map(|r| {
-                        QueryResponse::AccessKeyList(
-                            r.into_iter()
-                                .map(|(public_key, access_key)| AccessKeyInfoView {
-                                    public_key,
-                                    access_key: access_key.into(),
-                                })
-                                .collect(),
-                        )
+                        QueryResponse {
+                            response: QueryResponseKind::AccessKeyList(
+                                r.into_iter()
+                                    .map(|(public_key, access_key)| AccessKeyInfoView {
+                                        public_key,
+                                        access_key: access_key.into(),
+                                    })
+                                    .collect(),
+                            ),
+                            block_height,
+                        }
                     })
                 } else {
                     self.view_access_key(
@@ -947,14 +967,22 @@ impl RuntimeAdapter for NightshadeRuntime {
                         &AccountId::from(path_parts[1]),
                         &PublicKey::try_from(path_parts[2])?,
                     )
-                    .map(|r| QueryResponse::AccessKey(r.map(|access_key| access_key.into())))
+                    .map(|r| QueryResponse {
+                        response: QueryResponseKind::AccessKey(
+                            r.map(|access_key| access_key.into()),
+                        ),
+                        block_height,
+                    })
                 };
                 match result {
                     Ok(result) => Ok(result),
-                    Err(err) => Ok(QueryResponse::Error(QueryError {
-                        error: err.to_string(),
-                        logs: vec![],
-                    })),
+                    Err(err) => Ok(QueryResponse {
+                        response: QueryResponseKind::Error(QueryError {
+                            error: err.to_string(),
+                            logs: vec![],
+                        }),
+                        block_height,
+                    }),
                 }
             }
             _ => Err(format!("Unknown path {}", path_parts[0]).into()),

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -902,7 +902,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         match path_parts[0] {
             "account" => match self.view_account(*state_root, &AccountId::from(path_parts[1])) {
                 Ok(r) => Ok(QueryResponse {
-                    response: QueryResponseKind::ViewAccount(r.into()),
+                    kind: QueryResponseKind::ViewAccount(r.into()),
                     block_height,
                 }),
                 Err(e) => Err(e),
@@ -919,11 +919,11 @@ impl RuntimeAdapter for NightshadeRuntime {
                     &mut logs,
                 ) {
                     Ok(result) => Ok(QueryResponse {
-                        response: QueryResponseKind::CallResult(CallResult { result, logs }),
+                        kind: QueryResponseKind::CallResult(CallResult { result, logs }),
                         block_height,
                     }),
                     Err(err) => Ok(QueryResponse {
-                        response: QueryResponseKind::Error(QueryError {
+                        kind: QueryResponseKind::Error(QueryError {
                             error: err.to_string(),
                             logs,
                         }),
@@ -934,11 +934,11 @@ impl RuntimeAdapter for NightshadeRuntime {
             "contract" => {
                 match self.view_state(*state_root, &AccountId::from(path_parts[1]), data) {
                     Ok(result) => Ok(QueryResponse {
-                        response: QueryResponseKind::ViewState(result),
+                        kind: QueryResponseKind::ViewState(result),
                         block_height,
                     }),
                     Err(err) => Ok(QueryResponse {
-                        response: QueryResponseKind::Error(QueryError {
+                        kind: QueryResponseKind::Error(QueryError {
                             error: err.to_string(),
                             logs: vec![],
                         }),
@@ -950,7 +950,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 let result = if path_parts.len() == 2 {
                     self.view_access_keys(*state_root, &AccountId::from(path_parts[1])).map(|r| {
                         QueryResponse {
-                            response: QueryResponseKind::AccessKeyList(
+                            kind: QueryResponseKind::AccessKeyList(
                                 r.into_iter()
                                     .map(|(public_key, access_key)| AccessKeyInfoView {
                                         public_key,
@@ -968,7 +968,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         &PublicKey::try_from(path_parts[2])?,
                     )
                     .map(|r| QueryResponse {
-                        response: QueryResponseKind::AccessKey(
+                        kind: QueryResponseKind::AccessKey(
                             r.map(|access_key| access_key.into()),
                         ),
                         block_height,
@@ -977,7 +977,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 match result {
                     Ok(result) => Ok(result),
                     Err(err) => Ok(QueryResponse {
-                        response: QueryResponseKind::Error(QueryError {
+                        kind: QueryResponseKind::Error(QueryError {
                             error: err.to_string(),
                             logs: vec![],
                         }),

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -252,24 +252,20 @@ impl NightshadeRuntime {
                         .map(Clone::clone)
                         .collect(),
                 })
+            } else if !challenges_result.is_empty() {
+                Some(ValidatorAccountsUpdate {
+                    stake_info: Default::default(),
+                    validator_rewards: Default::default(),
+                    last_proposals: Default::default(),
+                    protocol_treasury_account_id: None,
+                    slashed_accounts: challenges_result
+                        .iter()
+                        .filter(|account_id| self.account_id_to_shard_id(account_id) == shard_id)
+                        .map(Clone::clone)
+                        .collect(),
+                })
             } else {
-                if !challenges_result.is_empty() {
-                    Some(ValidatorAccountsUpdate {
-                        stake_info: Default::default(),
-                        validator_rewards: Default::default(),
-                        last_proposals: Default::default(),
-                        protocol_treasury_account_id: None,
-                        slashed_accounts: challenges_result
-                            .iter()
-                            .filter(|account_id| {
-                                self.account_id_to_shard_id(account_id) == shard_id
-                            })
-                            .map(Clone::clone)
-                            .collect(),
-                    })
-                } else {
-                    None
-                }
+                None
             }
         };
 
@@ -923,10 +919,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         block_height,
                     }),
                     Err(err) => Ok(QueryResponse {
-                        kind: QueryResponseKind::Error(QueryError {
-                            error: err.to_string(),
-                            logs,
-                        }),
+                        kind: QueryResponseKind::Error(QueryError { error: err.to_string(), logs }),
                         block_height,
                     }),
                 }
@@ -968,9 +961,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                         &PublicKey::try_from(path_parts[2])?,
                     )
                     .map(|r| QueryResponse {
-                        kind: QueryResponseKind::AccessKey(
-                            r.map(|access_key| access_key.into()),
-                        ),
+                        kind: QueryResponseKind::AccessKey(r.map(|access_key| access_key.into())),
                         block_height,
                     })
                 };

--- a/near/tests/rpc_nodes.rs
+++ b/near/tests/rpc_nodes.rs
@@ -11,7 +11,7 @@ use near_network::test_utils::WaitOrTimeout;
 use near_primitives::serialize::{to_base, to_base64};
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::views::{FinalExecutionStatus, QueryResponse};
+use near_primitives::views::{FinalExecutionStatus, QueryResponseKind};
 use testlib::{genesis_block, start_nodes};
 
 /// Starts 2 validators and 2 light clients (not tracking anything).
@@ -310,8 +310,8 @@ fn test_rpc_routing() {
                                 .map_err(|err| {
                                     println!("Error retrieving account: {:?}", err);
                                 })
-                                .map(move |result| match result {
-                                    QueryResponse::ViewAccount(account_view) => {
+                                .map(move |result| match result.kind {
+                                    QueryResponseKind::ViewAccount(account_view) => {
                                         assert_eq!(account_view.amount, TESTING_INIT_BALANCE);
                                         System::current().stop();
                                     }

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -227,16 +227,18 @@ fn test_validator_kickout() {
                                             ),
                                             vec![],
                                         ))
-                                        .then(move |res| match res.unwrap().unwrap().unwrap().kind {
-                                            QueryResponseKind::ViewAccount(result) => {
-                                                if result.locked == 0
-                                                    || result.amount == TESTING_INIT_BALANCE
-                                                {
-                                                    mark.store(true, Ordering::SeqCst);
+                                        .then(move |res| {
+                                            match res.unwrap().unwrap().unwrap().kind {
+                                                QueryResponseKind::ViewAccount(result) => {
+                                                    if result.locked == 0
+                                                        || result.amount == TESTING_INIT_BALANCE
+                                                    {
+                                                        mark.store(true, Ordering::SeqCst);
+                                                    }
+                                                    futures::future::ok(())
                                                 }
-                                                futures::future::ok(())
+                                                _ => panic!("wrong return result"),
                                             }
-                                            _ => panic!("wrong return result"),
                                         }),
                                 );
                             }
@@ -253,17 +255,19 @@ fn test_validator_kickout() {
                                             ),
                                             vec![],
                                         ))
-                                        .then(move |res| match res.unwrap().unwrap().unwrap().kind {
-                                            QueryResponseKind::ViewAccount(result) => {
-                                                assert_eq!(result.locked, TESTING_INIT_STAKE);
-                                                assert_eq!(
-                                                    result.amount,
-                                                    TESTING_INIT_BALANCE - TESTING_INIT_STAKE
-                                                );
-                                                mark.store(true, Ordering::SeqCst);
-                                                futures::future::ok(())
+                                        .then(move |res| {
+                                            match res.unwrap().unwrap().unwrap().kind {
+                                                QueryResponseKind::ViewAccount(result) => {
+                                                    assert_eq!(result.locked, TESTING_INIT_STAKE);
+                                                    assert_eq!(
+                                                        result.amount,
+                                                        TESTING_INIT_BALANCE - TESTING_INIT_STAKE
+                                                    );
+                                                    mark.store(true, Ordering::SeqCst);
+                                                    futures::future::ok(())
+                                                }
+                                                _ => panic!("wrong return result"),
                                             }
-                                            _ => panic!("wrong return result"),
                                         }),
                                 );
                             }

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -17,7 +17,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, ValidatorId};
-use near_primitives::views::{QueryResponse, ValidatorInfo};
+use near_primitives::views::{QueryResponseKind, ValidatorInfo};
 use testlib::genesis_hash;
 
 #[derive(Clone)]
@@ -227,8 +227,8 @@ fn test_validator_kickout() {
                                             ),
                                             vec![],
                                         ))
-                                        .then(move |res| match res.unwrap().unwrap().unwrap() {
-                                            QueryResponse::ViewAccount(result) => {
+                                        .then(move |res| match res.unwrap().unwrap().unwrap().kind {
+                                            QueryResponseKind::ViewAccount(result) => {
                                                 if result.locked == 0
                                                     || result.amount == TESTING_INIT_BALANCE
                                                 {
@@ -253,8 +253,8 @@ fn test_validator_kickout() {
                                             ),
                                             vec![],
                                         ))
-                                        .then(move |res| match res.unwrap().unwrap().unwrap() {
-                                            QueryResponse::ViewAccount(result) => {
+                                        .then(move |res| match res.unwrap().unwrap().unwrap().kind {
+                                            QueryResponseKind::ViewAccount(result) => {
                                                 assert_eq!(result.locked, TESTING_INIT_STAKE);
                                                 assert_eq!(
                                                     result.amount,
@@ -368,8 +368,8 @@ fn test_validator_join() {
                                         format!("account/{}", test_nodes[1].account_id.clone()),
                                         vec![],
                                     ))
-                                    .then(move |res| match res.unwrap().unwrap().unwrap() {
-                                        QueryResponse::ViewAccount(result) => {
+                                    .then(move |res| match res.unwrap().unwrap().unwrap().kind {
+                                        QueryResponseKind::ViewAccount(result) => {
                                             if result.locked == 0 {
                                                 done1_copy2.store(true, Ordering::SeqCst);
                                             }
@@ -385,8 +385,8 @@ fn test_validator_join() {
                                         format!("account/{}", test_nodes[2].account_id.clone()),
                                         vec![],
                                     ))
-                                    .then(move |res| match res.unwrap().unwrap().unwrap() {
-                                        QueryResponse::ViewAccount(result) => {
+                                    .then(move |res| match res.unwrap().unwrap().unwrap().kind {
+                                        QueryResponseKind::ViewAccount(result) => {
                                             if result.locked == TESTING_INIT_STAKE {
                                                 done2_copy2.store(true, Ordering::SeqCst);
                                             }

--- a/runtime/runtime/src/adapter.rs
+++ b/runtime/runtime/src/adapter.rs
@@ -27,7 +27,7 @@ pub trait ViewRuntimeAdapter {
         state_root: MerkleHash,
         account_id: &AccountId,
         public_key: &PublicKey,
-    ) -> Result<Option<AccessKey>, Box<dyn std::error::Error>>;
+    ) -> Result<AccessKey, Box<dyn std::error::Error>>;
 
     fn view_access_keys(
         &self,

--- a/runtime/runtime/src/state_viewer.rs
+++ b/runtime/runtime/src/state_viewer.rs
@@ -42,12 +42,13 @@ impl TrieViewer {
         state_update: &TrieUpdate,
         account_id: &AccountId,
         public_key: &PublicKey,
-    ) -> Result<Option<AccessKey>, Box<dyn std::error::Error>> {
+    ) -> Result<AccessKey, Box<dyn std::error::Error>> {
         if !is_valid_account_id(account_id) {
             return Err(format!("Account ID '{}' is not valid", account_id).into());
         }
 
-        get_access_key(state_update, account_id, public_key).map_err(|e| Box::new(e).into())
+        get_access_key(state_update, account_id, public_key)?
+            .ok_or_else(|| format!("access key {} does not exist while viewing", public_key).into())
     }
 
     pub fn view_state(

--- a/test-utils/loadtester/src/remote_node.rs
+++ b/test-utils/loadtester/src/remote_node.rs
@@ -140,9 +140,7 @@ impl RemoteNode {
             .iter()
             .zip(self.signers.iter().map(|s| &s.public_key))
             .map(|(account_id, public_key)| {
-                get_result(|| self.get_access_key(&account_id, &public_key))
-                    .expect("No access key for given public key")
-                    .nonce
+                get_result(|| self.get_access_key(&account_id, &public_key)).nonce
             })
             .collect();
         self.nonces = nonces;
@@ -161,7 +159,7 @@ impl RemoteNode {
         &self,
         account_id: &AccountId,
         public_key: &PublicKey,
-    ) -> Result<Option<AccessKeyView>, Box<dyn std::error::Error>> {
+    ) -> Result<AccessKeyView, Box<dyn std::error::Error>> {
         let user = RpcUser::new(
             &self.addr.to_string(),
             account_id.to_string(),

--- a/test-utils/testlib/src/standard_test_cases.rs
+++ b/test-utils/testlib/src/standard_test_cases.rs
@@ -540,12 +540,8 @@ pub fn test_swap_key(node: impl Node) {
 
     assert!(node_user
         .get_access_key(&eve_dot_alice_account(), &node.signer().public_key())
-        .unwrap()
-        .is_none());
-    assert!(node_user
-        .get_access_key(&eve_dot_alice_account(), &signer2.public_key)
-        .unwrap()
-        .is_some());
+        .is_ok());
+    assert!(node_user.get_access_key(&eve_dot_alice_account(), &signer2.public_key).is_ok());
 }
 
 pub fn test_add_key(node: impl Node) {
@@ -555,8 +551,8 @@ pub fn test_add_key(node: impl Node) {
 
     add_access_key(&node, node_user.as_ref(), &AccessKey::full_access(), &signer2);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
-    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_some());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
 }
 
 pub fn test_add_existing_key(node: impl Node) {
@@ -576,7 +572,7 @@ pub fn test_add_existing_key(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(root, new_root);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
 }
 
 pub fn test_delete_key(node: impl Node) {
@@ -592,8 +588,8 @@ pub fn test_delete_key(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_none());
-    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_some());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
 }
 
 pub fn test_delete_key_not_owned(node: impl Node) {
@@ -614,8 +610,8 @@ pub fn test_delete_key_not_owned(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
-    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_none());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
 }
 
 pub fn test_delete_key_last(node: impl Node) {
@@ -630,7 +626,7 @@ pub fn test_delete_key_last(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_none());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
 }
 
 pub fn test_add_access_key_function_call(node: impl Node) {
@@ -647,10 +643,10 @@ pub fn test_add_access_key_function_call(node: impl Node) {
     let signer2 = InMemorySigner::from_random("".to_string(), KeyType::ED25519);
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
 
     let view_access_key = node_user.get_access_key(account_id, &signer2.public_key).unwrap();
-    assert_eq!(view_access_key, Some(access_key.into()));
+    assert_eq!(view_access_key, access_key.into());
 }
 
 pub fn test_delete_access_key(node: impl Node) {
@@ -675,8 +671,8 @@ pub fn test_delete_access_key(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
-    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_none());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
 }
 
 pub fn test_add_access_key_with_allowance(node: impl Node) {
@@ -700,9 +696,9 @@ pub fn test_add_access_key_with_allowance(node: impl Node) {
     let account = node_user.view_account(account_id).unwrap();
     assert_eq!(account.amount, initial_balance - add_access_key_cost);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
     let view_access_key = node_user.get_access_key(account_id, &signer2.public_key).unwrap();
-    assert_eq!(view_access_key, Some(access_key.into()));
+    assert_eq!(view_access_key, access_key.into());
 }
 
 pub fn test_delete_access_key_with_allowance(node: impl Node) {
@@ -735,8 +731,8 @@ pub fn test_delete_access_key_with_allowance(node: impl Node) {
     let account = node_user.view_account(account_id).unwrap();
     assert_eq!(account.amount, initial_balance - add_access_key_cost - delete_access_key_cost);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).unwrap().is_some());
-    assert!(node_user.get_access_key(&account_id, &signer2.public_key).unwrap().is_none());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
 }
 
 pub fn test_access_key_smart_contract(node: impl Node) {
@@ -774,17 +770,15 @@ pub fn test_access_key_smart_contract(node: impl Node) {
     let view_access_key = node_user.get_access_key(account_id, &signer2.public_key).unwrap();
     assert_eq!(
         view_access_key,
-        Some(
-            AccessKey {
-                nonce: 1,
-                permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
-                    allowance: Some(FUNCTION_CALL_AMOUNT - function_call_cost),
-                    receiver_id: bob_account(),
-                    method_names: vec![],
-                }),
-            }
-            .into()
-        )
+        AccessKey {
+            nonce: 1,
+            permission: AccessKeyPermission::FunctionCall(FunctionCallPermission {
+                allowance: Some(FUNCTION_CALL_AMOUNT - function_call_cost),
+                receiver_id: bob_account(),
+                method_names: vec![],
+            }),
+        }
+        .into()
     );
 }
 

--- a/test-utils/testlib/src/standard_test_cases.rs
+++ b/test-utils/testlib/src/standard_test_cases.rs
@@ -540,7 +540,7 @@ pub fn test_swap_key(node: impl Node) {
 
     assert!(node_user
         .get_access_key(&eve_dot_alice_account(), &node.signer().public_key())
-        .is_ok());
+        .is_err());
     assert!(node_user.get_access_key(&eve_dot_alice_account(), &signer2.public_key).is_ok());
 }
 
@@ -580,6 +580,10 @@ pub fn test_delete_key(node: impl Node) {
     let signer2 = InMemorySigner::from_random("".to_string(), KeyType::ED25519);
     let node_user = node.user();
     add_access_key(&node, node_user.as_ref(), &AccessKey::full_access(), &signer2);
+
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
+
     let root = node_user.get_state_root();
     let transaction_result =
         node_user.delete_key(account_id.clone(), node.signer().public_key()).unwrap();
@@ -588,7 +592,7 @@ pub fn test_delete_key(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_err());
     assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
 }
 
@@ -596,8 +600,11 @@ pub fn test_delete_key_not_owned(node: impl Node) {
     let account_id = &node.account_id().unwrap();
     let signer2 = InMemorySigner::from_random("".to_string(), KeyType::ED25519);
     let node_user = node.user();
-    let root = node_user.get_state_root();
 
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_err());
+
+    let root = node_user.get_state_root();
     let transaction_result =
         node_user.delete_key(account_id.clone(), signer2.public_key.clone()).unwrap();
     assert_eq!(
@@ -611,7 +618,7 @@ pub fn test_delete_key_not_owned(node: impl Node) {
     assert_ne!(new_root, root);
 
     assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
-    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_err());
 }
 
 pub fn test_delete_key_last(node: impl Node) {
@@ -619,6 +626,7 @@ pub fn test_delete_key_last(node: impl Node) {
     let node_user = node.user();
     let root = node_user.get_state_root();
 
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
     let transaction_result =
         node_user.delete_key(account_id.clone(), node.signer().public_key()).unwrap();
     assert_eq!(transaction_result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
@@ -626,7 +634,7 @@ pub fn test_delete_key_last(node: impl Node) {
     let new_root = node_user.get_state_root();
     assert_ne!(new_root, root);
 
-    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_err());
 }
 
 pub fn test_add_access_key_function_call(node: impl Node) {
@@ -663,6 +671,9 @@ pub fn test_delete_access_key(node: impl Node) {
     let signer2 = InMemorySigner::from_random("".to_string(), KeyType::ED25519);
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
 
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
+
     let root = node_user.get_state_root();
     let transaction_result =
         node_user.delete_key(account_id.clone(), signer2.public_key.clone()).unwrap();
@@ -672,7 +683,7 @@ pub fn test_delete_access_key(node: impl Node) {
     assert_ne!(new_root, root);
 
     assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
-    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_err());
 }
 
 pub fn test_add_access_key_with_allowance(node: impl Node) {
@@ -719,6 +730,9 @@ pub fn test_delete_access_key_with_allowance(node: impl Node) {
     let add_access_key_cost = fee_helper.add_key_cost(0);
     add_access_key(&node, node_user.as_ref(), &access_key, &signer2);
 
+    assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
+
     let root = node_user.get_state_root();
     let delete_access_key_cost = fee_helper.delete_key_cost();
     let transaction_result =
@@ -732,7 +746,7 @@ pub fn test_delete_access_key_with_allowance(node: impl Node) {
     assert_eq!(account.amount, initial_balance - add_access_key_cost - delete_access_key_cost);
 
     assert!(node_user.get_access_key(&account_id, &node.signer().public_key()).is_ok());
-    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_ok());
+    assert!(node_user.get_access_key(&account_id, &signer2.public_key).is_err());
 }
 
 pub fn test_access_key_smart_contract(node: impl Node) {

--- a/test-utils/testlib/src/user/mod.rs
+++ b/test-utils/testlib/src/user/mod.rs
@@ -41,9 +41,8 @@ pub trait User {
     fn add_receipt(&self, receipt: Receipt) -> Result<(), String>;
 
     fn get_access_key_nonce_for_signer(&self, account_id: &AccountId) -> Result<u64, String> {
-        self.get_access_key(account_id, &self.signer().public_key()).and_then(|access_key| {
-            access_key.ok_or_else(|| "Access key doesn't exist".to_string()).map(|a| a.nonce)
-        })
+        self.get_access_key(account_id, &self.signer().public_key())
+            .map(|access_key| access_key.nonce)
     }
 
     fn get_best_block_index(&self) -> Option<u64>;
@@ -62,7 +61,7 @@ pub trait User {
         &self,
         account_id: &AccountId,
         public_key: &PublicKey,
-    ) -> Result<Option<AccessKeyView>, String>;
+    ) -> Result<AccessKeyView, String>;
 
     fn signer(&self) -> Arc<dyn Signer>;
 

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -119,7 +119,7 @@ impl User for RpcUser {
         &self,
         account_id: &AccountId,
         public_key: &PublicKey,
-    ) -> Result<Option<AccessKeyView>, String> {
+    ) -> Result<AccessKeyView, String> {
         self.query(format!("access_key/{}/{}", account_id, public_key), &[])?.try_into()
     }
 

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -229,11 +229,11 @@ impl User for RuntimeUser {
         &self,
         account_id: &AccountId,
         public_key: &PublicKey,
-    ) -> Result<Option<AccessKeyView>, String> {
+    ) -> Result<AccessKeyView, String> {
         let state_update = self.client.read().expect(POISONED_LOCK_ERR).get_state_update();
         self.trie_viewer
             .view_access_key(&state_update, account_id, public_key)
-            .map(|value| value.map(|access_key| access_key.into()))
+            .map(|access_key| access_key.into())
             .map_err(|err| err.to_string())
     }
 


### PR DESCRIPTION
*Resolves #1778*

I have renamed `QueryResponse` to `QueryResponseKind` and added a wrapper `QueryResponse` struct which include `kind` + `block_height`.

I use `serde(flatten)` on the `kind` field to keep the API response backward compatible. From the RPC client point of view, a single `block_height` field has been added [a test case is added to ensure this] (cc @vgrichina):

```
$ http post http://127.0.0.1:3030/ jsonrpc=2.0 id=dontcare method=query 'params:=["account/test.near", ""]'

{
    "id": "dontcare",
    "jsonrpc": "2.0",
    "result": {
        "amount": "1000000000000000000000000000",
        "block_height": 83,
        "code_hash": "11111111111111111111111111111111",
        "locked": "50000000000000000000000000",
        "storage_paid_at": 0,
        "storage_usage": 182
    }
}
```