### PR TITLE
test_kickout already working

### DIFF
--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -141,7 +141,6 @@ fn test_stake_nodes() {
     });
 }
 
-/// TODO(1094): Enable kickout test after figuring
 #[test]
 fn test_validator_kickout() {
     heavy_test(|| {


### PR DESCRIPTION
Test `test_validator_kickout` doesn't look flaky anymore.
#1094 can be closed.