### PR TITLE
Enable overflow-checks for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,12 @@ testlib = { path = "./test-utils/testlib" }
 [profile.release]
 lto = true        # Enable full link-time optimization.
 codegen-units = 1 # Use only 1 codegen-unit to enable full optimizations.
+overflow-checks = true
 
 [profile.bench]
 lto = true
 codegen-units = 1 # Use only 1 codegen-unit to enable full optimizations.
+overflow-checks = true
 
 [profile.dev.overrides.hex]
 opt-level = 3 # BLS library is too slow to use in debug

--- a/tests/test_overflows.rs
+++ b/tests/test_overflows.rs
@@ -1,0 +1,21 @@
+#[test]
+fn test_overflow() {
+    let a = std::u64::MAX;
+    let b = 5u64;
+    std::panic::catch_unwind(move || {
+        let c = u128::from(a + b);
+        println!("{} + {} = {}", a, b, c);
+    })
+    .unwrap_err();
+}
+
+#[test]
+fn test_underflow() {
+    let a = 10u64;
+    let b = 5u64;
+    std::panic::catch_unwind(move || {
+        let c = u128::from(b - a);
+        println!("{} - {} = {}", b, a, c);
+    })
+    .unwrap_err();
+}


### PR DESCRIPTION
By default Rust has `overflow-checks=off` for release.
This change enables panic on integer overflows with `profile.release`. This is not a nightly feature, because it's not an override.

Test plan:
 - Added units test to check for overflow. This is useless because `cargo test --release` doesn't follow `profile.release` but instead some weird mix.
- Added explicit `std::panic::catch_unwind` to near main function. But overflow panic is too powerful to catch with panic catcher, so I reverted this check. But during this check observed the overflow panic, so I confirmed the overflow panics for the main binary. 