### PR TITLE
sync parts timeout fix + colorful info

### DIFF
--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -658,7 +658,7 @@ impl StateSync {
                                       Yellow.bold().paint("part_id"),
                                       text)
                           }
-                          _ => { assert!(false); format!("should never happen") },
+                          _ => unreachable!("timeout cannot happen when all state is downloaded"),
                       },
                 );
             }

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -647,13 +647,13 @@ impl StateSync {
                                                                           shard_sync_download.downloads[0].last_target),
                           ShardSyncStatus::StateDownloadParts => { let mut text = "".to_string();
                               for (i, download) in shard_sync_download.downloads.iter().enumerate() {
-                                  text.push_str(&format!("[ {} | {} | {} | {:?} ] ",
+                                  text.push_str(&format!("[{}: {}, {}, {:?}] ",
                                                          Yellow.bold().paint(i.to_string()),
                                                          download.done,
                                                          download.state_requests_count,
                                                          download.last_target));
                               }
-                              format!("{} [ {} | is_done | requests sent | last target ] {}",
+                              format!("{} [{}: is_done, requests sent, last target] {}",
                                       Purple.bold().paint("PARTS"),
                                       Yellow.bold().paint("part_id"),
                                       text)


### PR DESCRIPTION
The issue of https://github.com/nearprotocol/nearcore/pull/1904 is rewriting value of `download_timeout` in parts. Rewriting `download_timeout` means that timeout happened only with last part which is not desirable behaviour.

This PR fixes the issue + pretty printing SyncState.