### PR TITLE
Remove genesis split

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -122,7 +122,6 @@ pub fn setup(
         runtime.clone(),
         network_adapter.clone(),
         config.clone(),
-        None,
     )
     .unwrap();
 

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -72,21 +72,10 @@ impl ViewClientActor {
         runtime_adapter: Arc<dyn RuntimeAdapter>,
         network_adapter: Arc<dyn NetworkAdapter>,
         config: ClientConfig,
-        expected_genesis_hash: Option<String>,
     ) -> Result<Self, Error> {
         // TODO: should we create shared ChainStore that is passed to both Client and ViewClient?
         let mut chain =
             Chain::new(runtime_adapter.clone(), chain_genesis, DoomslugThresholdMode::HalfStake)?;
-        if let Some(expected_genesis_hash) = expected_genesis_hash {
-            let genesis_hash =
-                chain.get_block_by_height(chain_genesis.height).unwrap().hash().to_string();
-            if genesis_hash != expected_genesis_hash {
-                panic!(
-                    "Expected genesis hash to be {}, actual {}",
-                    expected_genesis_hash, genesis_hash,
-                );
-            }
-        }
         Ok(ViewClientActor {
             #[cfg(feature = "adversarial")]
             adv_disable_header_sync: false,

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -77,7 +77,6 @@ pub fn setup_network_node(
             runtime.clone(),
             network_adapter.clone(),
             client_config,
-            None,
         )
         .unwrap()
         .start();

--- a/near/res/testnet_genesis_hash
+++ b/near/res/testnet_genesis_hash
@@ -1,1 +1,0 @@
-ENiDAjkhBgRiC2TNkF9erqiC1DhNVKBug1vNhHSdnfdh

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -135,7 +135,6 @@ pub const CONFIG_FILENAME: &str = "config.json";
 pub const GENESIS_CONFIG_FILENAME: &str = "genesis.json";
 pub const NODE_KEY_FILE: &str = "node_key.json";
 pub const VALIDATOR_KEY_FILE: &str = "validator_key.json";
-pub const GENESIS_HASH_FILE: &str = "genesis_hash";
 
 pub const DEFAULT_TELEMETRY_URL: &str = "https://explorer.nearprotocol.com/api/nodes";
 
@@ -541,9 +540,7 @@ pub fn init_configs(
     test_seed: Option<&str>,
     num_shards: ShardId,
     fast: bool,
-    genesis_records: Option<&str>,
-    genesis_config: Option<&str>,
-    genesis_hash: Option<&str>,
+    genesis: Option<&str>,
 ) {
     fs::create_dir_all(dir).expect("Failed to create directory");
     // Check if config already exists in home dir.
@@ -560,7 +557,7 @@ pub fn init_configs(
             // TODO:
             unimplemented!();
         }
-        "testnet" | "staging" => {
+        "testnet" | "betanet" | "devnet" => {
             if test_seed.is_some() {
                 panic!("Test seed is not supported for official TestNet");
             }
@@ -581,15 +578,8 @@ pub fn init_configs(
             let network_signer = InMemorySigner::from_random("".to_string(), KeyType::ED25519);
             network_signer.write_to_file(&dir.join(config.node_key_file));
 
-            std::fs::write(
-                &dir.join(GENESIS_HASH_FILE),
-                genesis_hash.expect("Genesis hash is required for testnet."),
-            )
-            .expect("Failed to write a genesis hash file.");
-
-            let mut genesis = Genesis::from_files(
-                genesis_config.expect("Genesis config file is required for testnet."),
-                genesis_records.expect("Genesis records file is required for testnet."),
+            let mut genesis = Genesis::from_file(
+                genesis.expect(&format!("Genesis file is required for {}.", &chain_id)),
             );
             genesis.config.chain_id = chain_id;
 

--- a/near/src/lib.rs
+++ b/near/src/lib.rs
@@ -1,6 +1,4 @@
 use std::fs;
-use std::fs::File;
-use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -15,7 +13,6 @@ use near_store::create_store;
 use near_telemetry::TelemetryActor;
 use tracing::trace;
 
-use crate::config::GENESIS_HASH_FILE;
 pub use crate::config::{init_configs, load_config, load_test_config, NearConfig, NEAR_BASE};
 pub use crate::runtime::NightshadeRuntime;
 
@@ -50,18 +47,6 @@ pub fn get_default_home() -> String {
     }
 }
 
-fn get_expected_genesis_hash(home_dir: &Path) -> Option<String> {
-    let path = home_dir.join(GENESIS_HASH_FILE);
-
-    if path.exists() {
-        let mut file = File::open(path).expect("Could not open genesis hash file.");
-        let mut genesis_hash = String::new();
-        file.read_to_string(&mut genesis_hash).expect("Could not read from genesis hash file.");
-        return Some(genesis_hash);
-    }
-    None
-}
-
 pub fn start_with_config(
     home_dir: &Path,
     config: NearConfig,
@@ -86,7 +71,6 @@ pub fn start_with_config(
         runtime.clone(),
         network_adapter.clone(),
         config.client_config.clone(),
-        get_expected_genesis_hash(home_dir),
     )
     .unwrap()
     .start();

--- a/near/src/main.rs
+++ b/near/src/main.rs
@@ -70,9 +70,7 @@ fn main() {
             .arg(Arg::with_name("test-seed").long("test-seed").takes_value(true).help("Specify private key generated from seed (TESTING ONLY)"))
             .arg(Arg::with_name("num-shards").long("num-shards").takes_value(true).help("Number of shards to initialize the chain with"))
             .arg(Arg::with_name("fast").long("fast").takes_value(false).help("Makes block production fast (TESTING ONLY)"))
-            .arg(Arg::with_name("genesis-records").long("genesis-records").takes_value(true).help("Genesis records file to use when initialize testnet"))
-            .arg(Arg::with_name("genesis-config").long("genesis-config").takes_value(true).help("Genesis config file to use when initialize testnet"))
-            .arg(Arg::with_name("genesis-hash").long("genesis-hash").takes_value(true).help("Genesis hash when initialize testnet"))
+            .arg(Arg::with_name("genesis").long("genesis").takes_value(true).help("Genesis file to use when initialize testnet"))
         )
         .subcommand(SubCommand::with_name("testnet").about("Setups testnet configuration with all necessary files (validator key, node key, genesis and config)")
             .arg(Arg::with_name("v").long("v").takes_value(true).help("Number of validators to initialize the testnet with (default 4)"))
@@ -114,25 +112,13 @@ fn main() {
             let chain_id = args.value_of("chain-id");
             let account_id = args.value_of("account-id");
             let test_seed = args.value_of("test-seed");
-            let genesis_records = args.value_of("genesis-records");
-            let genesis_config = args.value_of("genesis-config");
-            let genesis_hash = args.value_of("genesis-hash");
+            let genesis = args.value_of("genesis");
             let num_shards = args
                 .value_of("num-shards")
                 .map(|s| s.parse().expect("Number of shards must be a number"))
                 .unwrap_or(1);
             let fast = args.is_present("fast");
-            init_configs(
-                home_dir,
-                chain_id,
-                account_id,
-                test_seed,
-                num_shards,
-                fast,
-                genesis_records,
-                genesis_config,
-                genesis_hash,
-            );
+            init_configs(home_dir, chain_id, account_id, test_seed, num_shards, fast, genesis);
         }
         ("testnet", Some(args)) => {
             let num_validators = args

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -350,42 +350,15 @@ fn main() {
             let mut genesis_config = near_config.genesis.config.clone();
             genesis_config.genesis_height = genesis_height;
             let genesis = Arc::new(Genesis::new(genesis_config, records.into()));
-
-            println!("Calculating new genesis hash");
-            let store = near_store::test_utils::create_test_store();
-            let runtime = Arc::new(NightshadeRuntime::new(
-                &home_dir,
-                Arc::clone(&store),
-                Arc::clone(&genesis),
-                near_config.client_config.tracked_accounts.clone(),
-                near_config.client_config.tracked_shards.clone(),
-            ));
-            let chain_genesis = near_chain::ChainGenesis::from(&genesis);
-
-            let mut chain = near_chain::Chain::new(
-                Arc::clone(&runtime) as Arc<dyn RuntimeAdapter>,
-                &chain_genesis,
-                DoomslugThresholdMode::HalfStake,
-            )
-            .unwrap();
-            let genesis_hash =
-                chain.get_block_by_height(genesis_height).unwrap().hash().to_string();
-
-            let output_path = home_dir.join(Path::new("output_config.json"));
-            let records_path =
-                home_dir.join(Path::new(&format!("output_records_{}.json", &genesis_hash)));
-            let genesis_hash_path = home_dir.join(Path::new("output_hash"));
-
+            
+            let output_path = home_dir.join(Path::new("output.json"));
             println!(
-                "Saving state at {:?} @ {} into {} and records {}",
+                "Saving state at {:?} @ {} into {}",
                 state_roots,
                 height,
                 output_path.display(),
-                records_path.display(),
             );
-            genesis.config.to_file(&output_path);
-            genesis.records.to_file(&records_path);
-            std::fs::write(&genesis_hash_path, &genesis_hash).unwrap();
+            genesis.to_file(&output_path);
         }
         ("chain", Some(args)) => {
             let start_index =

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -350,7 +350,7 @@ fn main() {
             let mut genesis_config = near_config.genesis.config.clone();
             genesis_config.genesis_height = genesis_height;
             let genesis = Arc::new(Genesis::new(genesis_config, records.into()));
-            
+
             let output_path = home_dir.join(Path::new("output.json"));
             println!(
                 "Saving state at {:?} @ {} into {}",


### PR DESCRIPTION
Given we never separately update genesis config part of genesis record part, it make sense to only host combined genesis.json on s3 and this is easier to keep genesis.json consistent with other node in devnet, betanet and testnet. Up to date config part of genesis.json (near/res/testnet_genesis_config.json) should be commited at every genesis change happens and as a nice debug helper, but devnet/betanet/testnet node should rely only on hosted s3 for both config and genesis.

Test Plan
------------
Manually test near init, w/o chain-id=testnet/devnet, state-viewer dump_state and near run after change.