### PR TITLE
Add storage_paid_at check during `apply_rent`

### DIFF
--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -437,7 +437,7 @@ impl Runtime {
         let mut account = get_account(state_update, account_id)?;
         let mut rent_paid = 0;
         if let Some(ref mut account) = account {
-            rent_paid = apply_rent(account_id, account, apply_state.block_index, &self.config);
+            rent_paid = apply_rent(account_id, account, apply_state.block_index, &self.config)?;
         }
         let mut actor_id = receipt.predecessor_id.clone();
         let mut result = ActionResult::default();


### PR DESCRIPTION
If an invalid state is given to the Runtime as part of a malicious challenge, the Runtime should fail with inconsistent state error instead of a crash or an overflow.

Test plan:

Added a unit test to verify the fix

Fixes: #2123 