### PR TITLE
fix: Separate genesis dump from upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ core/wasm/**/Cargo.lock
 # Python env
 .env
 *.pyc
+venv
 
 # Node
 **/node_modules/

--- a/scripts/new-genesis-from-existing-state.sh
+++ b/scripts/new-genesis-from-existing-state.sh
@@ -10,7 +10,3 @@ mv ${near_home}/output_records_${output_hash}.json near/res/testnet_genesis_reco
 mv ${near_home}/output_hash near/res/testnet_genesis_hash
 mv ${near_home}/output_config.json near/res/testnet_genesis_config.json
 
-echo "Uploading testnet genesis records into S3"
-aws s3 cp --acl public-read near/res/testnet_genesis_records_${output_hash}.json s3://testnet.nearprotocol.com/
-echo
-echo "Uploaded to: https://s3-us-west-1.amazonaws.com/testnet.nearprotocol.com/testnet_genesis_records_${output_hash}.json"

--- a/scripts/new-genesis-from-existing-state.sh
+++ b/scripts/new-genesis-from-existing-state.sh
@@ -9,4 +9,3 @@ echo "Moving result genesis config, records and genesis_hash into near/res"
 mv ${near_home}/output_records_${output_hash}.json near/res/testnet_genesis_records_${output_hash}.json
 mv ${near_home}/output_hash near/res/testnet_genesis_hash
 mv ${near_home}/output_config.json near/res/testnet_genesis_config.json
-

--- a/scripts/upload_genesis_records.sh
+++ b/scripts/upload_genesis_records.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+testnet_genesis_hash=$(cat near/res/testnet_genesis_hash)
+echo "Uploading testnet genesis records into S3"
+aws s3 cp --acl public-read near/res/testnet_genesis_records_${testnet_genesis_hash}.json s3://testnet.nearprotocol.com/
+echo
+echo "Uploaded to: https://s3-us-west-1.amazonaws.com/testnet.nearprotocol.com/testnet_genesis_records_${testnet_genesis_hash}.json"


### PR DESCRIPTION
Separate genesis dump from upload so we can run necessary migration script between two steps. @bowenwang1996 suggested passing migration script as a parameter to this dump script, but I think it's not ready to do that because:
1. Automatic state sanity check isn't there
2. Even if ^ is done, If test fails we would: debug the migration script, run again, test again, upload
So it make sense to separate these two. Once 1. is ready, it's easily to add script that do dump -> migrate with given migration file -> test -> upload.

Test Plans
----------
Test script locally to see they have same effect before split