### PR TITLE
fix: fixing cross_shard_tx* tests and small fixes for some other nigh…

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2533,7 +2533,7 @@ impl<'a> ChainUpdate<'a> {
             return Err(ErrorKind::Orphan.into());
         }
 
-        if block.header.inner_lite.height > head.height + self.epoch_length {
+        if block.header.inner_lite.height > head.height + self.epoch_length * 2 {
             return Err(ErrorKind::InvalidBlockHeight.into());
         }
 

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -281,7 +281,7 @@ pub fn setup_mock_all_validators(
     let num_shards = validators.iter().map(|x| x.len()).min().unwrap() as NumShards;
 
     let last_height_score =
-        Arc::new(RwLock::new(vec![(0, ScoreAndHeight::from_ints(0, 0)); key_pairs.len()]));
+        Arc::new(RwLock::new(vec![ScoreAndHeight::from_ints(0, 0); key_pairs.len()]));
     let largest_endorsed_height = Arc::new(RwLock::new(vec![0u64; key_pairs.len()]));
     let largest_skipped_height = Arc::new(RwLock::new(vec![0u64; key_pairs.len()]));
     let hash_to_score = Arc::new(RwLock::new(HashMap::new()));
@@ -344,8 +344,8 @@ pub fn setup_mock_all_validators(
                                         chain_id: "unittest".to_string(),
                                         hash: Default::default(),
                                     },
-                                    height: last_height_score2[i].0,
-                                    score: last_height_score2[i].1.score,
+                                    height: last_height_score2[i].height,
+                                    score: last_height_score2[i].score,
                                     tracked_shards: vec![],
                                 },
                                 edge_info: EdgeInfo::default(),
@@ -378,10 +378,8 @@ pub fn setup_mock_all_validators(
 
                             let my_height_score = &mut last_height_score1[my_ord];
 
-                            my_height_score.0 =
-                                max(my_height_score.0, block.header.inner_lite.height);
-                            my_height_score.1 =
-                                max(my_height_score.1, block.header.score_and_height());
+                            *my_height_score =
+                                max(*my_height_score, block.header.score_and_height());
 
                             hash_to_score1
                                 .write()

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -647,7 +647,7 @@ mod tests {
                 key_pairs.clone(),
                 validator_groups,
                 true,
-                400,
+                600,
                 false,
                 false,
                 5,

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -421,7 +421,7 @@ mod tests {
                 !test_doomslug,
                 20,
                 test_doomslug,
-                false,
+                true,
                 Arc::new(RwLock::new(move |_account_id: String, _msg: &NetworkRequests| {
                     (NetworkResponses::NoResponse, true)
                 })),

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -51,9 +51,9 @@ expensive near-client catching_up tests::test_catchup_random_single_part_sync_se
 expensive near-client catching_up tests::test_catchup_random_single_part_sync_non_zero_amounts
 expensive near-client catching_up tests::test_catchup_random_single_part_sync_height_6
 expensive near-client catching_up tests::test_catchup_sanity_blocks_produced
-expensive near-client catching_up tests::test_all_chunks_accepted_1000
-expensive near-client catching_up tests::test_all_chunks_accepted_1000_slow
-expensive near-client catching_up tests::test_all_chunks_accepted_1000_rare_epoch_changing
+expensive --timeout=3600 near-client catching_up tests::test_all_chunks_accepted_1000
+# expensive --timeout=7200 near-client catching_up tests::test_all_chunks_accepted_1000_slow
+expensive --timeout=1800 near-client catching_up tests::test_all_chunks_accepted_1000_rare_epoch_changing
 expensive near-client catching_up tests::test_catchup_sanity_blocks_produced_doomslug
 
 expensive nearcore test_catchup test_catchup
@@ -66,8 +66,8 @@ expensive --timeout=3600 near-client cross_shard_tx tests::test_cross_shard_tx_w
 
 # doomslug / finality gadget safety and light client fuzzy tests
 expensive --timeout=900 near-chain doomslug tests::test_fuzzy_doomslug_liveness_and_safety
-expensive --timeout=900 near-epoch-manager finality tests::test_fuzzy_safety
-expensive --timeout=900 near-epoch-manager finality tests::test_fuzzy_light_client
+expensive --timeout=2400 near-epoch-manager finality tests::test_fuzzy_safety
+expensive --timeout=1200 near-epoch-manager finality tests::test_fuzzy_light_client
 
 # state sync tests
 expensive near sync_state_nodes sync_state_nodes_multishard

--- a/pytest/tests/sanity/state_sync.py
+++ b/pytest/tests/sanity/state_sync.py
@@ -87,6 +87,7 @@ boot_heights = boot_node.get_all_heights()
 
 assert catch_up_height in boot_heights, "%s not in %s" % (catch_up_height, boot_heights)
 
+tracker.offset = 0 # the transition might have happened before we initialized the tracker
 if catch_up_height >= 100:
     assert tracker.check("transition to State Sync")
 elif catch_up_height <= 30:

--- a/pytest/tests/sanity/state_sync_late.py
+++ b/pytest/tests/sanity/state_sync_late.py
@@ -87,6 +87,7 @@ boot_heights = boot_node.get_all_heights()
 
 assert catch_up_height in boot_heights, "%s not in %s" % (catch_up_height, boot_heights)
 
+tracker.offset = 0 # the transition might have happened before we initialized the tracker
 if catch_up_height >= 100:
     assert tracker.check("transition to State Sync")
 elif catch_up_height <= 30:

--- a/pytest/tests/sanity/state_sync_routed.py
+++ b/pytest/tests/sanity/state_sync_routed.py
@@ -101,6 +101,7 @@ boot_heights = boot_node.get_all_heights()
 
 assert catch_up_height in boot_heights, "%s not in %s" % (catch_up_height, boot_heights)
 
+tracker.offset = 0 # the transition might have happened before we initialized the tracker
 if catch_up_height >= 100:
     assert tracker4.check("transition to State Sync")
 elif catch_up_height <= 30:


### PR DESCRIPTION
…tly failures

There were several issues in the test infra:
1. The peer info in the client test infra was the largest height and the
largest score ever observed. If a block with a higher score but lower
height than the previous tip was created, it would report incorrect peer
info, and peers would attempt header sync believing the peer has higher
header head height, and such header sync would fail.
2. The tests tamper with the FG, and the last final block could be way
more than 5 epochs in the past. That makes creating light client blocks
potentially require blocks from 5 epoch lengths ago. I'm just making all
nodes in cross_shard_tx archival. In practice if one epoch has been
lasting for five epoch lengths, we have bigger problems.
3. We historically see cross_shard_tx tests fail with
`InvalidBlockHeight` error when a block is more than epoch length ahead
of the previous block. Since that check is a heuristic anyway, I'm
doubling the distance, to reduce the flakiness of the test.

Separately, increasing the timeouts for NFG tests, they take more than
15 minutes.

Also bumping timeouts for the `test_all_chunks_accepted_1000*` tests,
it's clear that they need at least 2000 / 4000 / 1000 seconds to
complete, I set the timeouts to 3600 / 7200 / 1800 for some extra room.
Also the one that requires 7200 (`*_slow`) seems to provide no value
compared to the base test, and is the slowest test in our entire suite,
so I completely disable it.

Separately, fixing the issue with state sync tests, where the transition
to state sync happens before the log tracker is initialized, and the
check for the transition in the log later fails

Slightly bumping block production time in
`test_catchup_sanity_blocks_produced`, it works on local machine, but on
the gcloud runner doesn't keep up.

Test plan
---------
All cross_shard_tx* tests passed at least three runs.
If they are flaky, nightly will catch that.