### PR TITLE
Broadcast block immediately after receiving it

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -669,10 +669,7 @@ impl Client {
             self.collect_block_approval(&approval, false);
         } else {
             let approval_message = ApprovalMessage::new(approval, next_block_producer);
-            self.network_adapter.do_send(NetworkRequests::BlockHeaderAnnounce {
-                header: self.chain.get_block_header(&parent_hash)?.clone(),
-                approval_message: Some(approval_message),
-            });
+            self.network_adapter.do_send(NetworkRequests::Approval { approval_message });
         }
 
         Ok(())
@@ -705,11 +702,6 @@ impl Client {
                     self.collect_block_approval(&approval, false);
                 }
             }
-
-            self.network_adapter.do_send(NetworkRequests::BlockHeaderAnnounce {
-                header: block.header.clone(),
-                approval_message: None,
-            });
         }
 
         if status.is_new_head() {

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -617,7 +617,7 @@ impl ClientActor {
             // Don't care about challenge here since it will be handled when we actually process
             // the block.
             if self.client.chain.process_block_header(&block.header, |_| {}).is_ok() {
-                self.network_adapter.do_send(NetworkRequests::Block { block: block.clone() });
+                self.client.rebroadcast_block(block.clone());
             }
         }
         let (accepted_blocks, result) = self.client.process_block(block, provenance);

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -604,11 +604,8 @@ pub fn setup_mock_all_validators(
                                 }
                             }
                         }
-                        NetworkRequests::BlockHeaderAnnounce {
-                            header,
-                            approval_message: Some(approval_message),
-                        } => {
-                            let height_mod = header.inner_lite.height % 300;
+                        NetworkRequests::Approval { approval_message } => {
+                            let height_mod = approval_message.approval.target_height % 300;
 
                             let do_propagate = if tamper_with_fg {
                                 if height_mod < 100 {
@@ -705,7 +702,6 @@ pub fn setup_mock_all_validators(
                         | NetworkRequests::PingTo(_, _)
                         | NetworkRequests::FetchPingPongInfo
                         | NetworkRequests::BanPeer { .. }
-                        | NetworkRequests::BlockHeaderAnnounce { .. }
                         | NetworkRequests::TxStatus(_, _, _)
                         | NetworkRequests::Query { .. }
                         | NetworkRequests::Challenge(_)

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -126,7 +126,7 @@ fn test_verify_block_double_sign_challenge() {
     let (_, result) = env.clients[0].process_block(b2, Provenance::NONE);
     assert!(result.is_ok());
     let mut last_message = env.network_adapters[0].pop().unwrap();
-    if let NetworkRequests::BlockHeaderAnnounce { .. } = last_message {
+    if let NetworkRequests::Approval { .. } = last_message {
         last_message = env.network_adapters[0].pop().unwrap();
     }
     if let NetworkRequests::Challenge(network_challenge) = last_message {

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -126,7 +126,7 @@ fn test_verify_block_double_sign_challenge() {
     let (_, result) = env.clients[0].process_block(b2, Provenance::NONE);
     assert!(result.is_ok());
     let mut last_message = env.network_adapters[0].pop().unwrap();
-    if let NetworkRequests::Approval { .. } = last_message {
+    if let NetworkRequests::Block { .. } = last_message {
         last_message = env.network_adapters[0].pop().unwrap();
     }
     if let NetworkRequests::Challenge(network_challenge) = last_message {

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -196,7 +196,6 @@ impl Peer {
         // Record block requests in tracker.
         match &msg {
             PeerMessage::Block(b) if self.tracker.has_received(b.hash()) => return,
-            PeerMessage::BlockHeaderAnnounce(h) if self.tracker.has_received(h.hash()) => return,
             PeerMessage::BlockRequest(h) => self.tracker.push_request(*h),
             _ => (),
         };
@@ -389,13 +388,6 @@ impl Peer {
                     max(self.chain_info.height, block.header.inner_lite.height);
                 self.chain_info.score = max(self.chain_info.score, block.header.inner_rest.score);
                 NetworkClientMessages::Block(block, peer_id, self.tracker.has_request(block_hash))
-            }
-            PeerMessage::BlockHeaderAnnounce(header) => {
-                let block_hash = header.hash();
-                self.tracker.push_received(block_hash);
-                self.chain_info.height = max(self.chain_info.height, header.inner_lite.height);
-                self.chain_info.score = max(self.chain_info.score, header.inner_rest.score);
-                NetworkClientMessages::BlockHeader(header, peer_id)
             }
             PeerMessage::Transaction(transaction) => {
                 near_metrics::inc_counter(&metrics::PEER_TRANSACTION_RECEIVED_TOTAL);

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -834,17 +834,11 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                 self.broadcast_message(ctx, SendMessage { message: PeerMessage::Block(block) });
                 NetworkResponses::NoResponse
             }
-            NetworkRequests::BlockHeaderAnnounce { header, approval_message } => {
-                if let Some(approval_message) = approval_message {
-                    self.send_message_to_account(
-                        ctx,
-                        &approval_message.target,
-                        RoutedMessageBody::BlockApproval(approval_message.approval),
-                    );
-                }
-                self.broadcast_message(
+            NetworkRequests::Approval { approval_message } => {
+                self.send_message_to_account(
                     ctx,
-                    SendMessage { message: PeerMessage::BlockHeaderAnnounce(header) },
+                    &approval_message.target,
+                    RoutedMessageBody::BlockApproval(approval_message.approval),
                 );
                 NetworkResponses::NoResponse
             }

--- a/near/tests/sync_nodes.rs
+++ b/near/tests/sync_nodes.rs
@@ -16,7 +16,7 @@ use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
 use near_network::{NetworkClientMessages, PeerInfo};
 use near_primitives::block::Approval;
 use near_primitives::hash::CryptoHash;
-use near_primitives::test_utils::{heavy_test, init_integration_logger};
+use near_primitives::test_utils::{heavy_test, init_integration_logger, init_test_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{BlockHeightDelta, EpochId, ValidatorStake};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
@@ -87,7 +87,7 @@ fn add_blocks(
 #[test]
 fn sync_nodes() {
     heavy_test(|| {
-        init_integration_logger();
+        init_test_logger();
 
         let mut genesis_config = GenesisConfig::test(vec!["other"], 1);
         genesis_config.epoch_length = 5;

--- a/near/tests/sync_nodes.rs
+++ b/near/tests/sync_nodes.rs
@@ -16,7 +16,7 @@ use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
 use near_network::{NetworkClientMessages, PeerInfo};
 use near_primitives::block::Approval;
 use near_primitives::hash::CryptoHash;
-use near_primitives::test_utils::{heavy_test, init_integration_logger, init_test_logger};
+use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{BlockHeightDelta, EpochId, ValidatorStake};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
@@ -87,7 +87,7 @@ fn add_blocks(
 #[test]
 fn sync_nodes() {
     heavy_test(|| {
-        init_test_logger();
+        init_integration_logger();
 
         let mut genesis_config = GenesisConfig::test(vec!["other"], 1);
         genesis_config.epoch_length = 5;


### PR DESCRIPTION
This PR changes a couple things in block propagation to make it faster:
* Right now when a node receives a block it first processes it and only after the block is accepted does it get broadcast to other nodes. This slows down the propagation of blocks and therefore chunk production. This PR changes it so that when a block is received it will be rebroadcasted if it passes some basic validation.
* Currently header and approval are bundled together and every time an approval is sent, the message also contains the latest block header, which causes the block header to be unnecessarily broadcast to every peer. This PR removes this bundling and the block header broadcast altogether.

Test Plan
---------
* All existing tests pass.
* Test that when a block doesn't pass basic validation it will not be broadcast.