### PR TITLE
Check for invalid shard id

### DIFF
--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -6,6 +6,7 @@ use failure::{Backtrace, Context, Fail};
 
 use near_primitives::challenge::{ChunkProofs, ChunkState};
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
+use near_primitives::types::ShardId;
 
 #[derive(Debug)]
 pub struct Error {
@@ -130,6 +131,9 @@ pub enum ErrorKind {
     /// Invalid Balance Burnt
     #[fail(display = "Invalid Balance Burnt")]
     InvalidBalanceBurnt,
+    /// Invalid shard id
+    #[fail(display = "Shard id {} does not exist", _0)]
+    InvalidShardId(ShardId),
     /// Someone is not a validator. Usually happens in signature verification
     #[fail(display = "Not A Validator")]
     NotAValidator,
@@ -233,6 +237,7 @@ impl Error {
             | ErrorKind::InvalidReward
             | ErrorKind::InvalidBalanceBurnt
             | ErrorKind::InvalidRent
+            | ErrorKind::InvalidShardId(_)
             | ErrorKind::NotAValidator => true,
         }
     }

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -245,16 +245,26 @@ impl Handler<GetChunk> for ViewClientActor {
             GetChunk::ChunkHash(chunk_hash) => self.chain.get_chunk(&chunk_hash).map(Clone::clone),
             GetChunk::BlockHash(block_hash, shard_id) => {
                 self.chain.get_block(&block_hash).map(Clone::clone).and_then(|block| {
-                    self.chain
-                        .get_chunk(&block.chunks[shard_id as usize].chunk_hash())
-                        .map(Clone::clone)
+                    let chunk_hash = block
+                        .chunks
+                        .get(shard_id as usize)
+                        .ok_or_else(|| {
+                            near_chain::Error::from(ErrorKind::InvalidShardId(shard_id))
+                        })?
+                        .chunk_hash();
+                    self.chain.get_chunk(&chunk_hash).map(Clone::clone)
                 })
             }
             GetChunk::Height(height, shard_id) => {
                 self.chain.get_block_by_height(height).map(Clone::clone).and_then(|block| {
-                    self.chain
-                        .get_chunk(&block.chunks[shard_id as usize].chunk_hash())
-                        .map(Clone::clone)
+                    let chunk_hash = block
+                        .chunks
+                        .get(shard_id as usize)
+                        .ok_or_else(|| {
+                            near_chain::Error::from(ErrorKind::InvalidShardId(shard_id))
+                        })?
+                        .chunk_hash();
+                    self.chain.get_chunk(&chunk_hash).map(Clone::clone)
                 })
             }
         }

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -67,7 +67,7 @@ fn test_block_by_hash() {
     .unwrap();
 }
 
-/// Retrieve blocks via json rpc
+/// Retrieve chunk via json rpc
 #[test]
 fn test_chunk_by_hash() {
     init_test_logger();
@@ -111,6 +111,27 @@ fn test_chunk_by_hash() {
                 },
             ),
         );
+    })
+    .unwrap();
+}
+
+/// Retrieve chunk via json rpc
+#[test]
+fn test_chunk_invalid_shard_id() {
+    init_test_logger();
+
+    System::run(|| {
+        let (_view_client_addr, addr) = start_all(true);
+
+        let mut client = new_client(&format!("http://{}", addr.clone()));
+        actix::spawn(client.chunk(ChunkId::BlockShardId(BlockId::Height(0), 100)).then(|res| {
+            if res.is_err() {
+                System::current().stop();
+            } else {
+                panic!("should result in an error")
+            }
+            future::ready(())
+        }));
     })
     .unwrap();
 }

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -125,10 +125,13 @@ fn test_chunk_invalid_shard_id() {
 
         let mut client = new_client(&format!("http://{}", addr.clone()));
         actix::spawn(client.chunk(ChunkId::BlockShardId(BlockId::Height(0), 100)).then(|res| {
-            if res.is_err() {
-                System::current().stop();
-            } else {
-                panic!("should result in an error")
+            match res {
+                Ok(_) => panic!("should result in an error"),
+                Err(e) => {
+                    let s = serde_json::to_string(&e.data.unwrap()).unwrap();
+                    assert!(s.starts_with("\"Shard id 100 does not exist"));
+                    System::current().stop();
+                }
             }
             future::ready(())
         }));


### PR DESCRIPTION
When we receive some requests that contain shard id we should first check its validity before using it to index into an array. Fixes #1948 