### PR TITLE
Allow empty method names for access_key created in a smart contract

### DIFF
--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -1439,7 +1439,7 @@ impl<'a> VMLogic<'a> {
         let method_names =
             self.get_vec_from_memory_or_register(method_names_ptr, method_names_len)?;
         // Use `,` separator to split `method_names` into a vector of method names.
-        let method_names =  if method_names.is_empty() {
+        let method_names = if method_names.is_empty() {
             vec![]
         } else {
             method_names
@@ -1453,7 +1453,7 @@ impl<'a> VMLogic<'a> {
                 })
                 .collect::<Result<Vec<_>>>()?
         };
-            
+
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
 
         // +1 is to account for null-terminating characters.

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -1439,7 +1439,9 @@ impl<'a> VMLogic<'a> {
         let method_names =
             self.get_vec_from_memory_or_register(method_names_ptr, method_names_len)?;
         // Use `,` separator to split `method_names` into a vector of method names.
-        let method_names =
+        let method_names =  if method_names.is_empty() {
+            vec![]
+        } else {
             method_names
                 .split(|c| *c == b',')
                 .map(|v| {
@@ -1449,8 +1451,9 @@ impl<'a> VMLogic<'a> {
                         Ok(v.to_vec())
                     }
                 })
-                .collect::<Result<Vec<_>>>()?;
-
+                .collect::<Result<Vec<_>>>()?
+        };
+            
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
 
         // +1 is to account for null-terminating characters.

--- a/runtime/near-vm-logic/tests/test_promises.rs
+++ b/runtime/near-vm-logic/tests/test_promises.rs
@@ -385,7 +385,8 @@ fn test_promise_batch_action_add_key_with_function_call_empty_method_name() {
         allowance,
         receiver_id,
         method_names,
-    ).expect("should add an access key with allowance to call any method on receiver");
+    )
+    .expect("should add an access key with allowance to call any method on receiver");
 
     let expected = serde_json::json!(
     [

--- a/runtime/near-vm-logic/tests/test_promises.rs
+++ b/runtime/near-vm-logic/tests/test_promises.rs
@@ -364,6 +364,63 @@ fn test_promise_batch_action_add_key_with_function_call() {
 }
 
 #[test]
+fn test_promise_batch_action_add_key_with_function_call_empty_method_name() {
+    let mut context = get_context(vec![], false);
+    context.account_balance = 100;
+
+    let mut logic_builder = VMLogicBuilder::default();
+    let mut logic = logic_builder.build(context);
+    let index = promise_create(&mut logic, b"rick.test", 0, 0).expect("should create a promise");
+    let key = b"ed25519:5do5nkAEVhL8iteDvXNgxi4pWK78Y7DDadX11ArFNyrf";
+    let nonce = 1;
+    let allowance = 999u128;
+    let receiver_id = b"sam";
+    let method_names = b"";
+
+    promise_batch_action_add_key_with_function_call(
+        &mut logic,
+        index,
+        key,
+        nonce,
+        allowance,
+        receiver_id,
+        method_names,
+    ).expect("should add an access key with allowance to call any method on receiver");
+
+    let expected = serde_json::json!(
+    [
+        {
+            "receipt_indices": [],
+            "receiver_id": "rick.test",
+            "actions": [
+                {
+                    "FunctionCall": {
+                        "method_name": "promise_create",
+                        "args": "args",
+                        "gas": 0,
+                        "deposit": 0
+                    }
+                },
+                {
+                    "AddKeyWithFunctionCall": {
+                        "public_key": "RLb4qQXoZPAFqzZhiLFAcGFPFC7JWcDd8xKvQHHEqLUgDXuQkr2ehKAN28MNGQN9vUZ1qGZ",
+                        "nonce": 1,
+                        "allowance": 999,
+                        "receiver_id": "sam",
+                        "method_names": [
+                        ]
+                    }
+                }
+            ]
+        }
+    ]);
+    assert_eq!(
+        &serde_json::to_string(logic_builder.ext.get_receipt_create_calls()).unwrap(),
+        &expected.to_string()
+    );
+}
+
+#[test]
 fn test_promise_batch_then() {
     let mut context = get_context(vec![], false);
     context.account_balance = 100;


### PR DESCRIPTION
fixes #2183
