### PR TITLE
fix(chain): archive flag + test_catchup_receipts_sync_distant_epoch fix

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -74,6 +74,7 @@ pub fn setup(
     min_block_prod_time: u64,
     max_block_prod_time: u64,
     enable_doomslug: bool,
+    archive: bool,
     network_adapter: Arc<dyn NetworkAdapter>,
     transaction_validity_period: NumBlocks,
     genesis_time: DateTime<Utc>,
@@ -115,6 +116,7 @@ pub fn setup(
         min_block_prod_time,
         max_block_prod_time,
         num_validator_seats,
+        archive,
     );
     let view_client = ViewClientActor::new(
         store.clone(),
@@ -189,6 +191,7 @@ pub fn setup_mock_with_validity_period(
         100,
         200,
         enable_doomslug,
+        false,
         network_adapter.clone(),
         transaction_validity_period,
         Utc::now(),
@@ -255,6 +258,7 @@ pub fn setup_mock_all_validators(
     tamper_with_fg: bool,
     epoch_length: BlockHeightDelta,
     enable_doomslug: bool,
+    archive: bool,
     network_mock: Arc<RwLock<dyn FnMut(String, &NetworkRequests) -> (NetworkResponses, bool)>>,
 ) -> (Block, Vec<(Addr<ClientActor>, Addr<ViewClientActor>)>) {
     let validators_clone = validators.clone();
@@ -725,6 +729,7 @@ pub fn setup_mock_all_validators(
                 block_prod_time,
                 block_prod_time * 3,
                 enable_doomslug,
+                archive,
                 Arc::new(network_adapter),
                 10000,
                 genesis_time,
@@ -792,7 +797,7 @@ pub fn setup_client_with_runtime(
         Arc::new(InMemoryValidatorSigner::from_seed(x, KeyType::ED25519, x))
             as Arc<dyn ValidatorSigner>
     });
-    let mut config = ClientConfig::test(true, 10, 20, num_validator_seats);
+    let mut config = ClientConfig::test(true, 10, 20, num_validator_seats, false);
     config.epoch_length = chain_genesis.epoch_length;
     let mut client = Client::new(
         config,

--- a/chain/client/tests/bug_repros.rs
+++ b/chain/client/tests/bug_repros.rs
@@ -46,6 +46,7 @@ fn repro_1183() {
             false,
             5,
             false,
+            false,
             Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {
                 if let NetworkRequests::Block { block } = msg {
                     let mut last_block = last_block.write().unwrap();

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -141,6 +141,7 @@ mod tests {
                 false,
                 5,
                 false,
+                true,
                 Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {
                     let account_from = "test3.3".to_string();
                     let account_to = "test1.1".to_string();
@@ -434,6 +435,7 @@ mod tests {
                 false,
                 5,
                 false,
+                false,
                 Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {
                     let mut seen_heights_same_block = seen_heights_same_block.write().unwrap();
                     let mut phase = phase.write().unwrap();
@@ -650,6 +652,7 @@ mod tests {
                 false,
                 5,
                 false,
+                false,
                 Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {
                     if let NetworkRequests::Block { block } = msg {
                         check_height(block.hash(), block.header.inner_lite.height);
@@ -707,6 +710,7 @@ mod tests {
                 false,
                 5,
                 true,
+                false,
                 Arc::new(RwLock::new(move |_account_id: String, msg: &NetworkRequests| {
                     let propagate = if let NetworkRequests::Block { block } = msg {
                         check_height(block.hash(), block.header.inner_lite.height);
@@ -776,6 +780,7 @@ mod tests {
                 false,
                 false,
                 5,
+                false,
                 false,
                 Arc::new(RwLock::new(move |sender_account_id: String, msg: &NetworkRequests| {
                     let mut grieving_chunk_hash = grieving_chunk_hash.write().unwrap();
@@ -936,6 +941,7 @@ mod tests {
                 false,
                 false,
                 epoch_length,
+                false,
                 false,
                 Arc::new(RwLock::new(move |sender_account_id: String, msg: &NetworkRequests| {
                     let mut seen_chunk_same_sender = seen_chunk_same_sender.write().unwrap();

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -119,6 +119,7 @@ fn chunks_produced_and_distributed_common(
             false,
             5,
             true,
+            false,
             Arc::new(RwLock::new(move |from_whom: String, msg: &NetworkRequests| {
                 match msg {
                     NetworkRequests::Block { block } => {

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -34,6 +34,7 @@ fn test_keyvalue_runtime_balances() {
             false,
             5,
             false,
+            false,
             Arc::new(RwLock::new(move |_account_id: String, _msg: &NetworkRequests| {
                 (NetworkResponses::NoResponse, true)
             })),
@@ -420,6 +421,7 @@ mod tests {
                 !test_doomslug,
                 20,
                 test_doomslug,
+                false,
                 Arc::new(RwLock::new(move |_account_id: String, _msg: &NetworkRequests| {
                     (NetworkResponses::NoResponse, true)
                 })),

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -55,7 +55,7 @@ pub fn setup_network_node(
         ChainGenesis::new(genesis_time, 1_000_000, 100, 1_000_000_000, 0, 0, 1000, 5);
 
     let peer_manager = PeerManagerActor::create(move |ctx| {
-        let mut client_config = ClientConfig::test(false, 100, 200, num_validators);
+        let mut client_config = ClientConfig::test(false, 100, 200, num_validators, false);
         client_config.ttl_account_id_router = config.ttl_account_id_router;
         let network_adapter = NetworkRecipient::new();
         network_adapter.set_recipient(ctx.address().recipient());

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -80,6 +80,7 @@ impl ClientConfig {
         min_block_prod_time: u64,
         max_block_prod_time: u64,
         num_block_producer_seats: NumSeats,
+        archive: bool,
     ) -> Self {
         ClientConfig {
             version: Default::default(),
@@ -119,7 +120,7 @@ impl ClientConfig {
             block_header_fetch_horizon: 50,
             tracked_accounts: vec![],
             tracked_shards: vec![],
-            archive: false,
+            archive,
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/nearprotocol/nearcore/issues/2145.
I guess the problem was in very specific way of validators assigning in the test. Nodes try to build State Headers and asked for (previously deleted) chunks from ourselves, then fail because of having no chunks.
This fix turns off GC by adding `archive` flag and passes it to the config.