### PR TITLE
Fix u32 overflow during contract preparation

### DIFF
--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -653,7 +653,8 @@ impl<'a> VMLogic<'a> {
     /// * If we exceed usage limit imposed on burnt gas returns `GasLimitExceeded`;
     /// * If we exceed the `prepaid_gas` then returns `GasExceeded`.
     pub fn gas(&mut self, gas_amount: u32) -> Result<()> {
-        self.gas_counter.deduct_gas(Gas::from(gas_amount), Gas::from(gas_amount))
+        let value = Gas::from(gas_amount) * Gas::from(self.config.regular_op_cost);
+        self.gas_counter.deduct_gas(value, value)
     }
 
     // ################

--- a/runtime/near-vm-runner/src/prepare.rs
+++ b/runtime/near-vm-runner/src/prepare.rs
@@ -56,8 +56,7 @@ impl<'a> ContractModule<'a> {
 
     fn inject_gas_metering(self) -> Result<Self, PrepareError> {
         let Self { module, config } = self;
-        let gas_rules = rules::Set::new(config.regular_op_cost, Default::default())
-            .with_grow_cost(config.grow_mem_cost);
+        let gas_rules = rules::Set::new(1, Default::default()).with_grow_cost(config.grow_mem_cost);
         let module = pwasm_utils::inject_gas_counter(module, &gas_rules)
             .map_err(|_| PrepareError::GasInstrumentation)?;
         Ok(Self { module, config })


### PR DESCRIPTION
The root of the problem is an overflow that happens in pwasm-utils