### PR TITLE
fix: Increasing tolerance in stress.py, and fixing nightly.txt

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -18,7 +18,6 @@ pytest --timeout=600 sanity/state_sync_routed.py manytx 100
 pytest --timeout=300 sanity/state_sync_late.py notx
 pytest sanity/rpc_tx_forwarding.py
 pytest --timeout=240 sanity/skip_epoch.py
-pytest --timeout=600 sanity/fork_sync.py
 pytest --timeout=240 sanity/one_val.py
 pytest --timeout=240 sanity/lightclnt.py
 pytest --timeout=240 sanity/rpc_query.py
@@ -35,6 +34,7 @@ pytest --timeout=2000 stress/stress.py 3 2 4 0 staking transactions node_set
 # pytest stress/network_stress.py
 
 # python adversarial tests
+pytest --timeout=600 adversarial/fork_sync.py
 pytest adversarial/wrong_sync_info.py
 pytest adversarial/malicious_chain.py
 pytest adversarial/malicious_chain.py valid_blocks_only

--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -187,3 +187,19 @@ def user_name():
     if username == 'root':  # digitalocean
         username = gcloud.list()[0].username.replace('_nearprotocol_com', '')
     return username
+
+# from https://stackoverflow.com/questions/107705/disable-output-buffering
+# this class allows making print always flush by executing
+#
+#     sys.stdout = Unbuffered(sys.stdout)
+class Unbuffered(object):
+   def __init__(self, stream):
+       self.stream = stream
+   def write(self, data):
+       self.stream.write(data)
+       self.stream.flush()
+   def writelines(self, datas):
+       self.stream.writelines(datas)
+       self.stream.flush()
+   def __getattr__(self, attr):
+       return getattr(self.stream, attr)

--- a/pytest/tests/stress/stress.py
+++ b/pytest/tests/stress/stress.py
@@ -29,9 +29,11 @@ from multiprocessing import Process, Value, Lock
 sys.path.append('lib')
 
 from cluster import init_cluster, spin_up_node, load_config
-from utils import TxContext
+from utils import TxContext, Unbuffered
 from transaction import sign_payment_tx, sign_staking_tx
 from network import init_network_pillager, stop_network, resume_network
+
+sys.stdout = Unbuffered(sys.stdout)
 
 TIMEOUT = 1500 # after how much time to shut down the test
 TIMEOUT_SHUTDOWN = 120 # time to wait after the shutdown was initiated before 
@@ -449,14 +451,14 @@ def doit(s, n, N, k, monkeys, timeout):
         if config['local']:
             init_network_pillager()
             expect_network_issues()
-        block_timeout += 20
+        block_timeout += 40
         tx_tolerance += 0.3
     if 'monkey_node_restart' in monkey_names:
         expect_network_issues()
     if 'monkey_node_restart' in monkey_names or 'monkey_node_set' in monkey_names:
-        block_timeout += 20
+        block_timeout += 40
         balances_timeout += 10
-        tx_tolerance += 0.4
+        tx_tolerance += 0.5
 
     stopped = Value('i', 0)
     error = Value('i', 0)


### PR DESCRIPTION
Further investigation of `stress.py` failures in nightly shows that all
the workers appear to work as expected, but frequent restarts cause
block production to be delayed more than the current tolerance.
Locally spradically also more than 50% of transactions get lost if the
node get restarted too frequently.
Increasing both tolerances.

Also making the prints unbuffered, otherwise several workers in the
nightly runs don't flush their outputs.

Finally, fixing a typo in the nightly.txt

Test plan
---------
Locally `stress.py` doesn't fail, so there's no easy way to test whether
the new tolerances would be sufficient.
It also doesn't completely fix all the known issues, there are some
other failures in stress.py that I haven't gotten to yet