### PR TITLE
fix(adversary): start_from_genesis test relies on Doomslug

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -373,6 +373,11 @@ impl Chain {
         })
     }
 
+    #[cfg(feature = "adversarial")]
+    pub fn adv_disable_doomslug(&mut self) {
+        self.doomslug_threshold_mode = DoomslugThresholdMode::NoApprovals
+    }
+
     pub fn process_approval(
         &mut self,
         me: &Option<AccountId>,

--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -330,6 +330,11 @@ impl Doomslug {
         }
     }
 
+    #[cfg(feature = "adversarial")]
+    pub fn adv_disable(&mut self) {
+        self.threshold_mode = DoomslugThresholdMode::NoApprovals
+    }
+
     /// Returns the `(hash, height)` of the current tip. Currently is only used by tests.
     pub fn get_tip(&self) -> (CryptoHash, BlockHeight) {
         (self.tip.block_hash, self.tip.height)

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -18,9 +18,7 @@ use near_chain::{
 use near_chain_configs::ClientConfig;
 use near_crypto::Signature;
 #[cfg(feature = "adversarial")]
-use near_network::types::NetworkAdversarialMessage::{
-    AdvDisableHeaderSync, AdvGetSavedBlocks, AdvProduceBlocks,
-};
+use near_network::types::NetworkAdversarialMessage;
 use near_network::types::{NetworkInfo, ReasonForBan, StateResponseInfo};
 use near_network::{
     NetworkAdapter, NetworkClientMessages, NetworkClientResponses, NetworkRequests,
@@ -55,6 +53,8 @@ pub struct ClientActor {
     pub adv_sync_info: Option<(u64, u64)>,
     #[cfg(feature = "adversarial")]
     pub adv_disable_header_sync: bool,
+    #[cfg(feature = "adversarial")]
+    pub adv_disable_doomslug: bool,
 
     client: Client,
     network_adapter: Arc<dyn NetworkAdapter>,
@@ -114,6 +114,8 @@ impl ClientActor {
             adv_sync_info: None,
             #[cfg(feature = "adversarial")]
             adv_disable_header_sync: false,
+            #[cfg(feature = "adversarial")]
+            adv_disable_doomslug: false,
             client,
             network_adapter,
             node_id,
@@ -164,12 +166,19 @@ impl Handler<NetworkClientMessages> for ClientActor {
             #[cfg(feature = "adversarial")]
             NetworkClientMessages::Adversarial(adversarial_msg) => {
                 return match adversarial_msg {
-                    AdvDisableHeaderSync => {
+                    NetworkAdversarialMessage::AdvDisableDoomslug => {
+                        info!(target: "adversary", "Turning Doomslug off");
+                        self.adv_disable_doomslug = true;
+                        self.client.doomslug.adv_disable();
+                        self.client.chain.adv_disable_doomslug();
+                        NetworkClientResponses::NoResponse
+                    }
+                    NetworkAdversarialMessage::AdvDisableHeaderSync => {
                         info!(target: "adversary", "Blocking header sync");
                         self.adv_disable_header_sync = true;
                         NetworkClientResponses::NoResponse
                     }
-                    AdvProduceBlocks(num_blocks, only_valid) => {
+                    NetworkAdversarialMessage::AdvProduceBlocks(num_blocks, only_valid) => {
                         info!(target: "adversary", "Producing {} blocks", num_blocks);
                         self.client.adv_produce_blocks = true;
                         self.client.adv_produce_blocks_only_valid = only_valid;
@@ -204,7 +213,7 @@ impl Handler<NetworkClientMessages> for ClientActor {
                         }
                         NetworkClientResponses::NoResponse
                     }
-                    AdvGetSavedBlocks => {
+                    NetworkAdversarialMessage::AdvGetSavedBlocks => {
                         info!(target: "adversary", "Requested number of saved blocks");
                         let store = self.client.chain.store().store();
                         let mut num_blocks = 0;
@@ -214,7 +223,7 @@ impl Handler<NetworkClientMessages> for ClientActor {
                         NetworkClientResponses::AdvU64(num_blocks)
                     }
                     _ => panic!("invalid adversary message"),
-                }
+                };
             }
             NetworkClientMessages::Transaction(tx) => self.client.process_tx(tx),
             NetworkClientMessages::Block(block, peer_id, was_requested) => {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -16,7 +16,7 @@ use near_chain::{
 };
 use near_chain_configs::ClientConfig;
 #[cfg(feature = "adversarial")]
-use near_network::types::NetworkAdversarialMessage::{AdvDisableHeaderSync, AdvSetSyncInfo};
+use near_network::types::NetworkAdversarialMessage;
 use near_network::types::{
     NetworkViewClientMessages, NetworkViewClientResponses, ReasonForBan, StateResponseInfo,
 };
@@ -44,6 +44,8 @@ const REQUEST_WAIT_TIME: u64 = 1000;
 pub struct ViewClientActor {
     #[cfg(feature = "adversarial")]
     pub adv_disable_header_sync: bool,
+    #[cfg(feature = "adversarial")]
+    pub adv_disable_doomslug: bool,
     #[cfg(feature = "adversarial")]
     pub adv_sync_info: Option<(u64, u64)>,
 
@@ -91,6 +93,8 @@ impl ViewClientActor {
         Ok(ViewClientActor {
             #[cfg(feature = "adversarial")]
             adv_disable_header_sync: false,
+            #[cfg(feature = "adversarial")]
+            adv_disable_doomslug: false,
             #[cfg(feature = "adversarial")]
             adv_sync_info: None,
             chain,
@@ -508,12 +512,18 @@ impl Handler<NetworkViewClientMessages> for ViewClientActor {
             #[cfg(feature = "adversarial")]
             NetworkViewClientMessages::Adversarial(adversarial_msg) => {
                 return match adversarial_msg {
-                    AdvSetSyncInfo(height, score) => {
+                    NetworkAdversarialMessage::AdvDisableDoomslug => {
+                        info!(target: "adversary", "Turning Doomslug off");
+                        self.adv_disable_doomslug = true;
+                        self.chain.adv_disable_doomslug();
+                        NetworkViewClientResponses::NoResponse
+                    }
+                    NetworkAdversarialMessage::AdvSetSyncInfo(height, score) => {
                         info!(target: "adversary", "Setting adversarial stats: ({}, {})", height, score);
                         self.adv_sync_info = Some((height, score));
                         NetworkViewClientResponses::NoResponse
                     }
-                    AdvDisableHeaderSync => {
+                    NetworkAdversarialMessage::AdvDisableHeaderSync => {
                         info!(target: "adversary", "Blocking header sync");
                         self.adv_disable_header_sync = true;
                         NetworkViewClientResponses::NoResponse

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1119,6 +1119,7 @@ pub struct StateResponseInfo {
 pub enum NetworkAdversarialMessage {
     AdvProduceBlocks(u64, bool),
     AdvDisableHeaderSync,
+    AdvDisableDoomslug,
     AdvGetSavedBlocks,
     AdvSetSyncInfo(u64, u64),
 }

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -41,6 +41,8 @@ pytest adversarial/malicious_chain.py
 pytest adversarial/malicious_chain.py valid_blocks_only
 pytest adversarial/start_from_genesis.py
 pytest adversarial/start_from_genesis.py overtake
+pytest adversarial/start_from_genesis.py doomslug_off
+pytest adversarial/start_from_genesis.py overtake doomslug_off
 
 # catchup tests
 expensive near-client catching_up tests::test_catchup_receipts_sync_third_epoch

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -18,8 +18,7 @@ pytest --timeout=600 sanity/state_sync_routed.py manytx 100
 pytest --timeout=300 sanity/state_sync_late.py notx
 pytest sanity/rpc_tx_forwarding.py
 pytest --timeout=240 sanity/skip_epoch.py
-# disabled, see #2206
-# pytest --timeout=600 sanity/fork_sync.py
+pytest --timeout=600 sanity/fork_sync.py
 pytest --timeout=240 sanity/one_val.py
 pytest --timeout=240 sanity/lightclnt.py
 pytest --timeout=240 sanity/rpc_query.py

--- a/pytest/tests/adversarial/fork_sync.py
+++ b/pytest/tests/adversarial/fork_sync.py
@@ -22,11 +22,19 @@ cur_height = 0
 fork1_height = 0
 fork2_height = 0
 
+for i in range(2, 4):
+    # TODO Alex
+    # nodes 2 and 3 will not produce any blocks with doomslug enabled after killing nodes 0 and 1
+    # check if is it expected behavior
+    res = nodes[i].json_rpc('adv_disable_doomslug', [])
+    assert 'result' in res, res
+
 # step 1, let nodes run for some time
 while cur_height < FIRST_STEP_WAIT:
     status = nodes[0].get_status()
     cur_height = status['sync_info']['latest_block_height']
-    time.sleep(0.1)
+    print(status)
+    time.sleep(0.9)
 
 for i in range(2):
     nodes[i].kill()
@@ -35,7 +43,8 @@ print("killing node 0 and 1")
 while fork1_height < FIRST_STEP_WAIT + SECOND_STEP_WAIT:
     status = nodes[2].get_status()
     fork1_height = status['sync_info']['latest_block_height']
-    time.sleep(0.5)
+    print(status)
+    time.sleep(0.9)
 
 for i in range(2, 4):
     nodes[i].kill()
@@ -44,16 +53,21 @@ print("killing node 2 and 3")
 
 for i in range(2):
     nodes[i].start(nodes[i].node_key.pk, nodes[i].addr())
+    res = nodes[i].json_rpc('adv_disable_doomslug', [])
+    assert 'result' in res, res
 
 time.sleep(1)
 
 while fork2_height < FIRST_STEP_WAIT + SECOND_STEP_WAIT:
     status = nodes[0].get_status()
     fork2_height = status['sync_info']['latest_block_height']
-    time.sleep(0.5)
+    print(status)
+    time.sleep(0.9)
 
 for i in range(2, 4):
     nodes[i].start(nodes[i].node_key.pk, nodes[i].addr())
+    res = nodes[i].json_rpc('adv_disable_doomslug', [])
+    assert 'result' in res, res
 
 time.sleep(1)
 
@@ -77,6 +91,7 @@ while cur_height < TIMEOUT:
             succeed = False
             break
     if statuses[0][1] > FINAL_HEIGHT_THRESHOLD and succeed:
+        print("Epic")
         exit(0)
     time.sleep(0.5)
 

--- a/pytest/tests/adversarial/fork_sync.py
+++ b/pytest/tests/adversarial/fork_sync.py
@@ -23,9 +23,6 @@ fork1_height = 0
 fork2_height = 0
 
 for i in range(2, 4):
-    # TODO Alex
-    # nodes 2 and 3 will not produce any blocks with doomslug enabled after killing nodes 0 and 1
-    # check if is it expected behavior
     res = nodes[i].json_rpc('adv_disable_doomslug', [])
     assert 'result' in res, res
 

--- a/pytest/tests/adversarial/start_from_genesis.py
+++ b/pytest/tests/adversarial/start_from_genesis.py
@@ -4,9 +4,13 @@ sys.path.append('lib')
 
 from cluster import start_cluster
 
-overtake = False # create a new chain which should not be accepted
+overtake = False # create a new chain which is shorter than current one
 if "overtake" in sys.argv:
-    overtake = True # create a new chain which head should be accepted and then the chain is restored completely
+    overtake = True # create a new chain which is longer than current one
+
+doomslug = True
+if "doomslug_off" in sys.argv:
+    doomslug = False # turn off doomslug
 
 TIMEOUT = 300
 BLOCKS = 30
@@ -39,6 +43,9 @@ assert 'result' in res, res
 
 time.sleep(2)
 nodes[0].start(nodes[0].node_key.pk, nodes[0].addr())
+if not doomslug:
+    res = nodes[0].json_rpc('adv_disable_doomslug', [])
+    assert 'result' in res, res
 
 time.sleep(2)
 status = nodes[0].get_status()
@@ -65,11 +72,10 @@ print("SAVED BLOCKS AFTER MALICIOUS INJECTION", saved_blocks_2)
 print("HEIGHT", height)
 
 assert saved_blocks['result'] < BLOCKS + 10
-if not overtake:
-    # node 0 should not accept additional blocks from node 1
-    assert saved_blocks_2['result'] < saved_blocks['result'] + 10
-else:
-    # node 0 should accept additional blocks from node 1
+if overtake and not doomslug:
+    # node 0 should accept additional blocks from node 1 because of new chain is longer and doomslug is turned off
     assert saved_blocks_2['result'] >= BLOCKS + num_produce_blocks
+else:
+    assert saved_blocks_2['result'] < saved_blocks['result'] + 10
 
 print("Epic")


### PR DESCRIPTION
After Doomslug introduction, it's impossible to create a chain from genesis to overtake the current max block height. `start_from_genesis` test should take it to account.
Also fixes https://github.com/nearprotocol/nearcore/issues/2206.