### PR TITLE
Blacklist

### DIFF
--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -15,5 +15,6 @@ pub mod peer_store;
 mod rate_counter;
 pub mod routing;
 pub mod types;
+pub mod utils;
 
 pub mod test_utils;

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -144,6 +144,8 @@ impl PeerManagerActor {
         addr: Addr<Peer>,
         ctx: &mut Context<Self>,
     ) {
+        debug!(target: "network", "Connected to {:?}", full_peer_info);
+
         if self.outgoing_peers.contains(&full_peer_info.peer_info.id) {
             self.outgoing_peers.remove(&full_peer_info.peer_info.id);
         }
@@ -1045,7 +1047,7 @@ impl Handler<OutboundTcpConnect> for PeerManagerActor {
                 .then(move |res, act, ctx| match res {
                     Ok(res) => match res {
                         Ok(stream) => {
-                            debug!(target: "network", "Connected to {}", msg.peer_info);
+                            debug!(target: "network", "Connecting to {}", msg.peer_info);
                             let edge_info = act.propose_edge(msg.peer_info.id.clone(), None);
 
                             act.connect_peer(
@@ -1080,6 +1082,7 @@ impl Handler<Consolidate> for PeerManagerActor {
     type Result = ConsolidateResponse;
 
     fn handle(&mut self, msg: Consolidate, ctx: &mut Self::Context) -> Self::Result {
+        // Check if this is a blacklisted peer.
         if msg.peer_info.addr.as_ref().map_or(true, |addr| self.is_blacklisted(addr)) {
             debug!(target: "network", "Dropping connection from blacklisted peer or unknown address: {:?}", msg.peer_info);
             return ConsolidateResponse::Reject;

--- a/chain/network/src/peer_store.rs
+++ b/chain/network/src/peer_store.rs
@@ -128,11 +128,13 @@ impl PeerStore {
     }
 
     /// Return unconnected or peers with unknown status that we can try to connect to.
+    /// Peers with unknown addresses are filtered out
     pub fn unconnected_peers(&self, ignore_list: &HashSet<PeerId>) -> Vec<PeerInfo> {
         self.find_peers(
             |p| {
                 (p.status == KnownPeerStatus::NotConnected || p.status == KnownPeerStatus::Unknown)
                     && !ignore_list.contains(&p.peer_info.id)
+                    && p.peer_info.addr.is_some()
             },
             0,
         )

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -49,7 +49,7 @@ impl NetworkConfig {
             max_routes_to_store: 1,
             most_weighted_peer_horizon: 5 * WEIGHT_MULTIPLIER,
             push_info_period: Duration::from_millis(100),
-            blacklist: vec![],
+            blacklist: HashMap::new(),
         }
     }
 }

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -49,6 +49,7 @@ impl NetworkConfig {
             max_routes_to_store: 1,
             most_weighted_peer_horizon: 5 * WEIGHT_MULTIPLIER,
             push_info_period: Duration::from_millis(100),
+            blacklist: vec![],
         }
     }
 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -752,6 +752,12 @@ impl PeerMessage {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum BlockedPorts {
+    All,
+    Some(HashSet<u16>),
+}
+
 /// Configuration for the peer-to-peer manager.
 #[derive(Clone)]
 pub struct NetworkConfig {
@@ -784,7 +790,7 @@ pub struct NetworkConfig {
     pub push_info_period: Duration,
     /// Peers on blacklist by IP:Port.
     /// Nodes will not accept or try to establish connection to such peers.
-    pub blacklist: Vec<PatternAddr>,
+    pub blacklist: HashMap<IpAddr, BlockedPorts>,
 }
 
 /// Used to match a socket addr by IP:Port or only by IP

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -3,7 +3,7 @@ use std::convert::{From, TryInto};
 use std::convert::{Into, TryFrom};
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::net::SocketAddr;
+use std::net::{AddrParseError, IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -782,6 +782,37 @@ pub struct NetworkConfig {
     pub most_weighted_peer_horizon: u128,
     /// Period between pushing network info to client
     pub push_info_period: Duration,
+    /// Peers on blacklist by IP:Port.
+    /// Nodes will not accept or try to establish connection to such peers.
+    pub blacklist: Vec<PatternAddr>,
+}
+
+/// Used to match a socket addr by IP:Port or only by IP
+#[derive(Clone, Debug)]
+pub enum PatternAddr {
+    Ip(IpAddr),
+    IpPort(SocketAddr),
+}
+
+impl PatternAddr {
+    pub fn contains(&self, addr: &SocketAddr) -> bool {
+        match self {
+            PatternAddr::Ip(pattern) => &addr.ip() == pattern,
+            PatternAddr::IpPort(pattern) => addr == pattern,
+        }
+    }
+}
+
+impl FromStr for PatternAddr {
+    type Err = AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Ok(pattern) = s.parse::<IpAddr>() {
+            return Ok(PatternAddr::Ip(pattern));
+        }
+
+        s.parse::<SocketAddr>().map(PatternAddr::IpPort)
+    }
 }
 
 /// Status of the known peers.

--- a/chain/network/src/utils.rs
+++ b/chain/network/src/utils.rs
@@ -1,0 +1,35 @@
+use std::collections::{HashMap, HashSet};
+use std::iter::FromIterator;
+use std::net::IpAddr;
+
+use crate::types::{BlockedPorts, PatternAddr};
+
+pub fn blacklist_from_vec(blacklist: &Vec<String>) -> HashMap<IpAddr, BlockedPorts> {
+    let mut blacklist_map = HashMap::new();
+    for addr in blacklist.iter() {
+        if let Ok(res) = addr.parse::<PatternAddr>() {
+            match res {
+                PatternAddr::Ip(addr) => {
+                    blacklist_map
+                        .entry(addr)
+                        .and_modify(|blocked_ports| *blocked_ports = BlockedPorts::All)
+                        .or_insert(BlockedPorts::All);
+                }
+                PatternAddr::IpPort(addr) => {
+                    blacklist_map
+                        .entry(addr.ip())
+                        .and_modify(|blocked_ports| {
+                            if let BlockedPorts::Some(ports) = blocked_ports {
+                                ports.insert(addr.port());
+                            }
+                        })
+                        .or_insert_with(|| {
+                            BlockedPorts::Some(HashSet::from_iter(vec![addr.port()]))
+                        });
+                }
+            }
+        }
+    }
+
+    blacklist_map
+}

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
-use actix::{Actor, Addr, AsyncContext, System};
+use actix::{Actor, Addr, AsyncContext, Context, System};
 use chrono::{DateTime, Utc};
 use futures::{future, Future};
 
@@ -14,7 +14,7 @@ use near_crypto::{InMemorySigner, KeyType};
 use near_network::test_utils::{
     convert_boot_nodes, expected_routing_tables, open_port, WaitOrTimeout,
 };
-use near_network::types::{OutboundTcpConnect, StopSignal};
+use near_network::types::{OutboundTcpConnect, PatternAddr, StopSignal};
 use near_network::{
     NetworkConfig, NetworkRecipient, NetworkRequests, NetworkResponses, PeerInfo, PeerManagerActor,
 };
@@ -22,6 +22,7 @@ use near_primitives::test_utils::init_test_logger;
 use near_primitives::types::ValidatorId;
 use near_store::test_utils::create_test_store;
 use near_telemetry::{TelemetryActor, TelemetryConfig};
+use std::collections::{HashMap, HashSet};
 
 /// Sets up a node with a valid Client, Peer
 pub fn setup_network_node(
@@ -31,6 +32,7 @@ pub fn setup_network_node(
     validators: Vec<String>,
     genesis_time: DateTime<Utc>,
     peer_max_count: u32,
+    blacklist: Vec<PatternAddr>,
 ) -> Addr<PeerManagerActor> {
     let store = create_test_store();
 
@@ -39,6 +41,7 @@ pub fn setup_network_node(
     let mut config = NetworkConfig::from_seed(account_id.as_str(), port);
     config.peer_max_count = peer_max_count;
     config.ttl_account_id_router = ttl_account_id_router;
+    config.blacklist = blacklist;
 
     let boot_nodes = boot_nodes.iter().map(|(acc_id, port)| (acc_id.as_str(), *port)).collect();
     config.boot_nodes = convert_boot_nodes(boot_nodes);
@@ -111,6 +114,8 @@ enum Action {
     CheckPingPong(usize, Vec<(usize, usize)>, Vec<(usize, usize)>),
     // Send stop signal to some node.
     Stop(usize),
+    // Wait time in milliseconds
+    Wait(usize),
 }
 
 #[derive(Clone)]
@@ -120,7 +125,7 @@ struct RunningInfo {
 }
 
 struct StateMachine {
-    actions: Vec<Box<dyn FnMut(RunningInfo, Arc<AtomicBool>)>>,
+    actions: Vec<Box<dyn FnMut(RunningInfo, Arc<AtomicBool>, &mut Context<WaitOrTimeout>)>>,
 }
 
 impl StateMachine {
@@ -131,24 +136,30 @@ impl StateMachine {
     pub fn push(&mut self, action: Action) {
         match action {
             Action::AddEdge(u, v) => {
-                self.actions.push(Box::new(move |info: RunningInfo, flag: Arc<AtomicBool>| {
-                    let addr = info.pm_addr[u].clone();
-                    let peer_info = info.peers_info[v].clone();
-                    actix::spawn(addr.send(OutboundTcpConnect { peer_info }).then(move |res| {
-                        match res {
-                            Ok(_) => {
-                                flag.store(true, Ordering::Relaxed);
-                                future::ok(())
-                            }
-                            Err(e) => {
-                                panic!("Error adding edge. {:?}", e);
-                            }
-                        }
-                    }));
-                }));
+                self.actions.push(Box::new(
+                    move |info: RunningInfo,
+                          flag: Arc<AtomicBool>,
+                          _ctx: &mut Context<WaitOrTimeout>| {
+                        let addr = info.pm_addr[u].clone();
+                        let peer_info = info.peers_info[v].clone();
+                        actix::spawn(addr.send(OutboundTcpConnect { peer_info }).then(
+                            move |res| match res {
+                                Ok(_) => {
+                                    flag.store(true, Ordering::Relaxed);
+                                    future::ok(())
+                                }
+                                Err(e) => {
+                                    panic!("Error adding edge. {:?}", e);
+                                }
+                            },
+                        ));
+                    },
+                ));
             }
-            Action::CheckRoutingTable(u, expected) => {
-                self.actions.push(Box::new(move |info: RunningInfo, flag: Arc<AtomicBool>| {
+            Action::CheckRoutingTable(u, expected) => self.actions.push(Box::new(
+                move |info: RunningInfo,
+                      flag: Arc<AtomicBool>,
+                      _ctx: &mut Context<WaitOrTimeout>| {
                     let expected = expected
                         .clone()
                         .into_iter()
@@ -181,102 +192,130 @@ impl StateMachine {
                                 future::ok(())
                             }),
                     );
-                }))
-            }
+                },
+            )),
             Action::CheckAccountId(source, known_validators) => {
-                self.actions.push(Box::new(move |info: RunningInfo, flag: Arc<AtomicBool>| {
-                    let expected_known: Vec<_> = known_validators
-                        .clone()
-                        .into_iter()
-                        .map(|u| info.peers_info[u].account_id.clone().unwrap())
-                        .collect();
+                self.actions.push(Box::new(
+                    move |info: RunningInfo,
+                          flag: Arc<AtomicBool>,
+                          _ctx: &mut Context<WaitOrTimeout>| {
+                        let expected_known: Vec<_> = known_validators
+                            .clone()
+                            .into_iter()
+                            .map(|u| info.peers_info[u].account_id.clone().unwrap())
+                            .collect();
 
-                    actix::spawn(
-                        info.pm_addr
-                            .get(source)
-                            .unwrap()
-                            .send(NetworkRequests::FetchRoutingTable)
-                            .map_err(|_| ())
-                            .and_then(move |res| {
-                                if let NetworkResponses::RoutingTableInfo(routing_table) = res {
-                                    if expected_known.into_iter().all(|validator| {
-                                        routing_table.account_peers.contains_key(&validator)
-                                    }) {
-                                        flag.store(true, Ordering::Relaxed);
+                        actix::spawn(
+                            info.pm_addr
+                                .get(source)
+                                .unwrap()
+                                .send(NetworkRequests::FetchRoutingTable)
+                                .map_err(|_| ())
+                                .and_then(move |res| {
+                                    if let NetworkResponses::RoutingTableInfo(routing_table) = res {
+                                        if expected_known.into_iter().all(|validator| {
+                                            routing_table.account_peers.contains_key(&validator)
+                                        }) {
+                                            flag.store(true, Ordering::Relaxed);
+                                        }
                                     }
-                                }
-                                future::ok(())
-                            }),
-                    );
-                }));
+                                    future::ok(())
+                                }),
+                        );
+                    },
+                ));
             }
             Action::PingTo(source, nonce, target) => {
-                self.actions.push(Box::new(move |info: RunningInfo, flag: Arc<AtomicBool>| {
-                    let target = info.peers_info[target].id.clone();
-                    let _ = info.pm_addr[source].do_send(NetworkRequests::PingTo(nonce, target));
-                    flag.store(true, Ordering::Relaxed);
-                }));
+                self.actions.push(Box::new(
+                    move |info: RunningInfo,
+                          flag: Arc<AtomicBool>,
+                          _ctx: &mut Context<WaitOrTimeout>| {
+                        let target = info.peers_info[target].id.clone();
+                        let _ =
+                            info.pm_addr[source].do_send(NetworkRequests::PingTo(nonce, target));
+                        flag.store(true, Ordering::Relaxed);
+                    },
+                ));
             }
             Action::Stop(source) => {
-                self.actions.push(Box::new(move |info: RunningInfo, flag: Arc<AtomicBool>| {
-                    actix::spawn(
-                        info.pm_addr
-                            .get(source)
-                            .unwrap()
-                            .send(StopSignal {})
-                            .map_err(|_| ())
-                            .and_then(move |_| {
-                                flag.store(true, Ordering::Relaxed);
-                                future::ok(())
-                            }),
-                    );
-                }));
+                self.actions.push(Box::new(
+                    move |info: RunningInfo,
+                          flag: Arc<AtomicBool>,
+                          _ctx: &mut Context<WaitOrTimeout>| {
+                        actix::spawn(
+                            info.pm_addr
+                                .get(source)
+                                .unwrap()
+                                .send(StopSignal {})
+                                .map_err(|_| ())
+                                .and_then(move |_| {
+                                    flag.store(true, Ordering::Relaxed);
+                                    future::ok(())
+                                }),
+                        );
+                    },
+                ));
+            }
+            Action::Wait(time) => {
+                self.actions.push(Box::new(
+                    move |_info: RunningInfo,
+                          flag: Arc<AtomicBool>,
+                          ctx: &mut Context<WaitOrTimeout>| {
+                        ctx.run_later(Duration::from_millis(time as u64), move |_, _| {
+                            flag.store(true, Ordering::Relaxed);
+                        });
+                    },
+                ));
             }
             Action::CheckPingPong(source, pings, pongs) => {
-                self.actions.push(Box::new(move |info: RunningInfo, flag: Arc<AtomicBool>| {
-                    let pings_expected: Vec<_> = pings
-                        .clone()
-                        .into_iter()
-                        .map(|(nonce, source)| (nonce, info.peers_info[source].id.clone()))
-                        .collect();
+                self.actions.push(Box::new(
+                    move |info: RunningInfo,
+                          flag: Arc<AtomicBool>,
+                          _ctx: &mut Context<WaitOrTimeout>| {
+                        let pings_expected: Vec<_> = pings
+                            .clone()
+                            .into_iter()
+                            .map(|(nonce, source)| (nonce, info.peers_info[source].id.clone()))
+                            .collect();
 
-                    let pongs_expected: Vec<_> = pongs
-                        .clone()
-                        .into_iter()
-                        .map(|(nonce, source)| (nonce, info.peers_info[source].id.clone()))
-                        .collect();
+                        let pongs_expected: Vec<_> = pongs
+                            .clone()
+                            .into_iter()
+                            .map(|(nonce, source)| (nonce, info.peers_info[source].id.clone()))
+                            .collect();
 
-                    actix::spawn(
-                        info.pm_addr
-                            .get(source)
-                            .unwrap()
-                            .send(NetworkRequests::FetchPingPongInfo)
-                            .map_err(|_| ())
-                            .and_then(move |res| {
-                                if let NetworkResponses::PingPongInfo { pings, pongs } = res {
-                                    let ping_ok =
-                                        pings_expected.into_iter().all(|(nonce, source)| {
-                                            pings
-                                                .get(&nonce)
-                                                .map_or(false, |ping| ping.source == source)
-                                        });
+                        actix::spawn(
+                            info.pm_addr
+                                .get(source)
+                                .unwrap()
+                                .send(NetworkRequests::FetchPingPongInfo)
+                                .map_err(|_| ())
+                                .and_then(move |res| {
+                                    if let NetworkResponses::PingPongInfo { pings, pongs } = res {
+                                        let ping_ok =
+                                            pings_expected.into_iter().all(|(nonce, source)| {
+                                                pings
+                                                    .get(&nonce)
+                                                    .map_or(false, |ping| ping.source == source)
+                                            });
 
-                                    let pong_ok =
-                                        pongs_expected.into_iter().all(|(nonce, source)| {
-                                            pongs
-                                                .get(&nonce)
-                                                .map_or(false, |pong| pong.source == source)
-                                        });
+                                        let pong_ok =
+                                            pongs_expected.into_iter().all(|(nonce, source)| {
+                                                pongs
+                                                    .get(&nonce)
+                                                    .map_or(false, |pong| pong.source == source)
+                                            });
 
-                                    if ping_ok && pong_ok {
-                                        flag.store(true, Ordering::Relaxed);
+                                        if ping_ok && pong_ok {
+                                            flag.store(true, Ordering::Relaxed);
+                                        }
                                     }
-                                }
 
-                                future::ok(())
-                            }),
-                    );
-                }));
+                                    future::ok(())
+                                }),
+                        );
+                    },
+                ));
             }
         }
     }
@@ -287,11 +326,32 @@ struct Runner {
     num_validators: usize,
     peer_max_count: u32,
     state_machine: Option<StateMachine>,
+    /// If v is in the list from u, it means v is blacklisted from u point of view.
+    /// blacklist[u].contains(v) <=> v is blacklisted from u.
+    blacklist: HashMap<usize, HashSet<Option<usize>>>,
+    boot_nodes: Vec<usize>,
 }
 
 impl Runner {
     fn new(num_nodes: usize, num_validators: usize, peer_max_count: u32) -> Self {
-        Self { num_nodes, num_validators, peer_max_count, state_machine: Some(StateMachine::new()) }
+        Self {
+            num_nodes,
+            num_validators,
+            peer_max_count,
+            state_machine: Some(StateMachine::new()),
+            blacklist: HashMap::new(),
+            boot_nodes: vec![],
+        }
+    }
+
+    fn add_to_blacklist(mut self, u: usize, v: Option<usize>) -> Self {
+        self.blacklist.entry(u).or_insert_with(HashSet::new).insert(v);
+        self
+    }
+
+    fn use_boot_nodes(mut self, boot_nodes: Vec<usize>) -> Self {
+        self.boot_nodes = boot_nodes;
+        self
     }
 
     fn push(&mut self, action: Action) {
@@ -310,20 +370,38 @@ impl Runner {
         let mut peers_info =
             convert_boot_nodes(accounts_id.iter().map(|x| x.as_str()).zip(ports.clone()).collect());
 
-        // Save validators accounts on
         for (validator, peer_info) in validators.iter().zip(peers_info.iter_mut()) {
             peer_info.account_id = Some(validator.clone());
         }
 
+        let boot_nodes: Vec<_> =
+            self.boot_nodes.iter().map(|ix| (accounts_id[*ix].clone(), ports[*ix])).collect();
+
         let pm_addr: Vec<_> = (0..self.num_nodes)
             .map(|ix| {
+                let blacklist: Vec<PatternAddr> = self
+                    .blacklist
+                    .get(&ix)
+                    .cloned()
+                    .unwrap_or_else(HashSet::new)
+                    .iter()
+                    .map(|x| {
+                        if let Some(x) = x {
+                            format!("127.0.0.1:{}", ports[*x]).parse().unwrap()
+                        } else {
+                            "127.0.0.1".parse().unwrap()
+                        }
+                    })
+                    .collect();
+
                 setup_network_node(
                     accounts_id[ix].clone(),
                     ports[ix].clone(),
-                    vec![],
+                    boot_nodes.clone(),
                     validators.clone(),
                     genesis_time,
                     self.peer_max_count,
+                    blacklist,
                 )
             })
             .collect();
@@ -341,7 +419,7 @@ impl Runner {
         // TODO(MarX, #1312): Switch WaitOrTimeout for other mechanism that triggers events on given timeouts
         //  instead of using fixed `check_interval_ms`.
         WaitOrTimeout::new(
-            Box::new(move |_| {
+            Box::new(move |ctx| {
                 if flag.load(Ordering::Relaxed) {
                     pointer = Some(pointer.map_or(0, |x| x + 1));
                     flag = Arc::new(AtomicBool::new(false));
@@ -351,7 +429,7 @@ impl Runner {
                     System::current().stop();
                 } else {
                     let action = state_machine.actions.get_mut(pointer.unwrap()).unwrap();
-                    action(info.clone(), flag.clone());
+                    action(info.clone(), flag.clone(), ctx);
                 }
             }),
             50,
@@ -369,6 +447,21 @@ fn simple() {
         let mut runner = Runner::new(2, 1, 0);
 
         runner.push(Action::AddEdge(0, 1));
+        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
+        runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
+
+        runner.run();
+    })
+    .unwrap();
+}
+
+#[test]
+fn from_boot_nodes() {
+    init_test_logger();
+
+    System::run(|| {
+        let mut runner = Runner::new(2, 1, 1).use_boot_nodes(vec![0]);
+
         runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
         runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
@@ -566,6 +659,54 @@ fn churn_attack() {
         runner.push(Action::Stop(3));
         runner.push(Action::CheckRoutingTable(0, vec![(2, vec![2])]));
         runner.push(Action::CheckRoutingTable(2, vec![(0, vec![0])]));
+
+        runner.run();
+    })
+    .unwrap();
+}
+
+#[test]
+fn blacklist_01() {
+    init_test_logger();
+
+    System::run(|| {
+        let mut runner = Runner::new(2, 2, 1).add_to_blacklist(0, Some(1)).use_boot_nodes(vec![0]);
+
+        runner.push(Action::Wait(100));
+        runner.push(Action::CheckRoutingTable(1, vec![]));
+        runner.push(Action::CheckRoutingTable(0, vec![]));
+
+        runner.run();
+    })
+    .unwrap();
+}
+
+#[test]
+fn blacklist_10() {
+    init_test_logger();
+
+    System::run(|| {
+        let mut runner = Runner::new(2, 2, 1).add_to_blacklist(1, Some(0)).use_boot_nodes(vec![0]);
+
+        runner.push(Action::Wait(100));
+        runner.push(Action::CheckRoutingTable(1, vec![]));
+        runner.push(Action::CheckRoutingTable(0, vec![]));
+
+        runner.run();
+    })
+    .unwrap();
+}
+
+#[test]
+fn blacklist_all() {
+    init_test_logger();
+
+    System::run(|| {
+        let mut runner = Runner::new(2, 2, 1).add_to_blacklist(0, None).use_boot_nodes(vec![0]);
+
+        runner.push(Action::Wait(100));
+        runner.push(Action::CheckRoutingTable(1, vec![]));
+        runner.push(Action::CheckRoutingTable(0, vec![]));
 
         runner.run();
     })

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -328,6 +328,8 @@ struct Runner {
     state_machine: Option<StateMachine>,
     /// If v is in the list from u, it means v is blacklisted from u point of view.
     /// blacklist[u].contains(v) <=> v is blacklisted from u.
+    /// If None is in the list of node u, it means that all other nodes are blacklisted.
+    /// It add 127.0.0.1 to the blacklist of node u.
     blacklist: HashMap<usize, HashSet<Option<usize>>>,
     boot_nodes: Vec<usize>,
 }

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -19,6 +19,7 @@ use near_crypto::{InMemorySigner, KeyFile, KeyType, PublicKey, Signer};
 use near_jsonrpc::RpcConfig;
 use near_network::test_utils::open_port;
 use near_network::types::PROTOCOL_VERSION;
+use near_network::utils::blacklist_from_vec;
 use near_network::NetworkConfig;
 use near_primitives::account::AccessKey;
 use near_primitives::hash::{hash, CryptoHash};
@@ -373,12 +374,7 @@ impl NearConfig {
                 max_routes_to_store: MAX_ROUTES_TO_STORE,
                 most_weighted_peer_horizon: MOST_WEIGHTED_PEER_HORIZON,
                 push_info_period: Duration::from_millis(100),
-                blacklist: config
-                    .network
-                    .blacklist
-                    .iter()
-                    .filter_map(|x| x.parse().map(|p| Some(p)).unwrap_or(None))
-                    .collect(),
+                blacklist: blacklist_from_vec(&config.network.blacklist),
             },
             telemetry_config: config.telemetry,
             rpc_config: config.rpc,

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -156,6 +156,9 @@ pub struct Network {
     pub skip_sync_wait: bool,
     /// Ban window for peers who misbehave.
     pub ban_window: Duration,
+    /// List of addresses that will not be accepted as valid neighbors.
+    /// It can be IP:Port or IP (to blacklist all connections coming from this address).
+    pub blacklist: Vec<String>,
 }
 
 impl Default for Network {
@@ -169,6 +172,7 @@ impl Default for Network {
             reconnect_delay: Duration::from_secs(60),
             skip_sync_wait: false,
             ban_window: Duration::from_secs(3 * 60 * 60),
+            blacklist: vec![],
         }
     }
 }
@@ -238,7 +242,6 @@ pub struct Config {
     pub consensus: Consensus,
     pub tracked_accounts: Vec<AccountId>,
     pub tracked_shards: Vec<ShardId>,
-    pub blacklist: Vec<String>,
 }
 
 impl Default for Config {
@@ -253,7 +256,6 @@ impl Default for Config {
             consensus: Consensus::default(),
             tracked_accounts: vec![],
             tracked_shards: vec![],
-            blacklist: vec![],
         }
     }
 }
@@ -371,6 +373,7 @@ impl NearConfig {
                 most_weighted_peer_horizon: MOST_WEIGHTED_PEER_HORIZON,
                 push_info_period: Duration::from_millis(100),
                 blacklist: config
+                    .network
                     .blacklist
                     .iter()
                     .filter_map(|x| x.parse().map(|p| Some(p)).unwrap_or(None))

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -158,6 +158,7 @@ pub struct Network {
     pub ban_window: Duration,
     /// List of addresses that will not be accepted as valid neighbors.
     /// It can be IP:Port or IP (to blacklist all connections coming from this address).
+    #[serde(default)]
     pub blacklist: Vec<String>,
 }
 

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -238,6 +238,7 @@ pub struct Config {
     pub consensus: Consensus,
     pub tracked_accounts: Vec<AccountId>,
     pub tracked_shards: Vec<ShardId>,
+    pub blacklist: Vec<String>,
 }
 
 impl Default for Config {
@@ -252,6 +253,7 @@ impl Default for Config {
             consensus: Consensus::default(),
             tracked_accounts: vec![],
             tracked_shards: vec![],
+            blacklist: vec![],
         }
     }
 }
@@ -368,6 +370,11 @@ impl NearConfig {
                 max_routes_to_store: MAX_ROUTES_TO_STORE,
                 most_weighted_peer_horizon: MOST_WEIGHTED_PEER_HORIZON,
                 push_info_period: Duration::from_millis(100),
+                blacklist: config
+                    .blacklist
+                    .iter()
+                    .filter_map(|x| x.parse().map(|p| Some(p)).unwrap_or(None))
+                    .collect(),
             },
             telemetry_config: config.telemetry,
             rpc_config: config.rpc,

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -14,9 +14,7 @@ pytest sanity/state_sync.py onetx 30
 pytest --timeout=600 sanity/state_sync.py onetx 250
 pytest --timeout=240 sanity/state_sync1.py
 pytest --timeout=310 sanity/state_sync2.py
-pytest --timeout=600 sanity/state_sync_routed.py notx 50
-pytest --timeout=600 sanity/state_sync_routed.py onetx 50
-pytest --timeout=600 sanity/state_sync_routed.py manytx 50
+pytest --timeout=600 sanity/state_sync_routed.py manytx 100
 pytest sanity/rpc_tx_forwarding.py
 pytest --timeout=240 sanity/skip_epoch.py
 pytest --timeout=600 sanity/fork_sync.py

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -14,6 +14,9 @@ pytest sanity/state_sync.py onetx 30
 pytest --timeout=600 sanity/state_sync.py onetx 250
 pytest --timeout=240 sanity/state_sync1.py
 pytest --timeout=310 sanity/state_sync2.py
+pytest --timeout=600 sanity/state_sync_routed.py notx 50
+pytest --timeout=600 sanity/state_sync_routed.py onetx 50
+pytest --timeout=600 sanity/state_sync_routed.py manytx 50
 pytest sanity/rpc_tx_forwarding.py
 pytest --timeout=240 sanity/skip_epoch.py
 pytest --timeout=600 sanity/fork_sync.py

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -100,6 +100,21 @@ class BaseNode(object):
         r.raise_for_status()
         return json.loads(r.content)
 
+    def get_all_heights(self):
+        status = self.get_status()
+        hash_ = status['sync_info']['latest_block_hash']
+        heights = []
+
+        while True:
+            block = self.get_block(hash_)
+            height = block['result']['header']['height']
+            if height == 0:
+                break
+            heights.append(height)
+            hash_ = block['result']['header']['prev_hash']
+
+        return list(reversed(heights))
+
     def get_account(self, acc):
         print(f'get account {acc}')
         # if acc == 'test2':

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -125,7 +125,7 @@ class BaseNode(object):
         return self.json_rpc('block', [block_hash])
 
 class LocalNode(BaseNode):
-    def __init__(self, port, rpc_port, near_root, node_dir):
+    def __init__(self, port, rpc_port, near_root, node_dir, blacklist):
         super(LocalNode, self).__init__()
         self.port = port
         self.rpc_port = rpc_port
@@ -138,6 +138,7 @@ class LocalNode(BaseNode):
         # just a sanity assert that the setting name didn't change
         assert 0 <= config_json['consensus']['min_num_peers'] <= 3, config_json['consensus']['min_num_peers']
         config_json['network']['addr'] = '0.0.0.0:%s' % port
+        config_json['network']['blacklist'] = blacklist
         config_json['rpc']['addr'] = '0.0.0.0:%s' % rpc_port
         config_json['consensus']['min_num_peers'] = 1
         with open(os.path.join(node_dir, "config.json"), 'w') as f:
@@ -292,15 +293,19 @@ chmod +x near
         rc.run(f'gcloud compute firewall-rules delete {self.machine.name}-stop', input='yes\n')
 
 
-def spin_up_node(config, near_root, node_dir, ordinal, boot_key, boot_addr):
+def spin_up_node(config, near_root, node_dir, ordinal, boot_key, boot_addr, blacklist=[]):
     is_local = config['local']
 
     print("Starting node %s %s" % (ordinal, ("as BOOT NODE" if boot_addr is None else (
         "with boot=%s@%s:%s" % (boot_key, boot_addr[0], boot_addr[1])))))
     if is_local:
+        blacklist = ["127.0.0.1:%s" % (24567 + 10 + bl_ordinal) for bl_ordinal in blacklist]
         node = LocalNode(24567 + 10 + ordinal, 3030 +
-                         10 + ordinal, near_root, node_dir)
+                         10 + ordinal, near_root, node_dir, blacklist)
     else:
+        # TODO: Figure out how to know IP address beforehand for remote deployment.
+        assert len(blacklist) == 0, "Blacklist is only supporte with LOCAL deployment."
+
         instance_name = '{}-{}-{}'.format(config['remote'].get('instance_name', 'near-pytest'), ordinal, uuid.uuid4())
         zones = config['remote']['zones']
         zone = zones[ordinal % len(zones)]

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -304,7 +304,7 @@ def spin_up_node(config, near_root, node_dir, ordinal, boot_key, boot_addr, blac
                          10 + ordinal, near_root, node_dir, blacklist)
     else:
         # TODO: Figure out how to know IP address beforehand for remote deployment.
-        assert len(blacklist) == 0, "Blacklist is only supporte with LOCAL deployment."
+        assert len(blacklist) == 0, "Blacklist is only supported in LOCAL deployment."
 
         instance_name = '{}-{}-{}'.format(config['remote'].get('instance_name', 'near-pytest'), ordinal, uuid.uuid4())
         zones = config['remote']['zones']

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -15,6 +15,7 @@ sys.path.append('lib')
 
 if len(sys.argv) < 3:
     print("python state_sync.py [notx, onetx, manytx] <launch_at_block>")
+    exit(1)
 
 mode = sys.argv[1]
 assert mode in ['notx', 'onetx', 'manytx']
@@ -39,7 +40,6 @@ last_balances = [x for x in ctx.expected_balances]
 
 sent_txs = False
 
-seen_boot_heights = set()
 observed_height = 0
 while observed_height < START_AT_BLOCK:
     assert time.time() - started < TIMEOUT
@@ -48,7 +48,6 @@ while observed_height < START_AT_BLOCK:
     hash_ = status['sync_info']['latest_block_hash']
     if new_height > observed_height:
         observed_height = new_height
-        seen_boot_heights.add(new_height)
         print("Boot node got to height %s" % new_height);
 
     if mode == 'onetx' and not sent_txs:
@@ -79,7 +78,6 @@ while catch_up_height < observed_height:
 
     status = boot_node.get_status()
     boot_height = status['sync_info']['latest_block_height']
-    seen_boot_heights.add(boot_height)
 
     if mode == 'manytx':
         if ctx.get_balances() == ctx.expected_balances:
@@ -87,7 +85,9 @@ while catch_up_height < observed_height:
             print("Sending moar txs at height %s" % boot_height)
     time.sleep(0.1)
 
-assert catch_up_height in seen_boot_heights, "%s not in %s" % (catch_up_height, seen_boot_heights)
+boot_heights = boot_node.get_all_heights()
+
+assert catch_up_height in boot_heights, "%s not in %s" % (catch_up_height, boot_heights)
 
 if catch_up_height >= 100:
     assert tracker.check("transition to State Sync")

--- a/pytest/tests/sanity/state_sync_routed.py
+++ b/pytest/tests/sanity/state_sync_routed.py
@@ -31,7 +31,7 @@ TIMEOUT = 150 + START_AT_BLOCK * 10
 
 config = load_config()
 
-near_root, node_dirs = init_cluster(2, 3, 1, config, [["min_gas_price", 0], ["max_inflation_rate", 0], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {u: {"tracked_shards": [0]} for u in range(2, 5)})
+near_root, node_dirs = init_cluster(2, 3, 1, config, [["min_gas_price", 0], ["max_inflation_rate", 0], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {4: {"tracked_shards": [0]}})
 
 started = time.time()
 
@@ -75,7 +75,7 @@ if mode == 'onetx':
     assert ctx.get_balances() == ctx.expected_balances
 
 node4 = spin_up_node(config, near_root, node_dirs[4], 4, boot_node.node_key.pk, boot_node.addr(), [0, 1])
-tracker = LogTracker(node4)
+tracker4 = LogTracker(node4)
 time.sleep(3)
 
 catch_up_height = 0
@@ -102,9 +102,12 @@ boot_heights = boot_node.get_all_heights()
 assert catch_up_height in boot_heights, "%s not in %s" % (catch_up_height, boot_heights)
 
 if catch_up_height >= 100:
-    assert tracker.check("transition to State Sync")
+    assert tracker4.check("transition to State Sync")
 elif catch_up_height <= 30:
-    assert not tracker.check("transition to State Sync")
+    assert not tracker4.check("transition to State Sync")
+
+tracker4.reset()
+assert tracker4.count("Connected to FullPeerInfo") == 2
 
 if mode == 'manytx':
     while ctx.get_balances() != ctx.expected_balances:

--- a/pytest/tests/sanity/state_sync_routed.py
+++ b/pytest/tests/sanity/state_sync_routed.py
@@ -1,6 +1,9 @@
-# Spins up a node, then waits for couple epochs
-# and spins up another node
-# Makes sure that eventually the second node catches up
+# Spins two block producers and two observers.
+# Wait several epochs and spin up another observer that
+# is blacklisted by both block producers.
+#
+# Make sure the new observer sync via routing through other observers.
+#
 # Three modes:
 #   - notx: no transactions are sent, just checks that
 #     the second node starts and catches up
@@ -27,14 +30,24 @@ START_AT_BLOCK = int(sys.argv[2])
 TIMEOUT = 150 + START_AT_BLOCK * 10
 
 config = load_config()
-near_root, node_dirs = init_cluster(2, 1, 1, config, [["min_gas_price", 0], ["max_inflation_rate", 0], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {2: {"tracked_shards": [0]}})
+
+near_root, node_dirs = init_cluster(2, 3, 1, config, [["min_gas_price", 0], ["max_inflation_rate", 0], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {u: {"tracked_shards": [0]} for u in range(2, 5)})
 
 started = time.time()
 
-boot_node = spin_up_node(config, near_root, node_dirs[0], 0, None, None)
-node1 = spin_up_node(config, near_root, node_dirs[1], 1, boot_node.node_key.pk, boot_node.addr())
+# First observer
+node2 = spin_up_node(config, near_root, node_dirs[2], 2, None, None)
+# Boot from observer since block producer will blacklist third observer
+boot_node = node2
 
-ctx = TxContext([0, 0], [boot_node, node1])
+# Second observer
+node3 = spin_up_node(config, near_root, node_dirs[3], 3, boot_node.node_key.pk, boot_node.addr())
+
+# Spin up validators
+node0 = spin_up_node(config, near_root, node_dirs[0], 0, boot_node.node_key.pk, boot_node.addr(), [4])
+node1 = spin_up_node(config, near_root, node_dirs[1], 1, boot_node.node_key.pk, boot_node.addr(), [4])
+
+ctx = TxContext([0, 0], [node0, node1])
 
 sent_txs = False
 
@@ -61,18 +74,19 @@ while observed_height < START_AT_BLOCK:
 if mode == 'onetx':
     assert ctx.get_balances() == ctx.expected_balances
 
-node2 = spin_up_node(config, near_root, node_dirs[2], 2, boot_node.node_key.pk, boot_node.addr())
-tracker = LogTracker(node2)
+node4 = spin_up_node(config, near_root, node_dirs[4], 4, boot_node.node_key.pk, boot_node.addr(), [0, 1])
+tracker = LogTracker(node4)
 time.sleep(3)
 
 catch_up_height = 0
 while catch_up_height < observed_height:
     assert time.time() - started < TIMEOUT
-    status = node2.get_status()
+    status = node4.get_status()
     new_height = status['sync_info']['latest_block_height']
+    print("Latest block at:", new_height)
     if new_height > catch_up_height:
         catch_up_height = new_height
-        print("Second node got to height %s" % new_height);
+        print("Last observer got to height %s" % new_height);
 
     status = boot_node.get_status()
     boot_height = status['sync_info']['latest_block_height']
@@ -99,7 +113,7 @@ if mode == 'manytx':
         time.sleep(1)
 
     # requery the balances from the newly started node
-    ctx.nodes.append(node2)
+    ctx.nodes.append(node4)
     ctx.act_to_val = [2, 2, 2]
 
     while ctx.get_balances() != ctx.expected_balances:


### PR DESCRIPTION
Introduce blacklist, allowing nodes to forbid connection to other IP:Port addresses.
Add test that check that a node is able to sync, even if it is not directly connected to block producers.