### PR TITLE
fix(jsonrpc_client): Fix tests with confusing panic output

### DIFF
--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -200,7 +200,8 @@ fn test_replay_protection() {
                 .map_err(|_| {
                     System::current().stop();
                 })
-                .map(move |_| panic!("transaction should not succeed")),
+                .map_ok(move |_| panic!("transaction should not succeed"))
+                .map(drop),
         );
         wait_or_panic(10000);
     })
@@ -223,7 +224,8 @@ fn test_tx_status_invalid_account_id() {
                     assert!(s.starts_with("\"Invalid account id"));
                     System::current().stop();
                 })
-                .map(move |_| panic!("transaction should not succeed")),
+                .map_ok(move |_| panic!("transaction should not succeed"))
+                .map(drop),
         );
         wait_or_panic(10000);
     })


### PR DESCRIPTION
These tests have a confusing behavior where they always explicitly
panic but in case of success they do it after stopping the system
with 0 code so it gets ignored.
Move the panic to the failure branch.

# Test plan
Run the test manually and see no panic in the output
Swap map_ok and map_err branches and see that it fails