### PR TITLE
Correct rust-rocksdb options

### DIFF
--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -257,12 +257,12 @@ fn rocksdb_options() -> Options {
 
 fn rocksdb_block_based_options() -> BlockBasedOptions {
     let mut block_opts = BlockBasedOptions::default();
-    block_opts.set_block_size(1024 * 1024 * 8);
+    block_opts.set_block_size(1024 * 16);
     let cache_size = 1024 * 1024 * 512 / 3;
     block_opts.set_lru_cache(cache_size);
     block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
     block_opts.set_cache_index_and_filter_blocks(true);
-
+    block_opts.set_bloom_filter(10, true);
     block_opts
 }
 


### PR DESCRIPTION
I was misread one of parity kvdb-rocksdb option and steal it here. This fix #1883 , total initial get time decrease from eight minutes to 700ms.
IMPORTANT: as I tested for existing testnet node, must delete ~/.near/data and boot it from other node to get correct rocksdb config effective
