### PR TITLE
Fix dockerfile after rust-rocksdb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apt-get update -qq && apt-get install -y \
     pkg-config \
     libssl-dev \
     curl \
+    llvm \
+    clang \
     && rm -rf /var/lib/apt/lists/*
 
 COPY ./rust-toolchain /tmp/rust-toolchain


### PR DESCRIPTION
Test docker build, works well. Also updated in https://github.com/nearprotocol/docs/. For stakewar seems no longer have rust instructions there, so not updated.