### PR TITLE
feat(network): Network metric recorder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ expensive_tests = []
 regression_tests = []
 old_tests = []
 adversarial = ["near/adversarial", "near-jsonrpc/adversarial"]
+metric_recorder = ["near/metric_recorder"]
 
 [patch.crates-io]
 actix-rt = { git = "https://github.com/actix/actix-net", rev="602db1779eb51d60e0fe5a33d725d1d7fdf540fd" }

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -40,3 +40,4 @@ near = { path = "../../near" }
 byzantine_asserts = ["near-chain/byzantine_asserts"]
 expensive_tests = []
 adversarial = ["near-network/adversarial", "near-chain/adversarial"]
+metric_recorder = []

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -17,6 +17,7 @@ use near_chain::{
 };
 use near_chain_configs::ClientConfig;
 use near_crypto::Signature;
+use near_network::recorder::MetricRecorder;
 #[cfg(feature = "adversarial")]
 use near_network::types::NetworkAdversarialMessage;
 use near_network::types::{NetworkInfo, ReasonForBan, StateResponseInfo};
@@ -124,6 +125,7 @@ impl ClientActor {
                 received_bytes_per_sec: 0,
                 sent_bytes_per_sec: 0,
                 known_producers: vec![],
+                metric_recorder: MetricRecorder::default(),
             },
             last_validator_announce_height: None,
             last_validator_announce_time: None,
@@ -478,6 +480,7 @@ impl Handler<GetNetworkInfo> for ClientActor {
             sent_bytes_per_sec: self.network_info.sent_bytes_per_sec,
             received_bytes_per_sec: self.network_info.received_bytes_per_sec,
             known_producers: self.network_info.known_producers.clone(),
+            metric_recorder: self.network_info.metric_recorder.clone(),
         })
     }
 }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -17,6 +17,7 @@ use near_chain::{
 };
 use near_chain_configs::ClientConfig;
 use near_crypto::Signature;
+#[cfg(feature = "metric_recorder")]
 use near_network::recorder::MetricRecorder;
 #[cfg(feature = "adversarial")]
 use near_network::types::NetworkAdversarialMessage;
@@ -125,6 +126,7 @@ impl ClientActor {
                 received_bytes_per_sec: 0,
                 sent_bytes_per_sec: 0,
                 known_producers: vec![],
+                #[cfg(feature = "metric_recorder")]
                 metric_recorder: MetricRecorder::default(),
             },
             last_validator_announce_height: None,
@@ -480,6 +482,7 @@ impl Handler<GetNetworkInfo> for ClientActor {
             sent_bytes_per_sec: self.network_info.sent_bytes_per_sec,
             received_bytes_per_sec: self.network_info.received_bytes_per_sec,
             known_producers: self.network_info.known_producers.clone(),
+            #[cfg(feature = "metric_recorder")]
             metric_recorder: self.network_info.metric_recorder.clone(),
         })
     }

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -14,6 +14,7 @@ use near_chain::test_utils::KeyValueRuntime;
 use near_chain::{Chain, ChainGenesis, DoomslugThresholdMode, Provenance, RuntimeAdapter};
 use near_chain_configs::ClientConfig;
 use near_crypto::{InMemorySigner, KeyType, PublicKey};
+#[cfg(feature = "metric_recorder")]
 use near_network::recorder::MetricRecorder;
 use near_network::routing::EdgeInfo;
 use near_network::types::{
@@ -358,6 +359,7 @@ pub fn setup_mock_all_validators(
                             sent_bytes_per_sec: 0,
                             received_bytes_per_sec: 0,
                             known_producers: vec![],
+                            #[cfg(feature = "metric_recorder")]
                             metric_recorder: MetricRecorder::default(),
                         };
                         client_addr.do_send(NetworkClientMessages::NetworkInfo(info));

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -14,6 +14,7 @@ use near_chain::test_utils::KeyValueRuntime;
 use near_chain::{Chain, ChainGenesis, DoomslugThresholdMode, Provenance, RuntimeAdapter};
 use near_chain_configs::ClientConfig;
 use near_crypto::{InMemorySigner, KeyType, PublicKey};
+use near_network::recorder::MetricRecorder;
 use near_network::routing::EdgeInfo;
 use near_network::types::{
     AccountOrPeerIdOrHash, NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses,
@@ -357,6 +358,7 @@ pub fn setup_mock_all_validators(
                             sent_bytes_per_sec: 0,
                             received_bytes_per_sec: 0,
                             known_producers: vec![],
+                            metric_recorder: MetricRecorder::default(),
                         };
                         client_addr.do_send(NetworkClientMessages::NetworkInfo(info));
                     }

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "metric_recorder")]
 use near_network::recorder::MetricRecorder;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -223,6 +224,7 @@ pub struct NetworkInfoResponse {
     pub received_bytes_per_sec: u64,
     /// Accounts of known block and chunk producers from routing table.
     pub known_producers: Vec<KnownProducer>,
+    #[cfg(feature = "metric_recorder")]
     pub metric_recorder: MetricRecorder,
 }
 

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -1,3 +1,4 @@
+use near_network::recorder::MetricRecorder;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -222,6 +223,7 @@ pub struct NetworkInfoResponse {
     pub received_bytes_per_sec: u64,
     /// Accounts of known block and chunk producers from routing table.
     pub known_producers: Vec<KnownProducer>,
+    pub metric_recorder: MetricRecorder,
 }
 
 /// Status of given transaction including all the subsequent receipts.

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -10,6 +10,7 @@ use near_client::test_utils::setup_mock_all_validators;
 use near_client::test_utils::{setup_client, setup_mock, MockNetworkAdapter, TestEnv};
 use near_client::{Client, GetBlock};
 use near_crypto::{InMemorySigner, KeyType, Signature, Signer};
+#[cfg(feature = "metric_recorder")]
 use near_network::recorder::MetricRecorder;
 use near_network::routing::EdgeInfo;
 use near_network::test_utils::wait_or_panic;
@@ -589,6 +590,7 @@ fn client_sync_headers() {
             sent_bytes_per_sec: 0,
             received_bytes_per_sec: 0,
             known_producers: vec![],
+            #[cfg(feature = "metric_recorder")]
             metric_recorder: MetricRecorder::default(),
         }));
         wait_or_panic(2000);

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -10,6 +10,7 @@ use near_client::test_utils::setup_mock_all_validators;
 use near_client::test_utils::{setup_client, setup_mock, MockNetworkAdapter, TestEnv};
 use near_client::{Client, GetBlock};
 use near_crypto::{InMemorySigner, KeyType, Signature, Signer};
+use near_network::recorder::MetricRecorder;
 use near_network::routing::EdgeInfo;
 use near_network::test_utils::wait_or_panic;
 use near_network::types::{NetworkInfo, PeerChainInfo};
@@ -588,6 +589,7 @@ fn client_sync_headers() {
             sent_bytes_per_sec: 0,
             received_bytes_per_sec: 0,
             known_producers: vec![],
+            metric_recorder: MetricRecorder::default(),
         }));
         wait_or_panic(2000);
     })

--- a/chain/network/Cargo.toml
+++ b/chain/network/Cargo.toml
@@ -40,6 +40,7 @@ testlib = { path = "../../test-utils/testlib" }
 
 [features]
 adversarial = []
+metric_recorder = []
 
 [[bench]]
 name = "graph"

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -13,6 +13,7 @@ mod peer;
 mod peer_manager;
 pub mod peer_store;
 mod rate_counter;
+mod recorder;
 pub mod routing;
 pub mod types;
 pub mod utils;

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -13,7 +13,7 @@ mod peer;
 mod peer_manager;
 pub mod peer_store;
 mod rate_counter;
-mod recorder;
+pub mod recorder;
 pub mod routing;
 pub mod types;
 pub mod utils;

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -13,6 +13,7 @@ mod peer;
 mod peer_manager;
 pub mod peer_store;
 mod rate_counter;
+#[cfg(feature = "metric_recorder")]
 pub mod recorder;
 pub mod routing;
 pub mod types;

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -203,9 +203,8 @@ impl Peer {
         };
         #[cfg(feature = "metric_recorder")]
         let metadata = {
-            let mut metadata = PeerMessageMetadata::into_metadata(&msg)
-                .set_source(self.node_id())
-                .set_status(Status::Sent);
+            let mut metadata: PeerMessageMetadata = (&msg).into();
+            metadata = metadata.set_source(self.node_id()).set_status(Status::Sent);
             if let Some(target) = self.peer_id() {
                 metadata = metadata.set_target(target);
             }
@@ -552,10 +551,9 @@ impl StreamHandler<Vec<u8>> for Peer {
 
         #[cfg(feature = "metric_recorder")]
         {
-            let mut metadata = PeerMessageMetadata::into_metadata(&peer_msg)
-                .set_size(msg_size)
-                .set_target(self.node_id())
-                .set_status(Status::Received);
+            let mut metadata: PeerMessageMetadata = (&peer_msg).into();
+            metadata =
+                metadata.set_size(msg_size).set_target(self.node_id()).set_status(Status::Received);
 
             if let Some(peer_id) = self.peer_id() {
                 metadata = metadata.set_source(peer_id);

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -779,6 +779,7 @@ impl PeerManagerActor {
                     addr: None,
                 })
                 .collect(),
+            metric_recorder: self.metric_recorder.clone(),
         }
     }
 

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -110,7 +110,8 @@ impl PeerManagerActor {
         debug!(target: "network", "Found known peers: {} (boot nodes={})", peer_store.len(), config.boot_nodes.len());
         debug!(target: "network", "Blacklist: {:?}", config.blacklist);
 
-        let me = config.public_key.clone().into();
+        let me: PeerId = config.public_key.clone().into();
+
         Ok(PeerManagerActor {
             peer_id: config.public_key.clone().into(),
             config,
@@ -119,10 +120,10 @@ impl PeerManagerActor {
             peer_store,
             active_peers: HashMap::default(),
             outgoing_peers: HashSet::default(),
-            routing_table: RoutingTable::new(me, store),
+            routing_table: RoutingTable::new(me.clone(), store),
             monitor_peers_attempts: 0,
             pending_update_nonce_request: HashMap::new(),
-            metric_recorder: MetricRecorder::default(),
+            metric_recorder: MetricRecorder::default().set_me(me),
         })
     }
 

--- a/chain/network/src/recorder.rs
+++ b/chain/network/src/recorder.rs
@@ -169,23 +169,6 @@ pub struct PeerMessageMetadata {
 }
 
 impl PeerMessageMetadata {
-    pub fn into_metadata(msg: &PeerMessage) -> Self {
-        let hash = match msg {
-            PeerMessage::Challenge(challenge) => Some(challenge.hash),
-            PeerMessage::Block(block) => Some(block.hash()),
-            _ => None,
-        };
-
-        Self {
-            source: None,
-            target: None,
-            status: None,
-            message_type: msg.to_string(),
-            size: None,
-            hash,
-        }
-    }
-
     pub fn set_source(mut self, peer_id: PeerId) -> Self {
         self.source = Some(peer_id);
         self
@@ -211,6 +194,25 @@ impl PeerMessageMetadata {
             Some(Status::Received) => self.source.clone(),
             Some(Status::Sent) => self.target.clone(),
             _ => None,
+        }
+    }
+}
+
+impl From<&PeerMessage> for PeerMessageMetadata {
+    fn from(msg: &PeerMessage) -> Self {
+        let hash = match msg {
+            PeerMessage::Challenge(challenge) => Some(challenge.hash),
+            PeerMessage::Block(block) => Some(block.hash()),
+            _ => None,
+        };
+
+        Self {
+            source: None,
+            target: None,
+            status: None,
+            message_type: msg.to_string(),
+            size: None,
+            hash,
         }
     }
 }

--- a/chain/network/src/recorder.rs
+++ b/chain/network/src/recorder.rs
@@ -55,7 +55,7 @@ impl HashAggregator {
     }
 
     /// Number of different hashes added to the aggregator so far.
-    fn different_hashes(&self) -> usize {
+    fn num_different_hashes(&self) -> usize {
         self.all.len()
     }
 }
@@ -67,7 +67,7 @@ impl Serialize for HashAggregator {
     {
         let mut dic = serializer.serialize_map(Some(2))?;
         dic.serialize_entry("total", &self.total)?;
-        dic.serialize_entry("different", &self.different_hashes())?;
+        dic.serialize_entry("different", &self.num_different_hashes())?;
         dic.end()
     }
 }

--- a/chain/network/src/recorder.rs
+++ b/chain/network/src/recorder.rs
@@ -1,0 +1,175 @@
+use crate::types::PeerMessage;
+use actix::Message;
+use near_primitives::{hash::CryptoHash, network::PeerId};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+};
+use tracing::info;
+
+#[derive(Clone, Copy)]
+pub enum Status {
+    Sent,
+    Received,
+}
+#[derive(Default, Debug)]
+struct CountSize {
+    count: usize,
+    bytes: usize,
+}
+
+impl CountSize {
+    fn update(&mut self, bytes: usize) {
+        self.count += 1;
+        self.bytes += bytes;
+    }
+}
+
+#[derive(Default, Debug)]
+struct SentReceived {
+    sent: CountSize,
+    received: CountSize,
+}
+
+impl SentReceived {
+    fn get(&mut self, status: Status) -> &mut CountSize {
+        match status {
+            Status::Sent => &mut self.sent,
+            Status::Received => &mut self.received,
+        }
+    }
+}
+
+#[derive(Default)]
+struct HashAggregator {
+    total: usize,
+    all: HashSet<CryptoHash>,
+}
+
+impl HashAggregator {
+    fn add(&mut self, hash: CryptoHash) {
+        self.total += 1;
+        self.all.insert(hash);
+    }
+
+    fn different(&self) -> usize {
+        self.all.len()
+    }
+}
+
+impl Debug for HashAggregator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HashAggregator {{ total: {}, different: {} }}", self.total, self.different())
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct MetricRecorder {
+    overall: SentReceived,
+    per_type: HashMap<String, SentReceived>,
+    per_peer: HashMap<Option<PeerId>, SentReceived>,
+    graph: Vec<(PeerId, PeerId)>,
+    challenge_hashes: HashAggregator,
+    block_hashes: HashAggregator,
+}
+
+impl MetricRecorder {
+    pub fn handle_peer_message(&mut self, peer_message_metadata: PeerMessageMetadata) {
+        self.overall
+            .get(peer_message_metadata.status.unwrap())
+            .update(peer_message_metadata.size.unwrap());
+
+        self.per_type
+            .entry(peer_message_metadata.message_type.clone())
+            .or_insert(SentReceived::default())
+            .get(peer_message_metadata.status.unwrap())
+            .update(peer_message_metadata.size.unwrap());
+
+        let peer = peer_message_metadata.other_peer();
+
+        self.per_peer
+            .entry(peer)
+            .or_insert(SentReceived::default())
+            .get(peer_message_metadata.status.unwrap())
+            .update(peer_message_metadata.size.unwrap());
+
+        match peer_message_metadata.message_type.as_str() {
+            "Challenge" => self.challenge_hashes.add(peer_message_metadata.hash.unwrap()),
+            "Block" => self.block_hashes.add(peer_message_metadata.hash.unwrap()),
+            _ => {}
+        }
+    }
+
+    pub fn report(&self) {
+        info!(target: "stats", "{:?}", self);
+    }
+
+    pub fn set_graph(&mut self, graph: &HashMap<PeerId, HashSet<PeerId>>) {
+        self.graph.clear();
+        for (u, u_adj) in graph.iter() {
+            for v in u_adj {
+                if u < v {
+                    self.graph.push((u.clone(), v.clone()));
+                }
+            }
+        }
+    }
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct PeerMessageMetadata {
+    source: Option<PeerId>,
+    target: Option<PeerId>,
+    status: Option<Status>,
+    message_type: String,
+    size: Option<usize>,
+    hash: Option<CryptoHash>,
+}
+
+impl PeerMessageMetadata {
+    pub fn into_metadata(msg: &PeerMessage) -> Self {
+        let hash = match msg {
+            PeerMessage::Challenge(challenge) => Some(challenge.hash),
+            PeerMessage::Block(block) => Some(block.hash()),
+            _ => None,
+        };
+
+        Self {
+            source: None,
+            target: None,
+            status: None,
+            message_type: msg.to_string(),
+            size: None,
+            hash,
+        }
+    }
+
+    pub fn set_source(mut self, peer_id: PeerId) -> Self {
+        self.source = Some(peer_id);
+        self
+    }
+
+    pub fn set_target(mut self, peer_id: PeerId) -> Self {
+        self.target = Some(peer_id);
+        self
+    }
+
+    pub fn set_status(mut self, status: Status) -> Self {
+        self.status = Some(status);
+        self
+    }
+
+    pub fn set_size(mut self, size: usize) -> Self {
+        self.size = Some(size);
+        self
+    }
+
+    fn other_peer(&self) -> Option<PeerId> {
+        match self.status {
+            Some(Status::Received) => self.source.clone(),
+            Some(Status::Sent) => self.target.clone(),
+            _ => None,
+        }
+    }
+}

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -696,6 +696,10 @@ impl RoutingTable {
                 })
         }
     }
+
+    pub fn get_raw_graph(&self) -> &HashMap<PeerId, HashSet<PeerId>> {
+        &self.raw_graph.adjacency
+    }
 }
 
 pub struct ProcessEdgeResult {

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -315,8 +315,8 @@ impl RoutingTable {
         &self.raw_graph.source
     }
 
-    pub fn reachable_peers(&self) -> Vec<PeerId> {
-        self.peer_forwarding.keys().cloned().collect()
+    pub fn reachable_peers(&self) -> impl Iterator<Item = &PeerId> {
+        self.peer_forwarding.keys()
     }
 
     /// Find peer that is connected to `source` and belong to the shortest path

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -24,10 +24,14 @@ use near_store::{
 };
 
 use crate::metrics;
-use crate::types::{PeerIdOrHash, Ping, Pong};
+use crate::{
+    types::{PeerIdOrHash, Ping, Pong},
+    utils::cache_to_hashmap,
+};
 
 const ANNOUNCE_ACCOUNT_CACHE_SIZE: usize = 10_000;
 const ROUTE_BACK_CACHE_SIZE: usize = 10_000;
+const PING_PONG_CACHE_SIZE: usize = 1_000;
 const ROUND_ROBIN_MAX_NONCE_DIFFERENCE_ALLOWED: usize = 10;
 const ROUND_ROBIN_NONCE_CACHE_SIZE: usize = 10_000;
 /// Routing table will clean edges if there is at least one node that is not reachable
@@ -261,14 +265,14 @@ pub struct RoutingTable {
     route_nonce: SizedCache<PeerId, usize>,
     /// Flag to know if there is state recalculation pending.
     recalculation_scheduled: Option<Instant>,
-    /// Ping received by nonce. Used for testing only.
-    ping_info: Option<HashMap<usize, Ping>>,
-    /// Ping received by nonce. Used for testing only.
-    pong_info: Option<HashMap<usize, Pong>>,
+    /// Ping received by nonce.
+    ping_info: SizedCache<usize, Ping>,
+    /// Ping received by nonce.
+    pong_info: SizedCache<usize, Pong>,
     /// List of pings sent for which we haven't received any pong yet.
-    waiting_pong: HashMap<PeerId, HashMap<usize, Instant>>,
+    waiting_pong: SizedCache<PeerId, SizedCache<usize, Instant>>,
     /// Last nonce sent to each peer through pings.
-    last_ping_nonce: HashMap<PeerId, usize>,
+    last_ping_nonce: SizedCache<PeerId, usize>,
     /// Last nonce used to store edges on disk.
     pub component_nonce: u64,
 }
@@ -299,10 +303,10 @@ impl RoutingTable {
             raw_graph: Graph::new(peer_id),
             route_nonce: SizedCache::with_size(ROUND_ROBIN_NONCE_CACHE_SIZE),
             recalculation_scheduled: None,
-            ping_info: None,
-            pong_info: None,
-            waiting_pong: HashMap::default(),
-            last_ping_nonce: HashMap::default(),
+            ping_info: SizedCache::with_size(PING_PONG_CACHE_SIZE),
+            pong_info: SizedCache::with_size(PING_PONG_CACHE_SIZE),
+            waiting_pong: SizedCache::with_size(PING_PONG_CACHE_SIZE),
+            last_ping_nonce: SizedCache::with_size(PING_PONG_CACHE_SIZE),
             component_nonce,
         }
     }
@@ -556,54 +560,47 @@ impl RoutingTable {
     }
 
     pub fn add_ping(&mut self, ping: Ping) {
-        if self.ping_info.is_none() {
-            self.ping_info = Some(HashMap::new());
-        }
-
-        if let Some(ping_info) = self.ping_info.as_mut() {
-            ping_info.entry(ping.nonce as usize).or_insert(ping);
-        }
+        self.ping_info.cache_set(ping.nonce as usize, ping);
     }
 
     /// Return time of the round trip of ping + pong
     pub fn add_pong(&mut self, pong: Pong) -> Option<f64> {
-        if self.pong_info.is_none() {
-            self.pong_info = Some(HashMap::new());
-        }
-
         let mut res = None;
 
-        if let Some(nonces) = self.waiting_pong.get_mut(&pong.source) {
+        if let Some(nonces) = self.waiting_pong.cache_get_mut(&pong.source) {
             res = nonces
-                .remove(&(pong.nonce as usize))
+                .cache_remove(&(pong.nonce as usize))
                 .and_then(|sent| Some(Instant::now().duration_since(sent).as_secs_f64() * 1000f64));
         }
-        if let Some(pong_info) = self.pong_info.as_mut() {
-            pong_info.entry(pong.nonce as usize).or_insert(pong);
-        }
+
+        self.pong_info.cache_set(pong.nonce as usize, pong);
 
         res
     }
 
     pub fn sending_ping(&mut self, nonce: usize, target: PeerId) {
-        self.waiting_pong.entry(target).or_default().entry(nonce).or_insert_with(|| Instant::now());
+        let entry = if let Some(entry) = self.waiting_pong.cache_get_mut(&target) {
+            entry
+        } else {
+            self.waiting_pong.cache_set(target.clone(), SizedCache::with_size(10));
+            self.waiting_pong.cache_get_mut(&target).unwrap()
+        };
+
+        entry.cache_set(nonce, Instant::now());
     }
 
     pub fn get_ping(&mut self, peer_id: PeerId) -> usize {
-        let nonce = self
-            .last_ping_nonce
-            .entry(peer_id)
-            .and_modify(|nonce| {
-                *nonce += 1;
-            })
-            .or_insert(1);
-        *nonce - 1
+        if let Some(entry) = self.last_ping_nonce.cache_get_mut(&peer_id) {
+            *entry += 1;
+            *entry - 1
+        } else {
+            self.last_ping_nonce.cache_set(peer_id, 1);
+            0
+        }
     }
 
     pub fn fetch_ping_pong(&self) -> (HashMap<usize, Ping>, HashMap<usize, Pong>) {
-        let pings = self.ping_info.clone().unwrap_or_else(HashMap::new);
-        let pongs = self.pong_info.clone().unwrap_or_else(HashMap::new);
-        (pings, pongs)
+        (cache_to_hashmap(&self.ping_info), cache_to_hashmap(&self.pong_info))
     }
 
     pub fn info(&mut self) -> RoutingTableInfo {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -32,7 +32,10 @@ use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryRespo
 
 use crate::metrics;
 use crate::peer::Peer;
-use crate::routing::{Edge, EdgeInfo, RoutingTableInfo};
+use crate::{
+    recorder::MetricRecorder,
+    routing::{Edge, EdgeInfo, RoutingTableInfo},
+};
 
 /// Number of hops a message is allowed to travel before being dropped.
 /// This is used to avoid infinite loop because of inconsistent view of the network
@@ -1065,6 +1068,7 @@ pub struct NetworkInfo {
     pub received_bytes_per_sec: u64,
     /// Accounts of known block and chunk producers from routing table.
     pub known_producers: Vec<KnownProducer>,
+    pub metric_recorder: MetricRecorder,
 }
 
 impl<A, M> MessageResponse<A, M> for NetworkInfo

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -32,10 +32,9 @@ use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryRespo
 
 use crate::metrics;
 use crate::peer::Peer;
-use crate::{
-    recorder::MetricRecorder,
-    routing::{Edge, EdgeInfo, RoutingTableInfo},
-};
+#[cfg(feature = "metric_recorder")]
+use crate::recorder::MetricRecorder;
+use crate::routing::{Edge, EdgeInfo, RoutingTableInfo};
 
 /// Number of hops a message is allowed to travel before being dropped.
 /// This is used to avoid infinite loop because of inconsistent view of the network
@@ -1068,6 +1067,7 @@ pub struct NetworkInfo {
     pub received_bytes_per_sec: u64,
     /// Accounts of known block and chunk producers from routing table.
     pub known_producers: Vec<KnownProducer>,
+    #[cfg(feature = "metric_recorder")]
     pub metric_recorder: MetricRecorder,
 }
 

--- a/chain/network/src/utils.rs
+++ b/chain/network/src/utils.rs
@@ -1,6 +1,7 @@
+use cached::SizedCache;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
-use std::net::IpAddr;
+use std::{hash::Hash, net::IpAddr};
 
 use crate::types::{BlockedPorts, PatternAddr};
 
@@ -32,4 +33,9 @@ pub fn blacklist_from_vec(blacklist: &Vec<String>) -> HashMap<IpAddr, BlockedPor
     }
 
     blacklist_map
+}
+
+pub fn cache_to_hashmap<K: Hash + Eq + Clone, V: Clone>(cache: &SizedCache<K, V>) -> HashMap<K, V> {
+    let keys: Vec<_> = cache.key_order().cloned().collect();
+    keys.into_iter().zip(cache.value_order().cloned()).collect()
 }

--- a/near/Cargo.toml
+++ b/near/Cargo.toml
@@ -46,3 +46,4 @@ testlib = { path = "../test-utils/testlib" }
 
 [features]
 adversarial =  ["near-client/adversarial", "near-network/adversarial"]
+metric_recorder = ["near-network/metric_recorder", "near-client/metric_recorder"]


### PR DESCRIPTION
This PR expose extra information about networking via RPC. Using this data you can create a dashboard using [near-node-debug](https://github.com/nearprotocol/near-node-debug). It provides the following information:

- Number of peers
- Network diameter
- Network topology
<img width="1675" alt="Screen Shot 2020-03-09 at 1 05 19 PM" src="https://user-images.githubusercontent.com/28708963/76239708-67dcb780-6208-11ea-8e55-8f4a168096c9.png">

- Latency between every pair of nodes (heat map with hover for detailed info)
- Bytes transferred between every pair of nodes (heat map with hover for detailed info)
- Messages transferred between every pair of nodes (heat map with hover for detailed info)
<img width="1676" alt="Screen Shot 2020-03-09 at 1 15 06 PM" src="https://user-images.githubusercontent.com/28708963/76239755-7f1ba500-6208-11ea-8960-ae04c54ecd39.png">

- Bytes received by one node separated by type.
- Total message received by one node separated by type.
<img width="1330" alt="Screen Shot 2020-03-09 at 1 15 31 PM" src="https://user-images.githubusercontent.com/28708963/76239895-affbda00-6208-11ea-9adb-b6efc191fa92.png">

- Number of peers each node has:
<img width="1558" alt="Screen Shot 2020-03-09 at 1 16 12 PM" src="https://user-images.githubusercontent.com/28708963/76239958-cf930280-6208-11ea-8a5e-72f6d5748d0a.png">

