### PR TITLE
fix: Disabling some tests + small fixes

### DIFF
--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -480,9 +480,9 @@ mod tests {
             }
 
             near_network::test_utils::wait_or_panic(if rotate_validators {
-                1000 * 60 * 15 * 4
+                1000 * 60 * 80
             } else {
-                1000 * 60 * 15 * 2
+                1000 * 60 * 30
             });
         })
         .unwrap();
@@ -515,11 +515,11 @@ mod tests {
 
     #[test]
     fn test_cross_shard_tx_with_validator_rotation_1() {
-        test_cross_shard_tx_common(16, true, false, false, 150);
+        test_cross_shard_tx_common(8, true, false, false, 200);
     }
 
     #[test]
     fn test_cross_shard_tx_with_validator_rotation_2() {
-        test_cross_shard_tx_common(64, true, false, false, 400);
+        test_cross_shard_tx_common(24, true, false, false, 400);
     }
 }

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -77,12 +77,13 @@ expensive near sync_state_nodes sync_state_nodes_multishard
 # testnet rpc
 expensive nearcore test_tps_regression test::test_highload
 
-expensive nearcore test_cases_testnet_rpc test::test_smart_contract_simple_testnet
-expensive nearcore test_cases_testnet_rpc test::test_smart_contract_self_call_testnet
-expensive nearcore test_cases_testnet_rpc test::test_smart_contract_bad_method_name_testnet
-expensive nearcore test_cases_testnet_rpc test::test_smart_contract_empty_method_name_with_no_tokens_testnet
-expensive nearcore test_cases_testnet_rpc test::test_smart_contract_empty_method_name_with_tokens_testnet
-expensive nearcore test_cases_testnet_rpc test::test_smart_contract_with_args_testnet
+# The next six tests are disabled due to #2208
+# expensive nearcore test_cases_testnet_rpc test::test_smart_contract_simple_testnet
+# expensive nearcore test_cases_testnet_rpc test::test_smart_contract_self_call_testnet
+# expensive nearcore test_cases_testnet_rpc test::test_smart_contract_bad_method_name_testnet
+# expensive nearcore test_cases_testnet_rpc test::test_smart_contract_empty_method_name_with_no_tokens_testnet
+# expensive nearcore test_cases_testnet_rpc test::test_smart_contract_empty_method_name_with_tokens_testnet
+# expensive nearcore test_cases_testnet_rpc test::test_smart_contract_with_args_testnet
 expensive nearcore test_cases_testnet_rpc test::test_nonce_update_when_deploying_contract_testnet
 expensive nearcore test_cases_testnet_rpc test::test_nonce_updated_when_tx_failed_testnet
 expensive nearcore test_cases_testnet_rpc test::test_upload_contract_testnet
@@ -104,7 +105,8 @@ expensive nearcore test_cases_testnet_rpc test::test_add_key_testnet
 expensive nearcore test_cases_testnet_rpc test::test_delete_access_key_testnet
 expensive nearcore test_cases_testnet_rpc test::test_add_access_key_with_allowance_testnet
 expensive nearcore test_cases_testnet_rpc test::test_delete_access_key_with_allowance_testnet
-expensive nearcore test_cases_testnet_rpc test::test_access_key_smart_contract_testnet
+# The next test is disabled due to #2208
+# expensive nearcore test_cases_testnet_rpc test::test_access_key_smart_contract_testnet
 
 # other tests
 expensive nearcore test_simple test::test_2_10_multiple_nodes

--- a/pytest/tests/sanity/state_sync2.py
+++ b/pytest/tests/sanity/state_sync2.py
@@ -10,7 +10,7 @@ sys.path.append('lib')
 from cluster import start_cluster
 from utils import LogTracker
 
-TIMEOUT = 300
+TIMEOUT = 600
 BLOCKS = 105 # should be enough to trigger state sync for node 1 later, see comments there
 
 nodes = start_cluster(2, 0, 2, None, [["num_block_producer_seats", 199], ["num_block_producer_seats_per_shard", [24, 25, 25, 25, 25, 25, 25, 25]], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})

--- a/pytest/tests/sanity/state_sync_routed.py
+++ b/pytest/tests/sanity/state_sync_routed.py
@@ -108,7 +108,7 @@ elif catch_up_height <= 30:
     assert not tracker4.check("transition to State Sync")
 
 tracker4.reset()
-assert tracker4.count("Connected to FullPeerInfo") == 2
+assert tracker4.count("Consolidated connection with FullPeerInfo") == 2
 
 if mode == 'manytx':
     while ctx.get_balances() != ctx.expected_balances:


### PR DESCRIPTION
Disabling old tests that fail due to the runtime cache unti they are
fixed;

Changing the `cross_shard_tx_with_validator_rotation` slightly based on
its performance on gcloud.
(increasing the block prod time speeds up test, because it results in
fewer forks, so the 150->200 change is to make more iterations fit.
With 150ms it fits ~6 iterations into one hour)