### PR TITLE
fix: Fix pytest after log to stderr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ core/wasm/**/Cargo.lock
 # Python env
 .env
 *.pyc
+venv
 
 # Node
 **/node_modules/

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -372,7 +372,7 @@ def init_cluster(num_nodes, num_observers, num_shards, config, genesis_config_ch
     assert 0 == process.returncode, err
 
     node_dirs = [line.split()[-1]
-                 for line in out.decode('utf8').split('\n') if '/test' in line]
+                 for line in err.decode('utf8').split('\n') if '/test' in line]
     assert len(node_dirs) == num_nodes + num_observers, "node dirs: %s num_nodes: %s num_observers: %s" % (len(node_dirs), num_nodes, num_observers)
 
     # apply config changes


### PR DESCRIPTION
Similar to #1985 but now we changed back to log to stderr

Test Plans
-------------
Run pytest locally, now it's no longer have `AssertionError: node dirs: 0 num_nodes: 4 num_observers: 0` error