### PR TITLE
fix: Fixing a minor issue that was causing NFG tests to fail

### DIFF
--- a/chain/epoch_manager/tests/finality.rs
+++ b/chain/epoch_manager/tests/finality.rs
@@ -302,7 +302,7 @@ mod tests {
                     );
                     let (mut chain, _, signer) = setup();
                     let mut em = setup_default_epoch_manager(
-                        block_producers1.iter().map(|_| ("test", 1000000)).collect(),
+                        block_producers1.iter().map(|name| (name.as_str(), 1000000)).collect(),
                         10,
                         4,
                         7,


### PR DESCRIPTION
In one of the recent changes a check was added to the epoch manager that
disallows duplicate proposals on construction. NFG tests do not rely on
the actual proposals, and were using the same name for all of them.
Fixing to use different names.

Test plan
---------
Both `test_fuzzy_safety` and `test_fuzzy_light_client` pass