### PR TITLE
provide a "dev" folder and draft README

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -1,0 +1,21 @@
+# Core Developer Documentation
+
+The documentation within this folder affects mostly the **NEAR Protocol Core Team**, Core-Collaborators (Contributors with access to project resources) and Core-Contributors.
+
+The term "Core" implies that those developer know what they are doing, even if it is "deep in the systems core".
+
+## Contents
+
+* SETUP.md
+* BRANCHES.md
+* CI.md
+* RELEASES.md
+* (...)
+
+## Writing Documentation
+
+Documentation must be kept minimal. If you describe something too much, then it's an indicator that it must be simplified or automated.
+
+Automation should be provided either within cross-platform tools, or cross-platform scripting (usually node.js or python)
+
+Remember that you address capable (core-) developers, it is not necessary to describe things much. Let cli-commands or code talk, go straight to the point. Add now and then some link to high-quality documentation.


### PR DESCRIPTION
re #2168

The suggestion is to keep "core-dev" documentation within this folder, right within the repo. 

The doc-site handles dapp-developer documentation.