### PR TITLE
fix: Fixing old rust multi-node tests

### DIFF
--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -244,7 +244,6 @@ impl EpochManager {
         last_block_hash: &CryptoHash,
         rng_seed: RngSeed,
     ) -> Result<EpochId, EpochError> {
-        println!("finalize epoch");
         let EpochSummary {
             prev_epoch_last_block_hash,
             all_proposals,

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -112,4 +112,5 @@ expensive nearcore test_simple test::test_4_10_multiple_nodes
 expensive nearcore test_simple test::test_7_10_multiple_nodes
 
 expensive nearcore test_rejoin test::test_4_20_kill1
+expensive nearcore test_rejoin test::test_4_20_kill1_two_shards
 expensive nearcore test_rejoin test::test_4_20_kill2

--- a/test-utils/testlib/src/node/process_node.rs
+++ b/test-utils/testlib/src/node/process_node.rs
@@ -93,7 +93,7 @@ impl ProcessNode {
     pub fn new(config: NearConfig) -> ProcessNode {
         let mut rng = rand::thread_rng();
         let work_dir = format!(
-            "{}process_node_{}",
+            "{}/process_node_{}",
             env::temp_dir().as_path().to_str().unwrap(),
             rng.gen::<u64>()
         );

--- a/test-utils/testlib/src/node/thread_node.rs
+++ b/test-utils/testlib/src/node/thread_node.rs
@@ -52,6 +52,7 @@ impl Node for ThreadNode {
             ThreadNodeState::Stopped => panic!("Node is not running"),
             ThreadNodeState::Running(handle) => {
                 handle.shutdown();
+                self.state = ThreadNodeState::Stopped;
             }
         }
     }

--- a/tests/test_rejoin.rs
+++ b/tests/test_rejoin.rs
@@ -7,8 +7,10 @@ mod test {
     use std::thread;
     use std::time::Duration;
 
+    use near_chain_configs::Genesis;
     use near_primitives::transaction::SignedTransaction;
     use near_primitives::types::AccountId;
+    use node_runtime::config::RuntimeConfig;
     use testlib::node::{create_nodes, sample_queryable_node, sample_two_nodes, Node, NodeConfig};
     use testlib::test_helpers::{heavy_test, wait, wait_for_catchup};
 
@@ -42,29 +44,39 @@ mod test {
                 account_names[to].clone(),
                 &*nodes[from].read().unwrap().signer(),
                 1000,
-                nodes[from].read().unwrap().user().get_best_block_hash().unwrap(),
+                nodes[k].read().unwrap().user().get_best_block_hash().unwrap(),
             ))
             .unwrap();
     }
 
-    fn test_kill_1(num_nodes: usize, num_trials: usize, test_prefix: &str) {
+    fn test_kill_1(num_nodes: usize, num_trials: usize, two_shards: bool, test_prefix: &str) {
         warmup();
         // Start all nodes, crash node#2, proceed, restart node #2 but crash node #3
         let crash1 = 2;
         let crash2 = 3;
         let nodes = create_nodes(num_nodes, test_prefix);
-        // Convert some of the thread nodes into processes.
+        // Convert all the thread nodes into processes (otherwise killing doesn't free up the port)
+        // Disable fees (so that we can validate exact balances)
+        // Add one more shard, so that the chunk production schedule doesn't get perfectly aligned
+        //   with the block production schedule (otherwise chunk from 0 would always be included in
+        //   the block by 2, and thus when 2 is killed, 0 won't be able to have their tx through)
         let nodes: Vec<_> = nodes
             .into_iter()
             .map(|node_cfg| {
-                if rand::random::<bool>() {
-                    if let NodeConfig::Thread(cfg) = node_cfg {
-                        NodeConfig::Process(cfg)
-                    } else {
-                        unimplemented!()
-                    }
+                // Disable fees
+                if let NodeConfig::Thread(cfg) = node_cfg {
+                    let mut new_cfg = cfg;
+
+                    let Genesis { config, records, .. } = &*new_cfg.genesis;
+                    let mut config = config.clone();
+                    config.runtime_config = RuntimeConfig::free();
+                    config.num_block_producer_seats = 17;
+                    config.num_block_producer_seats_per_shard =
+                        if two_shards { vec![8, 9] } else { vec![17] };
+                    new_cfg.genesis = Arc::new(Genesis::new(config, records.clone()));
+                    NodeConfig::Process(new_cfg)
                 } else {
-                    node_cfg
+                    unreachable!()
                 }
             })
             .collect();
@@ -80,7 +92,7 @@ mod test {
         let mut expected_balances = vec![0; num_nodes];
         let mut nonces = vec![1; num_nodes];
         for i in 0..num_nodes {
-            nonces[i] = nodes[0]
+            nonces[i] = nodes[i]
                 .read()
                 .unwrap()
                 .get_access_key_nonce_for_signer(&account_names[i])
@@ -89,13 +101,15 @@ mod test {
             let account = nodes[0].read().unwrap().view_account(&account_names[i]).unwrap();
             expected_balances[i] = account.amount;
         }
-        let trial_duration = 60000;
+        let trial_duration = 90000;
         for trial in 0..num_trials {
             println!("TRIAL #{}", trial);
             if trial % 10 == 3 {
                 println!("Killing node {}", crash1);
                 nodes[crash1].write().unwrap().kill();
-                thread::sleep(Duration::from_secs(2));
+                // Need to wait enough time for others to remove the killed node as a peer, so
+                // that future transactions don't get routed to them
+                thread::sleep(Duration::from_secs(10));
             }
             if trial % 10 == 6 {
                 println!("Restarting node {}", crash1);
@@ -103,6 +117,9 @@ mod test {
                 wait_for_catchup(&nodes);
                 println!("Killing node {}", crash2);
                 nodes[crash2].write().unwrap().kill();
+                // Need to wait enough time for others to remove the killed node as a peer, so
+                // that future transactions don't get routed to them
+                thread::sleep(Duration::from_secs(10));
             }
             if trial % 10 == 9 {
                 println!("Restarting node {}", crash2);
@@ -214,7 +231,12 @@ mod test {
 
     #[test]
     fn test_4_20_kill1() {
-        heavy_test(|| test_kill_1(4, 10, "4_10_kill1"));
+        heavy_test(|| test_kill_1(4, 10, false, "4_10_kill1"));
+    }
+
+    #[test]
+    fn test_4_20_kill1_two_shards() {
+        heavy_test(|| test_kill_1(4, 10, true, "4_10_kill1"));
     }
 
     #[test]

--- a/tests/test_simple.rs
+++ b/tests/test_simple.rs
@@ -28,7 +28,7 @@ mod test {
             println!("TRIAL #{}", trial);
             let (i, j) = sample_two_nodes(num_nodes);
             let (k, r) = sample_two_nodes(num_nodes);
-            let nonce_i = nodes[k]
+            let nonce_i = nodes[i]
                 .read()
                 .unwrap()
                 .get_access_key_nonce_for_signer(&account_names[i])


### PR DESCRIPTION
Fixing the following issues:
1. `ThreadNode` was not properly setting its state on kill
2. `ThreadNode` doesn't properly free up its port, but instead of
figuring out why, I just replaced it with `ProcessNode` in the tests
that are affected
3. `test_4_20_kill1` wasn't accounting for fees. Disabling fees.
4. In the same test, the same chunk producer was always mapped to the
same block producer, and thus killing the second node was making the
0-th chunk producer (who happens to be attached to the 2nd BP) to not be
able to have their transactions included. Address it by having 17 seats.
Also split the test in two, with one shard and with two shards
5. In multiple places we were using the wrong node to get the access key

Test plan
---------
Locally `test_4_20_kill1` and `test_*_multiple_nodes` pass, let's see
how the next nightly looks