### PR TITLE
Test connection reset by peer

### DIFF
--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1364,8 +1364,13 @@ impl Handler<PeerRequest> for PeerManagerActor {
 impl Handler<StopSignal> for PeerManagerActor {
     type Result = ();
 
-    fn handle(&mut self, _msg: StopSignal, ctx: &mut Self::Context) -> Self::Result {
+    fn handle(&mut self, msg: StopSignal, ctx: &mut Self::Context) -> Self::Result {
         debug!(target: "network", "Receive Stop Signal. Me: {:?}", self.peer_id);
-        ctx.stop();
+
+        if msg.should_panic {
+            panic!("Node crashed");
+        } else {
+            ctx.stop();
+        }
     }
 }

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1,16 +1,19 @@
 use std::cmp;
 use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
 
 use actix::actors::resolver::{ConnectAddr, Resolver};
 use actix::io::FramedWrite;
 use actix::{
-    Actor, ActorContext, ActorFuture, Addr, AsyncContext, Context, ContextFutureSpawner, Handler,
-    Recipient, Running, StreamHandler, SystemService, WrapFuture,
+    Actor, ActorFuture, Addr, AsyncContext, Context, ContextFutureSpawner, Handler, Recipient,
+    Running, StreamHandler, SystemService, WrapFuture,
 };
 use chrono::offset::TimeZone;
 use chrono::{DateTime, Utc};
+use futures::task::Poll;
 use futures::{future, Stream, StreamExt};
 use rand::{thread_rng, Rng};
 use tokio::net::{TcpListener, TcpStream};
@@ -33,15 +36,11 @@ use crate::types::{
     NetworkViewClientMessages, NetworkViewClientResponses, OutboundTcpConnect, PeerId,
     PeerIdOrHash, PeerList, PeerManagerRequest, PeerMessage, PeerRequest, PeerResponse, PeerType,
     PeersRequest, PeersResponse, Ping, Pong, QueryPeerStats, RawRoutedMessage, ReasonForBan,
-    RoutedMessage, RoutedMessageBody, RoutedMessageFrom, SendMessage, StopSignal, SyncData,
-    Unregister,
+    RoutedMessage, RoutedMessageBody, RoutedMessageFrom, SendMessage, SyncData, Unregister,
 };
 use crate::types::{
     NetworkClientMessages, NetworkConfig, NetworkRequests, NetworkResponses, PeerInfo,
 };
-use futures::task::Poll;
-use std::net::SocketAddr;
-use std::pin::Pin;
 
 /// How often to request peers from active peers.
 const REQUEST_PEERS_SECS: i64 = 60;
@@ -1376,20 +1375,6 @@ impl Handler<PeerRequest> for PeerManagerActor {
                 );
                 PeerResponse::NoResponse
             }
-        }
-    }
-}
-
-impl Handler<StopSignal> for PeerManagerActor {
-    type Result = ();
-
-    fn handle(&mut self, msg: StopSignal, ctx: &mut Self::Context) -> Self::Result {
-        debug!(target: "network", "Receive Stop Signal. Me: {:?}", self.peer_id);
-
-        if msg.should_panic {
-            panic!("Node crashed");
-        } else {
-            ctx.stop();
         }
     }
 }

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -2,19 +2,20 @@ use std::collections::{HashMap, HashSet};
 use std::net::TcpListener;
 use std::time::Duration;
 
-use actix::{Actor, AsyncContext, Context, Handler, Message};
+use actix::{Actor, ActorContext, AsyncContext, Context, Handler, Message};
 use futures::{future, FutureExt};
+use log::debug;
 use rand::{thread_rng, RngCore};
 use tokio::time::delay_for;
 
+use near_chain::chain::WEIGHT_MULTIPLIER;
 use near_crypto::{KeyType, SecretKey};
 use near_primitives::hash::hash;
 use near_primitives::types::EpochId;
+use near_primitives::utils::index_to_bytes;
 
 use crate::types::{NetworkConfig, NetworkInfo, PeerId, PeerInfo, ROUTED_MESSAGE_TTL};
 use crate::PeerManagerActor;
-use near_chain::chain::WEIGHT_MULTIPLIER;
-use near_primitives::utils::index_to_bytes;
 
 /// Returns available port.
 pub fn open_port() -> u16 {
@@ -197,5 +198,35 @@ impl Handler<GetInfo> for PeerManagerActor {
 
     fn handle(&mut self, _msg: GetInfo, _ctx: &mut Context<Self>) -> Self::Result {
         self.get_network_info()
+    }
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct StopSignal {
+    pub should_panic: bool,
+}
+
+impl StopSignal {
+    pub fn new() -> Self {
+        Self { should_panic: false }
+    }
+
+    pub fn should_panic() -> Self {
+        Self { should_panic: true }
+    }
+}
+
+impl Handler<StopSignal> for PeerManagerActor {
+    type Result = ();
+
+    fn handle(&mut self, msg: StopSignal, ctx: &mut Self::Context) -> Self::Result {
+        debug!(target: "network", "Receive Stop Signal.");
+
+        if msg.should_panic {
+            panic!("Node crashed");
+        } else {
+            ctx.stop();
+        }
     }
 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::net::{AddrParseError, IpAddr, SocketAddr};
 use std::str::FromStr;
+use std::sync::RwLock;
 use std::time::Duration;
 
 use actix::dev::{MessageResponse, ResponseChannel};
@@ -32,7 +33,6 @@ use near_primitives::views::{FinalExecutionOutcomeView, QueryResponse};
 use crate::metrics;
 use crate::peer::Peer;
 use crate::routing::{Edge, EdgeInfo, RoutingTableInfo};
-use std::sync::RwLock;
 
 /// Current latest version of the protocol
 pub const PROTOCOL_VERSION: u32 = 4;
@@ -1378,22 +1378,6 @@ pub struct PartialEncodedChunkRequestMsg {
     pub tracking_shards: HashSet<ShardId>,
 }
 
-#[derive(Message)]
-#[rtype(result = "()")]
-pub struct StopSignal {
-    pub should_panic: bool,
-}
-
-impl StopSignal {
-    pub fn new() -> Self {
-        Self { should_panic: false }
-    }
-
-    pub fn should_panic() -> Self {
-        Self { should_panic: true }
-    }
-}
-
 /// Adapter to break dependency of sub-components on the network requests.
 /// For tests use MockNetworkAdapter that accumulates the requests to network.
 pub trait NetworkAdapter: Sync + Send {
@@ -1448,8 +1432,9 @@ impl NetworkAdapter for NetworkRecipient {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use std::mem::size_of;
+
+    use super::*;
 
     const ALLOWED_SIZE: usize = 1 << 20;
     const NOTIFY_SIZE: usize = 1024;
@@ -1513,6 +1498,5 @@ mod tests {
         assert_size!(StateResponseInfo);
         assert_size!(QueryPeerStats);
         assert_size!(PartialEncodedChunkRequestMsg);
-        assert_size!(StopSignal);
     }
 }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1380,7 +1380,19 @@ pub struct PartialEncodedChunkRequestMsg {
 
 #[derive(Message)]
 #[rtype(result = "()")]
-pub struct StopSignal {}
+pub struct StopSignal {
+    pub should_panic: bool,
+}
+
+impl StopSignal {
+    pub fn new() -> Self {
+        Self { should_panic: false }
+    }
+
+    pub fn should_panic() -> Self {
+        Self { should_panic: true }
+    }
+}
 
 /// Adapter to break dependency of sub-components on the network requests.
 /// For tests use MockNetworkAdapter that accumulates the requests to network.

--- a/chain/network/tests/peer_handshake.rs
+++ b/chain/network/tests/peer_handshake.rs
@@ -142,7 +142,7 @@ fn peer_recover() {
                     state.store(1, Ordering::Relaxed);
                 } else if state.load(Ordering::Relaxed) == 1 {
                     // Stop node2.
-                    let _ = pm2.do_send(StopSignal {});
+                    let _ = pm2.do_send(StopSignal::new());
                     state.store(2, Ordering::Relaxed);
                 } else if state.load(Ordering::Relaxed) == 2 {
                     // Wait until node0 removes node2 from active validators.

--- a/chain/network/tests/peer_handshake.rs
+++ b/chain/network/tests/peer_handshake.rs
@@ -7,8 +7,8 @@ use actix::System;
 use futures::{future, FutureExt};
 
 use near_client::{ClientActor, ViewClientActor};
-use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, WaitOrTimeout};
-use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses, StopSignal};
+use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, StopSignal, WaitOrTimeout};
+use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses};
 use near_network::{NetworkClientResponses, NetworkConfig, PeerManagerActor};
 use near_primitives::block::WeightAndScore;
 use near_primitives::test_utils::init_test_logger;

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -13,9 +13,9 @@ use near_chain::ChainGenesis;
 use near_client::{BlockProducer, ClientActor, ClientConfig, ViewClientActor};
 use near_crypto::{InMemorySigner, KeyType};
 use near_network::test_utils::{
-    convert_boot_nodes, expected_routing_tables, open_port, WaitOrTimeout,
+    convert_boot_nodes, expected_routing_tables, open_port, StopSignal, WaitOrTimeout,
 };
-use near_network::types::{OutboundTcpConnect, StopSignal, ROUTED_MESSAGE_TTL};
+use near_network::types::{OutboundTcpConnect, ROUTED_MESSAGE_TTL};
 use near_network::utils::blacklist_from_vec;
 use near_network::{
     NetworkConfig, NetworkRecipient, NetworkRequests, NetworkResponses, PeerInfo, PeerManagerActor,

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -237,7 +237,7 @@ impl StateMachine {
                             info.pm_addr
                                 .get(source)
                                 .unwrap()
-                                .send(StopSignal {})
+                                .send(StopSignal::new())
                                 .map_err(|_| ())
                                 .and_then(move |_| {
                                     flag.store(true, Ordering::Relaxed);

--- a/chain/network/tests/stress_network.rs
+++ b/chain/network/tests/stress_network.rs
@@ -8,8 +8,8 @@ use futures::FutureExt;
 use tracing::info;
 
 use near_client::{ClientActor, ViewClientActor};
-use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, WaitOrTimeout};
-use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses, StopSignal};
+use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, StopSignal, WaitOrTimeout};
+use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses};
 use near_network::{NetworkClientResponses, NetworkConfig, PeerManagerActor};
 use near_primitives::block::WeightAndScore;
 use near_primitives::test_utils::init_test_logger_allow_panic;

--- a/chain/network/tests/stress_network.rs
+++ b/chain/network/tests/stress_network.rs
@@ -1,0 +1,164 @@
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use actix::actors::mocker::Mocker;
+use actix::{Actor, AsyncContext, System};
+use futures::FutureExt;
+
+use near_client::{ClientActor, ViewClientActor};
+use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, WaitOrTimeout};
+use near_network::types::{NetworkViewClientMessages, NetworkViewClientResponses, StopSignal};
+use near_network::{NetworkClientResponses, NetworkConfig, PeerManagerActor};
+use near_primitives::block::WeightAndScore;
+use near_primitives::test_utils::init_test_logger_allow_panic;
+use near_store::test_utils::create_test_store;
+
+use tracing::info;
+
+type ClientMock = Mocker<ClientActor>;
+type ViewClientMock = Mocker<ViewClientActor>;
+
+fn make_peer_manager(seed: &str, port: u16, boot_nodes: Vec<(&str, u16)>) -> PeerManagerActor {
+    let store = create_test_store();
+    let mut config = NetworkConfig::from_seed(seed, port);
+    config.boot_nodes = convert_boot_nodes(boot_nodes);
+    let client_addr = ClientMock::mock(Box::new(move |_msg, _ctx| {
+        Box::new(Some(NetworkClientResponses::NoResponse))
+    }))
+    .start();
+    let view_client_addr = ViewClientMock::mock(Box::new(move |msg, _ctx| {
+        let msg = msg.downcast_ref::<NetworkViewClientMessages>().unwrap();
+        match msg {
+            NetworkViewClientMessages::GetChainInfo => {
+                Box::new(Some(NetworkViewClientResponses::ChainInfo {
+                    genesis_id: Default::default(),
+                    height: 1,
+                    weight_and_score: WeightAndScore::from_ints(1, 0),
+                    tracked_shards: vec![],
+                }))
+            }
+            _ => Box::new(Some(NetworkViewClientResponses::NoResponse)),
+        }
+    }))
+    .start();
+    PeerManagerActor::new(store, config, client_addr.recipient(), view_client_addr.recipient())
+        .unwrap()
+}
+
+/// This test spawns several (7) nodes but node 0 crash very frequently and restart.
+/// Other nodes should not panic because node 0 behavior.
+///
+/// If everything goes well this test should panic after the timeout triggered by WaitOrTimeout.
+/// The test is stopped gracefully (no panic) if some node other than node0 panicked.
+///
+/// This was fixed in (#1954). To reproduce this bug:
+/// ```
+/// git checkout 1f5eab0344235960dfcf767d143fb90a02c7c567
+/// cargo test --package near-network --test stress_network stress_test -- --exact --ignored
+/// ```
+///
+/// Logs observed on failing commit:
+/// ```
+/// thread 'stress_test' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" }', src/libcore/result.rs:1165:5
+/// thread 'stress_test' panicked at 'Decoder error: Os { code: 104, kind: ConnectionReset, message: "Connection reset by peer" }', src/libcore/result.rs:1165:5
+/// ```
+#[test]
+#[should_panic]
+#[ignore]
+fn stress_test() {
+    init_test_logger_allow_panic();
+
+    System::run(|| {
+        let num_nodes = 7;
+        let ports: Vec<_> = (0..num_nodes).map(|_| open_port()).collect();
+
+        let boot_nodes: Vec<_> =
+            ports.iter().enumerate().map(|(ix, port)| (format!("test{}", ix), *port)).collect();
+
+        let mut pms: Vec<_> = (0..num_nodes)
+            .map(|ix| {
+                Arc::new(
+                    make_peer_manager(
+                        format!("test{}", ix).as_str(),
+                        ports[ix],
+                        boot_nodes.iter().map(|(acc, port)| (acc.as_str(), *port)).collect(),
+                    )
+                    .start(),
+                )
+            })
+            .collect();
+
+        pms[0].do_send(StopSignal::should_panic());
+
+        // States:
+        // 0 -> Check other nodes health.
+        // 1 -> Spawn node0 and schedule crash.
+        // 2 -> Timeout.
+        let state = Arc::new(AtomicUsize::new(0));
+        let flags: Vec<_> = (0..num_nodes).map(|_| Arc::new(AtomicBool::new(false))).collect();
+        let round = Arc::new(AtomicUsize::new(0));
+
+        WaitOrTimeout::new(
+            Box::new(move |ctx| {
+                let s = state.load(Ordering::Relaxed);
+                if s == 0 {
+                    info!(target: "test", "Start round: {}", round.fetch_add(1, Ordering::Relaxed));
+
+                    for (ix, flag) in flags.iter().enumerate().skip(1) {
+                        if !flag.load(Ordering::Relaxed) {
+                            let flag1 = flag.clone();
+
+                            actix::spawn(pms[ix].send(GetInfo {}).then(move |info| {
+                                if let Ok(info) = info {
+                                    if info.num_active_peers == num_nodes - 2 {
+                                        flag1.store(true, Ordering::Relaxed);
+                                    }
+                                } else {
+                                    info!(target: "test", "Node {} have failed", ix);
+                                    System::current().stop();
+                                }
+
+                                futures::future::ready(())
+                            }));
+                        }
+                    }
+
+                    if flags.iter().skip(1).all(|flag| flag.load(Ordering::Relaxed)) {
+                        state.store(1, Ordering::Relaxed);
+                    }
+                } else if s == 1 {
+                    state.store(2, Ordering::Relaxed);
+
+                    for flag in flags.iter() {
+                        flag.store(false, Ordering::Relaxed);
+                    }
+
+                    pms[0] = Arc::new(
+                        make_peer_manager(
+                            "test0",
+                            ports[0],
+                            boot_nodes.iter().map(|(acc, port)| (acc.as_str(), *port)).collect(),
+                        )
+                        .start(),
+                    );
+
+                    let pm0 = pms[0].clone();
+
+                    ctx.run_later(Duration::from_millis(10), move |_, _| {
+                        pm0.do_send(StopSignal::should_panic());
+                    });
+
+                    let state1 = state.clone();
+                    ctx.run_later(Duration::from_millis(100), move |_, _| {
+                        state1.store(0, Ordering::Relaxed);
+                    });
+                }
+            }),
+            100,
+            10000,
+        )
+        .start();
+    })
+    .unwrap();
+}

--- a/chain/network/tests/stress_network.rs
+++ b/chain/network/tests/stress_network.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use actix::actors::mocker::Mocker;
 use actix::{Actor, AsyncContext, System};
 use futures::FutureExt;
+use tracing::info;
 
 use near_client::{ClientActor, ViewClientActor};
 use near_network::test_utils::{convert_boot_nodes, open_port, GetInfo, WaitOrTimeout};
@@ -13,8 +14,6 @@ use near_network::{NetworkClientResponses, NetworkConfig, PeerManagerActor};
 use near_primitives::block::WeightAndScore;
 use near_primitives::test_utils::init_test_logger_allow_panic;
 use near_store::test_utils::create_test_store;
-
-use tracing::info;
 
 type ClientMock = Mocker<ClientActor>;
 type ViewClientMock = Mocker<ViewClientActor>;

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -38,6 +38,15 @@ pub fn init_test_logger() {
     init_stop_on_panic();
 }
 
+pub fn init_test_logger_allow_panic() {
+    let _ = env_logger::Builder::new()
+        .filter_module("tokio_reactor", LevelFilter::Info)
+        .filter_module("tokio_core", LevelFilter::Info)
+        .filter_module("hyper", LevelFilter::Info)
+        .filter(None, LevelFilter::Debug)
+        .try_init();
+}
+
 pub fn init_test_module_logger(module: &str) {
     let _ = env_logger::Builder::new()
         .filter_module("tokio_reactor", LevelFilter::Info)


### PR DESCRIPTION
Test that #1954 is properly fixed. In the first commit (without the patch) this test reproduce the error, but right now it shows new error:

```
thread 'stress_test' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 107, kind: NotConnected, message: "Transport endpoint is not connected" }', src/libcore/result.rs:1165:5
```

Not sure why this error is happening. 