### PR TITLE
Check account id inside tx status query

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -31,8 +31,8 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::serialize::{from_base, from_base64, BaseEncode};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockId, MaybeBlockId, StateChangesRequest};
-use near_primitives::views::FinalExecutionStatus;
 use near_primitives::utils::is_valid_account_id;
+use near_primitives::views::FinalExecutionStatus;
 
 mod metrics;
 pub mod test_utils;
@@ -298,7 +298,10 @@ impl JsonRpcHandler {
     async fn tx_status(&self, params: Option<Value>) -> Result<Value, RpcError> {
         let (hash, account_id) = parse_params::<(String, String)>(params)?;
         if !is_valid_account_id(&account_id) {
-            return Err(RpcError::invalid_params(Some(format!("Invalid account id: {}", account_id))))
+            return Err(RpcError::invalid_params(Some(format!(
+                "Invalid account id: {}",
+                account_id
+            ))));
         }
         let tx_hash = from_base_or_parse_err(hash).and_then(|bytes| {
             CryptoHash::try_from(bytes).map_err(|err| RpcError::parse_error(err.to_string()))

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -32,6 +32,7 @@ use near_primitives::serialize::{from_base, from_base64, BaseEncode};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockId, MaybeBlockId, StateChangesRequest};
 use near_primitives::views::FinalExecutionStatus;
+use near_primitives::utils::is_valid_account_id;
 
 mod metrics;
 pub mod test_utils;
@@ -296,6 +297,9 @@ impl JsonRpcHandler {
 
     async fn tx_status(&self, params: Option<Value>) -> Result<Value, RpcError> {
         let (hash, account_id) = parse_params::<(String, String)>(params)?;
+        if !is_valid_account_id(&account_id) {
+            return Err(RpcError::invalid_params(Some(format!("Invalid account id: {}", account_id))))
+        }
         let tx_hash = from_base_or_parse_err(hash).and_then(|bytes| {
             CryptoHash::try_from(bytes).map_err(|err| RpcError::parse_error(err.to_string()))
         })?;

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -10,7 +10,7 @@ use near_jsonrpc::client::new_client;
 use near_jsonrpc::test_utils::{start_all, start_all_with_validity_period};
 use near_network::test_utils::{wait_or_panic, WaitOrTimeout};
 use near_primitives::block::BlockHeader;
-use near_primitives::hash::hash;
+use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::serialize::to_base64;
 use near_primitives::test_utils::{init_integration_logger, init_test_logger};
 use near_primitives::transaction::SignedTransaction;
@@ -198,6 +198,29 @@ fn test_replay_protection() {
             client
                 .broadcast_tx_commit(to_base64(&bytes))
                 .map_err(|_| {
+                    System::current().stop();
+                })
+                .map(move |_| panic!("transaction should not succeed")),
+        );
+        wait_or_panic(10000);
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_tx_status_invalid_account_id() {
+    init_test_logger();
+
+    System::run(|| {
+        let (_, addr) = start_all(true);
+
+        let mut client = new_client(&format!("http://{}", addr));
+        actix::spawn(
+            client
+                .tx(to_base64(&CryptoHash::default()), "".to_string())
+                .map_err(|e| {
+                    let s = serde_json::to_string(&e.data.unwrap()).unwrap();
+                    assert!(s.starts_with("\"Invalid account id"));
                     System::current().stop();
                 })
                 .map(move |_| panic!("transaction should not succeed")),


### PR DESCRIPTION
Do not allow invalid account ids when we process transaction status queries.