### PR TITLE
Allow rpc to query final result

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -503,6 +503,8 @@ pub struct Tip {
     pub last_block_hash: CryptoHash,
     /// Previous block
     pub prev_block_hash: CryptoHash,
+    /// Last final block hash
+    pub last_final_block_hash: CryptoHash,
     /// Total weight on that fork
     pub weight_and_score: WeightAndScore,
     /// The timestamp of the head block
@@ -518,6 +520,7 @@ impl Tip {
             height: header.inner_lite.height,
             last_block_hash: header.hash(),
             prev_block_hash: header.prev_hash,
+            last_final_block_hash: header.inner_rest.last_quorum_pre_commit,
             weight_and_score: header.inner_rest.weight_and_score(),
             prev_timestamp,
             epoch_id: header.inner_lite.epoch_id.clone(),

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -284,11 +284,13 @@ pub struct Query {
     pub path: String,
     pub data: Vec<u8>,
     pub id: String,
+    /// Whether to only query results that are final
+    pub is_final: bool,
 }
 
 impl Query {
-    pub fn new(path: String, data: Vec<u8>) -> Self {
-        Query { path, data, id: generate_random_string(10) }
+    pub fn new(path: String, data: Vec<u8>, is_final: bool) -> Self {
+        Query { path, data, id: generate_random_string(10), is_final }
     }
 }
 

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -290,6 +290,7 @@ mod tests {
                                                 .send(Query::new(
                                                     "account/".to_string() + &account_to,
                                                     vec![],
+                                                    false,
                                                 ))
                                                 .then(move |res| {
                                                     let res_inner = res.unwrap();
@@ -481,6 +482,7 @@ mod tests {
                                                     .send(Query::new(
                                                         "account/".to_string() + flat_validators[j],
                                                         vec![],
+                                                        false,
                                                     ))
                                                     .then(move |res| {
                                                         let res_inner = res.unwrap();

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -49,7 +49,7 @@ fn test_keyvalue_runtime_balances() {
             actix::spawn(
                 connectors_[i]
                     .1
-                    .send(Query::new("account/".to_string() + flat_validators[i], vec![]))
+                    .send(Query::new("account/".to_string() + flat_validators[i], vec![], false))
                     .then(move |res| {
                         let query_response = res.unwrap().unwrap().unwrap();
                         if let ViewAccount(view_account_result) = query_response.kind {
@@ -187,7 +187,7 @@ mod tests {
                     connectors_[account_id_to_shard_id(&account_id, 8) as usize
                         + (*presumable_epoch.read().unwrap() * 8) % 24]
                         .1
-                        .send(Query::new("account/".to_owned() + &account_id, vec![]))
+                        .send(Query::new("account/".to_owned() + &account_id, vec![], false))
                         .then(move |x| {
                             test_cross_shard_tx_callback(
                                 x,
@@ -278,6 +278,7 @@ mod tests {
                                 .send(Query::new(
                                     "account/".to_string() + validators[i].clone(),
                                     vec![],
+                                    false,
                                 ))
                                 .then(move |x| {
                                     test_cross_shard_tx_callback(
@@ -324,7 +325,7 @@ mod tests {
                     connectors_[account_id_to_shard_id(&account_id, 8) as usize
                         + (*presumable_epoch.read().unwrap() * 8) % 24]
                         .1
-                        .send(Query::new("account/".to_string() + &account_id, vec![]))
+                        .send(Query::new("account/".to_string() + &account_id, vec![], false))
                         .then(move |x| {
                             test_cross_shard_tx_callback(
                                 x,
@@ -431,6 +432,7 @@ mod tests {
                         .send(Query::new(
                             "account/".to_string() + flat_validators[i].clone(),
                             vec![],
+                            false,
                         ))
                         .then(move |x| {
                             test_cross_shard_tx_callback(

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -13,7 +13,7 @@ fn query_client() {
     init_test_logger();
     System::run(|| {
         let (_, view_client) = setup_no_network(vec!["test"], "other", true);
-        actix::spawn(view_client.send(Query::new("account/test".to_string(), vec![])).then(
+        actix::spawn(view_client.send(Query::new("account/test".to_string(), vec![], false)).then(
             |res| {
                 match res.unwrap().unwrap().unwrap().kind {
                     QueryResponseKind::ViewAccount(_) => (),

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -184,7 +184,7 @@ macro_rules! jsonrpc_client {
 jsonrpc_client!(pub struct JsonRpcClient {
     pub fn broadcast_tx_async(&mut self, tx: String) -> RpcRequest<String>;
     pub fn broadcast_tx_commit(&mut self, tx: String) -> RpcRequest<FinalExecutionOutcomeView>;
-    pub fn query(&mut self, path: String, data: String) -> RpcRequest<QueryResponse>;
+    pub fn query(&mut self, path: String, data: String, is_final: bool) -> RpcRequest<QueryResponse>;
     pub fn status(&mut self) -> RpcRequest<StatusResponse>;
     pub fn health(&mut self) -> RpcRequest<()>;
     pub fn tx(&mut self, hash: String, account_id: String) -> RpcRequest<FinalExecutionOutcomeView>;

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -248,7 +248,7 @@ impl JsonRpcHandler {
     }
 
     async fn query(&self, params: Option<Value>) -> Result<Value, RpcError> {
-        let (path, data) = parse_params::<(String, String)>(params)?;
+        let (path, data, is_final) = parse_params::<(String, String, bool)>(params)?;
         let data = from_base_or_parse_err(data)?;
         let query_data_size = path.len() + data.len();
         if query_data_size > QUERY_DATA_MAX_SIZE {
@@ -257,7 +257,7 @@ impl JsonRpcHandler {
                 query_data_size
             ))));
         }
-        let query = Query::new(path, data);
+        let query = Query::new(path, data, is_final);
         timeout(self.polling_config.polling_timeout, async {
             loop {
                 let result = self.view_client_addr.send(query.clone()).compat().await;

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -125,7 +125,7 @@ fn test_query_account() {
         let (_view_client_addr, addr) = start_all(false);
 
         let mut client = new_client(&format!("http://{}", addr));
-        actix::spawn(client.query("account/test".to_string(), "".to_string()).then(
+        actix::spawn(client.query("account/test".to_string(), "".to_string(), false).then(
             |query_response| {
                 let query_response = query_response.unwrap();
                 assert_eq!(query_response.block_height, 0);
@@ -160,7 +160,7 @@ fn test_query_access_keys() {
         let (_view_client_addr, addr) = start_all(false);
 
         let mut client = new_client(&format!("http://{}", addr));
-        actix::spawn(client.query("access_key/test".to_string(), "".to_string()).then(
+        actix::spawn(client.query("access_key/test".to_string(), "".to_string(), false).then(
             |query_response| {
                 let query_response = query_response.unwrap();
                 assert_eq!(query_response.block_height, 0);
@@ -193,7 +193,7 @@ fn test_query_access_key() {
         let (_view_client_addr, addr) = start_all(false);
 
         let mut client = new_client(&format!("http://{}", addr));
-        actix::spawn(client.query("access_key/test/xxx".to_string(), "".to_string()).then(
+        actix::spawn(client.query("access_key/test/xxx".to_string(), "".to_string(), false).then(
             |query_response| {
                 let query_response = query_response.unwrap();
                 assert_eq!(query_response.block_height, 0);

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -277,8 +277,8 @@ impl Peer {
             PeerMessage::Routed(message) => {
                 msg_hash = message.hash();
                 match message.body {
-                    RoutedMessageBody::QueryRequest { path, data, id } => {
-                        NetworkViewClientMessages::Query { path, data, id }
+                    RoutedMessageBody::QueryRequest { path, data, id, is_final } => {
+                        NetworkViewClientMessages::Query { path, data, id, is_final }
                     }
                     RoutedMessageBody::QueryResponse { response, id } => {
                         NetworkViewClientMessages::QueryResponse { response, id }

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -831,11 +831,11 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                 );
                 NetworkResponses::NoResponse
             }
-            NetworkRequests::Query { account_id, path, data, id } => {
+            NetworkRequests::Query { account_id, path, data, id, is_final } => {
                 self.send_message_to_account(
                     ctx,
                     &account_id,
-                    RoutedMessageBody::QueryRequest { path, data, id },
+                    RoutedMessageBody::QueryRequest { path, data, id, is_final },
                 );
                 NetworkResponses::NoResponse
             }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -303,6 +303,7 @@ pub enum RoutedMessageBody {
         path: String,
         data: Vec<u8>,
         id: String,
+        is_final: bool,
     },
     QueryResponse {
         response: Result<QueryResponse, String>,
@@ -1020,6 +1021,7 @@ pub enum NetworkRequests {
         path: String,
         data: Vec<u8>,
         id: String,
+        is_final: bool,
     },
     /// Request for receipt execution outcome
     ReceiptOutComeRequest(AccountId, CryptoHash),
@@ -1209,7 +1211,7 @@ pub enum NetworkViewClientMessages {
     /// Transaction status response
     TxStatusResponse(FinalExecutionOutcomeView),
     /// General query
-    Query { path: String, data: Vec<u8>, id: String },
+    Query { path: String, data: Vec<u8>, id: String, is_final: bool },
     /// Query response
     QueryResponse { response: Result<QueryResponse, String>, id: String },
     /// Request for receipt outcome

--- a/near/src/runtime.rs
+++ b/near/src/runtime.rs
@@ -1312,6 +1312,7 @@ mod test {
                     epoch_id: EpochId::default(),
                     prev_timestamp: 0,
                     weight_and_score: WeightAndScore::from_ints(0, 0),
+                    last_final_block_hash: Default::default(),
                 },
                 state_roots,
                 last_receipts: HashMap::default(),
@@ -1383,6 +1384,7 @@ mod test {
                     self.head.weight_and_score.weight.to_num() + 1,
                     self.head.weight_and_score.score.to_num(),
                 ),
+                last_final_block_hash: Default::default(),
             };
         }
 

--- a/near/tests/rpc_nodes.rs
+++ b/near/tests/rpc_nodes.rs
@@ -8,6 +8,7 @@ use near_client::{GetBlock, TxStatus};
 use near_crypto::{InMemorySigner, KeyType};
 use near_jsonrpc::client::new_client;
 use near_network::test_utils::WaitOrTimeout;
+use near_primitives::hash::CryptoHash;
 use near_primitives::serialize::{to_base, to_base64};
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
@@ -302,11 +303,12 @@ fn test_rpc_routing() {
             Box::new(move |_ctx| {
                 let rpc_addrs_copy = rpc_addrs.clone();
                 actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    if res.unwrap().unwrap().header.height > 1 {
+                    if res.unwrap().unwrap().header.last_quorum_pre_commit != CryptoHash::default()
+                    {
                         let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
                         actix::spawn(
                             client
-                                .query("account/near.2".to_string(), "".to_string())
+                                .query("account/near.2".to_string(), "".to_string(), true)
                                 .map_err(|err| {
                                     println!("Error retrieving account: {:?}", err);
                                 })
@@ -348,11 +350,12 @@ fn test_rpc_routing_error() {
             Box::new(move |_ctx| {
                 let rpc_addrs_copy = rpc_addrs.clone();
                 actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    if res.unwrap().unwrap().header.height > 1 {
+                    if res.unwrap().unwrap().header.last_quorum_pre_commit != CryptoHash::default()
+                    {
                         let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
                         actix::spawn(
                             client
-                                .query("account/nonexistent".to_string(), "".to_string())
+                                .query("account/nonexistent".to_string(), "".to_string(), true)
                                 .map_err(|err| {
                                     println!("error: {}", err.to_string());
                                     System::current().stop();

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -226,6 +226,7 @@ fn test_validator_kickout() {
                                                 test_nodes[i as usize].account_id.clone()
                                             ),
                                             vec![],
+                                            false,
                                         ))
                                         .then(move |res| {
                                             match res.unwrap().unwrap().unwrap().kind {
@@ -254,6 +255,7 @@ fn test_validator_kickout() {
                                                 test_nodes[i as usize].account_id.clone()
                                             ),
                                             vec![],
+                                            false,
                                         ))
                                         .then(move |res| {
                                             match res.unwrap().unwrap().unwrap().kind {
@@ -371,6 +373,7 @@ fn test_validator_join() {
                                     .send(Query::new(
                                         format!("account/{}", test_nodes[1].account_id.clone()),
                                         vec![],
+                                        false,
                                     ))
                                     .then(move |res| match res.unwrap().unwrap().unwrap().kind {
                                         QueryResponseKind::ViewAccount(result) => {
@@ -388,6 +391,7 @@ fn test_validator_join() {
                                     .send(Query::new(
                                         format!("account/{}", test_nodes[2].account_id.clone()),
                                         vec![],
+                                        false,
                                     ))
                                     .then(move |res| match res.unwrap().unwrap().unwrap().kind {
                                         QueryResponseKind::ViewAccount(result) => {

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -100,11 +100,9 @@ class BaseNode(object):
         r.raise_for_status()
         return json.loads(r.content)
 
-    def get_account(self, acc):
+    def get_account(self, acc, final=True):
         print(f'get account {acc}')
-        # if acc == 'test2':
-        #     input('pause')
-        return self.json_rpc('query', ["account/%s" % acc, ""])
+        return self.json_rpc('query', ["account/%s" % acc, "", final])
 
     def get_block(self, block_hash):
         return self.json_rpc('block', [block_hash])
@@ -171,11 +169,11 @@ class LocalNode(BaseNode):
         if os.path.exists(target_path) and os.path.isdir(target_path):
             shutil.rmtree(target_path)
         os.rename(self.node_dir, target_path)
-    
+
     def stop_network(self):
         print("Stopping network for process %s" % self.pid.value)
         network.stop(self.pid.value)
-    
+
     def resume_network(self):
         print("Resuming network for process %s" % self.pid.value)
         network.resume_network(self.pid.value)
@@ -261,10 +259,10 @@ chmod +x near
         rc.run(f'mkdir -p /tmp/pytest_remote_log')
         self.machine.download('/tmp/python-rc.log', f'/tmp/pytest_remote_log/{self.machine.name}.log')
         self.destroy_machine()
-    
+
     def json_rpc(self, method, params, timeout=10):
         return super().json_rpc(method, params, timeout=timeout)
-    
+
     def get_status(self):
         r = requests.get("http://%s:%s/status" % self.rpc_addr(), timeout=10)
         r.raise_for_status()
@@ -272,7 +270,7 @@ chmod +x near
 
     def stop_network(self):
         rc.run(f'gcloud compute firewall-rules create {self.machine.name}-stop --direction=EGRESS --priority=1000 --network=default --action=DENY --rules=all --target-tags={self.machine.name}')
-    
+
     def resume_network(self):
         rc.run(f'gcloud compute firewall-rules delete {self.machine.name}-stop', input='yes\n')
 

--- a/pytest/tests/sanity/rpc_query.py
+++ b/pytest/tests/sanity/rpc_query.py
@@ -29,8 +29,9 @@ for i in range(4):
             if 'error' in result:
                 assert False, result
 
-time.sleep(2)
+# sleep some time to wait for blocks to be finalized
+time.sleep(10)
 for i in range(4):
     query_result1 = nodes[-2].get_account("test%s" % i)
     query_result2 = nodes[-1].get_account("test%s" % i)
-    assert query_result1 == query_result2, "query same account gives different result"
+    assert query_result1 == query_result2, "query same account gives different result: %s, %s" % (query_result1, query_result2)

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -39,7 +39,7 @@ impl RpcUser {
 
     pub fn query(&self, path: String, data: &[u8]) -> Result<QueryResponse, String> {
         System::new("actix")
-            .block_on(self.client.write().unwrap().query(path, to_base(data)))
+            .block_on(self.client.write().unwrap().query(path, to_base(data), true))
             .map_err(|err| err.to_string())
     }
 }


### PR DESCRIPTION
For query rpc allow specifying whether to query from finalized blocks only. Need to change nearlib correspondingly.