### PR TITLE
store partial encoded chunks

### DIFF
--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -85,14 +85,16 @@ impl EncodedChunksCache {
         })
     }
 
+    pub fn height_within_front_horizon(&self, height: BlockHeight) -> bool {
+        height <= self.largest_seen_height + MAX_HEIGHTS_AHEAD
+    }
+
+    pub fn height_within_rear_horizon(&self, height: BlockHeight) -> bool {
+        height + HEIGHT_HORIZON >= self.largest_seen_height
+    }
+
     pub fn height_within_horizon(&self, height: BlockHeight) -> bool {
-        if height + HEIGHT_HORIZON < self.largest_seen_height {
-            false
-        } else if height > self.largest_seen_height + MAX_HEIGHTS_AHEAD {
-            false
-        } else {
-            true
-        }
+        self.height_within_front_horizon(height) || self.height_within_rear_horizon(height)
     }
 
     pub fn merge_in_partial_encoded_chunk(

--- a/chain/chunks/src/chunk_cache.rs
+++ b/chain/chunks/src/chunk_cache.rs
@@ -86,11 +86,11 @@ impl EncodedChunksCache {
     }
 
     pub fn height_within_front_horizon(&self, height: BlockHeight) -> bool {
-        height <= self.largest_seen_height + MAX_HEIGHTS_AHEAD
+        height >= self.largest_seen_height && height <= self.largest_seen_height + MAX_HEIGHTS_AHEAD
     }
 
     pub fn height_within_rear_horizon(&self, height: BlockHeight) -> bool {
-        height + HEIGHT_HORIZON >= self.largest_seen_height
+        height + HEIGHT_HORIZON >= self.largest_seen_height && height <= self.largest_seen_height
     }
 
     pub fn height_within_horizon(&self, height: BlockHeight) -> bool {

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -65,7 +65,6 @@ pub enum ProcessPartialEncodedChunkResult {
     NeedMorePartsOrReceipts(ShardChunkHeader),
     /// PartialEncodedChunkMessage is received earlier than Block for the same height.
     /// Without the block we cannot restore the epoch and save encoded chunk data.
-    ///     We just
     NeedBlock,
 }
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -553,7 +553,7 @@ impl ShardsManager {
     pub fn prepare_chunks(
         &mut self,
         prev_block_hash: &CryptoHash,
-    ) -> Vec<(ShardId, ShardChunkHeader)> {
+    ) -> HashMap<ShardId, ShardChunkHeader> {
         self.encoded_chunks.get_chunk_headers_for_block(&prev_block_hash)
     }
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -806,12 +806,14 @@ impl ShardsManager {
 
         // 7. Checking epoch_id validity
         let prev_block_hash = header.inner.prev_block_hash;
-        if self.runtime_adapter.get_epoch_id_from_prev_block(&prev_block_hash).is_err() {
-            // It may happen because PartialChunkEncodedMessage appeared before Block announcement.
-            // We keep the chunk until Block is received.
-            return Ok(ProcessPartialEncodedChunkResult::NeedBlock);
-        }
-        let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(&prev_block_hash)?;
+        let epoch_id = match self.runtime_adapter.get_epoch_id_from_prev_block(&prev_block_hash) {
+            Ok(epoch_id) => epoch_id,
+            Err(_) => {
+                // It may happen because PartialChunkEncodedMessage appeared before Block announcement.
+                // We keep the chunk until Block is received.
+                return Ok(ProcessPartialEncodedChunkResult::NeedBlock);
+            }
+        };
 
         // 8. Checking part_ords' validity
         let num_total_parts = self.runtime_adapter.num_total_parts();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -688,7 +688,10 @@ impl Client {
             self.shards_mgr.get_stored_partial_encoded_chunks(next_height);
         for (_shard_id, partial_encoded_chunk) in partial_encoded_chunks.drain() {
             // We will request chunks later if cannot process them here
-            let _ = self.process_partial_encoded_chunk(partial_encoded_chunk);
+            let accepted_blocks = self.process_partial_encoded_chunk(partial_encoded_chunk);
+            if accepted_blocks.is_ok() {
+                debug_assert!(accepted_blocks.unwrap().len() == 0);
+            }
         }
 
         // If we produced the block, then it should have already been broadcasted.

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -818,7 +818,7 @@ impl Client {
                 // Executing process_partial_encoded_chunk can unlock some blocks.
                 // Any block that is in the blocks_with_missing_chunks which doesn't have any chunks
                 // for which we track shards will be unblocked here.
-                for accepted_block in accepted_blocks.into_iter() {
+                for accepted_block in accepted_blocks {
                     self.on_block_accepted(
                         accepted_block.hash,
                         accepted_block.status,

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -613,7 +613,7 @@ impl ClientActor {
 
     /// Process all blocks that were accepted by calling other relevant services.
     fn process_accepted_blocks(&mut self, accepted_blocks: Vec<AcceptedBlock>) {
-        for accepted_block in accepted_blocks.into_iter() {
+        for accepted_block in accepted_blocks {
             self.client.on_block_accepted(
                 accepted_block.hash,
                 accepted_block.status,

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -853,19 +853,12 @@ mod tests {
                     } = msg
                     {
                         let header = partial_encoded_chunk.header.as_ref().unwrap();
-                        /*println!(
-                            "S {:?} R {:?} H {:?} PEC {:?}",
-                            sender_account_id,
-                            account_id,
-                            header.inner.height_created,
-                            partial_encoded_chunk
-                        );*/
                         if seen_chunk_same_sender.contains(&(
                             account_id.clone(),
                             header.inner.height_created,
                             header.inner.shard_id,
                         )) {
-                            //println!("=== SAME CHUNK AGAIN!");
+                            println!("=== SAME CHUNK AGAIN!");
                             assert!(false);
                         };
                         seen_chunk_same_sender.insert((
@@ -877,13 +870,12 @@ mod tests {
                     if let NetworkRequests::PartialEncodedChunkRequest { account_id: _, request } =
                         msg
                     {
-                        //println!("S {:?} R {:?} PEQ {:?}", sender_account_id, account_id, request);
                         if requested.contains(&(
                             sender_account_id.clone(),
                             request.part_ords.clone(),
                             request.chunk_hash.clone(),
                         )) {
-                            //println!("== SAME REQUEST AGAIN!");
+                            // do nothing
                         };
                         requested.insert((
                             sender_account_id.clone(),
@@ -896,13 +888,12 @@ mod tests {
                         partial_encoded_chunk,
                     } = msg
                     {
-                        //println!("S {:?} PER {:?}", sender_account_id, partial_encoded_chunk);
                         if responded.contains(&(
                             route_back.clone(),
                             partial_encoded_chunk.parts.iter().map(|x| x.part_ord).collect(),
                             partial_encoded_chunk.chunk_hash.clone(),
                         )) {
-                            //println!("== SAME RESPONSE AGAIN!");
+                            // do nothing
                         };
                         responded.insert((
                             route_back.clone(),

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -792,7 +792,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore]
     fn test_all_chunks_accepted_10() {
         test_all_chunks_accepted_common(10, 1000, 5)
     }
@@ -812,7 +811,7 @@ mod tests {
     #[test]
     #[cfg(feature = "expensive_tests")]
     fn test_all_chunks_accepted_1000_rare_epoch_changing() {
-        test_all_chunks_accepted_common(1000, 3000, 100)
+        test_all_chunks_accepted_common(1000, 1000, 100)
     }
 
     fn test_all_chunks_accepted_common(
@@ -854,19 +853,19 @@ mod tests {
                     } = msg
                     {
                         let header = partial_encoded_chunk.header.as_ref().unwrap();
-                        println!(
+                        /*println!(
                             "S {:?} R {:?} H {:?} PEC {:?}",
                             sender_account_id,
                             account_id,
                             header.inner.height_created,
                             partial_encoded_chunk
-                        );
+                        );*/
                         if seen_chunk_same_sender.contains(&(
                             account_id.clone(),
                             header.inner.height_created,
                             header.inner.shard_id,
                         )) {
-                            println!("=== SAME CHUNK AGAIN!");
+                            //println!("=== SAME CHUNK AGAIN!");
                             assert!(false);
                         };
                         seen_chunk_same_sender.insert((
@@ -875,15 +874,16 @@ mod tests {
                             header.inner.shard_id,
                         ));
                     }
-                    if let NetworkRequests::PartialEncodedChunkRequest { account_id, request } = msg
+                    if let NetworkRequests::PartialEncodedChunkRequest { account_id: _, request } =
+                        msg
                     {
-                        println!("S {:?} R {:?} PEQ {:?}", sender_account_id, account_id, request);
+                        //println!("S {:?} R {:?} PEQ {:?}", sender_account_id, account_id, request);
                         if requested.contains(&(
                             sender_account_id.clone(),
                             request.part_ords.clone(),
                             request.chunk_hash.clone(),
                         )) {
-                            println!("== SAME REQUEST AGAIN!");
+                            //println!("== SAME REQUEST AGAIN!");
                         };
                         requested.insert((
                             sender_account_id.clone(),
@@ -896,13 +896,13 @@ mod tests {
                         partial_encoded_chunk,
                     } = msg
                     {
-                        println!("S {:?} PER {:?}", sender_account_id, partial_encoded_chunk);
+                        //println!("S {:?} PER {:?}", sender_account_id, partial_encoded_chunk);
                         if responded.contains(&(
                             route_back.clone(),
                             partial_encoded_chunk.parts.iter().map(|x| x.part_ord).collect(),
                             partial_encoded_chunk.chunk_hash.clone(),
                         )) {
-                            println!("== SAME RESPONSE AGAIN!");
+                            //println!("== SAME RESPONSE AGAIN!");
                         };
                         responded.insert((
                             route_back.clone(),
@@ -914,7 +914,9 @@ mod tests {
                         // There is no chunks at height 1
                         if block.header.inner_lite.height > 1 {
                             println!("BLOCK {:?}", block,);
-                            assert_eq!(4, block.header.inner_rest.chunks_included);
+                            if block.header.inner_lite.height % epoch_length != 1 {
+                                assert_eq!(4, block.header.inner_rest.chunks_included);
+                            }
                             if block.header.inner_lite.height == last_height {
                                 System::current().stop();
                             }

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -826,6 +826,7 @@ mod tests {
                 Arc::new(RwLock::new(vec![]));
 
             let (validators, key_pairs) = get_validators_and_key_pairs();
+            let verbose = false;
 
             let _connectors1 = connectors.clone();
             let seen_chunk_same_sender =
@@ -875,7 +876,9 @@ mod tests {
                             request.part_ords.clone(),
                             request.chunk_hash.clone(),
                         )) {
-                            // do nothing
+                            if verbose {
+                                println!("=== SAME REQUEST AGAIN!");
+                            }
                         };
                         requested.insert((
                             sender_account_id.clone(),
@@ -893,7 +896,9 @@ mod tests {
                             partial_encoded_chunk.parts.iter().map(|x| x.part_ord).collect(),
                             partial_encoded_chunk.chunk_hash.clone(),
                         )) {
-                            // do nothing
+                            if verbose {
+                                println!("=== SAME RESPONSE AGAIN!");
+                            }
                         };
                         responded.insert((
                             route_back.clone(),

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -871,40 +871,40 @@ mod tests {
                     if let NetworkRequests::PartialEncodedChunkRequest { account_id: _, request } =
                         msg
                     {
-                        if requested.contains(&(
-                            sender_account_id.clone(),
-                            request.part_ords.clone(),
-                            request.chunk_hash.clone(),
-                        )) {
-                            if verbose {
+                        if verbose {
+                            if requested.contains(&(
+                                sender_account_id.clone(),
+                                request.part_ords.clone(),
+                                request.chunk_hash.clone(),
+                            )) {
                                 println!("=== SAME REQUEST AGAIN!");
-                            }
-                        };
-                        requested.insert((
-                            sender_account_id.clone(),
-                            request.part_ords.clone(),
-                            request.chunk_hash.clone(),
-                        ));
+                            };
+                            requested.insert((
+                                sender_account_id.clone(),
+                                request.part_ords.clone(),
+                                request.chunk_hash.clone(),
+                            ));
+                        }
                     }
                     if let NetworkRequests::PartialEncodedChunkResponse {
                         route_back,
                         partial_encoded_chunk,
                     } = msg
                     {
-                        if responded.contains(&(
-                            route_back.clone(),
-                            partial_encoded_chunk.parts.iter().map(|x| x.part_ord).collect(),
-                            partial_encoded_chunk.chunk_hash.clone(),
-                        )) {
-                            if verbose {
+                        if verbose {
+                            if responded.contains(&(
+                                route_back.clone(),
+                                partial_encoded_chunk.parts.iter().map(|x| x.part_ord).collect(),
+                                partial_encoded_chunk.chunk_hash.clone(),
+                            )) {
                                 println!("=== SAME RESPONSE AGAIN!");
                             }
-                        };
-                        responded.insert((
-                            route_back.clone(),
-                            partial_encoded_chunk.parts.iter().map(|x| x.part_ord).collect(),
-                            partial_encoded_chunk.chunk_hash.clone(),
-                        ));
+                            responded.insert((
+                                route_back.clone(),
+                                partial_encoded_chunk.parts.iter().map(|x| x.part_ord).collect(),
+                                partial_encoded_chunk.chunk_hash.clone(),
+                            ));
+                        }
                     }
                     if let NetworkRequests::Block { block } = msg {
                         // There is no chunks at height 1

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -922,7 +922,7 @@ mod tests {
                 })),
             );
             *connectors.write().unwrap() = conn;
-            let max_wait_ms = block_prod_time * last_height / 10 * 11 + 10000;
+            let max_wait_ms = block_prod_time * last_height / 10 * 13 + 10000;
 
             near_network::test_utils::wait_or_panic(max_wait_ms);
         })


### PR DESCRIPTION
Fixes https://github.com/nearprotocol/nearcore/issues/1971.
Also fixes calculation of `encoded_chunks.num_chunks_for_block()`.