### PR TITLE
Run test as non root in docker and check binary exist before mount to docker

### DIFF
--- a/scripts/parallel_coverage.py
+++ b/scripts/parallel_coverage.py
@@ -21,6 +21,9 @@ def coverage(test_binary):
     subprocess.check_output(f'mkdir -p {coverage_output}', shell=True)
     coverage_output = os.path.abspath(coverage_output)
 
+    if not os.path.isfile(test_binary):
+        return -1, '', f'{test_binary} does not exist'
+        
     p = subprocess.Popen(['docker', 'run', '--rm',
     '--security-opt', 'seccomp=unconfined',
     '-u', f'{os.getuid()}:{os.getgid()}',

--- a/scripts/testlib.py
+++ b/scripts/testlib.py
@@ -62,7 +62,9 @@ def run_test(test_binary, isolate=True):
     else:
         cmd = [test_binary]
     print(f'========= run test {test_binary}')
-    p = subprocess.Popen(cmd,
-                         stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
-    stdout, stderr = p.communicate()
-    return (p.returncode, stdout, stderr)
+    if os.path.isfile(test_binary):
+        p = subprocess.Popen(cmd,
+                            stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+        stdout, stderr = p.communicate()
+        return (p.returncode, stdout, stderr)
+    return -1, '', f'{test_binary} does not exist'

--- a/scripts/testlib.py
+++ b/scripts/testlib.py
@@ -55,6 +55,7 @@ def run_test(test_binary, isolate=True):
     """ Run a single test, save exitcode, stdout and stderr """
     if isolate:
         cmd = ['docker', 'run', '--rm',
+               '-u', f'{os.getuid()}:{os.getgid()}',
                '-v', f'{test_binary}:{test_binary}',
                'ailisp/near-test-runtime',
                'bash', '-c', f'chmod +x {test_binary} && RUST_BACKTRACE=1 {test_binary}']


### PR DESCRIPTION
Some fails https://gitlab.com/near-protocol/nearcore/-/jobs/386373532 report generated binary is directory, and when i ssh to host, they're indeed directory and owned by root. This happens because docker bind the binary as volume and use root user inside docker. In some rare case when test binary was cleaned (probably due to a maintenance after some task stuck), but pending tests are still going to run in docker, in this case docker detect the volume (file) doesn't exist, and it will create a directory (and since root user was used, the dir is owned by root, similar to what was happen to nearcore docker image), which cause issue in next build.