### PR TITLE
Use pure rust reed-solomon-erasure

### DIFF
--- a/chain/chunks/Cargo.toml
+++ b/chain/chunks/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4"
 borsh = "0.2.10"
 serde = "1.0"
 serde_derive = "1.0"
-reed-solomon-erasure = "3.1.1"
+reed-solomon-erasure = { version = "3.1.1", features = ["pure-rust"] }
 cached = "0.11.0"
 
 near-crypto = { path = "../../core/crypto" }

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -14,7 +14,7 @@ chrono = { version = "0.4.4", features = ["serde"] }
 serde = "1.0"
 serde_derive = "1.0"
 rand = "0.7"
-reed-solomon-erasure = "3.1.1"
+reed-solomon-erasure = {version = "3.1.1", features = ["pure-rust"]}
 byteorder = "1.2"
 lazy_static = "1.4"
 

--- a/core/primitives/Cargo.toml
+++ b/core/primitives/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1.0"
 rand = "0.7"
 env_logger = "0.7"
 log = "0.4"
-reed-solomon-erasure = "3.1.1"
+reed-solomon-erasure = {version = "3.1.1", features = ["pure-rust"]}
 jemallocator = { version = "0.3.0", optional = true }
 actix = "0.8.1"
 


### PR DESCRIPTION
This is the default in reed-solomon-erasure 4.x: https://github.com/darrenldl/reed-solomon-erasure, but in 3.x to avoid illegal instructions in docker build for pre-haswell cpus (when you build in a >=haswell cpu), this is needed. There's incompatible api changes in reed-solomon-erasure 4.x, but I can also consider upgrade to that if it's needed.
PS: pre-haswell: ix-3xxx laptop, ex-1xxx server.