### PR TITLE
Header sync in presense of adversaries + Adversarial testing infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,10 @@ tmp/
 
 # Vim tmp files
 *.swp
+rusty-tags.vi
+
+# target dir for building adversarial node for pytests
+pytest/.adversary
+
+# a file indicating that the person understands the risks of running adversarial tests
+pytest/.consent

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -81,7 +81,13 @@ impl Client {
             network_adapter.clone(),
         );
         let sync_status = SyncStatus::AwaitingPeers;
-        let header_sync = HeaderSync::new(network_adapter.clone());
+        let header_sync = HeaderSync::new(
+            network_adapter.clone(),
+            config.header_sync_initial_timeout,
+            config.header_sync_progress_timeout,
+            config.header_sync_stall_ban_timeout,
+            config.header_sync_expected_weight_per_second,
+        );
         let block_sync = BlockSync::new(network_adapter.clone(), config.block_fetch_horizon);
         let state_sync = StateSync::new(network_adapter.clone());
         let num_block_producers = config.num_block_producers as usize;

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -1,6 +1,7 @@
 use std::cmp::min;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration as TimeDuration;
 
 use chrono::{DateTime, Duration, Utc};
 use log::{debug, error, info};
@@ -15,11 +16,11 @@ use near_primitives::types::{AccountId, BlockIndex, ShardId, StateRootNode};
 use near_primitives::unwrap_or_return;
 
 use crate::types::{DownloadStatus, ShardSyncDownload, ShardSyncStatus, SyncStatus};
+use near_primitives::block::Weight;
+use near_primitives::utils::to_timestamp;
 
 /// Maximum number of block headers send over the network.
 pub const MAX_BLOCK_HEADERS: u64 = 512;
-
-const BLOCK_HEADER_PROGRESS_TIMEOUT: i64 = 2;
 
 /// Maximum number of block header hashes to send as part of a locator.
 pub const MAX_BLOCK_HEADER_HASHES: usize = 20;
@@ -37,6 +38,8 @@ const BLOCK_REQUEST_BROADCAST_OFFSET: u64 = 2;
 /// Sync state download timeout in seconds.
 pub const STATE_SYNC_TIMEOUT: i64 = 10;
 
+pub const NS_PER_SECOND: u128 = 1_000_000_000;
+
 /// Get random peer from the most weighted peers.
 pub fn most_weight_peer(most_weight_peers: &Vec<FullPeerInfo>) -> Option<FullPeerInfo> {
     if most_weight_peers.len() == 0 {
@@ -51,19 +54,34 @@ pub fn most_weight_peer(most_weight_peers: &Vec<FullPeerInfo>) -> Option<FullPee
 pub struct HeaderSync {
     network_adapter: Arc<dyn NetworkAdapter>,
     history_locator: Vec<(BlockIndex, CryptoHash)>,
-    prev_header_sync: (DateTime<Utc>, BlockIndex, BlockIndex),
+    prev_header_sync: (DateTime<Utc>, Weight, BlockIndex),
     syncing_peer: Option<FullPeerInfo>,
     stalling_ts: Option<DateTime<Utc>>,
+
+    initial_timeout: Duration,
+    progress_timeout: Duration,
+    stall_ban_timeout: Duration,
+    expected_weight_per_second: u128,
 }
 
 impl HeaderSync {
-    pub fn new(network_adapter: Arc<dyn NetworkAdapter>) -> Self {
+    pub fn new(
+        network_adapter: Arc<dyn NetworkAdapter>,
+        initial_timeout: TimeDuration,
+        progress_timeout: TimeDuration,
+        stall_ban_timeout: TimeDuration,
+        expected_weight_per_second: u128,
+    ) -> Self {
         HeaderSync {
             network_adapter,
             history_locator: vec![],
-            prev_header_sync: (Utc::now(), 0, 0),
+            prev_header_sync: (Utc::now(), 0.into(), 0),
             syncing_peer: None,
             stalling_ts: None,
+            initial_timeout: Duration::from_std(initial_timeout).unwrap(),
+            progress_timeout: Duration::from_std(progress_timeout).unwrap(),
+            stall_ban_timeout: Duration::from_std(stall_ban_timeout).unwrap(),
+            expected_weight_per_second,
         }
     }
 
@@ -111,15 +129,22 @@ impl HeaderSync {
         Ok(())
     }
 
+    fn compute_expected_weight(&self, old_weight: Weight, time_delta: Duration) -> Weight {
+        (old_weight.to_num()
+            + (time_delta.num_nanoseconds().unwrap() as u128 * self.expected_weight_per_second
+                / NS_PER_SECOND))
+            .into()
+    }
+
     fn header_sync_due(&mut self, sync_status: &SyncStatus, header_head: &Tip) -> bool {
         let now = Utc::now();
-        let (timeout, latest_height, prev_height) = self.prev_header_sync;
+        let (timeout, old_expected_weight, prev_height) = self.prev_header_sync;
 
         // Received all necessary header, can request more.
         let all_headers_received = header_head.height >= prev_height + MAX_BLOCK_HEADERS - 4;
 
-        // Did we stall downloading headers for given highest height? Request more or ban peer.
-        let stalling = header_head.height <= latest_height && now > timeout;
+        // Did we receive as many headers as we expected from the peer? Request more or ban peer.
+        let stalling = header_head.weight_and_score.weight <= old_expected_weight && now > timeout;
 
         // Always enable header sync on initial state transition from NoSync / AwaitingPeers.
         let force_sync = match sync_status {
@@ -128,15 +153,21 @@ impl HeaderSync {
         };
 
         if force_sync || all_headers_received || stalling {
-            self.prev_header_sync =
-                (now + Duration::seconds(10), header_head.height, header_head.height);
+            self.prev_header_sync = (
+                now + self.initial_timeout,
+                self.compute_expected_weight(
+                    header_head.weight_and_score.weight,
+                    self.initial_timeout,
+                ),
+                header_head.height,
+            );
 
             if stalling {
                 if self.stalling_ts.is_none() {
                     self.stalling_ts = Some(now);
-                } else {
-                    self.stalling_ts = None;
                 }
+            } else {
+                self.stalling_ts = None;
             }
 
             if all_headers_received {
@@ -146,7 +177,7 @@ impl HeaderSync {
                     if let Some(ref peer) = self.syncing_peer {
                         match sync_status {
                             SyncStatus::HeaderSync { highest_height, .. } => {
-                                if now > *stalling_ts + Duration::seconds(120)
+                                if now > *stalling_ts + self.stall_ban_timeout
                                     && *highest_height == peer.chain_info.height
                                 {
                                     info!(target: "sync", "Sync: ban a fraudulent peer: {}, claimed height: {}, total weight: {}, score: {}",
@@ -166,12 +197,23 @@ impl HeaderSync {
             true
         } else {
             // Resetting the timeout as long as we make progress.
-            if header_head.height > latest_height {
-                self.prev_header_sync = (
-                    now + Duration::seconds(BLOCK_HEADER_PROGRESS_TIMEOUT),
-                    header_head.height,
-                    prev_height,
+            let ns_time_till_timeout =
+                (to_timestamp(timeout).saturating_sub(to_timestamp(now))) as u128;
+            // `ns_till_timeout` will not exceed 1B * largest timeout we have, which is 10s
+            // `expected_weight_per_second` is on the order of `WEIGHT_MULTIPLIER` times
+            // 1B times a small constant. Thus the result of the multiplication is on the
+            // order of ~1B^3 * 10 * 10 = 10^29, which is way under the u128 limit
+            let remaining_expected_weight =
+                self.expected_weight_per_second * ns_time_till_timeout / NS_PER_SECOND;
+            if header_head.weight_and_score.weight.to_num()
+                >= old_expected_weight.to_num().saturating_sub(remaining_expected_weight)
+            {
+                let new_expected_weight = self.compute_expected_weight(
+                    header_head.weight_and_score.weight,
+                    self.progress_timeout,
                 );
+                self.prev_header_sync =
+                    (now + self.progress_timeout, new_expected_weight, prev_height);
             }
             false
         }
@@ -296,6 +338,7 @@ impl BlockSync {
     ) -> Result<bool, near_chain::Error> {
         if self.block_sync_due(chain)? {
             if self.block_sync(chain, most_weight_peers, self.block_fetch_horizon)? {
+                debug!(target: "sync", "Sync: transition to State Sync.");
                 return Ok(true);
             }
 
@@ -775,15 +818,18 @@ impl StateSync {
 mod test {
     use std::sync::Arc;
 
-    use near_chain::test_utils::setup;
+    use near_chain::test_utils::{new_block_no_epoch_switches, setup, setup_with_validators};
     use near_chain::Provenance;
-    use near_network::types::PeerChainInfo;
+    use near_network::types::{PeerChainInfo, PeerId};
     use near_network::PeerInfo;
     use near_primitives::block::{Block, GenesisId};
 
     use super::*;
     use crate::test_utils::MockNetworkAdapter;
+    use near_chain::chain::WEIGHT_MULTIPLIER;
+    use near_crypto::{KeyType, PublicKey};
     use near_network::routing::EdgeInfo;
+    use std::thread;
 
     #[test]
     fn test_get_locator_heights() {
@@ -808,7 +854,13 @@ mod test {
     #[test]
     fn test_sync_headers_fork() {
         let mock_adapter = Arc::new(MockNetworkAdapter::default());
-        let mut header_sync = HeaderSync::new(mock_adapter.clone());
+        let mut header_sync = HeaderSync::new(
+            mock_adapter.clone(),
+            TimeDuration::from_secs(10),
+            TimeDuration::from_secs(2),
+            TimeDuration::from_secs(120),
+            1_000_000_000,
+        );
         let (mut chain, _, signer) = setup();
         for _ in 0..3 {
             let prev = chain.get_block(&chain.head().unwrap().last_block_hash).unwrap();
@@ -855,5 +907,128 @@ mod test {
                 peer_id: peer1.peer_info.id
             }
         );
+    }
+
+    /// Sets up `HeaderSync` with particular tolerance for slowness, and makes sure that a peer that
+    /// sends headers below the threshold gets banned, and the peer that sends them faster doesn't get
+    /// banned.
+    /// Also makes sure that if `header_sync_due` is checked more frequently than the `progress_timeout`
+    /// the peer doesn't get banned. (specifically, that the expected weight downloaded gets properly
+    /// adjusted for time passed)
+    #[test]
+    fn test_slow_header_sync_common() {
+        let network_adapter = Arc::new(MockNetworkAdapter::default());
+        let highest_height = 1000;
+
+        // Setup header_sync with expectation of 2 full-stake-seconds worth of weight per second
+        // Or 6 full-stake-seconds worth of weight per three seconds
+        // Or 15 headers with 0.4 stake spaced one second away from each other per three seconds
+        let mut header_sync = HeaderSync::new(
+            network_adapter.clone(),
+            TimeDuration::from_secs(1),
+            TimeDuration::from_secs(1),
+            TimeDuration::from_secs(3),
+            1_000_000_000 * WEIGHT_MULTIPLIER * 2,
+        );
+
+        let set_syncing_peer = |header_sync: &mut HeaderSync| {
+            header_sync.syncing_peer = Some(FullPeerInfo {
+                peer_info: PeerInfo {
+                    id: PeerId::new(PublicKey::empty(KeyType::ED25519)),
+                    addr: None,
+                    account_id: None,
+                },
+                chain_info: Default::default(),
+                edge_info: Default::default(),
+            });
+            header_sync.syncing_peer.as_mut().unwrap().chain_info.height = highest_height;
+        };
+        set_syncing_peer(&mut header_sync);
+
+        let (mut chain, _, signers) = setup_with_validators(
+            vec!["test0", "test1", "test2", "test3", "test4"]
+                .iter()
+                .map(|x| x.to_string())
+                .collect(),
+            1,
+            1,
+            1000,
+            100,
+        );
+        let genesis = chain.get_block(&chain.genesis().hash()).unwrap().clone();
+
+        let now = genesis.header.inner_lite.timestamp;
+
+        let mut last_block = &genesis;
+        let mut all_blocks = vec![];
+        for i in 0..61 {
+            let current_height = 3 + i * 5;
+            let block = new_block_no_epoch_switches(
+                last_block,
+                current_height,
+                vec!["test3", "test4"],
+                &*signers[3],
+                // this collectively pushes the head 61 seconds from genesis time,
+                // which is within the 2 minutes allowance beyond which the blocks
+                // would be rejected
+                now + (1_000_000_000) as u64,
+                if last_block.header.prev_hash == CryptoHash::default() {
+                    0
+                } else {
+                    1_000_000_000
+                },
+            );
+
+            all_blocks.push(block);
+
+            last_block = &all_blocks[all_blocks.len() - 1];
+        }
+
+        let mut last_added_block_ord = 0;
+        // First send 6 blocks every second for a while and make sure it doesn't get
+        // banned
+        for _iter in 0..12 {
+            let block = &all_blocks[last_added_block_ord];
+            let current_height = block.header.inner_lite.height;
+            set_syncing_peer(&mut header_sync);
+            header_sync.header_sync_due(
+                &SyncStatus::HeaderSync { current_height, highest_height },
+                &Tip::from_header_and_prev_timestamp(
+                    &block.header,
+                    last_block.header.inner_lite.timestamp,
+                ),
+            );
+
+            last_added_block_ord += 3;
+
+            thread::sleep(TimeDuration::from_millis(500));
+        }
+        // 6 blocks / second is fast enough, we should not have banned the peer
+        assert!(network_adapter.requests.read().unwrap().is_empty());
+
+        // Now the same, but only four blocks / sec
+        for _iter in 0..12 {
+            let block = &all_blocks[last_added_block_ord];
+            let current_height = block.header.inner_lite.height;
+            set_syncing_peer(&mut header_sync);
+            header_sync.header_sync_due(
+                &SyncStatus::HeaderSync { current_height, highest_height },
+                &Tip::from_header_and_prev_timestamp(
+                    &block.header,
+                    last_block.header.inner_lite.timestamp,
+                ),
+            );
+
+            last_added_block_ord += 2;
+
+            thread::sleep(TimeDuration::from_millis(500));
+        }
+        // This time the peer should be banned, because 4 blocks/s is not fast enough
+        let ban_peer = network_adapter.requests.write().unwrap().pop_back().unwrap();
+        if let NetworkRequests::BanPeer { .. } = ban_peer {
+            /* expected */
+        } else {
+            assert!(false);
+        }
     }
 }

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -99,6 +99,14 @@ pub struct ClientConfig {
     pub sync_weight_threshold: u128,
     /// Sync height threshold: below this difference in height don't start syncing.
     pub sync_height_threshold: BlockIndex,
+    /// How much time to wait after initial header sync
+    pub header_sync_initial_timeout: Duration,
+    /// How much time to wait after some progress is made in header sync
+    pub header_sync_progress_timeout: Duration,
+    /// How much time to wait before banning a peer in header sync if sync is too slow
+    pub header_sync_stall_ban_timeout: Duration,
+    /// Expected increase of header head weight per second during header sync
+    pub header_sync_expected_weight_per_second: u128,
     /// Minimum number of peers to start syncing.
     pub min_num_peers: usize,
     /// Period between logging summary information.
@@ -154,6 +162,10 @@ impl ClientConfig {
             sync_step_period: Duration::from_millis(10),
             sync_weight_threshold: 0,
             sync_height_threshold: 1,
+            header_sync_initial_timeout: Duration::from_secs(10),
+            header_sync_progress_timeout: Duration::from_secs(2),
+            header_sync_stall_ban_timeout: Duration::from_secs(30),
+            header_sync_expected_weight_per_second: 1_000_000_000,
             min_num_peers: 1,
             log_summary_period: Duration::from_secs(10),
             produce_empty_blocks: true,

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -11,6 +11,7 @@ use chrono::{DateTime, Utc};
 use log::info;
 use serde_derive::{Deserialize, Serialize};
 
+use near_chain::chain::WEIGHT_MULTIPLIER;
 use near_chain::ChainGenesis;
 use near_client::BlockProducer;
 use near_client::ClientConfig;
@@ -313,6 +314,13 @@ impl NearConfig {
                 sync_step_period: Duration::from_millis(10),
                 sync_weight_threshold: 0,
                 sync_height_threshold: 1,
+                header_sync_initial_timeout: Duration::from_secs(10),
+                header_sync_progress_timeout: Duration::from_secs(2),
+                header_sync_stall_ban_timeout: Duration::from_secs(40),
+                // weight is measured in WM * ns, so if we expect `k` headers per second
+                // synced, and assuming most headers have most approvals, the value should
+                // be `k * WM * 1B`
+                header_sync_expected_weight_per_second: WEIGHT_MULTIPLIER * 1_000_000_000 * 10,
                 min_num_peers: config.consensus.min_num_peers,
                 log_summary_period: Duration::from_secs(10),
                 produce_empty_blocks: config.consensus.produce_empty_blocks,

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -13,6 +13,7 @@ pytest --timeout=600 sanity/state_sync.py manytx 250
 pytest sanity/state_sync.py onetx 30
 pytest --timeout=600 sanity/state_sync.py onetx 250
 pytest --timeout=240 sanity/state_sync1.py
+pytest --timeout=310 sanity/state_sync2.py
 pytest sanity/rpc_tx_forwarding.py
 pytest --timeout=240 sanity/skip_epoch.py
 pytest --timeout=600 sanity/fork_sync.py
@@ -26,6 +27,9 @@ pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart
 pytest --timeout=2000 stress/stress.py 3 2 4 0 staking transactions node_set
 
 pytest stress/network_stress.py
+
+# python adversarial tests
+pytest adversarial/wrong_sync_info.py
 
 # catchup tests
 expensive near-client catching_up tests::test_catchup_receipts_sync_third_epoch

--- a/pytest/lib/adversary.py
+++ b/pytest/lib/adversary.py
@@ -1,0 +1,75 @@
+import os, subprocess, sys
+
+if not os.path.exists('.consent'):
+    print("+---------------------------------------------------+", file=sys.stderr)
+    print("+ You are about to run a test that uses adversarial +", file=sys.stderr)
+    print("+ infrastructure. The infrastructure uses some git  +", file=sys.stderr)
+    print("+ manipulations, including an invocation of         +", file=sys.stderr)
+    print("+                                                   +", file=sys.stderr)
+    print("+     git reset --hard HEAD~                        +", file=sys.stderr)
+    print("+                                                   +", file=sys.stderr)
+    print("+ after cherry-picking. While Alex who wrote this   +", file=sys.stderr)
+    print("+ terrible code made everything possible to his     +", file=sys.stderr)
+    print("+ best knowledge to prevent loss of work, you need  +", file=sys.stderr)
+    print("+ to understand that Alex has no idea how git works +", file=sys.stderr)
+    print("+ and that any uncommitted changes can be lost      +", file=sys.stderr)
+    print("+ after running such tests.                         +", file=sys.stderr)
+    print("+                                                   +", file=sys.stderr)
+    print("+ Create a file named `.consent` in `pytest` dir to +", file=sys.stderr)
+    print("+ get rid of this message and actually run the test +", file=sys.stderr)
+    print("+---------------------------------------------------+", file=sys.stderr)
+    sys.exit(1)
+
+# A branch name or commit hash of the adversarial branch
+# The value will be passed to `git cherrypick <here>` command.
+ADVERSARIAL_BRANCH = 'adversary'
+
+HONEST_PATH = "../target/debug"
+ADVERSARIAL_PATH = "./.adversary/debug"
+
+def prepare_adversarial_binary():
+    honest_near = os.path.join(HONEST_PATH, "near")
+    adversarial_near = os.path.join(ADVERSARIAL_PATH, "near")
+    assert os.path.exists(honest_near)
+    
+    need_to_recompile = False
+    if not os.path.exists(adversarial_near):
+        print("Adversarial binary is missing, recompiling")
+        need_to_recompile = True
+    else:
+        honest_mtime = os.path.getmtime(honest_near)
+        adversarial_mtime = os.path.getmtime(adversarial_near)
+
+        if honest_mtime > adversarial_mtime:
+            print("Adversarial binary is older than honest, recompiling")
+            need_to_recompile = True
+
+    if need_to_recompile:
+        # Test that there are no uncommitted changes
+        check_uncommitted = subprocess.Popen(["git", "diff-index", "--quiet", "HEAD", "--"])
+        out, err = check_uncommitted.communicate()
+        assert 0 == check_uncommitted.returncode, "Make sure you have no uncommitted changes before running any adversarial tests.\n%s" % err
+
+        print("... Cherry-picking the adversarial branch")
+        cherrypick = subprocess.Popen(["git", "cherry-pick", ADVERSARIAL_BRANCH])
+        out, err = cherrypick.communicate()
+        assert 0 == cherrypick.returncode, err
+
+        print("... Building adversarial node")
+        build = subprocess.Popen(["cargo", "build", "-p", "near", "--target-dir", ".adversary"])
+        out, err = build.communicate()
+        assert 0 == build.returncode, err
+
+        # Hope that `diff-index` above was sufficiently reliable and no changes get lost here
+        print("... Git-resetting HARD to HEAD~.")
+        git_reset = subprocess.Popen(["git", "reset", "--hard", "HEAD~"])
+        out, err = git_reset.communicate()
+        assert 0 == git_reset.returncode, err
+
+def corrupt_node(node):
+    assert 'LocalNode' in str(type(node)), "Node type %s != LocalNode. There's no support for remote nodes yet." % str(type(node))
+    prepare_adversarial_binary()
+
+    print("Corrupting node %s:%s" % node.addr())
+    node.near_root = ADVERSARIAL_PATH
+

--- a/pytest/prepare_adversarial_binary.py
+++ b/pytest/prepare_adversarial_binary.py
@@ -1,0 +1,11 @@
+# Adversarial infrastructure will call to `prepare_adversarial_binary()` whenever
+# it corrupts a node, so calling this script before running adversarial tests is
+# not necessary. However, on a node that never ran any adversarial tests compiling
+# an adversarial node can take several minutes, causing tests to timeout, so for
+# tests that run via CI / nighly and have strict timeouts calling this script
+# before-hand is necessary
+
+from lib.adversary import prepare_adversarial_binary
+
+prepare_adversarial_binary()
+

--- a/pytest/tests/adversarial/wrong_sync_info.py
+++ b/pytest/tests/adversarial/wrong_sync_info.py
@@ -1,0 +1,64 @@
+# Runs two nodes, waits until they create some blocks.
+# Launches a third observing node, makes it connect to an
+# adversarial node that reports inflated sync info. Makes
+# sure the observer node ultimately manages to synchronize.
+
+import sys, time
+
+sys.path.append('lib')
+
+
+from cluster import start_cluster
+from adversary import corrupt_node
+from utils import LogTracker
+
+TIMEOUT = 300
+BLOCKS = 30
+LARGE_WEIGHT = '1267650600228229401496703205376'
+
+nodes = start_cluster(2, 1, 2, None, [["epoch_length", 7], ["block_producer_kickout_threshold", 80]], {})
+
+started = time.time()
+
+nodes[1].kill()
+nodes[2].kill()
+
+corrupt_node(nodes[1])
+tracker = LogTracker(nodes[1])
+
+nodes[1].start(nodes[0].node_key.pk, nodes[0].addr())
+time.sleep(2)
+assert tracker.check("ADVERSARIAL")
+
+print("Waiting for %s blocks..." % BLOCKS)
+
+while True:
+    assert time.time() - started < TIMEOUT
+    status = nodes[1].get_status()
+    height = status['sync_info']['latest_block_height']
+    if height >= BLOCKS:
+        break
+    time.sleep(1)
+
+print("Got to %s blocks, getting to fun stuff" % BLOCKS)
+
+res = nodes[1].json_rpc('adv_set_weight', [1000, LARGE_WEIGHT, LARGE_WEIGHT])
+assert 'result' in res, res
+res = nodes[1].json_rpc('adv_disable_header_sync', [])
+assert 'result' in res, res
+
+tracker = LogTracker(nodes[2])
+nodes[2].start(nodes[1].node_key.pk, nodes[1].addr())
+time.sleep(2)
+assert tracker.check(LARGE_WEIGHT)
+
+while True:
+    assert time.time() - started < TIMEOUT
+    status = nodes[2].get_status()
+    height = status['sync_info']['latest_block_height']
+    if height >= BLOCKS:
+        break
+
+assert tracker.check('ban a fraudulent peer')
+
+print("Epic")

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -90,9 +90,9 @@ while catch_up_height < observed_height:
 assert catch_up_height in seen_boot_heights, "%s not in %s" % (catch_up_height, seen_boot_heights)
 
 if catch_up_height >= 100:
-    assert tracker.check("State 0")
+    assert tracker.check("transition to State Sync")
 elif catch_up_height <= 30:
-    assert not tracker.check("State 0")
+    assert not tracker.check("transition to State Sync")
 
 if mode == 'manytx':
     while ctx.get_balances() != ctx.expected_balances:

--- a/pytest/tests/sanity/state_sync2.py
+++ b/pytest/tests/sanity/state_sync2.py
@@ -1,0 +1,47 @@
+# Spins up two block producing nodes. Uses a large number of block producer seats to ensure
+# both block producers are validating both shards.
+# Gets to 105 blocks and nukes + wipes one of the block producers. Makes sure it can recover
+# and sync
+
+import sys, time
+
+sys.path.append('lib')
+
+from cluster import start_cluster
+from utils import LogTracker
+
+TIMEOUT = 300
+BLOCKS = 105 # should be enough to trigger state sync for node 1 later, see comments there
+
+nodes = start_cluster(2, 0, 2, None, [["num_block_producers", 199], ["block_producers_per_shard", [24, 25, 25, 25, 25, 25, 25, 25]], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
+
+started = time.time()
+
+print("Waiting for %s blocks..." % BLOCKS)
+
+while True:
+    assert time.time() - started < TIMEOUT
+    status = nodes[1].get_status()
+    height = status['sync_info']['latest_block_height']
+    if height >= BLOCKS:
+        break
+    time.sleep(1)
+
+print("Got to %s blocks, rebooting the first node" % BLOCKS)
+
+nodes[0].kill()
+nodes[0].reset_data()
+tracker = LogTracker(nodes[0])
+nodes[0].start(nodes[1].node_key.pk, nodes[1].addr())
+
+while True:
+    assert time.time() - started < TIMEOUT
+    status = nodes[0].get_status()
+    height = status['sync_info']['latest_block_height']
+    if height >= BLOCKS:
+        break
+    time.sleep(1)
+
+# make sure `nodes[0]` actually state synced
+assert tracker.check("transition to State Sync")
+


### PR DESCRIPTION
The adversarial node can be found here:

   https://github.com/nearprotocol/nearcore/commit/cf7487f1e3b01262ec086ebbde10d4b1c5f026dc

- Made Header sync use weight/second to measure performance of the
header sync, and ban peer if for a prolonged period of time
weight/second is below expected value
- `process_block` now checks epoch before it checks if a block is an
orphan. It is needed to make it impossible to spam with fake blocks
without being penalized (more protections for it coming in future PRs).
- New infrastructure for adversarial testing that allows to corrupt node
and allows manipulating the behavior of the corrupted node.

Test plan:
- New python test (`wrong_sync_info`) that tests the adversary that
lies about their sync status
- Also new test `state_sync2` which is completely orthogonal to this
change.
- Unit test that makes sure that the weight/sec in the header sync works
as expected