### PR TITLE
feat(rpc): allow rpc to specify finality in query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -634,11 +634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cast"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "cc"
 version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,39 +771,6 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "criterion"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
- "tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1635,14 +1597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,7 +2026,6 @@ dependencies = [
  "blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "borsh 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "curve25519-dalek 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2889,15 +2842,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_os"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "rand_pcg"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2917,14 +2861,6 @@ dependencies = [
 [[package]]
 name = "rand_xorshift"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3190,14 +3126,6 @@ dependencies = [
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "same-file"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "schannel"
@@ -3608,15 +3536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3917,16 +3836,6 @@ dependencies = [
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
  "cmake 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "walkdir"
-version = "2.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -4275,7 +4184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bytestring 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b24c107a4432e408d2caa58d3f5e763b219236221406ea58a4076b62343a039d"
 "checksum c2-chacha 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
 "checksum cached 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b052fd10f32987c3bd028d91ef86190b36fba5c8fccb5515d42083f061e6104"
-"checksum cast 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "926013f2860c46252efceabb19f4a6b308197505082c609025aa6706c011d427"
 "checksum cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)" = "0213d356d3c4ea2c18c40b037c3be23cd639825c18f25ee670ac7813beeef99c"
 "checksum cexpr 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
@@ -4292,8 +4200,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum core-foundation 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "25b9e03f145fd4f2bf705e07b900cd41fc636598fe5dc452fd0db1441c3f496d"
 "checksum core-foundation-sys 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
-"checksum criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
-"checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
 "checksum crossbeam-channel 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "acec9a3b0b3559f15aee4f90746c4e5e293b701c0f7d3925d24e01645267b68c"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
@@ -4381,7 +4287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum indicatif 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8572bccfb0665e70b7faf44ee28841b8e0823450cd4ad562a76b5a3c4bf48487"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
 "checksum ipconfig 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa79fa216fbe60834a9c0737d7fcd30425b32d1c58854663e24d4c4b328ed83f"
-"checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jemalloc-sys 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0d3b9f3f5c9b31aa0f5ed3260385ac205db665baa41d49bb8338008ae94ede45"
 "checksum jemallocator 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "43ae63fcfc45e99ab3d1b29a46782ad679e98436c3169d15a167a1108a724b69"
@@ -4467,11 +4372,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
 "checksum rand_jitter 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 "checksum rand_os 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-"checksum rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
-"checksum rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
 "checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
 "checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
@@ -4494,7 +4397,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rustls 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b25a18b1bf7387f0145e7f8324e700805aade3842dd3db2e74e4cdeb4677c09e"
 "checksum rustls-native-certs 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "51ffebdbb48c14f84eba0b715197d673aff1dd22cc1007ca647e28483bbcc307"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "87f550b06b6cba9c8b8be3ee73f391990116bf527450d2556e9b9ce263b9a021"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum sct 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
@@ -4539,7 +4441,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum threadpool 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e2f0c90a5f3459330ac8bc0d2f879c693bb7a2f59689c1083fc4ef83834da865"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
-"checksum tinytemplate 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4574b75faccaacddb9b284faecdf0b544b80b6b294f3d062d325c5726a209c20"
 "checksum tokio 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "ffa2fdcfa937b20cb3c822a635ceecd5fc1a27a6a474527e5516aa24b8c8820a"
 "checksum tokio-macros 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "50a61f268a3db2acee8dcab514efc813dc6dbe8a00e86076f935f94304b59a7a"
 "checksum tokio-openssl 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
@@ -4574,7 +4475,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum wabt 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3c5c5c1286c6e578416982609f47594265f9d489f9b836157d403ad605a46693"
 "checksum wabt-sys 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "af5d153dc96aad7dc13ab90835b892c69867948112d95299e522d370c4e13a08"
-"checksum walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "9658c94fa8b940eab2250bd5a457f9c48b748420d71293b165c8cdbe2f55f71e"
 "checksum want 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
 "checksum wasi 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 "checksum wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)" = "5205e9afdf42282b192e2310a5b463a6d1c1d774e30dc3c791ac37ab42d2616c"

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -9,14 +9,13 @@ use serde::{Deserialize, Serialize};
 use near_network::types::{AccountOrPeerIdOrHash, KnownProducer};
 use near_network::PeerInfo;
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::Finality;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
     AccountId, BlockHeight, MaybeBlockId, ShardId, StateChanges, StateChangesRequest,
 };
 use near_primitives::utils::generate_random_string;
 use near_primitives::views::{
-    BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, GasPriceView,
+    BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, Finality, GasPriceView,
     LightClientBlockView, QueryRequest, QueryResponse,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use near_network::types::{AccountOrPeerIdOrHash, KnownProducer};
 use near_network::PeerInfo;
 use near_primitives::hash::CryptoHash;
+use near_primitives::rpc::Finality;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
     AccountId, BlockHeight, MaybeBlockId, ShardId, StateChanges, StateChangesRequest,
@@ -169,11 +170,12 @@ pub struct Query {
     pub query_id: String,
     pub block_id: MaybeBlockId,
     pub request: QueryRequest,
+    pub finality: Finality,
 }
 
 impl Query {
-    pub fn new(block_id: MaybeBlockId, request: QueryRequest) -> Self {
-        Query { query_id: generate_random_string(10), block_id, request }
+    pub fn new(block_id: MaybeBlockId, request: QueryRequest, finality: Finality) -> Self {
+        Query { query_id: generate_random_string(10), block_id, request, finality }
     }
 }
 

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -23,7 +23,7 @@ mod tests {
     use near_primitives::test_utils::init_integration_logger;
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::types::{BlockHeight, BlockHeightDelta};
-    use near_primitives::views::{QueryRequest, QueryResponseKind::ViewAccount};
+    use near_primitives::views::{Finality, QueryRequest, QueryResponseKind::ViewAccount};
 
     fn get_validators_and_key_pairs() -> (Vec<Vec<&'static str>>, Vec<PeerInfo>) {
         let validators = vec![
@@ -311,6 +311,7 @@ mod tests {
                                                     QueryRequest::ViewAccount {
                                                         account_id: account_to.clone(),
                                                     },
+                                                    Finality::None,
                                                 ))
                                                 .then(move |res| {
                                                     let res_inner = res.unwrap();
@@ -503,6 +504,7 @@ mod tests {
                                                             account_id: flat_validators[j]
                                                                 .to_string(),
                                                         },
+                                                        Finality::None,
                                                     ))
                                                     .then(move |res| {
                                                         let res_inner = res.unwrap();

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -7,9 +7,8 @@ use futures::{future, FutureExt};
 use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, Query, ViewClientActor};
 use near_network::{NetworkRequests, NetworkResponses, PeerInfo};
-use near_primitives::rpc::Finality;
 use near_primitives::test_utils::init_test_logger;
-use near_primitives::views::{QueryRequest, QueryResponseKind::ViewAccount};
+use near_primitives::views::{Finality, QueryRequest, QueryResponseKind::ViewAccount};
 
 /// Tests that the KeyValueRuntime properly sets balances in genesis and makes them queriable
 #[test]
@@ -91,12 +90,11 @@ mod tests {
         NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses, PeerInfo,
     };
     use near_primitives::hash::CryptoHash;
-    use near_primitives::rpc::Finality;
     use near_primitives::test_utils::init_test_logger;
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::types::AccountId;
     use near_primitives::views::QueryResponseKind::ViewAccount;
-    use near_primitives::views::{QueryRequest, QueryResponse};
+    use near_primitives::views::{Finality, QueryRequest, QueryResponse};
 
     fn send_tx(
         num_validators: usize,

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -7,6 +7,7 @@ use futures::{future, FutureExt};
 use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, Query, ViewClientActor};
 use near_network::{NetworkRequests, NetworkResponses, PeerInfo};
+use near_primitives::rpc::Finality;
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::views::{QueryRequest, QueryResponseKind::ViewAccount};
 
@@ -52,6 +53,7 @@ fn test_keyvalue_runtime_balances() {
                     .send(Query::new(
                         None,
                         QueryRequest::ViewAccount { account_id: flat_validators[i].to_string() },
+                        Finality::None,
                     ))
                     .then(move |res| {
                         let query_response = res.unwrap().unwrap().unwrap();
@@ -89,6 +91,7 @@ mod tests {
         NetworkClientMessages, NetworkClientResponses, NetworkRequests, NetworkResponses, PeerInfo,
     };
     use near_primitives::hash::CryptoHash;
+    use near_primitives::rpc::Finality;
     use near_primitives::test_utils::init_test_logger;
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::types::AccountId;
@@ -192,6 +195,7 @@ mod tests {
                         .send(Query::new(
                             None,
                             QueryRequest::ViewAccount { account_id: account_id.clone() },
+                            Finality::None,
                         ))
                         .then(move |x| {
                             test_cross_shard_tx_callback(
@@ -285,6 +289,7 @@ mod tests {
                                     QueryRequest::ViewAccount {
                                         account_id: validators[i].to_string(),
                                     },
+                                    Finality::None,
                                 ))
                                 .then(move |x| {
                                     test_cross_shard_tx_callback(
@@ -334,6 +339,7 @@ mod tests {
                         .send(Query::new(
                             None,
                             QueryRequest::ViewAccount { account_id: account_id.clone() },
+                            Finality::None,
                         ))
                         .then(move |x| {
                             test_cross_shard_tx_callback(
@@ -449,6 +455,7 @@ mod tests {
                             QueryRequest::ViewAccount {
                                 account_id: flat_validators[i].to_string(),
                             },
+                            Finality::None,
                         ))
                         .then(move |x| {
                             test_cross_shard_tx_callback(

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -3,6 +3,7 @@ use futures::{future, FutureExt};
 
 use near_client::test_utils::setup_no_network;
 use near_client::Query;
+use near_primitives::rpc::Finality;
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::views::{QueryRequest, QueryResponseKind};
 
@@ -14,7 +15,11 @@ fn query_client() {
         let (_, view_client) = setup_no_network(vec!["test"], "other", true, true);
         actix::spawn(
             view_client
-                .send(Query::new(None, QueryRequest::ViewAccount { account_id: "test".to_owned() }))
+                .send(Query::new(
+                    None,
+                    QueryRequest::ViewAccount { account_id: "test".to_owned() },
+                    Finality::None,
+                ))
                 .then(|res| {
                     match res.unwrap().unwrap().unwrap().kind {
                         QueryResponseKind::ViewAccount(_) => (),

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -3,9 +3,8 @@ use futures::{future, FutureExt};
 
 use near_client::test_utils::setup_no_network;
 use near_client::Query;
-use near_primitives::rpc::Finality;
 use near_primitives::test_utils::init_test_logger;
-use near_primitives::views::{QueryRequest, QueryResponseKind};
+use near_primitives::views::{Finality, QueryRequest, QueryResponseKind};
 
 /// Query account from view client
 #[test]

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -35,7 +35,7 @@ use near_network::types::NetworkViewClientMessages;
 use near_network::{NetworkClientMessages, NetworkClientResponses};
 use near_primitives::errors::{InvalidTxError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::RpcQueryRequest;
+use near_primitives::rpc::{RpcQueryRequest, Finality};
 use near_primitives::serialize::{from_base, from_base64, BaseEncode};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockId, MaybeBlockId, StateChangesRequest};
@@ -399,11 +399,11 @@ impl JsonRpcHandler {
                         ))))
                     }
                 };
-                RpcQueryRequest { block_id: None, request }
+                RpcQueryRequest { block_id: None, request, finality: Finality::NFG }
             } else {
                 parse_params::<RpcQueryRequest>(params)?
             };
-        let query = Query::new(query_request.block_id, query_request.request);
+        let query = Query::new(query_request.block_id, query_request.request, query_request.finality);
         timeout(self.polling_config.polling_timeout, async {
             loop {
                 let result = self.view_client_addr.send(query.clone()).await;

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -35,7 +35,7 @@ use near_network::types::NetworkViewClientMessages;
 use near_network::{NetworkClientMessages, NetworkClientResponses};
 use near_primitives::errors::{InvalidTxError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::{RpcQueryRequest, Finality};
+use near_primitives::rpc::{Finality, RpcQueryRequest};
 use near_primitives::serialize::{from_base, from_base64, BaseEncode};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockId, MaybeBlockId, StateChangesRequest};
@@ -403,7 +403,8 @@ impl JsonRpcHandler {
             } else {
                 parse_params::<RpcQueryRequest>(params)?
             };
-        let query = Query::new(query_request.block_id, query_request.request, query_request.finality);
+        let query =
+            Query::new(query_request.block_id, query_request.request, query_request.finality);
         timeout(self.polling_config.polling_timeout, async {
             loop {
                 let result = self.view_client_addr.send(query.clone()).await;

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -399,7 +399,8 @@ impl JsonRpcHandler {
                         ))))
                     }
                 };
-                RpcQueryRequest { block_id: None, request, finality: Finality::NFG }
+                // Use Finality::None here to make backward compatibility tests work
+                RpcQueryRequest { block_id: None, request, finality: Finality::None }
             } else {
                 parse_params::<RpcQueryRequest>(params)?
             };

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -35,12 +35,12 @@ use near_network::types::NetworkViewClientMessages;
 use near_network::{NetworkClientMessages, NetworkClientResponses};
 use near_primitives::errors::{InvalidTxError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::{Finality, RpcQueryRequest};
+use near_primitives::rpc::RpcQueryRequest;
 use near_primitives::serialize::{from_base, from_base64, BaseEncode};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockId, MaybeBlockId, StateChangesRequest};
 use near_primitives::utils::is_valid_account_id;
-use near_primitives::views::{FinalExecutionStatus, QueryRequest};
+use near_primitives::views::{FinalExecutionStatus, Finality, QueryRequest};
 
 mod metrics;
 pub mod test_utils;

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -178,7 +178,15 @@ fn test_query_account() {
             })
             .await
             .unwrap();
-        for query_response in [query_response_1, query_response_2, query_response_3, query_response_4, query_response_5].into_iter() {
+        for query_response in [
+            query_response_1,
+            query_response_2,
+            query_response_3,
+            query_response_4,
+            query_response_5,
+        ]
+        .into_iter()
+        {
             assert_eq!(query_response.block_height, 0);
             assert_eq!(query_response.block_hash, block_hash);
             let account_info = if let QueryResponseKind::ViewAccount(ref account) =
@@ -277,7 +285,7 @@ fn test_query_access_key() {
                     )
                     .unwrap(),
                 },
-                finality: Finality::None
+                finality: Finality::None,
             })
             .await
             .unwrap();
@@ -303,7 +311,7 @@ fn test_query_state() {
                     account_id: "test".to_string(),
                     prefix: vec![].into(),
                 },
-                finality: Finality::None
+                finality: Finality::None,
             })
             .await
             .unwrap();
@@ -329,7 +337,7 @@ fn test_query_call_function() {
                     method_name: "method".to_string(),
                     args: vec![].into(),
                 },
-                finality: Finality::None
+                finality: Finality::None,
             })
             .await
             .unwrap();

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -10,7 +10,7 @@ use near_jsonrpc_client::ChunkId;
 use near_network::test_utils::WaitOrTimeout;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::RpcQueryRequest;
+use near_primitives::rpc::{Finality, RpcQueryRequest};
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::types::{BlockId, ShardId};
 use near_primitives::views::{QueryRequest, QueryResponseKind};
@@ -142,6 +142,7 @@ fn test_query_account() {
             .query(RpcQueryRequest {
                 block_id: None,
                 request: QueryRequest::ViewAccount { account_id: "test".to_string() },
+                finality: Finality::None,
             })
             .await
             .unwrap();
@@ -149,6 +150,7 @@ fn test_query_account() {
             .query(RpcQueryRequest {
                 block_id: Some(BlockId::Height(0)),
                 request: QueryRequest::ViewAccount { account_id: "test".to_string() },
+                finality: Finality::None,
             })
             .await
             .unwrap();
@@ -156,10 +158,27 @@ fn test_query_account() {
             .query(RpcQueryRequest {
                 block_id: Some(BlockId::Hash(block_hash)),
                 request: QueryRequest::ViewAccount { account_id: "test".to_string() },
+                finality: Finality::None,
             })
             .await
             .unwrap();
-        for query_response in [query_response_1, query_response_2, query_response_3].into_iter() {
+        let query_response_4 = client
+            .query(RpcQueryRequest {
+                block_id: Some(BlockId::Hash(block_hash)),
+                request: QueryRequest::ViewAccount { account_id: "test".to_string() },
+                finality: Finality::DoomSlug,
+            })
+            .await
+            .unwrap();
+        let query_response_5 = client
+            .query(RpcQueryRequest {
+                block_id: Some(BlockId::Hash(block_hash)),
+                request: QueryRequest::ViewAccount { account_id: "test".to_string() },
+                finality: Finality::NFG,
+            })
+            .await
+            .unwrap();
+        for query_response in [query_response_1, query_response_2, query_response_3, query_response_4, query_response_5].into_iter() {
             assert_eq!(query_response.block_height, 0);
             assert_eq!(query_response.block_hash, block_hash);
             let account_info = if let QueryResponseKind::ViewAccount(ref account) =
@@ -205,6 +224,7 @@ fn test_query_access_keys() {
             .query(RpcQueryRequest {
                 block_id: None,
                 request: QueryRequest::ViewAccessKeyList { account_id: "test".to_string() },
+                finality: Finality::None,
             })
             .await
             .unwrap();
@@ -257,6 +277,7 @@ fn test_query_access_key() {
                     )
                     .unwrap(),
                 },
+                finality: Finality::None
             })
             .await
             .unwrap();
@@ -282,6 +303,7 @@ fn test_query_state() {
                     account_id: "test".to_string(),
                     prefix: vec![].into(),
                 },
+                finality: Finality::None
             })
             .await
             .unwrap();
@@ -307,6 +329,7 @@ fn test_query_call_function() {
                     method_name: "method".to_string(),
                     args: vec![].into(),
                 },
+                finality: Finality::None
             })
             .await
             .unwrap();

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -10,10 +10,10 @@ use near_jsonrpc_client::ChunkId;
 use near_network::test_utils::WaitOrTimeout;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::{Finality, RpcQueryRequest};
+use near_primitives::rpc::RpcQueryRequest;
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::types::{BlockId, ShardId};
-use near_primitives::views::{QueryRequest, QueryResponseKind};
+use near_primitives::views::{Finality, QueryRequest, QueryResponseKind};
 
 macro_rules! test_with_client {
     ($client:ident, $block:expr) => {

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -283,8 +283,8 @@ impl Peer {
             PeerMessage::Routed(message) => {
                 msg_hash = Some(message.hash());
                 match message.body {
-                    RoutedMessageBody::QueryRequest { query_id, block_id, request } => {
-                        NetworkViewClientMessages::Query { query_id, block_id, request }
+                    RoutedMessageBody::QueryRequest { query_id, block_id, request, finality } => {
+                        NetworkViewClientMessages::Query { query_id, block_id, request, finality }
                     }
                     RoutedMessageBody::QueryResponse { query_id, response } => {
                         NetworkViewClientMessages::QueryResponse { query_id, response }

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -961,11 +961,11 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                     NetworkResponses::RouteNotFound
                 }
             }
-            NetworkRequests::Query { query_id, account_id, block_id, request } => {
+            NetworkRequests::Query { query_id, account_id, block_id, request, finality } => {
                 if self.send_message_to_account(
                     ctx,
                     &account_id,
-                    RoutedMessageBody::QueryRequest { query_id, block_id, request },
+                    RoutedMessageBody::QueryRequest { query_id, block_id, request, finality },
                 ) {
                     NetworkResponses::NoResponse
                 } else {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -28,12 +28,11 @@ use near_primitives::sharding::{ChunkHash, PartialEncodedChunk};
 use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
 use near_primitives::types::{AccountId, BlockHeight, EpochId, MaybeBlockId, ShardId};
 use near_primitives::utils::{from_timestamp, to_timestamp};
-use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryResponse};
+use near_primitives::views::{FinalExecutionOutcomeView, Finality, QueryRequest, QueryResponse};
 
 use crate::metrics;
 use crate::peer::Peer;
 use crate::routing::{Edge, EdgeInfo, RoutingTableInfo};
-use near_primitives::rpc::Finality;
 
 /// Number of hops a message is allowed to travel before being dropped.
 /// This is used to avoid infinite loop because of inconsistent view of the network

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -33,6 +33,7 @@ use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryRespo
 use crate::metrics;
 use crate::peer::Peer;
 use crate::routing::{Edge, EdgeInfo, RoutingTableInfo};
+use near_primitives::rpc::Finality;
 
 /// Number of hops a message is allowed to travel before being dropped.
 /// This is used to avoid infinite loop because of inconsistent view of the network
@@ -215,6 +216,7 @@ pub enum RoutedMessageBody {
         query_id: String,
         block_id: MaybeBlockId,
         request: QueryRequest,
+        finality: Finality,
     },
     QueryResponse {
         query_id: String,
@@ -1007,6 +1009,7 @@ pub enum NetworkRequests {
         account_id: AccountId,
         block_id: MaybeBlockId,
         request: QueryRequest,
+        finality: Finality,
     },
     /// Request for receipt execution outcome
     ReceiptOutComeRequest(AccountId, CryptoHash),
@@ -1195,7 +1198,7 @@ pub enum NetworkViewClientMessages {
     /// Transaction status response
     TxStatusResponse(FinalExecutionOutcomeView),
     /// General query
-    Query { query_id: String, block_id: MaybeBlockId, request: QueryRequest },
+    Query { query_id: String, block_id: MaybeBlockId, request: QueryRequest, finality: Finality },
     /// Query response
     QueryResponse { query_id: String, response: Result<QueryResponse, String> },
     /// Request for receipt outcome

--- a/core/primitives/src/rpc.rs
+++ b/core/primitives/src/rpc.rs
@@ -1,8 +1,7 @@
-use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use super::types::MaybeBlockId;
-use super::views::QueryRequest;
+use super::views::{Finality, QueryRequest};
 
 #[derive(Serialize, Deserialize)]
 pub struct RpcQueryRequest {
@@ -10,12 +9,4 @@ pub struct RpcQueryRequest {
     #[serde(flatten)]
     pub request: QueryRequest,
     pub finality: Finality,
-}
-
-/// Different types of finality.
-#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
-pub enum Finality {
-    None,
-    DoomSlug,
-    NFG,
 }

--- a/core/primitives/src/rpc.rs
+++ b/core/primitives/src/rpc.rs
@@ -1,3 +1,4 @@
+use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use super::types::MaybeBlockId;
@@ -8,4 +9,13 @@ pub struct RpcQueryRequest {
     pub block_id: MaybeBlockId,
     #[serde(flatten)]
     pub request: QueryRequest,
+    pub finality: Finality,
+}
+
+/// Different types of finality.
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
+pub enum Finality {
+    None,
+    DoomSlug,
+    NFG,
 }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1020,11 +1020,11 @@ pub struct GasPriceView {
 /// Different types of finality.
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
 pub enum Finality {
-    #[serde(rename(serialize = "optimistic", deserialize = "optimistic"))]
+    #[serde(rename = "optimistic")]
     None,
-    #[serde(rename(serialize = "near-final", deserialize = "near-final"))]
+    #[serde(rename = "near-final")]
     DoomSlug,
-    #[serde(rename(serialize = "final", deserialize = "final"))]
+    #[serde(rename = "final")]
     NFG,
 }
 

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1016,3 +1016,17 @@ pub struct GasPriceView {
     #[serde(with = "u128_dec_format")]
     pub gas_price: Balance,
 }
+
+/// Different types of finality.
+#[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
+pub enum Finality {
+    None,
+    DoomSlug,
+    NFG,
+}
+
+impl Default for Finality {
+    fn default() -> Self {
+        Finality::NFG
+    }
+}

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -1020,8 +1020,11 @@ pub struct GasPriceView {
 /// Different types of finality.
 #[derive(Serialize, Deserialize, BorshSerialize, BorshDeserialize, Clone, Debug, PartialEq, Eq)]
 pub enum Finality {
+    #[serde(rename(serialize = "optimistic", deserialize = "optimistic"))]
     None,
+    #[serde(rename(serialize = "near-final", deserialize = "near-final"))]
     DoomSlug,
+    #[serde(rename(serialize = "final", deserialize = "final"))]
     NFG,
 }
 

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -15,11 +15,10 @@ use near_crypto::{InMemorySigner, KeyType};
 use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
 use near_network::NetworkClientMessages;
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::Finality;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeightDelta, NumSeats};
-use near_primitives::views::{QueryRequest, QueryResponseKind, ValidatorInfo};
+use near_primitives::views::{Finality, QueryRequest, QueryResponseKind, ValidatorInfo};
 use testlib::genesis_hash;
 
 #[derive(Clone)]

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -15,6 +15,7 @@ use near_crypto::{InMemorySigner, KeyType};
 use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
 use near_network::NetworkClientMessages;
 use near_primitives::hash::CryptoHash;
+use near_primitives::rpc::Finality;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeightDelta, NumSeats};
@@ -220,6 +221,7 @@ fn test_validator_kickout() {
                                                     .account_id
                                                     .clone(),
                                             },
+                                            Finality::None,
                                         ))
                                         .then(move |res| {
                                             match res.unwrap().unwrap().unwrap().kind {
@@ -249,6 +251,7 @@ fn test_validator_kickout() {
                                                     .account_id
                                                     .clone(),
                                             },
+                                            Finality::None,
                                         ))
                                         .then(move |res| {
                                             match res.unwrap().unwrap().unwrap().kind {
@@ -366,6 +369,7 @@ fn test_validator_join() {
                                         QueryRequest::ViewAccount {
                                             account_id: test_nodes[1].account_id.clone(),
                                         },
+                                        Finality::None,
                                     ))
                                     .then(move |res| match res.unwrap().unwrap().unwrap().kind {
                                         QueryResponseKind::ViewAccount(result) => {
@@ -385,6 +389,7 @@ fn test_validator_join() {
                                         QueryRequest::ViewAccount {
                                             account_id: test_nodes[2].account_id.clone(),
                                         },
+                                        Finality::None,
                                     ))
                                     .then(move |res| match res.unwrap().unwrap().unwrap().kind {
                                         QueryResponseKind::ViewAccount(result) => {

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -120,9 +120,8 @@ class BaseNode(object):
     def get_validators(self):
         return self.json_rpc('validators', [None])
 
-    def get_account(self, acc):
-        print(f'get account {acc}')
-        return self.json_rpc('query', ["account/%s" % acc, ""])
+    def get_account(self, acc, finality="None"):
+        return self.json_rpc('query', {"request_type": "view_account", "account_id": acc, "block_id": None, "finality": finality})
 
     def get_block(self, block_hash):
         return self.json_rpc('block', [block_hash])

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -120,7 +120,7 @@ class BaseNode(object):
     def get_validators(self):
         return self.json_rpc('validators', [None])
 
-    def get_account(self, acc, finality="None"):
+    def get_account(self, acc, finality='optimistic'):
         return self.json_rpc('query', {"request_type": "view_account", "account_id": acc, "block_id": None, "finality": finality})
 
     def get_block(self, block_hash):

--- a/pytest/tests/sanity/rpc_finality.py
+++ b/pytest/tests/sanity/rpc_finality.py
@@ -1,0 +1,44 @@
+# The test launches two validating node out of three validators.
+# Transfer some tokens between two accounts (thus changing state).
+# Query for no finality, doomslug finality
+
+import sys, time, base58, random
+
+sys.path.append('lib')
+
+
+from cluster import start_cluster
+from utils import TxContext
+from transaction import sign_payment_tx
+
+nodes = start_cluster(3, 1, 1, None, [["min_gas_price", 0], ["epoch_length", 100]], {})
+
+time.sleep(3)
+# kill one validating node so that no block can be finalized
+nodes[2].kill()
+time.sleep(1)
+
+acc0_balance = int(nodes[0].get_account('test0')['result']['amount'])
+acc1_balance = int(nodes[0].get_account('test1')['result']['amount'])
+
+token_transfer = 10
+status = nodes[0].get_status()
+latest_block_hash = status['sync_info']['latest_block_hash']
+tx = sign_payment_tx(nodes[0].signer_key, 'test1', token_transfer, 1, base58.b58decode(latest_block_hash.encode('utf8')))
+print(nodes[0].send_tx_and_wait(tx, timeout=20))
+
+# wait for doomslug finality
+time.sleep(5)
+for i in range(2):
+    acc_id = 'test0' if i == 0 else 'test1'
+    acc_no_finality = nodes[0].get_account(acc_id)
+    acc_doomslug_finality = nodes[0].get_account(acc_id, "DoomSlug")
+    acc_nfg_finality = nodes[0].get_account(acc_id, "NFG")
+    if i == 0:
+        assert int(acc_no_finality['result']['amount']) == acc0_balance - token_transfer
+        assert int(acc_doomslug_finality['result']['amount']) == acc0_balance - token_transfer
+        assert int(acc_nfg_finality['result']['amount']) == acc0_balance
+    else:
+        assert int(acc_no_finality['result']['amount']) == acc1_balance + token_transfer
+        assert int(acc_doomslug_finality['result']['amount']) == acc1_balance + token_transfer
+        assert int(acc_nfg_finality['result']['amount']) == acc1_balance

--- a/pytest/tests/sanity/rpc_finality.py
+++ b/pytest/tests/sanity/rpc_finality.py
@@ -32,8 +32,8 @@ time.sleep(5)
 for i in range(2):
     acc_id = 'test0' if i == 0 else 'test1'
     acc_no_finality = nodes[0].get_account(acc_id)
-    acc_doomslug_finality = nodes[0].get_account(acc_id, "DoomSlug")
-    acc_nfg_finality = nodes[0].get_account(acc_id, "NFG")
+    acc_doomslug_finality = nodes[0].get_account(acc_id, "near-final")
+    acc_nfg_finality = nodes[0].get_account(acc_id, "final")
     if i == 0:
         assert int(acc_no_finality['result']['amount']) == acc0_balance - token_transfer
         assert int(acc_doomslug_finality['result']['amount']) == acc0_balance - token_transfer


### PR DESCRIPTION
For rpc queries, currently we return the result from the latest block and don't consider any finality. This PR allows ones to specify the finality requirement for the query (nfg, doomslug, none).

Test plan
---------
* Sanity test that different types of finality can be processed.
* pytest `rpc_finality.py` which tests that when blocks cannot be finalized by NFG because not enough validators are online but can be finalized by doomslug, rpc specifying doomslug finality and NFG finality return different (and correct) values.