### PR TITLE
Don't crash on "Connection reset by peer"

### DIFF
--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -279,7 +279,7 @@ impl PeerManagerActor {
                     .take_while(|x| match x {
                         Ok(_) => future::ready(true),
                         Err(e) => {
-                            error!(target: "network", "Peer stream error: {:?}", e);
+                            warn!(target: "network", "Peer stream error: {:?}", e);
                             future::ready(false)
                         }
                     })

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -275,7 +275,15 @@ impl PeerManagerActor {
 
             // TODO: check if peer is banned or known based on IP address and port.
             Peer::add_stream(
-                FramedRead::new(read, Codec::new()).map(|x| x.expect("Decoder error")),
+                FramedRead::new(read, Codec::new())
+                    .take_while(|x| match x {
+                        Ok(_) => future::ready(true),
+                        Err(e) => {
+                            error!(target: "network", "Peer stream error: {:?}", e);
+                            future::ready(false)
+                        }
+                    })
+                    .map(Result::unwrap),
                 ctx,
             );
             Peer::new(


### PR DESCRIPTION
https://github.com/nearprotocol/nearcore/pull/1887 introduced
`expect("Decoder error")` which was incorrect because Decoder error is
not the only error case for FramedRead stream: error could come from the
underlying tcp stream.

The old behavior was to ignore the error, the behavior with this change
is to print the error and stop the stream.