### PR TITLE
Feat(rpc): add finality to block rpc

### DIFF
--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -9,10 +9,9 @@ use serde::{Deserialize, Serialize};
 use near_network::types::{AccountOrPeerIdOrHash, KnownProducer};
 use near_network::PeerInfo;
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
-    AccountId, BlockHeight, MaybeBlockId, ShardId, StateChanges, StateChangesRequest,
+    AccountId, BlockHeight, BlockId, MaybeBlockId, ShardId, StateChanges, StateChangesRequest,
 };
 use near_primitives::utils::generate_random_string;
 use near_primitives::views::{
@@ -143,7 +142,10 @@ impl SyncStatus {
 }
 
 /// Actor message requesting block by id or hash.
-pub struct GetBlock(pub BlockQueryInfo);
+pub enum GetBlock {
+    BlockId(BlockId),
+    Finality(Finality),
+}
 
 impl Message for GetBlock {
     type Result = Result<BlockView, String>;

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use near_network::types::{AccountOrPeerIdOrHash, KnownProducer};
 use near_network::PeerInfo;
 use near_primitives::hash::CryptoHash;
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
     AccountId, BlockHeight, MaybeBlockId, ShardId, StateChanges, StateChangesRequest,
@@ -142,11 +143,7 @@ impl SyncStatus {
 }
 
 /// Actor message requesting block by id or hash.
-pub enum GetBlock {
-    Best,
-    Height(BlockHeight),
-    Hash(CryptoHash),
-}
+pub struct GetBlock(pub BlockQueryInfo);
 
 impl Message for GetBlock {
     type Result = Result<BlockView, String>;

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -34,6 +34,7 @@ use near_store::Store;
 
 use crate::types::{Error, GetBlock, GetGasPrice, Query, TxStatus};
 use crate::{sync, GetChunk, GetKeyValueChanges, GetNextLightClientBlock, GetValidatorInfo};
+use near_primitives::rpc::BlockQueryInfo;
 
 /// Max number of queries that we keep.
 const QUERY_REQUEST_LIMIT: usize = 500;
@@ -118,6 +119,15 @@ impl ViewClientActor {
         need_request
     }
 
+    fn get_block_hash_by_finality(&mut self, finality: &Finality) -> Result<CryptoHash, Error> {
+        let head_header = self.chain.head_header()?;
+        match finality {
+            Finality::None => Ok(head_header.hash),
+            Finality::DoomSlug => Ok(head_header.inner_rest.last_ds_final_block),
+            Finality::NFG => Ok(head_header.inner_rest.last_quorum_pre_commit),
+        }
+    }
+
     fn handle_query(&mut self, msg: Query) -> Result<Option<QueryResponse>, String> {
         if let Some(response) = self.query_responses.cache_remove(&msg.query_id) {
             self.query_requests.cache_remove(&msg.query_id);
@@ -128,21 +138,9 @@ impl ViewClientActor {
             Some(BlockId::Height(block_height)) => self.chain.get_header_by_height(block_height),
             Some(BlockId::Hash(block_hash)) => self.chain.get_block_header(&block_hash),
             None => {
-                let head_header = match self.chain.head_header() {
-                    Ok(h) => h,
-                    Err(e) => return Err(e.to_string()),
-                };
-                match msg.finality {
-                    Finality::None => Ok(head_header),
-                    Finality::DoomSlug => {
-                        let last_ds_final_block_hash = head_header.inner_rest.last_ds_final_block;
-                        self.chain.get_block_header(&last_ds_final_block_hash)
-                    }
-                    Finality::NFG => {
-                        let last_final_block_hash = head_header.inner_rest.last_quorum_pre_commit;
-                        self.chain.get_block_header(&last_final_block_hash)
-                    }
-                }
+                let block_hash =
+                    self.get_block_hash_by_finality(&msg.finality).map_err(|e| e.to_string())?;
+                self.chain.get_block_header(&block_hash)
             }
         };
         let header = header.map_err(|e| e.to_string())?.clone();
@@ -340,13 +338,18 @@ impl Handler<GetBlock> for ViewClientActor {
     type Result = Result<BlockView, String>;
 
     fn handle(&mut self, msg: GetBlock, _: &mut Context<Self>) -> Self::Result {
-        match msg {
-            GetBlock::Best => match self.chain.head() {
-                Ok(head) => self.chain.get_block(&head.last_block_hash).map(Clone::clone),
-                Err(err) => Err(err),
-            },
-            GetBlock::Height(height) => self.chain.get_block_by_height(height).map(Clone::clone),
-            GetBlock::Hash(hash) => self.chain.get_block(&hash).map(Clone::clone),
+        match msg.0 {
+            BlockQueryInfo::Finality(finality) => {
+                let block_hash =
+                    self.get_block_hash_by_finality(&finality).map_err(|e| e.to_string())?;
+                self.chain.get_block(&block_hash).map(Clone::clone)
+            }
+            BlockQueryInfo::BlockId(BlockId::Height(height)) => {
+                self.chain.get_block_by_height(height).map(Clone::clone)
+            }
+            BlockQueryInfo::BlockId(BlockId::Hash(hash)) => {
+                self.chain.get_block(&hash).map(Clone::clone)
+            }
         }
         .and_then(|block| {
             self.runtime_adapter

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -15,11 +15,13 @@ use near_network::types::PartialEncodedChunkRequestMsg;
 use near_network::{NetworkClientMessages, NetworkRequests, NetworkResponses, PeerInfo};
 use near_primitives::block::BlockHeader;
 use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::sharding::{PartialEncodedChunk, ShardChunkHeader};
 use near_primitives::test_utils::init_integration_logger;
 use near_primitives::test_utils::{heavy_test, init_test_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
+use near_primitives::views::Finality;
 
 #[test]
 fn chunks_produced_and_distributed_all_in_all_shards() {
@@ -216,7 +218,7 @@ fn chunks_produced_and_distributed_common(
         *connectors.write().unwrap() = conn;
 
         let view_client = connectors.write().unwrap()[0].1.clone();
-        actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
+        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(move |res| {
             let header: BlockHeader = res.unwrap().unwrap().header.into();
             let block_hash = header.hash;
             let connectors_ = connectors.write().unwrap();

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -218,7 +218,7 @@ fn chunks_produced_and_distributed_common(
         *connectors.write().unwrap() = conn;
 
         let view_client = connectors.write().unwrap()[0].1.clone();
-        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(move |res| {
+        actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(move |res| {
             let header: BlockHeader = res.unwrap().unwrap().header.into();
             let block_hash = header.hash;
             let connectors_ = connectors.write().unwrap();

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -20,12 +20,14 @@ use near_primitives::block::{Approval, BlockHeader};
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::merklize;
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::sharding::EncodedShardChunk;
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::transaction::{SignedTransaction, Transaction};
 use near_primitives::types::{EpochId, MerkleHash};
 use near_primitives::utils::to_timestamp;
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
+use near_primitives::views::Finality;
 use near_store::test_utils::create_test_store;
 
 /// Runs block producing client and stops after network mock received two blocks.
@@ -106,13 +108,16 @@ fn produce_blocks_with_tx() {
             }),
         );
         near_network::test_utils::wait_or_panic(5000);
-        actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-            let header: BlockHeader = res.unwrap().unwrap().header.into();
-            let block_hash = header.hash;
-            client
-                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash)));
-            future::ready(())
-        }))
+        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+            move |res| {
+                let header: BlockHeader = res.unwrap().unwrap().header.into();
+                let block_hash = header.hash;
+                client.do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(
+                    block_hash,
+                )));
+                future::ready(())
+            },
+        ))
     })
     .unwrap();
 }
@@ -143,35 +148,37 @@ fn receive_network_block() {
                 NetworkResponses::NoResponse
             }),
         );
-        actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-            let last_block = res.unwrap().unwrap();
-            let signer = InMemoryValidatorSigner::from_seed("test1", KeyType::ED25519, "test1");
-            let block = Block::produce(
-                &last_block.header.clone().into(),
-                last_block.header.height + 1,
-                last_block.chunks.into_iter().map(Into::into).collect(),
-                EpochId::default(),
-                if last_block.header.prev_hash == CryptoHash::default() {
-                    EpochId(last_block.header.hash)
-                } else {
-                    EpochId(last_block.header.next_epoch_id.clone())
-                },
-                vec![],
-                0,
-                0,
-                None,
-                vec![],
-                vec![],
-                &signer,
-                0.into(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                last_block.header.next_bp_hash,
-            );
-            client.do_send(NetworkClientMessages::Block(block, PeerInfo::random().id, false));
-            future::ready(())
-        }));
+        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+            move |res| {
+                let last_block = res.unwrap().unwrap();
+                let signer = InMemoryValidatorSigner::from_seed("test1", KeyType::ED25519, "test1");
+                let block = Block::produce(
+                    &last_block.header.clone().into(),
+                    last_block.header.height + 1,
+                    last_block.chunks.into_iter().map(Into::into).collect(),
+                    EpochId::default(),
+                    if last_block.header.prev_hash == CryptoHash::default() {
+                        EpochId(last_block.header.hash)
+                    } else {
+                        EpochId(last_block.header.next_epoch_id.clone())
+                    },
+                    vec![],
+                    0,
+                    0,
+                    None,
+                    vec![],
+                    vec![],
+                    &signer,
+                    0.into(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    last_block.header.next_bp_hash,
+                );
+                client.do_send(NetworkClientMessages::Block(block, PeerInfo::random().id, false));
+                future::ready(())
+            },
+        ));
         near_network::test_utils::wait_or_panic(5000);
     })
     .unwrap();
@@ -207,40 +214,42 @@ fn receive_network_block_header() {
                 _ => NetworkResponses::NoResponse,
             }),
         );
-        actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-            let last_block = res.unwrap().unwrap();
-            let signer = InMemoryValidatorSigner::from_seed("test", KeyType::ED25519, "test");
-            let block = Block::produce(
-                &last_block.header.clone().into(),
-                last_block.header.height + 1,
-                last_block.chunks.into_iter().map(Into::into).collect(),
-                EpochId::default(),
-                if last_block.header.prev_hash == CryptoHash::default() {
-                    EpochId(last_block.header.hash)
-                } else {
-                    EpochId(last_block.header.next_epoch_id.clone())
-                },
-                vec![],
-                0,
-                0,
-                None,
-                vec![],
-                vec![],
-                &signer,
-                0.into(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                last_block.header.next_bp_hash,
-            );
-            client.do_send(NetworkClientMessages::Block(
-                block.clone(),
-                PeerInfo::random().id,
-                false,
-            ));
-            *block_holder.write().unwrap() = Some(block);
-            future::ready(())
-        }));
+        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+            move |res| {
+                let last_block = res.unwrap().unwrap();
+                let signer = InMemoryValidatorSigner::from_seed("test", KeyType::ED25519, "test");
+                let block = Block::produce(
+                    &last_block.header.clone().into(),
+                    last_block.header.height + 1,
+                    last_block.chunks.into_iter().map(Into::into).collect(),
+                    EpochId::default(),
+                    if last_block.header.prev_hash == CryptoHash::default() {
+                        EpochId(last_block.header.hash)
+                    } else {
+                        EpochId(last_block.header.next_epoch_id.clone())
+                    },
+                    vec![],
+                    0,
+                    0,
+                    None,
+                    vec![],
+                    vec![],
+                    &signer,
+                    0.into(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    last_block.header.next_bp_hash,
+                );
+                client.do_send(NetworkClientMessages::Block(
+                    block.clone(),
+                    PeerInfo::random().id,
+                    false,
+                ));
+                *block_holder.write().unwrap() = Some(block);
+                future::ready(())
+            },
+        ));
         near_network::test_utils::wait_or_panic(5000);
     })
     .unwrap();
@@ -292,54 +301,59 @@ fn produce_block_with_approvals() {
                 NetworkResponses::NoResponse
             }),
         );
-        actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-            let last_block = res.unwrap().unwrap();
-            let signer1 = InMemoryValidatorSigner::from_seed("test2", KeyType::ED25519, "test2");
-            let block = Block::produce(
-                &last_block.header.clone().into(),
-                last_block.header.height + 1,
-                last_block.chunks.into_iter().map(Into::into).collect(),
-                EpochId::default(),
-                if last_block.header.prev_hash == CryptoHash::default() {
-                    EpochId(last_block.header.hash)
-                } else {
-                    EpochId(last_block.header.next_epoch_id.clone())
-                },
-                vec![],
-                0,
-                0,
-                Some(0),
-                vec![],
-                vec![],
-                &signer1,
-                0.into(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                last_block.header.next_bp_hash,
-            );
-            client.do_send(NetworkClientMessages::Block(
-                block.clone(),
-                PeerInfo::random().id,
-                false,
-            ));
-
-            for i in 3..11 {
-                let s = if i > 10 { "test1".to_string() } else { format!("test{}", i) };
-                let signer = InMemoryValidatorSigner::from_seed(&s, KeyType::ED25519, &s);
-                let approval = Approval::new(
-                    block.hash(),
-                    Some(block.hash()),
-                    10, // the height at which "test1" is producing
-                    false,
-                    &signer,
+        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+            move |res| {
+                let last_block = res.unwrap().unwrap();
+                let signer1 =
+                    InMemoryValidatorSigner::from_seed("test2", KeyType::ED25519, "test2");
+                let block = Block::produce(
+                    &last_block.header.clone().into(),
+                    last_block.header.height + 1,
+                    last_block.chunks.into_iter().map(Into::into).collect(),
+                    EpochId::default(),
+                    if last_block.header.prev_hash == CryptoHash::default() {
+                        EpochId(last_block.header.hash)
+                    } else {
+                        EpochId(last_block.header.next_epoch_id.clone())
+                    },
+                    vec![],
+                    0,
+                    0,
+                    Some(0),
+                    vec![],
+                    vec![],
+                    &signer1,
+                    0.into(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    last_block.header.next_bp_hash,
                 );
-                client
-                    .do_send(NetworkClientMessages::BlockApproval(approval, PeerInfo::random().id));
-            }
+                client.do_send(NetworkClientMessages::Block(
+                    block.clone(),
+                    PeerInfo::random().id,
+                    false,
+                ));
 
-            future::ready(())
-        }));
+                for i in 3..11 {
+                    let s = if i > 10 { "test1".to_string() } else { format!("test{}", i) };
+                    let signer = InMemoryValidatorSigner::from_seed(&s, KeyType::ED25519, &s);
+                    let approval = Approval::new(
+                        block.hash(),
+                        Some(block.hash()),
+                        10, // the height at which "test1" is producing
+                        false,
+                        &signer,
+                    );
+                    client.do_send(NetworkClientMessages::BlockApproval(
+                        approval,
+                        PeerInfo::random().id,
+                    ));
+                }
+
+                future::ready(())
+            },
+        ));
         near_network::test_utils::wait_or_panic(5000);
     })
     .unwrap();
@@ -370,67 +384,69 @@ fn invalid_blocks() {
                 NetworkResponses::NoResponse
             }),
         );
-        actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-            let last_block = res.unwrap().unwrap();
-            let signer = InMemoryValidatorSigner::from_seed("test", KeyType::ED25519, "test");
-            // Send block with invalid chunk mask
-            let mut block = Block::produce(
-                &last_block.header.clone().into(),
-                last_block.header.height + 1,
-                last_block.chunks.iter().cloned().map(Into::into).collect(),
-                EpochId::default(),
-                if last_block.header.prev_hash == CryptoHash::default() {
-                    EpochId(last_block.header.hash)
-                } else {
-                    EpochId(last_block.header.next_epoch_id.clone())
-                },
-                vec![],
-                0,
-                0,
-                Some(0),
-                vec![],
-                vec![],
-                &signer,
-                0.into(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                last_block.header.next_bp_hash,
-            );
-            block.header.inner_rest.chunk_mask = vec![];
-            client.do_send(NetworkClientMessages::Block(
-                block.clone(),
-                PeerInfo::random().id,
-                false,
-            ));
+        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+            move |res| {
+                let last_block = res.unwrap().unwrap();
+                let signer = InMemoryValidatorSigner::from_seed("test", KeyType::ED25519, "test");
+                // Send block with invalid chunk mask
+                let mut block = Block::produce(
+                    &last_block.header.clone().into(),
+                    last_block.header.height + 1,
+                    last_block.chunks.iter().cloned().map(Into::into).collect(),
+                    EpochId::default(),
+                    if last_block.header.prev_hash == CryptoHash::default() {
+                        EpochId(last_block.header.hash)
+                    } else {
+                        EpochId(last_block.header.next_epoch_id.clone())
+                    },
+                    vec![],
+                    0,
+                    0,
+                    Some(0),
+                    vec![],
+                    vec![],
+                    &signer,
+                    0.into(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    last_block.header.next_bp_hash,
+                );
+                block.header.inner_rest.chunk_mask = vec![];
+                client.do_send(NetworkClientMessages::Block(
+                    block.clone(),
+                    PeerInfo::random().id,
+                    false,
+                ));
 
-            // Send proper block.
-            let block2 = Block::produce(
-                &last_block.header.clone().into(),
-                last_block.header.height + 1,
-                last_block.chunks.into_iter().map(Into::into).collect(),
-                EpochId::default(),
-                if last_block.header.prev_hash == CryptoHash::default() {
-                    EpochId(last_block.header.hash)
-                } else {
-                    EpochId(last_block.header.next_epoch_id.clone())
-                },
-                vec![],
-                0,
-                0,
-                Some(0),
-                vec![],
-                vec![],
-                &signer,
-                0.into(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                CryptoHash::default(),
-                last_block.header.next_bp_hash,
-            );
-            client.do_send(NetworkClientMessages::Block(block2, PeerInfo::random().id, false));
-            future::ready(())
-        }));
+                // Send proper block.
+                let block2 = Block::produce(
+                    &last_block.header.clone().into(),
+                    last_block.header.height + 1,
+                    last_block.chunks.into_iter().map(Into::into).collect(),
+                    EpochId::default(),
+                    if last_block.header.prev_hash == CryptoHash::default() {
+                        EpochId(last_block.header.hash)
+                    } else {
+                        EpochId(last_block.header.next_epoch_id.clone())
+                    },
+                    vec![],
+                    0,
+                    0,
+                    Some(0),
+                    vec![],
+                    vec![],
+                    &signer,
+                    0.into(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    CryptoHash::default(),
+                    last_block.header.next_bp_hash,
+                );
+                client.do_send(NetworkClientMessages::Block(block2, PeerInfo::random().id, false));
+                future::ready(())
+            },
+        ));
         near_network::test_utils::wait_or_panic(5000);
     })
     .unwrap();

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -200,7 +200,7 @@ impl JsonRpcClient {
     }
 
     pub fn block_by_id(&mut self, block_id: BlockId) -> RpcRequest<BlockView> {
-        call_method(&self.client, &self.server_addr, "block", BlockQueryInfo::BlockId(block_id))
+        call_method(&self.client, &self.server_addr, "block", [block_id])
     }
 
     pub fn block(&mut self, request: BlockQueryInfo) -> RpcRequest<BlockView> {

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use serde::Serialize;
 
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::RpcQueryRequest;
+use near_primitives::rpc::{BlockQueryInfo, RpcQueryRequest};
 use near_primitives::types::{BlockId, MaybeBlockId, ShardId};
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, GasPriceView,
@@ -182,7 +182,6 @@ jsonrpc_client!(pub struct JsonRpcClient {
     pub fn status(&mut self) -> RpcRequest<StatusResponse>;
     pub fn health(&mut self) -> RpcRequest<()>;
     pub fn tx(&mut self, hash: String, account_id: String) -> RpcRequest<FinalExecutionOutcomeView>;
-    pub fn block(&mut self, id: BlockId) -> RpcRequest<BlockView>;
     pub fn chunk(&mut self, id: ChunkId) -> RpcRequest<ChunkView>;
     pub fn changes(&mut self, block_hash: CryptoHash, key_prefix: Vec<u8>) -> RpcRequest<StateChangesView>;
     pub fn validators(&mut self, block_id: MaybeBlockId) -> RpcRequest<EpochValidatorInfo>;
@@ -198,6 +197,14 @@ impl JsonRpcClient {
 
     pub fn query(&mut self, request: RpcQueryRequest) -> RpcRequest<QueryResponse> {
         call_method(&self.client, &self.server_addr, "query", request)
+    }
+
+    pub fn block_by_id(&mut self, block_id: BlockId) -> RpcRequest<BlockView> {
+        call_method(&self.client, &self.server_addr, "block", BlockQueryInfo::BlockId(block_id))
+    }
+
+    pub fn block(&mut self, request: BlockQueryInfo) -> RpcRequest<BlockView> {
+        call_method(&self.client, &self.server_addr, "block", request)
     }
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -35,7 +35,7 @@ use near_network::types::NetworkViewClientMessages;
 use near_network::{NetworkClientMessages, NetworkClientResponses};
 use near_primitives::errors::{InvalidTxError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::{RpcQueryRequest, BlockQueryInfo};
+use near_primitives::rpc::{BlockQueryInfo, RpcQueryRequest};
 use near_primitives::serialize::{from_base, from_base64, BaseEncode};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockId, MaybeBlockId, StateChangesRequest};
@@ -440,14 +440,17 @@ impl JsonRpcHandler {
     }
 
     async fn block(&self, params: Option<Value>) -> Result<Value, RpcError> {
-        let block_query = if let Ok((block_id, )) = parse_params::<(BlockId,)>(params.clone()) {
+        let block_query = if let Ok((block_id,)) = parse_params::<(BlockId,)>(params.clone()) {
             BlockQueryInfo::BlockId(block_id)
         } else {
             parse_params::<BlockQueryInfo>(params)?
         };
         jsonify(
             self.view_client_addr
-                .send(GetBlock(block_query))
+                .send(match block_query {
+                    BlockQueryInfo::BlockId(block_id) => GetBlock::BlockId(block_id),
+                    BlockQueryInfo::Finality(finality) => GetBlock::Finality(finality),
+                })
                 .await,
         )
     }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -35,7 +35,7 @@ use near_network::types::NetworkViewClientMessages;
 use near_network::{NetworkClientMessages, NetworkClientResponses};
 use near_primitives::errors::{InvalidTxError, TxExecutionError};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::RpcQueryRequest;
+use near_primitives::rpc::{RpcQueryRequest, BlockQueryInfo};
 use near_primitives::serialize::{from_base, from_base64, BaseEncode};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockId, MaybeBlockId, StateChangesRequest};
@@ -440,13 +440,14 @@ impl JsonRpcHandler {
     }
 
     async fn block(&self, params: Option<Value>) -> Result<Value, RpcError> {
-        let (block_id,) = parse_params::<(BlockId,)>(params)?;
+        let block_query = if let Ok((block_id, )) = parse_params::<(BlockId,)>(params.clone()) {
+            BlockQueryInfo::BlockId(block_id)
+        } else {
+            parse_params::<BlockQueryInfo>(params)?
+        };
         jsonify(
             self.view_client_addr
-                .send(match block_id {
-                    BlockId::Height(height) => GetBlock::Height(height),
-                    BlockId::Hash(hash) => GetBlock::Hash(hash.into()),
-                })
+                .send(GetBlock(block_query))
                 .await,
         )
     }

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -10,7 +10,7 @@ use near_jsonrpc_client::ChunkId;
 use near_network::test_utils::WaitOrTimeout;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::RpcQueryRequest;
+use near_primitives::rpc::{BlockQueryInfo, RpcQueryRequest};
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::types::{BlockId, ShardId};
 use near_primitives::views::{Finality, QueryRequest, QueryResponseKind};
@@ -35,9 +35,9 @@ macro_rules! test_with_client {
 
 /// Retrieve blocks via json rpc
 #[test]
-fn test_block() {
+fn test_block_by_id_height() {
     test_with_client!(client, async move {
-        let block = client.block(BlockId::Height(0)).await.unwrap();
+        let block = client.block_by_id(BlockId::Height(0)).await.unwrap();
         assert_eq!(block.author, "test1");
         assert_eq!(block.header.height, 0);
         assert_eq!(block.header.epoch_id.0.as_ref(), &[0; 32]);
@@ -54,12 +54,49 @@ fn test_block() {
 
 /// Retrieve blocks via json rpc
 #[test]
-fn test_block_by_hash() {
+fn test_block_by_id_hash() {
     test_with_client!(client, async move {
-        let block = client.block(BlockId::Height(0)).await.unwrap();
-        let same_block = client.block(BlockId::Hash(block.header.hash)).await.unwrap();
+        let block = client.block_by_id(BlockId::Height(0)).await.unwrap();
+        let same_block = client.block_by_id(BlockId::Hash(block.header.hash)).await.unwrap();
         assert_eq!(block.header.height, 0);
         assert_eq!(same_block.header.height, 0);
+    });
+}
+
+/// Retrieve blocks via json rpc
+#[test]
+fn test_block_query() {
+    test_with_client!(client, async move {
+        let block_response1 = client
+            .block(BlockQueryInfo::BlockId(BlockId::Height(0)))
+            .await
+            .unwrap();
+        let block_response2 = client
+            .block(BlockQueryInfo::BlockId(BlockId::Hash(block_response1.header.hash)))
+            .await
+            .unwrap();
+        let block_response3 = client
+            .block(BlockQueryInfo::Finality(Finality::None))
+            .await
+            .unwrap();
+        for block in [block_response1, block_response2, block_response3].into_iter() {
+            assert_eq!(block.author, "test1");
+            assert_eq!(block.header.height, 0);
+            assert_eq!(block.header.epoch_id.0.as_ref(), &[0; 32]);
+            assert_eq!(block.header.hash.0.as_ref().len(), 32);
+            assert_eq!(block.header.prev_hash.0.as_ref(), &[0; 32]);
+            assert_eq!(
+                block.header.prev_state_root,
+                CryptoHash::try_from("7tkzFg8RHBmMw1ncRJZCCZAizgq4rwCftTKYLce8RU8t").unwrap()
+            );
+            assert!(block.header.timestamp > 0);
+            assert_eq!(block.header.validator_proposals.len(), 0);
+        }
+        // no doomslug final or nfg final block
+        assert!(client.block(BlockQueryInfo::Finality(Finality::DoomSlug))
+            .await.is_err());
+        assert!(client.block(BlockQueryInfo::Finality(Finality::NFG))
+            .await.is_err());
     });
 }
 
@@ -456,7 +493,7 @@ fn test_gas_price_by_height() {
 #[test]
 fn test_gas_price_by_hash() {
     test_with_client!(client, async move {
-        let block = client.block(BlockId::Height(0)).await.unwrap();
+        let block = client.block(BlockQueryInfo::BlockId(BlockId::Height(0))).await.unwrap();
         let gas_price = client.gas_price(Some(BlockId::Hash(block.header.hash))).await.unwrap();
         assert!(gas_price.gas_price > 0);
     });

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -67,18 +67,13 @@ fn test_block_by_id_hash() {
 #[test]
 fn test_block_query() {
     test_with_client!(client, async move {
-        let block_response1 = client
-            .block(BlockQueryInfo::BlockId(BlockId::Height(0)))
-            .await
-            .unwrap();
+        let block_response1 =
+            client.block(BlockQueryInfo::BlockId(BlockId::Height(0))).await.unwrap();
         let block_response2 = client
             .block(BlockQueryInfo::BlockId(BlockId::Hash(block_response1.header.hash)))
             .await
             .unwrap();
-        let block_response3 = client
-            .block(BlockQueryInfo::Finality(Finality::None))
-            .await
-            .unwrap();
+        let block_response3 = client.block(BlockQueryInfo::Finality(Finality::None)).await.unwrap();
         for block in [block_response1, block_response2, block_response3].into_iter() {
             assert_eq!(block.author, "test1");
             assert_eq!(block.header.height, 0);
@@ -93,10 +88,8 @@ fn test_block_query() {
             assert_eq!(block.header.validator_proposals.len(), 0);
         }
         // no doomslug final or nfg final block
-        assert!(client.block(BlockQueryInfo::Finality(Finality::DoomSlug))
-            .await.is_err());
-        assert!(client.block(BlockQueryInfo::Finality(Finality::NFG))
-            .await.is_err());
+        assert!(client.block(BlockQueryInfo::Finality(Finality::DoomSlug)).await.is_err());
+        assert!(client.block(BlockQueryInfo::Finality(Finality::NFG)).await.is_err());
     });
 }
 

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -11,7 +11,6 @@ use near_jsonrpc::test_utils::{start_all, start_all_with_validity_period};
 use near_network::test_utils::{wait_or_panic, WaitOrTimeout};
 use near_primitives::block::BlockHeader;
 use near_primitives::hash::{hash, CryptoHash};
-use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::serialize::to_base64;
 use near_primitives::test_utils::{init_integration_logger, init_test_logger};
 use near_primitives::transaction::SignedTransaction;
@@ -32,28 +31,26 @@ fn test_send_tx_async() {
         let tx_hash2_2 = tx_hash2.clone();
         let signer_account_id = "test1".to_string();
 
-        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-            move |res| {
-                let header: BlockHeader = res.unwrap().unwrap().header.into();
-                let block_hash = header.hash;
-                let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
-                let tx = SignedTransaction::send_money(
-                    1,
-                    signer_account_id,
-                    "test2".to_string(),
-                    &signer,
-                    100,
-                    block_hash,
-                );
-                let bytes = tx.try_to_vec().unwrap();
-                let tx_hash: String = (&tx.get_hash()).into();
-                *tx_hash2_1.lock().unwrap() = Some(tx.get_hash());
-                client
-                    .broadcast_tx_async(to_base64(&bytes))
-                    .map_ok(move |result| assert_eq!(tx_hash, result))
-                    .map(drop)
-            },
-        ));
+        actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(move |res| {
+            let header: BlockHeader = res.unwrap().unwrap().header.into();
+            let block_hash = header.hash;
+            let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
+            let tx = SignedTransaction::send_money(
+                1,
+                signer_account_id,
+                "test2".to_string(),
+                &signer,
+                100,
+                block_hash,
+            );
+            let bytes = tx.try_to_vec().unwrap();
+            let tx_hash: String = (&tx.get_hash()).into();
+            *tx_hash2_1.lock().unwrap() = Some(tx.get_hash());
+            client
+                .broadcast_tx_async(to_base64(&bytes))
+                .map_ok(move |result| assert_eq!(tx_hash, result))
+                .map(drop)
+        }));
         let mut client1 = new_client(&format!("http://{}", addr));
         WaitOrTimeout::new(
             Box::new(move |_| {
@@ -90,36 +87,31 @@ fn test_send_tx_commit() {
 
         let mut client = new_client(&format!("http://{}", addr));
 
-        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-            move |res| {
-                let header: BlockHeader = res.unwrap().unwrap().header.into();
-                let block_hash = header.hash;
-                let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
-                let tx = SignedTransaction::send_money(
-                    1,
-                    "test1".to_string(),
-                    "test2".to_string(),
-                    &signer,
-                    100,
-                    block_hash,
-                );
-                let bytes = tx.try_to_vec().unwrap();
-                client
-                    .broadcast_tx_commit(to_base64(&bytes))
-                    .map_err(|why| {
-                        System::current().stop();
-                        panic!(why);
-                    })
-                    .map_ok(move |result| {
-                        assert_eq!(
-                            result.status,
-                            FinalExecutionStatus::SuccessValue(to_base64(&[]))
-                        );
-                        System::current().stop();
-                    })
-                    .map(drop)
-            },
-        ));
+        actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(move |res| {
+            let header: BlockHeader = res.unwrap().unwrap().header.into();
+            let block_hash = header.hash;
+            let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
+            let tx = SignedTransaction::send_money(
+                1,
+                "test1".to_string(),
+                "test2".to_string(),
+                &signer,
+                100,
+                block_hash,
+            );
+            let bytes = tx.try_to_vec().unwrap();
+            client
+                .broadcast_tx_commit(to_base64(&bytes))
+                .map_err(|why| {
+                    System::current().stop();
+                    panic!(why);
+                })
+                .map_ok(move |result| {
+                    assert_eq!(result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
+                    System::current().stop();
+                })
+                .map(drop)
+        }));
         wait_or_panic(10000);
     })
     .unwrap();
@@ -140,47 +132,45 @@ fn test_expired_tx() {
                 let block_hash = block_hash.clone();
                 let block_height = block_height.clone();
                 let mut client = new_client(&format!("http://{}", addr));
-                actix::spawn(
-                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                        move |res| {
-                            let header: BlockHeader = res.unwrap().unwrap().header.into();
-                            let hash = block_hash.lock().unwrap().clone();
-                            let height = block_height.lock().unwrap().clone();
-                            if let Some(block_hash) = hash {
-                                if let Some(height) = height {
-                                    if header.inner_lite.height - height >= 2 {
-                                        let signer = InMemorySigner::from_seed(
-                                            "test1",
-                                            KeyType::ED25519,
-                                            "test1",
-                                        );
-                                        let tx = SignedTransaction::send_money(
-                                            1,
-                                            "test1".to_string(),
-                                            "test2".to_string(),
-                                            &signer,
-                                            100,
-                                            block_hash,
-                                        );
-                                        let bytes = tx.try_to_vec().unwrap();
-                                        actix::spawn(
-                                            client
-                                                .broadcast_tx_commit(to_base64(&bytes))
-                                                .map_err(|_| {
-                                                    System::current().stop();
-                                                })
-                                                .map(|_| ()),
-                                        );
-                                    }
+                actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(
+                    move |res| {
+                        let header: BlockHeader = res.unwrap().unwrap().header.into();
+                        let hash = block_hash.lock().unwrap().clone();
+                        let height = block_height.lock().unwrap().clone();
+                        if let Some(block_hash) = hash {
+                            if let Some(height) = height {
+                                if header.inner_lite.height - height >= 2 {
+                                    let signer = InMemorySigner::from_seed(
+                                        "test1",
+                                        KeyType::ED25519,
+                                        "test1",
+                                    );
+                                    let tx = SignedTransaction::send_money(
+                                        1,
+                                        "test1".to_string(),
+                                        "test2".to_string(),
+                                        &signer,
+                                        100,
+                                        block_hash,
+                                    );
+                                    let bytes = tx.try_to_vec().unwrap();
+                                    actix::spawn(
+                                        client
+                                            .broadcast_tx_commit(to_base64(&bytes))
+                                            .map_err(|_| {
+                                                System::current().stop();
+                                            })
+                                            .map(|_| ()),
+                                    );
                                 }
-                            } else {
-                                *block_hash.lock().unwrap() = Some(header.hash);
-                                *block_height.lock().unwrap() = Some(header.inner_lite.height);
-                            };
-                            future::ready(())
-                        },
-                    ),
-                );
+                            }
+                        } else {
+                            *block_hash.lock().unwrap() = Some(header.hash);
+                            *block_height.lock().unwrap() = Some(header.inner_lite.height);
+                        };
+                        future::ready(())
+                    },
+                ));
             }),
             100,
             1000,

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -11,10 +11,11 @@ use near_jsonrpc::test_utils::{start_all, start_all_with_validity_period};
 use near_network::test_utils::{wait_or_panic, WaitOrTimeout};
 use near_primitives::block::BlockHeader;
 use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::serialize::to_base64;
 use near_primitives::test_utils::{init_integration_logger, init_test_logger};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::views::FinalExecutionStatus;
+use near_primitives::views::{FinalExecutionStatus, Finality};
 
 /// Test sending transaction via json rpc without waiting.
 #[test]
@@ -31,26 +32,28 @@ fn test_send_tx_async() {
         let tx_hash2_2 = tx_hash2.clone();
         let signer_account_id = "test1".to_string();
 
-        actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-            let header: BlockHeader = res.unwrap().unwrap().header.into();
-            let block_hash = header.hash;
-            let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
-            let tx = SignedTransaction::send_money(
-                1,
-                signer_account_id,
-                "test2".to_string(),
-                &signer,
-                100,
-                block_hash,
-            );
-            let bytes = tx.try_to_vec().unwrap();
-            let tx_hash: String = (&tx.get_hash()).into();
-            *tx_hash2_1.lock().unwrap() = Some(tx.get_hash());
-            client
-                .broadcast_tx_async(to_base64(&bytes))
-                .map_ok(move |result| assert_eq!(tx_hash, result))
-                .map(drop)
-        }));
+        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+            move |res| {
+                let header: BlockHeader = res.unwrap().unwrap().header.into();
+                let block_hash = header.hash;
+                let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
+                let tx = SignedTransaction::send_money(
+                    1,
+                    signer_account_id,
+                    "test2".to_string(),
+                    &signer,
+                    100,
+                    block_hash,
+                );
+                let bytes = tx.try_to_vec().unwrap();
+                let tx_hash: String = (&tx.get_hash()).into();
+                *tx_hash2_1.lock().unwrap() = Some(tx.get_hash());
+                client
+                    .broadcast_tx_async(to_base64(&bytes))
+                    .map_ok(move |result| assert_eq!(tx_hash, result))
+                    .map(drop)
+            },
+        ));
         let mut client1 = new_client(&format!("http://{}", addr));
         WaitOrTimeout::new(
             Box::new(move |_| {
@@ -87,31 +90,36 @@ fn test_send_tx_commit() {
 
         let mut client = new_client(&format!("http://{}", addr));
 
-        actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-            let header: BlockHeader = res.unwrap().unwrap().header.into();
-            let block_hash = header.hash;
-            let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
-            let tx = SignedTransaction::send_money(
-                1,
-                "test1".to_string(),
-                "test2".to_string(),
-                &signer,
-                100,
-                block_hash,
-            );
-            let bytes = tx.try_to_vec().unwrap();
-            client
-                .broadcast_tx_commit(to_base64(&bytes))
-                .map_err(|why| {
-                    System::current().stop();
-                    panic!(why);
-                })
-                .map_ok(move |result| {
-                    assert_eq!(result.status, FinalExecutionStatus::SuccessValue(to_base64(&[])));
-                    System::current().stop();
-                })
-                .map(drop)
-        }));
+        actix::spawn(view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+            move |res| {
+                let header: BlockHeader = res.unwrap().unwrap().header.into();
+                let block_hash = header.hash;
+                let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
+                let tx = SignedTransaction::send_money(
+                    1,
+                    "test1".to_string(),
+                    "test2".to_string(),
+                    &signer,
+                    100,
+                    block_hash,
+                );
+                let bytes = tx.try_to_vec().unwrap();
+                client
+                    .broadcast_tx_commit(to_base64(&bytes))
+                    .map_err(|why| {
+                        System::current().stop();
+                        panic!(why);
+                    })
+                    .map_ok(move |result| {
+                        assert_eq!(
+                            result.status,
+                            FinalExecutionStatus::SuccessValue(to_base64(&[]))
+                        );
+                        System::current().stop();
+                    })
+                    .map(drop)
+            },
+        ));
         wait_or_panic(10000);
     })
     .unwrap();
@@ -132,40 +140,47 @@ fn test_expired_tx() {
                 let block_hash = block_hash.clone();
                 let block_height = block_height.clone();
                 let mut client = new_client(&format!("http://{}", addr));
-                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    let header: BlockHeader = res.unwrap().unwrap().header.into();
-                    let hash = block_hash.lock().unwrap().clone();
-                    let height = block_height.lock().unwrap().clone();
-                    if let Some(block_hash) = hash {
-                        if let Some(height) = height {
-                            if header.inner_lite.height - height >= 2 {
-                                let signer =
-                                    InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
-                                let tx = SignedTransaction::send_money(
-                                    1,
-                                    "test1".to_string(),
-                                    "test2".to_string(),
-                                    &signer,
-                                    100,
-                                    block_hash,
-                                );
-                                let bytes = tx.try_to_vec().unwrap();
-                                actix::spawn(
-                                    client
-                                        .broadcast_tx_commit(to_base64(&bytes))
-                                        .map_err(|_| {
-                                            System::current().stop();
-                                        })
-                                        .map(|_| ()),
-                                );
-                            }
-                        }
-                    } else {
-                        *block_hash.lock().unwrap() = Some(header.hash);
-                        *block_height.lock().unwrap() = Some(header.inner_lite.height);
-                    };
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            let header: BlockHeader = res.unwrap().unwrap().header.into();
+                            let hash = block_hash.lock().unwrap().clone();
+                            let height = block_height.lock().unwrap().clone();
+                            if let Some(block_hash) = hash {
+                                if let Some(height) = height {
+                                    if header.inner_lite.height - height >= 2 {
+                                        let signer = InMemorySigner::from_seed(
+                                            "test1",
+                                            KeyType::ED25519,
+                                            "test1",
+                                        );
+                                        let tx = SignedTransaction::send_money(
+                                            1,
+                                            "test1".to_string(),
+                                            "test2".to_string(),
+                                            &signer,
+                                            100,
+                                            block_hash,
+                                        );
+                                        let bytes = tx.try_to_vec().unwrap();
+                                        actix::spawn(
+                                            client
+                                                .broadcast_tx_commit(to_base64(&bytes))
+                                                .map_err(|_| {
+                                                    System::current().stop();
+                                                })
+                                                .map(|_| ()),
+                                        );
+                                    }
+                                }
+                            } else {
+                                *block_hash.lock().unwrap() = Some(header.hash);
+                                *block_height.lock().unwrap() = Some(header.inner_lite.height);
+                            };
+                            future::ready(())
+                        },
+                    ),
+                );
             }),
             100,
             1000,

--- a/core/primitives/src/rpc.rs
+++ b/core/primitives/src/rpc.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use super::types::MaybeBlockId;
 use super::views::{Finality, QueryRequest};
+use crate::types::BlockId;
 
 #[derive(Serialize, Deserialize)]
 pub struct RpcQueryRequest {
@@ -9,4 +10,11 @@ pub struct RpcQueryRequest {
     #[serde(flatten)]
     pub request: QueryRequest,
     pub finality: Finality,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockQueryInfo {
+    BlockId(BlockId),
+    Finality(Finality),
 }

--- a/core/primitives/src/rpc.rs
+++ b/core/primitives/src/rpc.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 
-use super::types::MaybeBlockId;
-use super::views::{Finality, QueryRequest};
 use crate::types::BlockId;
+use crate::types::MaybeBlockId;
+use crate::views::{Finality, QueryRequest};
 
 #[derive(Serialize, Deserialize)]
 pub struct RpcQueryRequest {

--- a/near/tests/rpc_nodes.rs
+++ b/near/tests/rpc_nodes.rs
@@ -8,7 +8,6 @@ use near_client::{GetBlock, TxStatus};
 use near_crypto::{InMemorySigner, KeyType};
 use near_jsonrpc::client::new_client;
 use near_network::test_utils::WaitOrTimeout;
-use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::serialize::to_base64;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
@@ -50,27 +49,24 @@ fn test_tx_propagation() {
                 let tx_hash_clone = tx_hash.clone();
                 // We are sending this tx unstop, just to get over the warm up period.
                 // Probably make sense to stop after 1 time though.
-                actix::spawn(
-                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                        move |res| {
-                            if res.unwrap().unwrap().header.height > 1 {
-                                let mut client =
-                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                                let bytes = transaction_copy.try_to_vec().unwrap();
-                                actix::spawn(
-                                    client
-                                        .broadcast_tx_async(to_base64(&bytes))
-                                        .map_err(|err| panic!(err.to_string()))
-                                        .map_ok(move |result| {
-                                            assert_eq!(String::from(&tx_hash_clone), result)
-                                        })
-                                        .map(drop),
-                                );
-                            }
-                            future::ready(())
-                        },
-                    ),
-                );
+                actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(
+                    move |res| {
+                        if res.unwrap().unwrap().header.height > 1 {
+                            let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                            let bytes = transaction_copy.try_to_vec().unwrap();
+                            actix::spawn(
+                                client
+                                    .broadcast_tx_async(to_base64(&bytes))
+                                    .map_err(|err| panic!(err.to_string()))
+                                    .map_ok(move |result| {
+                                        assert_eq!(String::from(&tx_hash_clone), result)
+                                    })
+                                    .map(drop),
+                            );
+                        }
+                        future::ready(())
+                    },
+                ));
                 actix::spawn(
                     view_client
                         .send(TxStatus { tx_hash, signer_account_id: "near.1".to_string() })
@@ -129,35 +125,30 @@ fn test_tx_propagation_through_rpc() {
                 let transaction_copy = transaction.clone();
                 // We are sending this tx unstop, just to get over the warm up period.
                 // Probably make sense to stop after 1 time though.
-                actix::spawn(
-                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                        move |res| {
-                            if res.unwrap().unwrap().header.height > 1 {
-                                let mut client =
-                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                                let bytes = transaction_copy.try_to_vec().unwrap();
-                                actix::spawn(
-                                    client
-                                        .broadcast_tx_commit(to_base64(&bytes))
-                                        .map_err(|err| panic!(err.to_string()))
-                                        .map_ok(move |result| {
-                                            if result.status
-                                                == FinalExecutionStatus::SuccessValue(
-                                                    "".to_string(),
-                                                )
-                                            {
-                                                System::current().stop();
-                                            } else {
-                                                panic!("wrong transaction status");
-                                            }
-                                        })
-                                        .map(drop),
-                                );
-                            }
-                            future::ready(())
-                        },
-                    ),
-                );
+                actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(
+                    move |res| {
+                        if res.unwrap().unwrap().header.height > 1 {
+                            let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                            let bytes = transaction_copy.try_to_vec().unwrap();
+                            actix::spawn(
+                                client
+                                    .broadcast_tx_commit(to_base64(&bytes))
+                                    .map_err(|err| panic!(err.to_string()))
+                                    .map_ok(move |result| {
+                                        if result.status
+                                            == FinalExecutionStatus::SuccessValue("".to_string())
+                                        {
+                                            System::current().stop();
+                                        } else {
+                                            panic!("wrong transaction status");
+                                        }
+                                    })
+                                    .map(drop),
+                            );
+                        }
+                        future::ready(())
+                    },
+                ));
             }),
             100,
             20000,
@@ -201,27 +192,24 @@ fn test_tx_status_with_light_client() {
                 let transaction_copy = transaction.clone();
                 let signer_account_id = transaction_copy.transaction.signer_id.clone();
                 let tx_hash_clone = tx_hash.clone();
-                actix::spawn(
-                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                        move |res| {
-                            if res.unwrap().unwrap().header.height > 1 {
-                                let mut client =
-                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                                let bytes = transaction_copy.try_to_vec().unwrap();
-                                actix::spawn(
-                                    client
-                                        .broadcast_tx_async(to_base64(&bytes))
-                                        .map_err(|err| panic!("{:?}", err))
-                                        .map_ok(move |result| {
-                                            assert_eq!(String::from(&tx_hash_clone), result)
-                                        })
-                                        .map(drop),
-                                );
-                            }
-                            future::ready(())
-                        },
-                    ),
-                );
+                actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(
+                    move |res| {
+                        if res.unwrap().unwrap().header.height > 1 {
+                            let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                            let bytes = transaction_copy.try_to_vec().unwrap();
+                            actix::spawn(
+                                client
+                                    .broadcast_tx_async(to_base64(&bytes))
+                                    .map_err(|err| panic!("{:?}", err))
+                                    .map_ok(move |result| {
+                                        assert_eq!(String::from(&tx_hash_clone), result)
+                                    })
+                                    .map(drop),
+                            );
+                        }
+                        future::ready(())
+                    },
+                ));
                 let mut client = new_client(&format!("http://{}", rpc_addrs_copy1[2].clone()));
                 actix::spawn(
                     client
@@ -277,27 +265,24 @@ fn test_tx_status_with_light_client1() {
                 let transaction_copy = transaction.clone();
                 let signer_account_id = transaction_copy.transaction.signer_id.clone();
                 let tx_hash_clone = tx_hash.clone();
-                actix::spawn(
-                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                        move |res| {
-                            if res.unwrap().unwrap().header.height > 1 {
-                                let mut client =
-                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                                let bytes = transaction_copy.try_to_vec().unwrap();
-                                actix::spawn(
-                                    client
-                                        .broadcast_tx_async(to_base64(&bytes))
-                                        .map_err(|err| panic!("{}", err.to_string()))
-                                        .map_ok(move |result| {
-                                            assert_eq!(String::from(&tx_hash_clone), result)
-                                        })
-                                        .map(drop),
-                                );
-                            }
-                            future::ready(())
-                        },
-                    ),
-                );
+                actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(
+                    move |res| {
+                        if res.unwrap().unwrap().header.height > 1 {
+                            let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                            let bytes = transaction_copy.try_to_vec().unwrap();
+                            actix::spawn(
+                                client
+                                    .broadcast_tx_async(to_base64(&bytes))
+                                    .map_err(|err| panic!("{}", err.to_string()))
+                                    .map_ok(move |result| {
+                                        assert_eq!(String::from(&tx_hash_clone), result)
+                                    })
+                                    .map(drop),
+                            );
+                        }
+                        future::ready(())
+                    },
+                ));
                 let mut client = new_client(&format!("http://{}", rpc_addrs_copy1[2].clone()));
                 actix::spawn(
                     client
@@ -335,35 +320,29 @@ fn test_rpc_routing() {
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
                 let rpc_addrs_copy = rpc_addrs.clone();
-                actix::spawn(
-                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                        move |res| {
-                            if res.unwrap().unwrap().header.height > 1 {
-                                let mut client =
-                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                                actix::spawn(
-                                    client
-                                        .query_by_path("account/near.2".to_string(), "".to_string())
-                                        .map_err(|err| {
-                                            println!("Error retrieving account: {:?}", err);
-                                        })
-                                        .map_ok(move |result| match result.kind {
-                                            QueryResponseKind::ViewAccount(account_view) => {
-                                                assert_eq!(
-                                                    account_view.amount,
-                                                    TESTING_INIT_BALANCE
-                                                );
-                                                System::current().stop();
-                                            }
-                                            _ => panic!("wrong query response"),
-                                        })
-                                        .map(drop),
-                                );
-                            }
-                            future::ready(())
-                        },
-                    ),
-                );
+                actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(
+                    move |res| {
+                        if res.unwrap().unwrap().header.height > 1 {
+                            let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                            actix::spawn(
+                                client
+                                    .query_by_path("account/near.2".to_string(), "".to_string())
+                                    .map_err(|err| {
+                                        println!("Error retrieving account: {:?}", err);
+                                    })
+                                    .map_ok(move |result| match result.kind {
+                                        QueryResponseKind::ViewAccount(account_view) => {
+                                            assert_eq!(account_view.amount, TESTING_INIT_BALANCE);
+                                            System::current().stop();
+                                        }
+                                        _ => panic!("wrong query response"),
+                                    })
+                                    .map(drop),
+                            );
+                        }
+                        future::ready(())
+                    },
+                ));
             }),
             100,
             20000,
@@ -390,30 +369,27 @@ fn test_rpc_routing_error() {
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
                 let rpc_addrs_copy = rpc_addrs.clone();
-                actix::spawn(
-                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                        move |res| {
-                            if res.unwrap().unwrap().header.height > 1 {
-                                let mut client =
-                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                                actix::spawn(
-                                    client
-                                        .query_by_path(
-                                            "account/nonexistent".to_string(),
-                                            "".to_string(),
-                                        )
-                                        .map_err(|err| {
-                                            println!("error: {}", err.to_string());
-                                            System::current().stop();
-                                        })
-                                        .map_ok(|_| panic!("wrong query response"))
-                                        .map(drop),
-                                );
-                            }
-                            future::ready(())
-                        },
-                    ),
-                );
+                actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(
+                    move |res| {
+                        if res.unwrap().unwrap().header.height > 1 {
+                            let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                            actix::spawn(
+                                client
+                                    .query_by_path(
+                                        "account/nonexistent".to_string(),
+                                        "".to_string(),
+                                    )
+                                    .map_err(|err| {
+                                        println!("error: {}", err.to_string());
+                                        System::current().stop();
+                                    })
+                                    .map_ok(|_| panic!("wrong query response"))
+                                    .map(drop),
+                            );
+                        }
+                        future::ready(())
+                    },
+                ));
             }),
             100,
             20000,
@@ -439,35 +415,32 @@ fn test_get_validator_info_rpc() {
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
                 let rpc_addrs_copy = rpc_addrs.clone();
-                actix::spawn(
-                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                        move |res| {
-                            let res = res.unwrap().unwrap();
-                            if res.header.height > 1 {
-                                let mut client =
-                                    new_client(&format!("http://{}", rpc_addrs_copy[0]));
-                                let block_hash = res.header.hash;
-                                actix::spawn(
-                                    client
-                                        .validators(Some(BlockId::Hash(block_hash)))
-                                        .map_err(|err| {
-                                            panic!(format!("error: {:?}", err));
-                                        })
-                                        .map_ok(move |result| {
-                                            assert_eq!(result.current_validators.len(), 1);
-                                            assert!(result
-                                                .current_validators
-                                                .iter()
-                                                .any(|r| r.account_id == "near.0".to_string()));
-                                            System::current().stop();
-                                        })
-                                        .map(drop),
-                                );
-                            }
-                            future::ready(())
-                        },
-                    ),
-                );
+                actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(
+                    move |res| {
+                        let res = res.unwrap().unwrap();
+                        if res.header.height > 1 {
+                            let mut client = new_client(&format!("http://{}", rpc_addrs_copy[0]));
+                            let block_hash = res.header.hash;
+                            actix::spawn(
+                                client
+                                    .validators(Some(BlockId::Hash(block_hash)))
+                                    .map_err(|err| {
+                                        panic!(format!("error: {:?}", err));
+                                    })
+                                    .map_ok(move |result| {
+                                        assert_eq!(result.current_validators.len(), 1);
+                                        assert!(result
+                                            .current_validators
+                                            .iter()
+                                            .any(|r| r.account_id == "near.0".to_string()));
+                                        System::current().stop();
+                                    })
+                                    .map(drop),
+                            );
+                        }
+                        future::ready(())
+                    },
+                ));
             }),
             100,
             20000,

--- a/near/tests/rpc_nodes.rs
+++ b/near/tests/rpc_nodes.rs
@@ -8,11 +8,12 @@ use near_client::{GetBlock, TxStatus};
 use near_crypto::{InMemorySigner, KeyType};
 use near_jsonrpc::client::new_client;
 use near_network::test_utils::WaitOrTimeout;
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::serialize::to_base64;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::BlockId;
-use near_primitives::views::{FinalExecutionStatus, QueryResponseKind};
+use near_primitives::views::{FinalExecutionStatus, Finality, QueryResponseKind};
 use testlib::{genesis_block, start_nodes};
 
 /// Starts 2 validators and 2 light clients (not tracking anything).
@@ -49,22 +50,27 @@ fn test_tx_propagation() {
                 let tx_hash_clone = tx_hash.clone();
                 // We are sending this tx unstop, just to get over the warm up period.
                 // Probably make sense to stop after 1 time though.
-                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    if res.unwrap().unwrap().header.height > 1 {
-                        let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                        let bytes = transaction_copy.try_to_vec().unwrap();
-                        actix::spawn(
-                            client
-                                .broadcast_tx_async(to_base64(&bytes))
-                                .map_err(|err| panic!(err.to_string()))
-                                .map_ok(move |result| {
-                                    assert_eq!(String::from(&tx_hash_clone), result)
-                                })
-                                .map(drop),
-                        );
-                    }
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            if res.unwrap().unwrap().header.height > 1 {
+                                let mut client =
+                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                                let bytes = transaction_copy.try_to_vec().unwrap();
+                                actix::spawn(
+                                    client
+                                        .broadcast_tx_async(to_base64(&bytes))
+                                        .map_err(|err| panic!(err.to_string()))
+                                        .map_ok(move |result| {
+                                            assert_eq!(String::from(&tx_hash_clone), result)
+                                        })
+                                        .map(drop),
+                                );
+                            }
+                            future::ready(())
+                        },
+                    ),
+                );
                 actix::spawn(
                     view_client
                         .send(TxStatus { tx_hash, signer_account_id: "near.1".to_string() })
@@ -123,28 +129,35 @@ fn test_tx_propagation_through_rpc() {
                 let transaction_copy = transaction.clone();
                 // We are sending this tx unstop, just to get over the warm up period.
                 // Probably make sense to stop after 1 time though.
-                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    if res.unwrap().unwrap().header.height > 1 {
-                        let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                        let bytes = transaction_copy.try_to_vec().unwrap();
-                        actix::spawn(
-                            client
-                                .broadcast_tx_commit(to_base64(&bytes))
-                                .map_err(|err| panic!(err.to_string()))
-                                .map_ok(move |result| {
-                                    if result.status
-                                        == FinalExecutionStatus::SuccessValue("".to_string())
-                                    {
-                                        System::current().stop();
-                                    } else {
-                                        panic!("wrong transaction status");
-                                    }
-                                })
-                                .map(drop),
-                        );
-                    }
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            if res.unwrap().unwrap().header.height > 1 {
+                                let mut client =
+                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                                let bytes = transaction_copy.try_to_vec().unwrap();
+                                actix::spawn(
+                                    client
+                                        .broadcast_tx_commit(to_base64(&bytes))
+                                        .map_err(|err| panic!(err.to_string()))
+                                        .map_ok(move |result| {
+                                            if result.status
+                                                == FinalExecutionStatus::SuccessValue(
+                                                    "".to_string(),
+                                                )
+                                            {
+                                                System::current().stop();
+                                            } else {
+                                                panic!("wrong transaction status");
+                                            }
+                                        })
+                                        .map(drop),
+                                );
+                            }
+                            future::ready(())
+                        },
+                    ),
+                );
             }),
             100,
             20000,
@@ -188,22 +201,27 @@ fn test_tx_status_with_light_client() {
                 let transaction_copy = transaction.clone();
                 let signer_account_id = transaction_copy.transaction.signer_id.clone();
                 let tx_hash_clone = tx_hash.clone();
-                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    if res.unwrap().unwrap().header.height > 1 {
-                        let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                        let bytes = transaction_copy.try_to_vec().unwrap();
-                        actix::spawn(
-                            client
-                                .broadcast_tx_async(to_base64(&bytes))
-                                .map_err(|err| panic!("{:?}", err))
-                                .map_ok(move |result| {
-                                    assert_eq!(String::from(&tx_hash_clone), result)
-                                })
-                                .map(drop),
-                        );
-                    }
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            if res.unwrap().unwrap().header.height > 1 {
+                                let mut client =
+                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                                let bytes = transaction_copy.try_to_vec().unwrap();
+                                actix::spawn(
+                                    client
+                                        .broadcast_tx_async(to_base64(&bytes))
+                                        .map_err(|err| panic!("{:?}", err))
+                                        .map_ok(move |result| {
+                                            assert_eq!(String::from(&tx_hash_clone), result)
+                                        })
+                                        .map(drop),
+                                );
+                            }
+                            future::ready(())
+                        },
+                    ),
+                );
                 let mut client = new_client(&format!("http://{}", rpc_addrs_copy1[2].clone()));
                 actix::spawn(
                     client
@@ -259,22 +277,27 @@ fn test_tx_status_with_light_client1() {
                 let transaction_copy = transaction.clone();
                 let signer_account_id = transaction_copy.transaction.signer_id.clone();
                 let tx_hash_clone = tx_hash.clone();
-                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    if res.unwrap().unwrap().header.height > 1 {
-                        let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                        let bytes = transaction_copy.try_to_vec().unwrap();
-                        actix::spawn(
-                            client
-                                .broadcast_tx_async(to_base64(&bytes))
-                                .map_err(|err| panic!("{}", err.to_string()))
-                                .map_ok(move |result| {
-                                    assert_eq!(String::from(&tx_hash_clone), result)
-                                })
-                                .map(drop),
-                        );
-                    }
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            if res.unwrap().unwrap().header.height > 1 {
+                                let mut client =
+                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                                let bytes = transaction_copy.try_to_vec().unwrap();
+                                actix::spawn(
+                                    client
+                                        .broadcast_tx_async(to_base64(&bytes))
+                                        .map_err(|err| panic!("{}", err.to_string()))
+                                        .map_ok(move |result| {
+                                            assert_eq!(String::from(&tx_hash_clone), result)
+                                        })
+                                        .map(drop),
+                                );
+                            }
+                            future::ready(())
+                        },
+                    ),
+                );
                 let mut client = new_client(&format!("http://{}", rpc_addrs_copy1[2].clone()));
                 actix::spawn(
                     client
@@ -312,27 +335,35 @@ fn test_rpc_routing() {
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
                 let rpc_addrs_copy = rpc_addrs.clone();
-                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    if res.unwrap().unwrap().header.height > 1 {
-                        let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                        actix::spawn(
-                            client
-                                .query_by_path("account/near.2".to_string(), "".to_string())
-                                .map_err(|err| {
-                                    println!("Error retrieving account: {:?}", err);
-                                })
-                                .map_ok(move |result| match result.kind {
-                                    QueryResponseKind::ViewAccount(account_view) => {
-                                        assert_eq!(account_view.amount, TESTING_INIT_BALANCE);
-                                        System::current().stop();
-                                    }
-                                    _ => panic!("wrong query response"),
-                                })
-                                .map(drop),
-                        );
-                    }
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            if res.unwrap().unwrap().header.height > 1 {
+                                let mut client =
+                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                                actix::spawn(
+                                    client
+                                        .query_by_path("account/near.2".to_string(), "".to_string())
+                                        .map_err(|err| {
+                                            println!("Error retrieving account: {:?}", err);
+                                        })
+                                        .map_ok(move |result| match result.kind {
+                                            QueryResponseKind::ViewAccount(account_view) => {
+                                                assert_eq!(
+                                                    account_view.amount,
+                                                    TESTING_INIT_BALANCE
+                                                );
+                                                System::current().stop();
+                                            }
+                                            _ => panic!("wrong query response"),
+                                        })
+                                        .map(drop),
+                                );
+                            }
+                            future::ready(())
+                        },
+                    ),
+                );
             }),
             100,
             20000,
@@ -359,22 +390,30 @@ fn test_rpc_routing_error() {
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
                 let rpc_addrs_copy = rpc_addrs.clone();
-                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    if res.unwrap().unwrap().header.height > 1 {
-                        let mut client = new_client(&format!("http://{}", rpc_addrs_copy[2]));
-                        actix::spawn(
-                            client
-                                .query_by_path("account/nonexistent".to_string(), "".to_string())
-                                .map_err(|err| {
-                                    println!("error: {}", err.to_string());
-                                    System::current().stop();
-                                })
-                                .map_ok(|_| panic!("wrong query response"))
-                                .map(drop),
-                        );
-                    }
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            if res.unwrap().unwrap().header.height > 1 {
+                                let mut client =
+                                    new_client(&format!("http://{}", rpc_addrs_copy[2]));
+                                actix::spawn(
+                                    client
+                                        .query_by_path(
+                                            "account/nonexistent".to_string(),
+                                            "".to_string(),
+                                        )
+                                        .map_err(|err| {
+                                            println!("error: {}", err.to_string());
+                                            System::current().stop();
+                                        })
+                                        .map_ok(|_| panic!("wrong query response"))
+                                        .map(drop),
+                                );
+                            }
+                            future::ready(())
+                        },
+                    ),
+                );
             }),
             100,
             20000,
@@ -400,30 +439,35 @@ fn test_get_validator_info_rpc() {
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
                 let rpc_addrs_copy = rpc_addrs.clone();
-                actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                    let res = res.unwrap().unwrap();
-                    if res.header.height > 1 {
-                        let mut client = new_client(&format!("http://{}", rpc_addrs_copy[0]));
-                        let block_hash = res.header.hash;
-                        actix::spawn(
-                            client
-                                .validators(Some(BlockId::Hash(block_hash)))
-                                .map_err(|err| {
-                                    panic!(format!("error: {:?}", err));
-                                })
-                                .map_ok(move |result| {
-                                    assert_eq!(result.current_validators.len(), 1);
-                                    assert!(result
-                                        .current_validators
-                                        .iter()
-                                        .any(|r| r.account_id == "near.0".to_string()));
-                                    System::current().stop();
-                                })
-                                .map(drop),
-                        );
-                    }
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            let res = res.unwrap().unwrap();
+                            if res.header.height > 1 {
+                                let mut client =
+                                    new_client(&format!("http://{}", rpc_addrs_copy[0]));
+                                let block_hash = res.header.hash;
+                                actix::spawn(
+                                    client
+                                        .validators(Some(BlockId::Hash(block_hash)))
+                                        .map_err(|err| {
+                                            panic!(format!("error: {:?}", err));
+                                        })
+                                        .map_ok(move |result| {
+                                            assert_eq!(result.current_validators.len(), 1);
+                                            assert!(result
+                                                .current_validators
+                                                .iter()
+                                                .any(|r| r.account_id == "near.0".to_string()));
+                                            System::current().stop();
+                                        })
+                                        .map(drop),
+                                );
+                            }
+                            future::ready(())
+                        },
+                    ),
+                );
             }),
             100,
             20000,

--- a/near/tests/run_nodes.rs
+++ b/near/tests/run_nodes.rs
@@ -4,8 +4,10 @@ use tempdir::TempDir;
 
 use near_client::GetBlock;
 use near_network::test_utils::WaitOrTimeout;
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::test_utils::heavy_test;
 use near_primitives::types::{BlockHeightDelta, NumSeats, NumShards};
+use near_primitives::views::Finality;
 use testlib::start_nodes;
 
 fn run_nodes(
@@ -25,14 +27,18 @@ fn run_nodes(
     let view_client = clients[clients.len() - 1].1.clone();
     WaitOrTimeout::new(
         Box::new(move |_ctx| {
-            actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                match &res {
-                    Ok(Ok(b)) if b.header.height > num_blocks => System::current().stop(),
-                    Err(_) => return future::ready(()),
-                    _ => {}
-                };
-                future::ready(())
-            }));
+            actix::spawn(
+                view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                    move |res| {
+                        match &res {
+                            Ok(Ok(b)) if b.header.height > num_blocks => System::current().stop(),
+                            Err(_) => return future::ready(()),
+                            _ => {}
+                        };
+                        future::ready(())
+                    },
+                ),
+            );
         }),
         100,
         40000,

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -15,7 +15,6 @@ use near_crypto::{InMemorySigner, KeyType};
 use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
 use near_network::NetworkClientMessages;
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeightDelta, NumSeats};
@@ -446,10 +445,8 @@ fn test_inflation() {
             Box::new(move |_ctx| {
                 let (done1_copy2, done2_copy2) = (done1_copy1.clone(), done2_copy1.clone());
                 actix::spawn(
-                    test_nodes[0]
-                        .view_client
-                        .send(GetBlock(BlockQueryInfo::Finality(Finality::None)))
-                        .then(move |res| {
+                    test_nodes[0].view_client.send(GetBlock::Finality(Finality::None)).then(
+                        move |res| {
                             let header_view = res.unwrap().unwrap().header;
                             if header_view.height >= 2 && header_view.height <= epoch_length {
                                 if header_view.total_supply == initial_total_supply {
@@ -457,13 +454,12 @@ fn test_inflation() {
                                 }
                             }
                             future::ready(())
-                        }),
+                        },
+                    ),
                 );
                 actix::spawn(
-                    test_nodes[0]
-                        .view_client
-                        .send(GetBlock(BlockQueryInfo::Finality(Finality::None)))
-                        .then(move |res| {
+                    test_nodes[0].view_client.send(GetBlock::Finality(Finality::None)).then(
+                        move |res| {
                             let header_view = res.unwrap().unwrap().header;
                             if header_view.height > epoch_length
                                 && header_view.height < epoch_length * 2
@@ -477,7 +473,8 @@ fn test_inflation() {
                                 }
                             }
                             future::ready(())
-                        }),
+                        },
+                    ),
                 );
                 if done1_copy1.load(Ordering::SeqCst) && done2_copy1.load(Ordering::SeqCst) {
                     System::current().stop();

--- a/near/tests/sync_nodes.rs
+++ b/near/tests/sync_nodes.rs
@@ -16,10 +16,12 @@ use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
 use near_network::{NetworkClientMessages, PeerInfo};
 use near_primitives::block::Approval;
 use near_primitives::hash::CryptoHash;
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{BlockHeightDelta, EpochId, ValidatorStake};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
+use near_primitives::views::Finality;
 use testlib::genesis_block;
 
 // This assumes that there is no height skipped. Otherwise epoch hash calculation will be wrong.
@@ -114,14 +116,18 @@ fn sync_nodes() {
 
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
-                actix::spawn(view_client2.send(GetBlock::Best).then(|res| {
-                    match &res {
-                        Ok(Ok(b)) if b.header.height == 13 => System::current().stop(),
-                        Err(_) => return future::ready(()),
-                        _ => {}
-                    };
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client2.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        |res| {
+                            match &res {
+                                Ok(Ok(b)) if b.header.height == 13 => System::current().stop(),
+                                Err(_) => return future::ready(()),
+                                _ => {}
+                            };
+                            future::ready(())
+                        },
+                    ),
+                );
             }),
             100,
             60000,
@@ -175,20 +181,30 @@ fn sync_after_sync_nodes() {
                 let client11 = client1.clone();
                 let signer1 = signer.clone();
                 let next_step1 = next_step.clone();
-                actix::spawn(view_client2.send(GetBlock::Best).then(move |res| {
-                    match &res {
-                        Ok(Ok(b)) if b.header.height == 13 => {
-                            if !next_step1.load(Ordering::Relaxed) {
-                                let _ = add_blocks(blocks1, client11, 10, epoch_length, &signer1);
-                                next_step1.store(true, Ordering::Relaxed);
-                            }
-                        }
-                        Ok(Ok(b)) if b.header.height > 20 => System::current().stop(),
-                        Err(_) => return future::ready(()),
-                        _ => {}
-                    };
-                    future::ready(())
-                }));
+                actix::spawn(
+                    view_client2.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            match &res {
+                                Ok(Ok(b)) if b.header.height == 13 => {
+                                    if !next_step1.load(Ordering::Relaxed) {
+                                        let _ = add_blocks(
+                                            blocks1,
+                                            client11,
+                                            10,
+                                            epoch_length,
+                                            &signer1,
+                                        );
+                                        next_step1.store(true, Ordering::Relaxed);
+                                    }
+                                }
+                                Ok(Ok(b)) if b.header.height > 20 => System::current().stop(),
+                                Err(_) => return future::ready(()),
+                                _ => {}
+                            };
+                            future::ready(())
+                        },
+                    ),
+                );
             }),
             100,
             60000,
@@ -248,30 +264,41 @@ fn sync_state_stake_change() {
                 let started_copy = started.clone();
                 let near2_copy = near2.clone();
                 let dir2_path_copy = dir2_path.clone();
-                actix::spawn(view_client1.send(GetBlock::Best).then(move |res| {
-                    let latest_height = res.unwrap().unwrap().header.height;
-                    if !started_copy.load(Ordering::SeqCst) && latest_height > 10 {
-                        started_copy.store(true, Ordering::SeqCst);
-                        let (_, view_client2) = start_with_config(&dir2_path_copy, near2_copy);
+                actix::spawn(
+                    view_client1.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                        move |res| {
+                            let latest_height = res.unwrap().unwrap().header.height;
+                            if !started_copy.load(Ordering::SeqCst) && latest_height > 10 {
+                                started_copy.store(true, Ordering::SeqCst);
+                                let (_, view_client2) =
+                                    start_with_config(&dir2_path_copy, near2_copy);
 
-                        WaitOrTimeout::new(
-                            Box::new(move |_ctx| {
-                                actix::spawn(view_client2.send(GetBlock::Best).then(move |res| {
-                                    if let Ok(block) = res.unwrap() {
-                                        if block.header.height > latest_height + 1 {
-                                            System::current().stop()
-                                        }
-                                    }
-                                    future::ready(())
-                                }));
-                            }),
-                            100,
-                            30000,
-                        )
-                        .start();
-                    }
-                    future::ready(())
-                }));
+                                WaitOrTimeout::new(
+                                    Box::new(move |_ctx| {
+                                        actix::spawn(
+                                            view_client2
+                                                .send(GetBlock(BlockQueryInfo::Finality(
+                                                    Finality::None,
+                                                )))
+                                                .then(move |res| {
+                                                    if let Ok(block) = res.unwrap() {
+                                                        if block.header.height > latest_height + 1 {
+                                                            System::current().stop()
+                                                        }
+                                                    }
+                                                    future::ready(())
+                                                }),
+                                        );
+                                    }),
+                                    100,
+                                    30000,
+                                )
+                                .start();
+                            }
+                            future::ready(())
+                        },
+                    ),
+                );
             }),
             100,
             35000,

--- a/near/tests/sync_state_nodes.rs
+++ b/near/tests/sync_state_nodes.rs
@@ -9,7 +9,9 @@ use near::{config::GenesisConfigExt, load_test_config, start_with_config};
 use near_chain_configs::GenesisConfig;
 use near_client::GetBlock;
 use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
+use near_primitives::views::Finality;
 
 /// One client is in front, another must sync to it using state (fast) sync.
 #[test]
@@ -36,47 +38,56 @@ fn sync_state_nodes() {
                     let view_client2_holder2 = view_client2_holder.clone();
                     let genesis_config2 = genesis_config.clone();
 
-                    actix::spawn(view_client1.send(GetBlock::Best).then(move |res| {
-                        match &res {
-                            Ok(Ok(b)) if b.header.height >= 101 => {
-                                let mut view_client2_holder2 =
-                                    view_client2_holder2.write().unwrap();
+                    actix::spawn(
+                        view_client1.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                            move |res| {
+                                match &res {
+                                    Ok(Ok(b)) if b.header.height >= 101 => {
+                                        let mut view_client2_holder2 =
+                                            view_client2_holder2.write().unwrap();
 
-                                if view_client2_holder2.is_none() {
-                                    let mut near2 =
-                                        load_test_config("test2", port2, &genesis_config2);
-                                    near2.client_config.skip_sync_wait = false;
-                                    near2.client_config.min_num_peers = 1;
-                                    near2.network_config.boot_nodes =
-                                        convert_boot_nodes(vec![("test1", port1)]);
+                                        if view_client2_holder2.is_none() {
+                                            let mut near2 =
+                                                load_test_config("test2", port2, &genesis_config2);
+                                            near2.client_config.skip_sync_wait = false;
+                                            near2.client_config.min_num_peers = 1;
+                                            near2.network_config.boot_nodes =
+                                                convert_boot_nodes(vec![("test1", port1)]);
 
-                                    let dir2 = TempDir::new("sync_nodes_2").unwrap();
-                                    let (_, view_client2) = start_with_config(dir2.path(), near2);
-                                    *view_client2_holder2 = Some(view_client2);
-                                }
-                            }
-                            Ok(Ok(b)) if b.header.height < 101 => {
-                                println!("FIRST STAGE {}", b.header.height)
-                            }
-                            Err(_) => return future::ready(()),
-                            _ => {}
-                        };
-                        future::ready(())
-                    }));
+                                            let dir2 = TempDir::new("sync_nodes_2").unwrap();
+                                            let (_, view_client2) =
+                                                start_with_config(dir2.path(), near2);
+                                            *view_client2_holder2 = Some(view_client2);
+                                        }
+                                    }
+                                    Ok(Ok(b)) if b.header.height < 101 => {
+                                        println!("FIRST STAGE {}", b.header.height)
+                                    }
+                                    Err(_) => return future::ready(()),
+                                    _ => {}
+                                };
+                                future::ready(())
+                            },
+                        ),
+                    );
                 }
 
                 if let Some(view_client2) = &*view_client2_holder.write().unwrap() {
-                    actix::spawn(view_client2.send(GetBlock::Best).then(|res| {
-                        match &res {
-                            Ok(Ok(b)) if b.header.height >= 101 => System::current().stop(),
-                            Ok(Ok(b)) if b.header.height < 101 => {
-                                println!("SECOND STAGE {}", b.header.height)
-                            }
-                            Err(_) => return future::ready(()),
-                            _ => {}
-                        };
-                        future::ready(())
-                    }));
+                    actix::spawn(
+                        view_client2.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                            |res| {
+                                match &res {
+                                    Ok(Ok(b)) if b.header.height >= 101 => System::current().stop(),
+                                    Ok(Ok(b)) if b.header.height < 101 => {
+                                        println!("SECOND STAGE {}", b.header.height)
+                                    }
+                                    Err(_) => return future::ready(()),
+                                    _ => {}
+                                };
+                                future::ready(())
+                            },
+                        ),
+                    );
                 } else {
                 }
             }),
@@ -148,63 +159,73 @@ fn sync_state_nodes_multishard() {
                     let view_client2_holder2 = view_client2_holder.clone();
                     let genesis_config2 = genesis_config.clone();
 
-                    actix::spawn(view_client1.send(GetBlock::Best).then(move |res| {
-                        match &res {
-                            Ok(Ok(b)) if b.header.height >= 101 => {
-                                let mut view_client2_holder2 =
-                                    view_client2_holder2.write().unwrap();
+                    actix::spawn(
+                        view_client1.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                            move |res| {
+                                match &res {
+                                    Ok(Ok(b)) if b.header.height >= 101 => {
+                                        let mut view_client2_holder2 =
+                                            view_client2_holder2.write().unwrap();
 
-                                if view_client2_holder2.is_none() {
-                                    let mut near2 =
-                                        load_test_config("test2", port2, &genesis_config2);
-                                    near2.client_config.skip_sync_wait = false;
-                                    near2.client_config.min_num_peers = 3;
-                                    near2.client_config.min_block_production_delay =
-                                        Duration::from_millis(200);
-                                    near2.client_config.max_block_production_delay =
-                                        Duration::from_millis(400);
-                                    near2.network_config.boot_nodes = convert_boot_nodes(vec![
-                                        ("test1", port1),
-                                        ("test3", port3),
-                                        ("test4", port4),
-                                    ]);
+                                        if view_client2_holder2.is_none() {
+                                            let mut near2 =
+                                                load_test_config("test2", port2, &genesis_config2);
+                                            near2.client_config.skip_sync_wait = false;
+                                            near2.client_config.min_num_peers = 3;
+                                            near2.client_config.min_block_production_delay =
+                                                Duration::from_millis(200);
+                                            near2.client_config.max_block_production_delay =
+                                                Duration::from_millis(400);
+                                            near2.network_config.boot_nodes =
+                                                convert_boot_nodes(vec![
+                                                    ("test1", port1),
+                                                    ("test3", port3),
+                                                    ("test4", port4),
+                                                ]);
 
-                                    let dir2 = TempDir::new("sync_nodes_2").unwrap();
-                                    let (_, view_client2) = start_with_config(dir2.path(), near2);
-                                    *view_client2_holder2 = Some(view_client2);
-                                }
-                            }
-                            Ok(Ok(b)) if b.header.height < 101 => {
-                                println!("FIRST STAGE {}", b.header.height)
-                            }
-                            Err(_) => return future::ready(()),
-                            _ => {}
-                        };
-                        future::ready(())
-                    }));
+                                            let dir2 = TempDir::new("sync_nodes_2").unwrap();
+                                            let (_, view_client2) =
+                                                start_with_config(dir2.path(), near2);
+                                            *view_client2_holder2 = Some(view_client2);
+                                        }
+                                    }
+                                    Ok(Ok(b)) if b.header.height < 101 => {
+                                        println!("FIRST STAGE {}", b.header.height)
+                                    }
+                                    Err(_) => return future::ready(()),
+                                    _ => {}
+                                };
+                                future::ready(())
+                            },
+                        ),
+                    );
                 }
 
                 if let Some(view_client2) = &*view_client2_holder.write().unwrap() {
-                    actix::spawn(view_client2.send(GetBlock::Best).then(|res| {
-                        match &res {
-                            Ok(Ok(b)) if b.header.height >= 101 => System::current().stop(),
-                            Ok(Ok(b)) if b.header.height < 101 => {
-                                println!("SECOND STAGE {}", b.header.height)
-                            }
-                            Ok(Err(e)) => {
-                                println!("SECOND STAGE ERROR1: {:?}", e);
-                                return future::ready(());
-                            }
-                            Err(e) => {
-                                println!("SECOND STAGE ERROR2: {:?}", e);
-                                return future::ready(());
-                            }
-                            _ => {
-                                assert!(false);
-                            }
-                        };
-                        future::ready(())
-                    }));
+                    actix::spawn(
+                        view_client2.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                            |res| {
+                                match &res {
+                                    Ok(Ok(b)) if b.header.height >= 101 => System::current().stop(),
+                                    Ok(Ok(b)) if b.header.height < 101 => {
+                                        println!("SECOND STAGE {}", b.header.height)
+                                    }
+                                    Ok(Err(e)) => {
+                                        println!("SECOND STAGE ERROR1: {:?}", e);
+                                        return future::ready(());
+                                    }
+                                    Err(e) => {
+                                        println!("SECOND STAGE ERROR2: {:?}", e);
+                                        return future::ready(());
+                                    }
+                                    _ => {
+                                        assert!(false);
+                                    }
+                                };
+                                future::ready(())
+                            },
+                        ),
+                    );
                 }
             }),
             100,
@@ -252,63 +273,74 @@ fn sync_empty_state() {
                     let genesis_config2 = genesis_config.clone();
                     let dir2 = dir2.clone();
 
-                    actix::spawn(view_client1.send(GetBlock::Best).then(move |res| {
-                        match &res {
-                            Ok(Ok(b)) if b.header.height >= state_sync_horizon + 1 => {
-                                let mut view_client2_holder2 =
-                                    view_client2_holder2.write().unwrap();
+                    actix::spawn(
+                        view_client1.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                            move |res| {
+                                match &res {
+                                    Ok(Ok(b)) if b.header.height >= state_sync_horizon + 1 => {
+                                        let mut view_client2_holder2 =
+                                            view_client2_holder2.write().unwrap();
 
-                                if view_client2_holder2.is_none() {
-                                    let mut near2 =
-                                        load_test_config("test2", port2, &genesis_config2);
-                                    near2.network_config.boot_nodes =
-                                        convert_boot_nodes(vec![("test1", port1)]);
-                                    near2.client_config.min_num_peers = 1;
-                                    near2.client_config.min_block_production_delay =
-                                        Duration::from_millis(200);
-                                    near2.client_config.max_block_production_delay =
-                                        Duration::from_millis(400);
-                                    near2.client_config.state_fetch_horizon = state_sync_horizon;
-                                    near2.client_config.block_header_fetch_horizon =
-                                        block_header_fetch_horizon;
-                                    near2.client_config.block_fetch_horizon = block_fetch_horizon;
-                                    near2.client_config.tracked_shards = vec![0, 1, 2, 3];
+                                        if view_client2_holder2.is_none() {
+                                            let mut near2 =
+                                                load_test_config("test2", port2, &genesis_config2);
+                                            near2.network_config.boot_nodes =
+                                                convert_boot_nodes(vec![("test1", port1)]);
+                                            near2.client_config.min_num_peers = 1;
+                                            near2.client_config.min_block_production_delay =
+                                                Duration::from_millis(200);
+                                            near2.client_config.max_block_production_delay =
+                                                Duration::from_millis(400);
+                                            near2.client_config.state_fetch_horizon =
+                                                state_sync_horizon;
+                                            near2.client_config.block_header_fetch_horizon =
+                                                block_header_fetch_horizon;
+                                            near2.client_config.block_fetch_horizon =
+                                                block_fetch_horizon;
+                                            near2.client_config.tracked_shards = vec![0, 1, 2, 3];
 
-                                    let (_, view_client2) = start_with_config(dir2.path(), near2);
-                                    *view_client2_holder2 = Some(view_client2);
-                                }
-                            }
-                            Ok(Ok(b)) if b.header.height <= state_sync_horizon => {
-                                println!("FIRST STAGE {}", b.header.height)
-                            }
-                            Err(_) => return future::ready(()),
-                            _ => {}
-                        };
-                        future::ready(())
-                    }));
+                                            let (_, view_client2) =
+                                                start_with_config(dir2.path(), near2);
+                                            *view_client2_holder2 = Some(view_client2);
+                                        }
+                                    }
+                                    Ok(Ok(b)) if b.header.height <= state_sync_horizon => {
+                                        println!("FIRST STAGE {}", b.header.height)
+                                    }
+                                    Err(_) => return future::ready(()),
+                                    _ => {}
+                                };
+                                future::ready(())
+                            },
+                        ),
+                    );
                 }
 
                 if let Some(view_client2) = &*view_client2_holder.write().unwrap() {
-                    actix::spawn(view_client2.send(GetBlock::Best).then(|res| {
-                        match &res {
-                            Ok(Ok(b)) if b.header.height >= 40 => System::current().stop(),
-                            Ok(Ok(b)) if b.header.height < 40 => {
-                                println!("SECOND STAGE {}", b.header.height)
-                            }
-                            Ok(Err(e)) => {
-                                println!("SECOND STAGE ERROR1: {:?}", e);
-                                return future::ready(());
-                            }
-                            Err(e) => {
-                                println!("SECOND STAGE ERROR2: {:?}", e);
-                                return future::ready(());
-                            }
-                            _ => {
-                                assert!(false);
-                            }
-                        };
-                        future::ready(())
-                    }));
+                    actix::spawn(
+                        view_client2.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                            |res| {
+                                match &res {
+                                    Ok(Ok(b)) if b.header.height >= 40 => System::current().stop(),
+                                    Ok(Ok(b)) if b.header.height < 40 => {
+                                        println!("SECOND STAGE {}", b.header.height)
+                                    }
+                                    Ok(Err(e)) => {
+                                        println!("SECOND STAGE ERROR1: {:?}", e);
+                                        return future::ready(());
+                                    }
+                                    Err(e) => {
+                                        println!("SECOND STAGE ERROR2: {:?}", e);
+                                        return future::ready(());
+                                    }
+                                    _ => {
+                                        assert!(false);
+                                    }
+                                };
+                                future::ready(())
+                            },
+                        ),
+                    );
                 }
             }),
             100,

--- a/near/tests/sync_state_nodes.rs
+++ b/near/tests/sync_state_nodes.rs
@@ -9,7 +9,6 @@ use near::{config::GenesisConfigExt, load_test_config, start_with_config};
 use near_chain_configs::GenesisConfig;
 use near_client::GetBlock;
 use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
-use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::views::Finality;
 
@@ -38,56 +37,52 @@ fn sync_state_nodes() {
                     let view_client2_holder2 = view_client2_holder.clone();
                     let genesis_config2 = genesis_config.clone();
 
-                    actix::spawn(
-                        view_client1.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                            move |res| {
-                                match &res {
-                                    Ok(Ok(b)) if b.header.height >= 101 => {
-                                        let mut view_client2_holder2 =
-                                            view_client2_holder2.write().unwrap();
+                    actix::spawn(view_client1.send(GetBlock::Finality(Finality::None)).then(
+                        move |res| {
+                            match &res {
+                                Ok(Ok(b)) if b.header.height >= 101 => {
+                                    let mut view_client2_holder2 =
+                                        view_client2_holder2.write().unwrap();
 
-                                        if view_client2_holder2.is_none() {
-                                            let mut near2 =
-                                                load_test_config("test2", port2, &genesis_config2);
-                                            near2.client_config.skip_sync_wait = false;
-                                            near2.client_config.min_num_peers = 1;
-                                            near2.network_config.boot_nodes =
-                                                convert_boot_nodes(vec![("test1", port1)]);
+                                    if view_client2_holder2.is_none() {
+                                        let mut near2 =
+                                            load_test_config("test2", port2, &genesis_config2);
+                                        near2.client_config.skip_sync_wait = false;
+                                        near2.client_config.min_num_peers = 1;
+                                        near2.network_config.boot_nodes =
+                                            convert_boot_nodes(vec![("test1", port1)]);
 
-                                            let dir2 = TempDir::new("sync_nodes_2").unwrap();
-                                            let (_, view_client2) =
-                                                start_with_config(dir2.path(), near2);
-                                            *view_client2_holder2 = Some(view_client2);
-                                        }
+                                        let dir2 = TempDir::new("sync_nodes_2").unwrap();
+                                        let (_, view_client2) =
+                                            start_with_config(dir2.path(), near2);
+                                        *view_client2_holder2 = Some(view_client2);
                                     }
-                                    Ok(Ok(b)) if b.header.height < 101 => {
-                                        println!("FIRST STAGE {}", b.header.height)
-                                    }
-                                    Err(_) => return future::ready(()),
-                                    _ => {}
-                                };
-                                future::ready(())
-                            },
-                        ),
-                    );
+                                }
+                                Ok(Ok(b)) if b.header.height < 101 => {
+                                    println!("FIRST STAGE {}", b.header.height)
+                                }
+                                Err(_) => return future::ready(()),
+                                _ => {}
+                            };
+                            future::ready(())
+                        },
+                    ));
                 }
 
                 if let Some(view_client2) = &*view_client2_holder.write().unwrap() {
-                    actix::spawn(
-                        view_client2.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                            |res| {
-                                match &res {
-                                    Ok(Ok(b)) if b.header.height >= 101 => System::current().stop(),
-                                    Ok(Ok(b)) if b.header.height < 101 => {
-                                        println!("SECOND STAGE {}", b.header.height)
-                                    }
-                                    Err(_) => return future::ready(()),
-                                    _ => {}
-                                };
-                                future::ready(())
-                            },
-                        ),
-                    );
+                    actix::spawn(view_client2.send(GetBlock::Finality(Finality::None)).then(
+                        |res| {
+                            match &res {
+                                Ok(Ok(b)) if b.header.height >= 101 => System::current().stop(),
+                                Ok(Ok(b)) if b.header.height < 101 => {
+                                    println!("SECOND STAGE {}", b.header.height)
+                                }
+                                Err(_) => return future::ready(()),
+                                _ => {}
+                            };
+                            future::ready(())
+                        },
+                    ));
                 } else {
                 }
             }),
@@ -159,73 +154,68 @@ fn sync_state_nodes_multishard() {
                     let view_client2_holder2 = view_client2_holder.clone();
                     let genesis_config2 = genesis_config.clone();
 
-                    actix::spawn(
-                        view_client1.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                            move |res| {
-                                match &res {
-                                    Ok(Ok(b)) if b.header.height >= 101 => {
-                                        let mut view_client2_holder2 =
-                                            view_client2_holder2.write().unwrap();
+                    actix::spawn(view_client1.send(GetBlock::Finality(Finality::None)).then(
+                        move |res| {
+                            match &res {
+                                Ok(Ok(b)) if b.header.height >= 101 => {
+                                    let mut view_client2_holder2 =
+                                        view_client2_holder2.write().unwrap();
 
-                                        if view_client2_holder2.is_none() {
-                                            let mut near2 =
-                                                load_test_config("test2", port2, &genesis_config2);
-                                            near2.client_config.skip_sync_wait = false;
-                                            near2.client_config.min_num_peers = 3;
-                                            near2.client_config.min_block_production_delay =
-                                                Duration::from_millis(200);
-                                            near2.client_config.max_block_production_delay =
-                                                Duration::from_millis(400);
-                                            near2.network_config.boot_nodes =
-                                                convert_boot_nodes(vec![
-                                                    ("test1", port1),
-                                                    ("test3", port3),
-                                                    ("test4", port4),
-                                                ]);
+                                    if view_client2_holder2.is_none() {
+                                        let mut near2 =
+                                            load_test_config("test2", port2, &genesis_config2);
+                                        near2.client_config.skip_sync_wait = false;
+                                        near2.client_config.min_num_peers = 3;
+                                        near2.client_config.min_block_production_delay =
+                                            Duration::from_millis(200);
+                                        near2.client_config.max_block_production_delay =
+                                            Duration::from_millis(400);
+                                        near2.network_config.boot_nodes = convert_boot_nodes(vec![
+                                            ("test1", port1),
+                                            ("test3", port3),
+                                            ("test4", port4),
+                                        ]);
 
-                                            let dir2 = TempDir::new("sync_nodes_2").unwrap();
-                                            let (_, view_client2) =
-                                                start_with_config(dir2.path(), near2);
-                                            *view_client2_holder2 = Some(view_client2);
-                                        }
+                                        let dir2 = TempDir::new("sync_nodes_2").unwrap();
+                                        let (_, view_client2) =
+                                            start_with_config(dir2.path(), near2);
+                                        *view_client2_holder2 = Some(view_client2);
                                     }
-                                    Ok(Ok(b)) if b.header.height < 101 => {
-                                        println!("FIRST STAGE {}", b.header.height)
-                                    }
-                                    Err(_) => return future::ready(()),
-                                    _ => {}
-                                };
-                                future::ready(())
-                            },
-                        ),
-                    );
+                                }
+                                Ok(Ok(b)) if b.header.height < 101 => {
+                                    println!("FIRST STAGE {}", b.header.height)
+                                }
+                                Err(_) => return future::ready(()),
+                                _ => {}
+                            };
+                            future::ready(())
+                        },
+                    ));
                 }
 
                 if let Some(view_client2) = &*view_client2_holder.write().unwrap() {
-                    actix::spawn(
-                        view_client2.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                            |res| {
-                                match &res {
-                                    Ok(Ok(b)) if b.header.height >= 101 => System::current().stop(),
-                                    Ok(Ok(b)) if b.header.height < 101 => {
-                                        println!("SECOND STAGE {}", b.header.height)
-                                    }
-                                    Ok(Err(e)) => {
-                                        println!("SECOND STAGE ERROR1: {:?}", e);
-                                        return future::ready(());
-                                    }
-                                    Err(e) => {
-                                        println!("SECOND STAGE ERROR2: {:?}", e);
-                                        return future::ready(());
-                                    }
-                                    _ => {
-                                        assert!(false);
-                                    }
-                                };
-                                future::ready(())
-                            },
-                        ),
-                    );
+                    actix::spawn(view_client2.send(GetBlock::Finality(Finality::None)).then(
+                        |res| {
+                            match &res {
+                                Ok(Ok(b)) if b.header.height >= 101 => System::current().stop(),
+                                Ok(Ok(b)) if b.header.height < 101 => {
+                                    println!("SECOND STAGE {}", b.header.height)
+                                }
+                                Ok(Err(e)) => {
+                                    println!("SECOND STAGE ERROR1: {:?}", e);
+                                    return future::ready(());
+                                }
+                                Err(e) => {
+                                    println!("SECOND STAGE ERROR2: {:?}", e);
+                                    return future::ready(());
+                                }
+                                _ => {
+                                    assert!(false);
+                                }
+                            };
+                            future::ready(())
+                        },
+                    ));
                 }
             }),
             100,
@@ -273,74 +263,70 @@ fn sync_empty_state() {
                     let genesis_config2 = genesis_config.clone();
                     let dir2 = dir2.clone();
 
-                    actix::spawn(
-                        view_client1.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                            move |res| {
-                                match &res {
-                                    Ok(Ok(b)) if b.header.height >= state_sync_horizon + 1 => {
-                                        let mut view_client2_holder2 =
-                                            view_client2_holder2.write().unwrap();
+                    actix::spawn(view_client1.send(GetBlock::Finality(Finality::None)).then(
+                        move |res| {
+                            match &res {
+                                Ok(Ok(b)) if b.header.height >= state_sync_horizon + 1 => {
+                                    let mut view_client2_holder2 =
+                                        view_client2_holder2.write().unwrap();
 
-                                        if view_client2_holder2.is_none() {
-                                            let mut near2 =
-                                                load_test_config("test2", port2, &genesis_config2);
-                                            near2.network_config.boot_nodes =
-                                                convert_boot_nodes(vec![("test1", port1)]);
-                                            near2.client_config.min_num_peers = 1;
-                                            near2.client_config.min_block_production_delay =
-                                                Duration::from_millis(200);
-                                            near2.client_config.max_block_production_delay =
-                                                Duration::from_millis(400);
-                                            near2.client_config.state_fetch_horizon =
-                                                state_sync_horizon;
-                                            near2.client_config.block_header_fetch_horizon =
-                                                block_header_fetch_horizon;
-                                            near2.client_config.block_fetch_horizon =
-                                                block_fetch_horizon;
-                                            near2.client_config.tracked_shards = vec![0, 1, 2, 3];
+                                    if view_client2_holder2.is_none() {
+                                        let mut near2 =
+                                            load_test_config("test2", port2, &genesis_config2);
+                                        near2.network_config.boot_nodes =
+                                            convert_boot_nodes(vec![("test1", port1)]);
+                                        near2.client_config.min_num_peers = 1;
+                                        near2.client_config.min_block_production_delay =
+                                            Duration::from_millis(200);
+                                        near2.client_config.max_block_production_delay =
+                                            Duration::from_millis(400);
+                                        near2.client_config.state_fetch_horizon =
+                                            state_sync_horizon;
+                                        near2.client_config.block_header_fetch_horizon =
+                                            block_header_fetch_horizon;
+                                        near2.client_config.block_fetch_horizon =
+                                            block_fetch_horizon;
+                                        near2.client_config.tracked_shards = vec![0, 1, 2, 3];
 
-                                            let (_, view_client2) =
-                                                start_with_config(dir2.path(), near2);
-                                            *view_client2_holder2 = Some(view_client2);
-                                        }
+                                        let (_, view_client2) =
+                                            start_with_config(dir2.path(), near2);
+                                        *view_client2_holder2 = Some(view_client2);
                                     }
-                                    Ok(Ok(b)) if b.header.height <= state_sync_horizon => {
-                                        println!("FIRST STAGE {}", b.header.height)
-                                    }
-                                    Err(_) => return future::ready(()),
-                                    _ => {}
-                                };
-                                future::ready(())
-                            },
-                        ),
-                    );
+                                }
+                                Ok(Ok(b)) if b.header.height <= state_sync_horizon => {
+                                    println!("FIRST STAGE {}", b.header.height)
+                                }
+                                Err(_) => return future::ready(()),
+                                _ => {}
+                            };
+                            future::ready(())
+                        },
+                    ));
                 }
 
                 if let Some(view_client2) = &*view_client2_holder.write().unwrap() {
-                    actix::spawn(
-                        view_client2.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                            |res| {
-                                match &res {
-                                    Ok(Ok(b)) if b.header.height >= 40 => System::current().stop(),
-                                    Ok(Ok(b)) if b.header.height < 40 => {
-                                        println!("SECOND STAGE {}", b.header.height)
-                                    }
-                                    Ok(Err(e)) => {
-                                        println!("SECOND STAGE ERROR1: {:?}", e);
-                                        return future::ready(());
-                                    }
-                                    Err(e) => {
-                                        println!("SECOND STAGE ERROR2: {:?}", e);
-                                        return future::ready(());
-                                    }
-                                    _ => {
-                                        assert!(false);
-                                    }
-                                };
-                                future::ready(())
-                            },
-                        ),
-                    );
+                    actix::spawn(view_client2.send(GetBlock::Finality(Finality::None)).then(
+                        |res| {
+                            match &res {
+                                Ok(Ok(b)) if b.header.height >= 40 => System::current().stop(),
+                                Ok(Ok(b)) if b.header.height < 40 => {
+                                    println!("SECOND STAGE {}", b.header.height)
+                                }
+                                Ok(Err(e)) => {
+                                    println!("SECOND STAGE ERROR1: {:?}", e);
+                                    return future::ready(());
+                                }
+                                Err(e) => {
+                                    println!("SECOND STAGE ERROR2: {:?}", e);
+                                    return future::ready(());
+                                }
+                                _ => {
+                                    assert!(false);
+                                }
+                            };
+                            future::ready(())
+                        },
+                    ));
                 }
             }),
             100,

--- a/near/tests/track_shards.rs
+++ b/near/tests/track_shards.rs
@@ -7,7 +7,6 @@ use tempdir::TempDir;
 use near_client::{GetBlock, GetChunk};
 use near_network::test_utils::WaitOrTimeout;
 use near_primitives::hash::CryptoHash;
-use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
 use near_primitives::views::Finality;
 use testlib::start_nodes;
@@ -41,21 +40,19 @@ fn track_shards() {
                     ));
                 } else {
                     let last_block_hash1 = last_block_hash.clone();
-                    actix::spawn(
-                        view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
-                            move |res| {
-                                match &res {
-                                    Ok(Ok(b)) if b.header.height > 10 => {
-                                        *last_block_hash1.write().unwrap() =
-                                            Some(b.header.hash.clone().into());
-                                    }
-                                    Err(_) => return future::ready(()),
-                                    _ => {}
-                                };
-                                future::ready(())
-                            },
-                        ),
-                    );
+                    actix::spawn(view_client.send(GetBlock::Finality(Finality::None)).then(
+                        move |res| {
+                            match &res {
+                                Ok(Ok(b)) if b.header.height > 10 => {
+                                    *last_block_hash1.write().unwrap() =
+                                        Some(b.header.hash.clone().into());
+                                }
+                                Err(_) => return future::ready(()),
+                                _ => {}
+                            };
+                            future::ready(())
+                        },
+                    ));
                 }
             }),
             100,

--- a/near/tests/track_shards.rs
+++ b/near/tests/track_shards.rs
@@ -7,7 +7,9 @@ use tempdir::TempDir;
 use near_client::{GetBlock, GetChunk};
 use near_network::test_utils::WaitOrTimeout;
 use near_primitives::hash::CryptoHash;
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::test_utils::{heavy_test, init_integration_logger};
+use near_primitives::views::Finality;
 use testlib::start_nodes;
 
 #[test]
@@ -39,17 +41,21 @@ fn track_shards() {
                     ));
                 } else {
                     let last_block_hash1 = last_block_hash.clone();
-                    actix::spawn(view_client.send(GetBlock::Best).then(move |res| {
-                        match &res {
-                            Ok(Ok(b)) if b.header.height > 10 => {
-                                *last_block_hash1.write().unwrap() =
-                                    Some(b.header.hash.clone().into());
-                            }
-                            Err(_) => return future::ready(()),
-                            _ => {}
-                        };
-                        future::ready(())
-                    }));
+                    actix::spawn(
+                        view_client.send(GetBlock(BlockQueryInfo::Finality(Finality::None))).then(
+                            move |res| {
+                                match &res {
+                                    Ok(Ok(b)) if b.header.height > 10 => {
+                                        *last_block_hash1.write().unwrap() =
+                                            Some(b.header.hash.clone().into());
+                                    }
+                                    Err(_) => return future::ready(()),
+                                    _ => {}
+                                };
+                                future::ready(())
+                            },
+                        ),
+                    );
                 }
             }),
             100,

--- a/pytest/tests/sanity/block_production.py
+++ b/pytest/tests/sanity/block_production.py
@@ -63,3 +63,9 @@ while max_height < BLOCKS:
 
 assert min_common() + 2 >= BLOCKS, heights_report()
 
+doomslug_final_block = nodes[0].json_rpc('block', {'finality': 'near-final'})
+assert(doomslug_final_block['result']['header']['height'] >= BLOCKS - 10)
+
+nfg_final_block = nodes[0].json_rpc('block', {'finality': 'final'})
+assert(nfg_final_block['result']['header']['height'] >= BLOCKS - 10)
+

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -22,6 +22,7 @@ use near_primitives::views::{
 };
 
 use crate::user::User;
+use near_primitives::rpc::BlockQueryInfo;
 
 pub struct RpcUser {
     account_id: AccountId,
@@ -113,7 +114,8 @@ impl User for RpcUser {
     }
 
     fn get_block(&self, height: BlockHeight) -> Option<BlockView> {
-        self.actix(move |mut client| client.block(BlockId::Height(height))).ok()
+        self.actix(move |mut client| client.block(BlockQueryInfo::BlockId(BlockId::Height(height))))
+            .ok()
     }
 
     fn get_transaction_result(&self, _hash: &CryptoHash) -> ExecutionOutcomeView {

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -13,6 +13,7 @@ use near_jsonrpc::client::{new_client, JsonRpcClient};
 use near_jsonrpc::ServerError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
+use near_primitives::rpc::BlockQueryInfo;
 use near_primitives::serialize::{to_base, to_base64};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeight, BlockId, MaybeBlockId};
@@ -22,7 +23,6 @@ use near_primitives::views::{
 };
 
 use crate::user::User;
-use near_primitives::rpc::BlockQueryInfo;
 
 pub struct RpcUser {
     account_id: AccountId,


### PR DESCRIPTION
Allow rpc to specify block finality when querying blocks. For example, previously we only allow queries like 
```
http post http://localhost:3030 jsonrpc=2.0 id=dontcare method=block 'params:=[48605]'
```
whereas the new API would allow
```
http post http://localhost:3030 jsonrpc=2.0 id=dontcare method=block 'params:={"block_id": 48605}'
```
as well as
```
http post http://localhost:3030 jsonrpc=2.0 id=dontcare method=block 'params:={"finality": "near-final"}'
```
Fixes #2175 

Test plan
---------
* Test that the new API is backward compatible by running old tests with the new API.
* Test that the new API works (sanity test `test_block_query`).
* Test in pytest `block_production.py` that the finality specified in the block rpc works properly.