### PR TITLE
Remove dead code warnings from test

### DIFF
--- a/chain/network/tests/churn_attack.rs
+++ b/chain/network/tests/churn_attack.rs
@@ -1,6 +1,6 @@
 use actix::System;
 
-use crate::runner::{Action, Runner};
+pub use runner::{Action, Runner};
 
 mod runner;
 

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -1,8 +1,8 @@
 use actix::System;
 
-use crate::runner::{Action, Runner};
+pub use runner::{Action, Runner};
 
-pub mod runner;
+mod runner;
 
 #[test]
 fn simple() {


### PR DESCRIPTION
Use workaround proposed [here](https://github.com/rust-lang/rust/issues/46379#issuecomment-487421236) to avoid dead code warning.