### PR TITLE
feat(chain): Extend `changes` RPC API to allow querying multiple accounts at once

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -887,81 +887,72 @@ impl ChainStoreAccess for ChainStore {
         //
         //    In this implementation, however, we decoupled this process into two steps:
         //
-        //    2.1. Split off the `block_hash` (using `common_storage_key_prefix_len`), thus we are
+        //    2.1. Split off the `block_hash` (internally in `KeyForStateChanges`), thus we are
         //         left working with a key that was used in the trie.
         //    2.2. Parse the trie key with a relevant KeyFor* implementation to ensure consistency
 
-        let data_key: Vec<u8> = match state_changes_request {
-            StateChangesRequest::AccountChanges { account_id } => {
-                utils::KeyForAccount::new(account_id).into()
-            }
-            StateChangesRequest::SingleAccessKeyChanges { account_id, access_key_pk } => {
-                utils::KeyForAccessKey::new(account_id, access_key_pk).into()
-            }
-            StateChangesRequest::AllAccessKeyChanges { account_id } => {
-                utils::KeyForAccessKey::get_prefix(account_id).into()
-            }
-            StateChangesRequest::CodeChanges { account_id } => {
-                utils::KeyForCode::new(account_id).into()
-            }
-            StateChangesRequest::DataChanges { account_id, key_prefix } => {
-                utils::KeyForData::new(account_id, key_prefix.as_ref()).into()
-            }
-        };
-        let storage_key = KeyForStateChanges::new(&block_hash, &data_key);
-
-        let mut changes_per_key_prefix = storage_key.find_iter(&self.store);
-
-        // It is a lifetime workaround. We cannot return `&mut changes_per_key_prefix.filter_map(...`
-        // as that is a temporary object created there with `filter_map`, and you cannot leak a
-        // reference to a temporary object.
-        let mut changes_per_exact_key;
-
-        let changes_per_key: &mut dyn Iterator<Item = _> = match state_changes_request {
-            // These request types are expected to match the key exactly:
-            StateChangesRequest::AccountChanges { .. }
-            | StateChangesRequest::SingleAccessKeyChanges { .. }
-            | StateChangesRequest::CodeChanges { .. } => {
-                changes_per_exact_key = changes_per_key_prefix.filter_map(|change| {
-                    let (key, state_changes) = match change {
-                        Ok(change) => change,
-                        error => {
-                            return Some(error);
-                        }
-                    };
-                    if key.len() != data_key.len() {
-                        None
-                    } else {
-                        debug_assert_eq!(key.as_ref(), data_key.as_ref() as &[u8]);
-                        Some(Ok((key, state_changes)))
-                    }
-                });
-                &mut changes_per_exact_key
-            }
-
-            StateChangesRequest::AllAccessKeyChanges { .. }
-            | StateChangesRequest::DataChanges { .. } => &mut changes_per_key_prefix,
-        };
-
         Ok(match state_changes_request {
-            StateChangesRequest::AccountChanges { account_id, .. } => {
-                StateChanges::from_account_changes(changes_per_key, account_id)?
+            StateChangesRequest::AccountChanges { account_ids } => {
+                let mut changes = StateChanges::new();
+                for account_id in account_ids {
+                    let data_key = utils::KeyForAccount::new(account_id);
+                    let storage_key = KeyForStateChanges::new(&block_hash, data_key.as_ref());
+                    let changes_per_key = storage_key.find_exact_iter(&self.store);
+                    changes
+                        .extend(StateChanges::from_account_changes(changes_per_key, account_id)?);
+                }
+                changes
             }
-            StateChangesRequest::SingleAccessKeyChanges { account_id, .. }
-            | StateChangesRequest::AllAccessKeyChanges { account_id, .. } => {
-                let access_key_pk = match state_changes_request {
-                    StateChangesRequest::SingleAccessKeyChanges { access_key_pk, .. } => {
-                        Some(access_key_pk)
-                    }
-                    _ => None,
-                };
-                StateChanges::from_access_key_changes(changes_per_key, account_id, access_key_pk)?
+            StateChangesRequest::SingleAccessKeyChanges { account_ids, access_key_pk } => {
+                let mut changes = StateChanges::new();
+                for account_id in account_ids {
+                    let data_key = utils::KeyForAccessKey::new(account_id, access_key_pk);
+                    let storage_key = KeyForStateChanges::new(&block_hash, data_key.as_ref());
+                    let changes_per_key = storage_key.find_exact_iter(&self.store);
+                    changes.extend(StateChanges::from_access_key_changes(
+                        changes_per_key,
+                        account_id,
+                        Some(access_key_pk),
+                    )?);
+                }
+                changes
             }
-            StateChangesRequest::CodeChanges { account_id, .. } => {
-                StateChanges::from_code_changes(changes_per_key, account_id)?
+            StateChangesRequest::AllAccessKeyChanges { account_ids } => {
+                let mut changes = StateChanges::new();
+                for account_id in account_ids {
+                    let data_key = utils::KeyForAccessKey::get_prefix(account_id);
+                    let storage_key = KeyForStateChanges::new(&block_hash, data_key.as_ref());
+                    let changes_per_key_prefix = storage_key.find_iter(&self.store);
+                    changes.extend(StateChanges::from_access_key_changes(
+                        changes_per_key_prefix,
+                        account_id,
+                        None,
+                    )?);
+                }
+                changes
             }
-            StateChangesRequest::DataChanges { account_id, .. } => {
-                StateChanges::from_data_changes(changes_per_key, account_id)?
+            StateChangesRequest::CodeChanges { account_ids } => {
+                let mut changes = StateChanges::new();
+                for account_id in account_ids {
+                    let data_key = utils::KeyForCode::new(account_id);
+                    let storage_key = KeyForStateChanges::new(&block_hash, data_key.as_ref());
+                    let changes_per_key = storage_key.find_exact_iter(&self.store);
+                    changes.extend(StateChanges::from_code_changes(changes_per_key, account_id)?);
+                }
+                changes
+            }
+            StateChangesRequest::DataChanges { account_ids, key_prefix } => {
+                let mut changes = StateChanges::new();
+                for account_id in account_ids {
+                    let data_key = utils::KeyForData::new(account_id, key_prefix.as_ref());
+                    let storage_key = KeyForStateChanges::new(&block_hash, data_key.as_ref());
+                    let changes_per_key_prefix = storage_key.find_iter(&self.store);
+                    changes.extend(StateChanges::from_data_changes(
+                        changes_per_key_prefix,
+                        account_id,
+                    )?);
+                }
+                changes
             }
         })
     }

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -10,13 +10,12 @@ use near_network::types::{AccountOrPeerIdOrHash, KnownProducer};
 use near_network::PeerInfo;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ChunkHash;
-use near_primitives::types::{
-    AccountId, BlockHeight, BlockIdOrFinality, MaybeBlockId, ShardId, StateChangesRequest,
-};
+use near_primitives::types::{AccountId, BlockHeight, BlockIdOrFinality, MaybeBlockId, ShardId};
 use near_primitives::utils::generate_random_string;
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, GasPriceView,
-    LightClientBlockView, QueryRequest, QueryResponse, StateChangesKindsView, StateChangesView,
+    LightClientBlockView, QueryRequest, QueryResponse, StateChangesKindsView,
+    StateChangesRequestView, StateChangesView,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 
@@ -244,7 +243,7 @@ impl Message for GetValidatorInfo {
 
 pub struct GetStateChanges {
     pub block_hash: CryptoHash,
-    pub state_changes_request: StateChangesRequest,
+    pub state_changes_request: StateChangesRequestView,
 }
 
 impl Message for GetStateChanges {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -467,7 +467,7 @@ impl Handler<GetStateChanges> for ViewClientActor {
     fn handle(&mut self, msg: GetStateChanges, _: &mut Context<Self>) -> Self::Result {
         self.chain
             .store()
-            .get_state_changes(&msg.block_hash, &msg.state_changes_request)
+            .get_state_changes(&msg.block_hash, &msg.state_changes_request.into())
             .map(|state_changes| state_changes.into_iter().map(Into::into).collect())
             .map_err(|e| e.to_string())
     }

--- a/core/primitives/src/rpc.rs
+++ b/core/primitives/src/rpc.rs
@@ -8,8 +8,10 @@ use validator::Validate;
 use validator_derive::Validate;
 
 use crate::hash::CryptoHash;
-use crate::types::{BlockIdOrFinality, StateChangesRequest};
-use crate::views::{QueryRequest, StateChangeWithCauseView, StateChangesKindsView};
+use crate::types::BlockIdOrFinality;
+use crate::views::{
+    QueryRequest, StateChangeWithCauseView, StateChangesKindsView, StateChangesRequestView,
+};
 
 #[derive(Debug, SmartDefault, Serialize, Deserialize, Validate)]
 #[serde(default)]
@@ -40,7 +42,7 @@ pub struct RpcStateChangesRequest {
     #[serde(flatten)]
     pub block_id_or_finality: BlockIdOrFinality,
     #[serde(flatten)]
-    pub state_changes_request: StateChangesRequest,
+    pub state_changes_request: StateChangesRequestView,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -181,20 +181,20 @@ pub type RawStateChanges = std::collections::BTreeMap<Vec<u8>, RawStateChangesLi
 #[serde(tag = "changes_type", rename_all = "snake_case")]
 pub enum StateChangesRequest {
     AccountChanges {
-        account_id: AccountId,
+        account_ids: Vec<AccountId>,
     },
     SingleAccessKeyChanges {
-        account_id: AccountId,
+        account_ids: Vec<AccountId>,
         access_key_pk: PublicKey,
     },
     AllAccessKeyChanges {
-        account_id: AccountId,
+        account_ids: Vec<AccountId>,
     },
     CodeChanges {
-        account_id: AccountId,
+        account_ids: Vec<AccountId>,
     },
     DataChanges {
-        account_id: AccountId,
+        account_ids: Vec<AccountId>,
         #[serde(rename = "key_prefix_base64", with = "base64_format")]
         key_prefix: StoreKey,
     },
@@ -223,9 +223,7 @@ pub type StateChanges = Vec<StateChangeWithCause>;
 #[easy_ext::ext(StateChangesExt)]
 impl StateChanges {
     pub fn from_account_changes<K: AsRef<[u8]>>(
-        raw_changes: &mut dyn Iterator<
-            Item = Result<(K, RawStateChangesWithMetadata), std::io::Error>,
-        >,
+        raw_changes: impl Iterator<Item = Result<(K, RawStateChangesWithMetadata), std::io::Error>>,
         account_id: &AccountId,
     ) -> Result<StateChanges, std::io::Error> {
         let mut changes = Self::new();
@@ -257,9 +255,7 @@ impl StateChanges {
     }
 
     pub fn from_access_key_changes<K: AsRef<[u8]>>(
-        raw_changes: &mut dyn Iterator<
-            Item = Result<(K, RawStateChangesWithMetadata), std::io::Error>,
-        >,
+        raw_changes: impl Iterator<Item = Result<(K, RawStateChangesWithMetadata), std::io::Error>>,
         account_id: &AccountId,
         access_key_pk: Option<&PublicKey>,
     ) -> Result<StateChanges, std::io::Error> {
@@ -303,9 +299,7 @@ impl StateChanges {
     }
 
     pub fn from_code_changes<K: AsRef<[u8]>>(
-        raw_changes: &mut dyn Iterator<
-            Item = Result<(K, RawStateChangesWithMetadata), std::io::Error>,
-        >,
+        raw_changes: impl Iterator<Item = Result<(K, RawStateChangesWithMetadata), std::io::Error>>,
         account_id: &AccountId,
     ) -> Result<StateChanges, std::io::Error> {
         let mut changes = Self::new();
@@ -337,9 +331,7 @@ impl StateChanges {
     }
 
     pub fn from_data_changes<K: AsRef<[u8]>>(
-        raw_changes: &mut dyn Iterator<
-            Item = Result<(K, RawStateChangesWithMetadata), std::io::Error>,
-        >,
+        raw_changes: impl Iterator<Item = Result<(K, RawStateChangesWithMetadata), std::io::Error>>,
         account_id: &AccountId,
     ) -> Result<StateChanges, std::io::Error> {
         let mut changes = Self::new();

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -264,9 +264,9 @@ impl KeyForData {
 
 #[derive(derive_more::AsRef, derive_more::Into)]
 #[as_ref(forward)]
-pub struct KeyForCode(Vec<u8>);
+pub struct KeyForContractCode(Vec<u8>);
 
-impl KeyForCode {
+impl KeyForContractCode {
     pub fn new(account_id: &AccountId) -> Self {
         Self(KeyForColumnAccountId::with_capacity(col::CODE, account_id, 0).into())
     }
@@ -651,8 +651,8 @@ mod tests {
     #[test]
     fn test_key_for_code_consistency() {
         for account_id in OK_ACCOUNT_IDS.iter().map(|x| AccountId::from(*x)) {
-            let key = KeyForCode::new(&account_id);
-            assert_eq!(KeyForCode::parse_account_id(&key).unwrap(), account_id);
+            let key = KeyForContractCode::new(&account_id);
+            assert_eq!(KeyForContractCode::parse_account_id(&key).unwrap(), account_id);
         }
     }
 

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -18,7 +18,7 @@ use near_primitives::receipt::{Receipt, ReceivedData};
 use near_primitives::serialize::to_base;
 use near_primitives::types::{AccountId, StorageUsage};
 use near_primitives::utils::{
-    KeyForAccessKey, KeyForAccount, KeyForCode, KeyForData, KeyForPostponedReceipt,
+    KeyForAccessKey, KeyForAccount, KeyForContractCode, KeyForData, KeyForPostponedReceipt,
     KeyForReceivedData,
 };
 
@@ -326,7 +326,7 @@ pub fn get_access_key_raw(
 }
 
 pub fn set_code(state_update: &mut TrieUpdate, account_id: &AccountId, code: &ContractCode) {
-    state_update.set(KeyForCode::new(account_id).into(), code.code.clone());
+    state_update.set(KeyForContractCode::new(account_id).into(), code.code.clone());
 }
 
 pub fn get_code(
@@ -334,7 +334,7 @@ pub fn get_code(
     account_id: &AccountId,
 ) -> Result<Option<ContractCode>, StorageError> {
     state_update
-        .get(KeyForCode::new(account_id))
+        .get(KeyForContractCode::new(account_id))
         .map(|opt| opt.map(|code| ContractCode::new(code.to_vec())))
 }
 
@@ -344,7 +344,7 @@ pub fn remove_account(
     account_id: &AccountId,
 ) -> Result<(), StorageError> {
     state_update.remove(KeyForAccount::new(account_id));
-    state_update.remove(KeyForCode::new(account_id));
+    state_update.remove(KeyForContractCode::new(account_id));
     state_update.remove_starts_with(KeyForAccessKey::get_prefix(account_id))?;
     state_update.remove_starts_with(KeyForData::get_prefix(account_id))?;
     Ok(())

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -637,6 +637,28 @@ impl KeyForStateChanges {
             },
         )
     }
+
+    pub fn find_exact_iter<'a: 'b, 'b>(
+        &'a self,
+        store: &'b Store,
+    ) -> impl Iterator<
+        Item = Result<(OwningRef<Vec<u8>, [u8]>, RawStateChangesWithMetadata), std::io::Error>,
+    > + 'b {
+        self.find_iter(store).filter_map(move |change| {
+            let (key, state_changes) = match change {
+                Ok(change) => change,
+                error => {
+                    return Some(error);
+                }
+            };
+            if key.len() != self.0.len() {
+                None
+            } else {
+                debug_assert_eq!(key.as_ref(), self.0.as_ref() as &[u8]);
+                Some(Ok((key, state_changes)))
+            }
+        })
+    }
 }
 
 impl Trie {

--- a/pytest/tests/sanity/rpc_state_changes.py
+++ b/pytest/tests/sanity/rpc_state_changes.py
@@ -49,7 +49,7 @@ expected_changes_in_block_response = {
 state_changes_request = {
     "block_id": state_changes_in_block_request['block_id'],
     "changes_type": "account_changes",
-    "account_id": new_account_id,
+    "account_ids": [new_account_id],
 }
 
 expected_changes_response = {
@@ -130,7 +130,7 @@ expected_changes_in_block_response = {
 state_changes_request = {
     "block_id": state_changes_in_block_request['block_id'],
     "changes_type": "all_access_key_changes",
-    "account_id": new_key.account_id,
+    "account_ids": [new_key.account_id],
 }
 
 expected_changes_response = {
@@ -194,7 +194,7 @@ expected_changes_in_block_response = {
 state_changes_request = {
     "block_id": state_changes_in_block_request['block_id'],
     "changes_type": "all_access_key_changes",
-    "account_id": new_key.account_id,
+    "account_ids": [new_key.account_id],
 }
 
 expected_changes_response = {
@@ -283,7 +283,7 @@ expected_changes_in_block_response = {
 state_changes_request = {
     "block_id": state_changes_in_block_request['block_id'],
     "changes_type": "code_changes",
-    "account_id": contract_key.account_id,
+    "account_ids": [contract_key.account_id],
 }
 
 expected_changes_response = {
@@ -375,7 +375,7 @@ expected_changes_in_block_response = {
 state_changes_request = {
     "block_id": state_changes_in_block_request['block_id'],
     "changes_type": "data_changes",
-    "account_id": contract_key.account_id,
+    "account_ids": [contract_key.account_id],
     "key_prefix_base64": base64.b64encode(b"my_key").decode('utf-8'),
 }
 

--- a/pytest/tests/sanity/rpc_state_changes.py
+++ b/pytest/tests/sanity/rpc_state_changes.py
@@ -17,407 +17,556 @@ import transaction
 
 nodes = start_cluster(4, 0, 1, None, [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
 
-# Plan:
-# 1. Create a new account.
-# 2. Observe the changes in the block where the receipt lands.
+def assert_changes_in_block_response(request, expected_response):
+    for node_index, node in enumerate(nodes):
+        response = node.get_changes_in_block(request)
+        assert 'result' in response, "the request did not succeed: %r" % response
+        response = response['result']
+        diff = deepdiff.DeepDiff(expected_response, response)
+        assert not diff, \
+            "query node #%d same changes gives different results %r (expected VS actual):\n%r\n%r" \
+            % (node_index, diff, expected_response, response)
 
-status = nodes[0].get_status()
-latest_block_hash = status['sync_info']['latest_block_hash']
-new_account_id = 'rpc_key_value_changes'
-create_account_tx = transaction.sign_create_account_tx(
-    nodes[0].signer_key,
-    new_account_id,
-    5,
-    base58.b58decode(latest_block_hash.encode('utf8'))
-)
-new_account_response = nodes[0].send_tx_and_wait(create_account_tx, 10)
 
-state_changes_in_block_request = {
-    "block_id": new_account_response['result']['receipts_outcome'][0]['block_hash'],
-}
+def assert_changes_response(request, expected_response, **kwargs):
+    for node_index, node in enumerate(nodes):
+        response = node.get_changes(request)
+        assert 'result' in response, "the request did not succeed: %r" % response
+        response = response['result']
+        diff = deepdiff.DeepDiff(expected_response, response, **kwargs)
+        assert not diff, \
+            "query node #%d same changes gives different results %r (expected VS actual):\n%r\n%r" \
+            % (node_index, diff, expected_response, response)
 
-expected_changes_in_block_response = {
-    "block_hash": state_changes_in_block_request['block_id'],
-    "changes": [
-        {
-            "type": "account_touched",
-            "account_id": new_account_id,
+
+def test_changes_with_new_account():
+    """
+    Plan:
+    1. Create a new account.
+    2. Observe the changes in the block where the receipt lands.
+    """
+    status = nodes[0].get_status()
+    latest_block_hash = status['sync_info']['latest_block_hash']
+    new_account_id = 'rpc_key_value_changes'
+    create_account_tx = transaction.sign_create_account_tx(
+        nodes[0].signer_key,
+        new_account_id,
+        5,
+        base58.b58decode(latest_block_hash.encode('utf8'))
+    )
+    new_account_response = nodes[0].send_tx_and_wait(create_account_tx, 10)
+
+    block_hash = new_account_response['result']['receipts_outcome'][0]['block_hash']
+    assert_changes_in_block_response(
+        request={"block_id": block_hash},
+        expected_response={
+            "block_hash": block_hash,
+            "changes": [
+                {
+                    "type": "account_touched",
+                    "account_id": new_account_id,
+                }
+            ]
         }
-    ]
-}
+    )
 
-state_changes_request = {
-    "block_id": state_changes_in_block_request['block_id'],
-    "changes_type": "account_changes",
-    "account_ids": [new_account_id],
-}
+    base_request = {
+        "block_id": block_hash,
+        "changes_type": "account_changes",
+    }
+    for request in [
+            # Test empty account_ids
+            {**base_request, "account_ids": []},
+            # Test an account_id that is a prefix of the original account_id.
+            {**base_request, "account_ids": [new_account_id[:-1]]},
+            # Test an account_id that has the original account_id as a prefix.
+            {**base_request, "account_ids": [new_account_id + '_extra']},
+        ]:
+        assert_changes_response(request=request, expected_response={"block_hash": block_hash, "changes": []})
 
-expected_changes_response = {
-    "block_hash": state_changes_request["block_id"],
-    "changes": [
-        {
-            "cause": {
-                "type": "receipt_processing",
-                "receipt_hash": new_account_response['result']['receipts_outcome'][0]['id']
-            },
-            "type": "account_update",
-            "change": {
-                "account_id": new_account_id,
-                "amount": "0",
-                "locked": "0",
-                "code_hash": "11111111111111111111111111111111",
-                "storage_usage": 100,
+    # Test happy-path
+    expected_response = {
+        "block_hash": block_hash,
+        "changes": [
+            {
+                "cause": {
+                    "type": "receipt_processing",
+                    "receipt_hash": new_account_response['result']['receipts_outcome'][0]['id']
+                },
+                "type": "account_update",
+                "change": {
+                    "account_id": new_account_id,
+                    "amount": "0",
+                    "locked": "0",
+                    "code_hash": "11111111111111111111111111111111",
+                    "storage_usage": 100,
+                }
             }
-        }
-    ]
-}
+        ]
+    }
 
-for node in nodes:
-    changes_in_block_response = nodes[0].get_changes_in_block(state_changes_in_block_request)['result']
-    assert not deepdiff.DeepDiff(changes_in_block_response, expected_changes_in_block_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_in_block_response, changes_in_block_response)
-
-    changes_response = nodes[0].get_changes(state_changes_request)['result']
-    del changes_response['changes'][0]['change']['storage_paid_at']
-    assert not deepdiff.DeepDiff(changes_response, expected_changes_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_response, changes_response)
-
-# Plan:
-# 1. Create a new account with an access key.
-# 2. Observe the changes in the block where the receipt lands.
-# 3. Remove the access key.
-# 4. Observe the changes in the block where the receipt lands.
-
-# re-use the key as a new account access key
-new_key = Key(
-    account_id='rpc_key_value_changes_full_access',
-    pk=nodes[1].signer_key.pk,
-    sk=nodes[1].signer_key.sk,
-)
-
-status = nodes[0].get_status()
-latest_block_hash = status['sync_info']['latest_block_hash']
-create_account_tx = transaction.sign_create_account_with_full_access_key_and_balance_tx(
-    creator_key=nodes[0].signer_key,
-    new_account_id=new_key.account_id,
-    new_key=new_key,
-    balance=10**17,
-    nonce=7,
-    block_hash=base58.b58decode(latest_block_hash.encode('utf8'))
-)
-new_account_response = nodes[0].send_tx_and_wait(create_account_tx, 10)
-
-state_changes_in_block_request = {
-    "block_id": new_account_response['result']['receipts_outcome'][0]['block_hash'],
-}
-
-expected_changes_in_block_response = {
-    "block_hash": state_changes_in_block_request['block_id'],
-    "changes": [
-        {
-            "type": "account_touched",
-            "account_id": new_key.account_id,
+    assert_changes_response(
+        request={
+            "block_id": block_hash,
+            "changes_type": "account_changes",
+            "account_ids": [new_account_id],
         },
-        {
-            "type": "access_key_touched",
-            "account_id": new_key.account_id,
+        expected_response=expected_response,
+        exclude_paths={"root['changes'][0]['change']['storage_paid_at']"}
+    )
+    assert_changes_response(
+        request={
+            "block_id": block_hash,
+            "changes_type": "account_changes",
+            "account_ids": [new_account_id + '_non_existing1', new_account_id, new_account_id + '_non_existing2'],
+        },
+        expected_response=expected_response,
+        exclude_paths={"root['changes'][0]['change']['storage_paid_at']"}
+    )
+
+
+
+def test_changes_with_new_account_with_access_key():
+    """
+    Plan:
+    1. Create a new account with an access key.
+    2. Observe the changes in the block where the receipt lands.
+    3. Remove the access key.
+    4. Observe the changes in the block where the receipt lands.
+    """
+
+    # re-use the key as a new account access key
+    new_key = Key(
+        account_id='rpc_key_value_changes_full_access',
+        pk=nodes[1].signer_key.pk,
+        sk=nodes[1].signer_key.sk,
+    )
+
+    # Step 1
+    status = nodes[0].get_status()
+    latest_block_hash = status['sync_info']['latest_block_hash']
+    create_account_tx = transaction.sign_create_account_with_full_access_key_and_balance_tx(
+        creator_key=nodes[0].signer_key,
+        new_account_id=new_key.account_id,
+        new_key=new_key,
+        balance=10**17,
+        nonce=7,
+        block_hash=base58.b58decode(latest_block_hash.encode('utf8'))
+    )
+    new_account_response = nodes[0].send_tx_and_wait(create_account_tx, 10)
+
+    # Step 2
+    block_hash = new_account_response['result']['receipts_outcome'][0]['block_hash']
+    assert_changes_in_block_response(
+        request={"block_id": block_hash},
+        expected_response={
+            "block_hash": block_hash,
+            "changes": [
+                {
+                    "type": "account_touched",
+                    "account_id": new_key.account_id,
+                },
+                {
+                    "type": "access_key_touched",
+                    "account_id": new_key.account_id,
+                }
+            ]
         }
-    ]
-}
+    )
 
-state_changes_request = {
-    "block_id": state_changes_in_block_request['block_id'],
-    "changes_type": "all_access_key_changes",
-    "account_ids": [new_key.account_id],
-}
+    base_request = {
+        "block_id": block_hash,
+        "changes_type": "all_access_key_changes",
+    }
+    for request in [
+            # Test empty account_ids
+            {**base_request, "account_ids": []},
+            # Test an account_id that is a prefix of the original account_id.
+            {**base_request, "account_ids": [new_key.account_id[:-1]]},
+            # Test an account_id that has the original account_id as a prefix.
+            {**base_request, "account_ids": [new_key.account_id + '_extra']},
+        ]:
+        assert_changes_response(request=request, expected_response={"block_hash": block_hash, "changes": []})
 
-expected_changes_response = {
-    "block_hash": state_changes_request["block_id"],
-    "changes": [
-        {
-            "cause": {
-                "type": "receipt_processing",
-                "receipt_hash": new_account_response["result"]["receipts_outcome"][0]["id"],
-            },
-            "type": "access_key_update",
-            "change": {
-                "account_id": new_key.account_id,
-                "public_key": new_key.pk,
-                "access_key": {"nonce": 0, "permission": "FullAccess"},
+    # Test happy-path
+    expected_response = {
+        "block_hash": block_hash,
+        "changes": [
+            {
+                "cause": {
+                    "type": "receipt_processing",
+                    "receipt_hash": new_account_response["result"]["receipts_outcome"][0]["id"],
+                },
+                "type": "access_key_update",
+                "change": {
+                    "account_id": new_key.account_id,
+                    "public_key": new_key.pk,
+                    "access_key": {"nonce": 0, "permission": "FullAccess"},
+                }
             }
-        }
-    ]
-}
-
-for node in nodes:
-    changes_in_block_response = nodes[0].get_changes_in_block(state_changes_in_block_request)['result']
-    assert not deepdiff.DeepDiff(changes_in_block_response, expected_changes_in_block_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_in_block_response, changes_in_block_response)
-
-    changes_response = nodes[0].get_changes(state_changes_request)['result']
-    assert not deepdiff.DeepDiff(changes_response, expected_changes_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_response, changes_response)
-
-status = nodes[0].get_status()
-latest_block_hash = status['sync_info']['latest_block_hash']
-delete_access_key_tx = transaction.sign_delete_access_key_tx(
-    signer_key=new_key,
-    target_account_id=new_key.account_id,
-    key_for_deletion=new_key,
-    nonce=8,
-    block_hash=base58.b58decode(latest_block_hash.encode('utf8'))
-)
-delete_access_key_response = nodes[1].send_tx_and_wait(delete_access_key_tx, 10)
-
-state_changes_in_block_request = {
-    "block_id": delete_access_key_response['result']['receipts_outcome'][0]['block_hash'],
-}
-
-expected_changes_in_block_response = {
-    "block_hash": state_changes_in_block_request['block_id'],
-    "changes": [
-        {
-            "type": "account_touched",
-            "account_id": new_key.account_id,
-        },
-        {
-            "type": "access_key_touched",
-            "account_id": new_key.account_id,
-        }
-    ]
-}
-
-state_changes_request = {
-    "block_id": state_changes_in_block_request['block_id'],
-    "changes_type": "all_access_key_changes",
-    "account_ids": [new_key.account_id],
-}
-
-expected_changes_response = {
-    "block_hash": state_changes_request["block_id"],
-    "changes": [
-        {
-            "cause": {
-                'type': 'transaction_processing',
-                'tx_hash': delete_access_key_response['result']['transaction']['hash'],
+        ]
+    }
+    for request in [
+            {
+                "block_id": block_hash,
+                "changes_type": "all_access_key_changes",
+                "account_ids": [new_key.account_id],
             },
-            "type": "access_key_update",
-            "change": {
-                "account_id": new_key.account_id,
-                "public_key": new_key.pk,
-                "access_key": {"nonce": 8, "permission": "FullAccess"},
-            }
-        },
-        {
-            "cause": {
-                "type": "receipt_processing",
-                "receipt_hash": delete_access_key_response["result"]["receipts_outcome"][0]["id"]
+            {
+                "block_id": block_hash,
+                "changes_type": "all_access_key_changes",
+                "account_ids": [new_key.account_id + '_non_existing1', new_key.account_id, new_key.account_id + '_non_existing2'],
             },
-            "type": "access_key_deletion",
-            "change": {
-                "account_id": new_key.account_id,
-                "public_key": new_key.pk,
-            }
+        ]:
+        assert_changes_response(request=request, expected_response=expected_response)
+
+    # Step 3
+    status = nodes[0].get_status()
+    latest_block_hash = status['sync_info']['latest_block_hash']
+    delete_access_key_tx = transaction.sign_delete_access_key_tx(
+        signer_key=new_key,
+        target_account_id=new_key.account_id,
+        key_for_deletion=new_key,
+        nonce=8,
+        block_hash=base58.b58decode(latest_block_hash.encode('utf8'))
+    )
+    delete_access_key_response = nodes[1].send_tx_and_wait(delete_access_key_tx, 10)
+
+    # Step 4
+    block_hash = delete_access_key_response['result']['receipts_outcome'][0]['block_hash']
+    assert_changes_in_block_response(
+        request={"block_id": block_hash},
+        expected_response={
+            "block_hash": block_hash,
+            "changes": [
+                {
+                    "type": "account_touched",
+                    "account_id": new_key.account_id,
+                },
+                {
+                    "type": "access_key_touched",
+                    "account_id": new_key.account_id,
+                }
+            ]
         }
-    ]
-}
+    )
 
-for node in nodes:
-    changes_in_block_response = nodes[0].get_changes_in_block(state_changes_in_block_request)['result']
-    assert not deepdiff.DeepDiff(changes_in_block_response, expected_changes_in_block_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_in_block_response, changes_in_block_response)
-
-    changes_response = nodes[0].get_changes(state_changes_request)['result']
-    assert not deepdiff.DeepDiff(changes_response, expected_changes_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_response, changes_response)
-
-
-# Plan:
-# 1. Deploy a contract.
-# 2. Observe the code changes in the block where the transaction outcome "lands".
-# 3. Send two transactions to be included into the same block setting and overriding the value of
-#    the same key (`my_key`).
-# 4. Observe the changes in the block where the transaction outcome "lands".
-
-contract_key = nodes[0].signer_key
-hello_smart_contract = load_binary_file('../tests/hello.wasm')
-status = nodes[0].get_status()
-latest_block_hash = status['sync_info']['latest_block_hash']
-deploy_contract_tx = transaction.sign_deploy_contract_tx(
-    contract_key,
-    hello_smart_contract,
-    10,
-    base58.b58decode(latest_block_hash.encode('utf8'))
-)
-deploy_contract_response = nodes[0].send_tx_and_wait(deploy_contract_tx, 10)
-
-state_changes_in_block_request = {
-    "block_id": deploy_contract_response['result']['transaction_outcome']['block_hash'],
-}
-
-expected_changes_in_block_response = {
-    "block_hash": state_changes_in_block_request['block_id'],
-    "changes": [
-        {
-            "type": "account_touched",
-            "account_id": contract_key.account_id,
-        },
-        {
-            "type": "code_touched",
-            "account_id": contract_key.account_id,
-        },
-        {
-            "type": "access_key_touched",
-            "account_id": contract_key.account_id,
-        }
-
-    ]
-}
-
-state_changes_request = {
-    "block_id": state_changes_in_block_request['block_id'],
-    "changes_type": "code_changes",
-    "account_ids": [contract_key.account_id],
-}
-
-expected_changes_response = {
-    "block_hash": state_changes_request["block_id"],
-    "changes": [
-        {
-            "cause": {
-                "type": "receipt_processing",
-                "receipt_hash": deploy_contract_response["result"]["receipts_outcome"][0]["id"],
+    base_request = {
+        "block_id": block_hash,
+        "changes_type": "all_access_key_changes",
+    }
+    for request in [
+            # Test empty account_ids
+            {**base_request, "account_ids": []},
+            # Test an account_id that is a prefix of the original account_id
+            {**base_request, "account_ids": [new_key.account_id[:-1]]},
+            # Test an account_id that has the original account_id as a prefix
+            {**base_request, "account_ids": [new_key.account_id + '_extra']},
+            # Test empty keys in single_access_key_changes request
+            {"block_id": block_hash, "changes_type": "single_access_key_changes", "keys": []},
+            # Test non-existing account_id
+            {
+                "block_id": block_hash,
+                "changes_type": "single_access_key_changes",
+                "keys": [
+                    {"account_id": new_key.account_id + '_non_existing1', "public_key": new_key.pk},
+                ],
             },
-            "type": "code_update",
-            "change": {
-                "account_id": contract_key.account_id,
-                "code_base64": base64.b64encode(hello_smart_contract).decode('utf-8'),
+            # Test non-existing public_key for an existing account_id
+            {
+                "block_id": block_hash,
+                "changes_type": "single_access_key_changes",
+                "keys": [
+                    {"account_id": new_key.account_id, "public_key": new_key.pk[:-3] + 'aaa'},
+                ],
+            },
+        ]:
+        assert_changes_response(request=request, expected_response={"block_hash": block_hash, "changes": []})
+
+    # Test happy-path
+    expected_response = {
+        "block_hash": block_hash,
+        "changes": [
+            {
+                "cause": {
+                    'type': 'transaction_processing',
+                    'tx_hash': delete_access_key_response['result']['transaction']['hash'],
+                },
+                "type": "access_key_update",
+                "change": {
+                    "account_id": new_key.account_id,
+                    "public_key": new_key.pk,
+                    "access_key": {"nonce": 8, "permission": "FullAccess"},
+                }
+            },
+            {
+                "cause": {
+                    "type": "receipt_processing",
+                    "receipt_hash": delete_access_key_response["result"]["receipts_outcome"][0]["id"]
+                },
+                "type": "access_key_deletion",
+                "change": {
+                    "account_id": new_key.account_id,
+                    "public_key": new_key.pk,
+                }
             }
+        ]
+    }
+
+    for request in [
+        {
+            "block_id": block_hash,
+            "changes_type": "all_access_key_changes",
+            "account_ids": [new_key.account_id],
         },
-    ]
-}
+        {
+            "block_id": block_hash,
+            "changes_type": "all_access_key_changes",
+            "account_ids": [new_key.account_id + '_non_existing1', new_key.account_id, new_key.account_id + '_non_existing2'],
+        },
+        {
+            "block_id": block_hash,
+            "changes_type": "single_access_key_changes",
+            "keys": [{"account_id": new_key.account_id, "public_key": new_key.pk}],
+        },
+        {
+            "block_id": block_hash,
+            "changes_type": "single_access_key_changes",
+            "keys": [
+                {"account_id": new_key.account_id + '_non_existing1', "public_key": new_key.pk},
+                {"account_id": new_key.account_id, "public_key": new_key.pk},
+            ],
+        },
+    ]:
+        assert_changes_response(request=request, expected_response=expected_response)
 
-for node in nodes:
-    changes_in_block_response = nodes[0].get_changes_in_block(state_changes_in_block_request)['result']
-    assert not deepdiff.DeepDiff(changes_in_block_response, expected_changes_in_block_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_in_block_response, changes_in_block_response)
 
-    changes_response = node.get_changes(state_changes_request)['result']
-    assert not deepdiff.DeepDiff(changes_response, expected_changes_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_response, changes_response)
+def test_key_value_changes():
+    """
+    Plan:
+    1. Deploy a contract.
+    2. Observe the code changes in the block where the transaction outcome "lands".
+    3. Send two transactions to be included into the same block setting and overriding the value of
+       the same key (`my_key`).
+    4. Observe the changes in the block where the transaction outcome "lands".
+    """
 
-status = nodes[1].get_status()
-latest_block_hash = status['sync_info']['latest_block_hash']
-function_caller_key = nodes[0].signer_key
+    contract_key = nodes[0].signer_key
+    hello_smart_contract = load_binary_file('../tests/hello.wasm')
 
-def set_value_1():
-    function_call_1_tx = transaction.sign_function_call_tx(
+    # Step 1
+    status = nodes[0].get_status()
+    latest_block_hash = status['sync_info']['latest_block_hash']
+    deploy_contract_tx = transaction.sign_deploy_contract_tx(
+        contract_key,
+        hello_smart_contract,
+        10,
+        base58.b58decode(latest_block_hash.encode('utf8'))
+    )
+    deploy_contract_response = nodes[0].send_tx_and_wait(deploy_contract_tx, 10)
+
+    # Step 2
+    block_hash = deploy_contract_response['result']['transaction_outcome']['block_hash']
+    assert_changes_in_block_response(
+        request={"block_id": block_hash},
+        expected_response={
+            "block_hash": block_hash,
+            "changes": [
+                {
+                    "type": "account_touched",
+                    "account_id": contract_key.account_id,
+                },
+                {
+                    "type": "contract_code_touched",
+                    "account_id": contract_key.account_id,
+                },
+                {
+                    "type": "access_key_touched",
+                    "account_id": contract_key.account_id,
+                }
+
+            ]
+        }
+    )
+
+    base_request = {
+        "block_id": block_hash,
+        "changes_type": "contract_code_changes",
+    }
+    for request in [
+            # Test empty account_ids
+            {**base_request, "account_ids": []},
+            # Test an account_id that is a prefix of the original account_id
+            {**base_request, "account_ids": [contract_key.account_id[:-1]]},
+            # Test an account_id that has the original account_id as a prefix
+            {**base_request, "account_ids": [contract_key.account_id + '_extra']},
+        ]:
+        assert_changes_response(request=request, expected_response={"block_hash": block_hash, "changes": []})
+
+    # Test happy-path
+    expected_response = {
+        "block_hash": block_hash,
+        "changes": [
+            {
+                "cause": {
+                    "type": "receipt_processing",
+                    "receipt_hash": deploy_contract_response["result"]["receipts_outcome"][0]["id"],
+                },
+                "type": "contract_code_update",
+                "change": {
+                    "account_id": contract_key.account_id,
+                    "code_base64": base64.b64encode(hello_smart_contract).decode('utf-8'),
+                }
+            },
+        ]
+    }
+    base_request = {
+        "block_id": block_hash,
+        "changes_type": "contract_code_changes",
+    }
+    for request in [
+            {**base_request, "account_ids": [contract_key.account_id]},
+            {**base_request, "account_ids": [contract_key.account_id + '_non_existing1', contract_key.account_id, contract_key.account_id + '_non_existing2']},
+        ]:
+        assert_changes_response(request=request, expected_response=expected_response)
+
+    # Step 3
+    status = nodes[1].get_status()
+    latest_block_hash = status['sync_info']['latest_block_hash']
+    function_caller_key = nodes[0].signer_key
+
+    def set_value_1():
+        function_call_1_tx = transaction.sign_function_call_tx(
+            function_caller_key,
+            contract_key.account_id,
+            'setKeyValue',
+            json.dumps({"key": "my_key", "value": "my_value_1"}).encode('utf-8'),
+            100000000000,
+            100000000000,
+            20,
+            base58.b58decode(latest_block_hash.encode('utf8'))
+        )
+        nodes[1].send_tx_and_wait(function_call_1_tx, 10)
+    function_call_1_thread = threading.Thread(target=set_value_1)
+    function_call_1_thread.start()
+
+    function_call_2_tx = transaction.sign_function_call_tx(
         function_caller_key,
         contract_key.account_id,
         'setKeyValue',
-        json.dumps({"key": "my_key", "value": "my_value_1"}).encode('utf-8'),
+        json.dumps({"key": "my_key", "value": "my_value_2"}).encode('utf-8'),
         100000000000,
         100000000000,
-        20,
+        30,
         base58.b58decode(latest_block_hash.encode('utf8'))
     )
-    res = nodes[1].send_tx_and_wait(function_call_1_tx, 10)
-function_call_1_thread = threading.Thread(target=set_value_1)
-function_call_1_thread.start()
+    function_call_2_response = nodes[1].send_tx_and_wait(function_call_2_tx, 10)
+    assert function_call_2_response['result']['receipts_outcome'][0]['outcome']['status'] == {'SuccessValue': ''}, \
+        "Expected successful execution, but the output was: %s" % function_call_2_response
+    function_call_1_thread.join()
 
-function_call_2_tx = transaction.sign_function_call_tx(
-    function_caller_key,
-    contract_key.account_id,
-    'setKeyValue',
-    json.dumps({"key": "my_key", "value": "my_value_2"}).encode('utf-8'),
-    100000000000,
-    100000000000,
-    30,
-    base58.b58decode(latest_block_hash.encode('utf8'))
-)
-function_call_2_response = nodes[1].send_tx_and_wait(function_call_2_tx, 10)
-assert function_call_2_response['result']['receipts_outcome'][0]['outcome']['status'] == {'SuccessValue': ''}, \
-    "Expected successful execution, but the output was: %s" % function_call_2_response
-function_call_1_thread.join()
+    tx_block_hash = function_call_2_response['result']['transaction_outcome']['block_hash']
 
-tx_block_hash = function_call_2_response['result']['transaction_outcome']['block_hash']
-
-state_changes_in_block_request = {
-    "block_id": tx_block_hash,
-}
-
-expected_changes_in_block_response = {
-    "block_hash": state_changes_in_block_request['block_id'],
-    "changes": [
-        {
-            "type": "account_touched",
-            "account_id": contract_key.account_id,
-        },
-        {
-            "type": "data_touched",
-            "account_id": contract_key.account_id,
-        },
-        {
-            "type": "access_key_touched",
-            "account_id": contract_key.account_id,
+    # Step 4
+    assert_changes_in_block_response(
+        request={"block_id": tx_block_hash},
+        expected_response={
+            "block_hash": tx_block_hash,
+            "changes": [
+                {
+                    "type": "account_touched",
+                    "account_id": contract_key.account_id,
+                },
+                {
+                    "type": "data_touched",
+                    "account_id": contract_key.account_id,
+                },
+                {
+                    "type": "access_key_touched",
+                    "account_id": contract_key.account_id,
+                }
+            ]
         }
-    ]
-}
+    )
 
-state_changes_request = {
-    "block_id": state_changes_in_block_request['block_id'],
-    "changes_type": "data_changes",
-    "account_ids": [contract_key.account_id],
-    "key_prefix_base64": base64.b64encode(b"my_key").decode('utf-8'),
-}
-
-expected_changes_response = {
-    "block_hash": state_changes_request["block_id"],
-    "changes": [
-        {
-            "cause": {
-                "type": "receipt_processing",
+    base_request = {
+        "block_id": block_hash,
+        "changes_type": "data_changes",
+        "key_prefix_base64": base64.b64encode(b"my_key").decode('utf-8'),
+    }
+    for request in [
+            # Test empty account_ids
+            {**base_request, "account_ids": []},
+            # Test an account_id that is a prefix of the original account_id
+            {**base_request, "account_ids": [contract_key.account_id[:-1]]},
+            # Test an account_id that has the original account_id as a prefix
+            {**base_request, "account_ids": [contract_key.account_id + '_extra']},
+            # Test non-existing key prefix
+            {
+                **base_request,
+                "account_ids": [contract_key.account_id],
+                "key_prefix_base64": base64.b64encode(b"my_key_with_extra").decode('utf-8'),
             },
-            "type": "data_update",
-            "change": {
-                "account_id": contract_key.account_id,
-                "key_base64": base64.b64encode(b"my_key").decode('utf-8'),
-                "value_base64": base64.b64encode(b"my_value_1").decode('utf-8'),
-            }
-        },
-        {
-            "cause": {
-                "type": "receipt_processing",
-                "receipt_hash": function_call_2_response["result"]["receipts_outcome"][0]["id"]
+        ]:
+        assert_changes_response(request=request, expected_response={"block_hash": block_hash, "changes": []})
+
+    # Test happy-path
+    expected_response = {
+        "block_hash": tx_block_hash,
+        "changes": [
+            {
+                "cause": {
+                    "type": "receipt_processing",
+                },
+                "type": "data_update",
+                "change": {
+                    "account_id": contract_key.account_id,
+                    "key_base64": base64.b64encode(b"my_key").decode('utf-8'),
+                    "value_base64": base64.b64encode(b"my_value_1").decode('utf-8'),
+                }
             },
-            "type": "data_update",
-            "change": {
-                "account_id": contract_key.account_id,
-                "key_base64": base64.b64encode(b"my_key").decode('utf-8'),
-                "value_base64": base64.b64encode(b"my_value_2").decode('utf-8'),
+            {
+                "cause": {
+                    "type": "receipt_processing",
+                    "receipt_hash": function_call_2_response["result"]["receipts_outcome"][0]["id"],
+                },
+                "type": "data_update",
+                "change": {
+                    "account_id": contract_key.account_id,
+                    "key_base64": base64.b64encode(b"my_key").decode('utf-8'),
+                    "value_base64": base64.b64encode(b"my_value_2").decode('utf-8'),
+                }
             }
-        }
-    ]
-}
+        ]
+    }
 
-for node in nodes:
-    changes_in_block_response = nodes[0].get_changes_in_block(state_changes_in_block_request)['result']
-    assert not deepdiff.DeepDiff(changes_in_block_response, expected_changes_in_block_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_in_block_response, changes_in_block_response)
+    base_request = {
+        "block_id": tx_block_hash,
+        "changes_type": "data_changes",
+        "key_prefix_base64": base64.b64encode(b"my_key").decode('utf-8'),
+    }
+    for request in [
+            {**base_request, "account_ids": [contract_key.account_id]},
+            {**base_request, "account_ids": [contract_key.account_id + '_non_existing1', contract_key.account_id, contract_key.account_id + '_non_existing2']},
+            {
+                **base_request,
+                "account_ids": [contract_key.account_id],
+                "key_prefix_base64": base64.b64encode(b"").decode('utf-8'),
+            },
+            {
+                **base_request,
+                "account_ids": [contract_key.account_id],
+                "key_prefix_base64": base64.b64encode(b"my_ke").decode('utf-8'),
+            },
+        ]:
+        assert_changes_response(
+            request=request,
+            expected_response=expected_response,
+            exclude_paths={"root['changes'][0]['cause']['receipt_hash']"},
+        )
 
-    changes_response = node.get_changes(state_changes_request)['result']
-    # We fetch the transaction in a separate thread, so receiving the right receipt hash is a bit
-    # involved process, nevermind.
-    del changes_response['changes'][0]['cause']['receipt_hash']
-    assert not deepdiff.DeepDiff(changes_response, expected_changes_response), \
-        "query same changes gives different results (expected VS actual):\n%r\n%r" \
-        % (expected_changes_response, changes_response)
+
+if __name__ == '__main__':
+    test_changes_with_new_account()
+    test_changes_with_new_account_with_access_key()
+    test_key_value_changes()


### PR DESCRIPTION
*Resolves #2129*

I opted to just replace `account_id` input arguments with `account_ids` expecting a list of those. It is technically a breaking change, but since the API is experimental, it should be expected to evolve rapidly.

Documentation request is here: https://github.com/nearprotocol/docs/issues/173

## API

`EXPERIMENTAL_changes` RPC endpoint accepts the following types of requests:

```js
{
    "block_id": /* block hash | block height | omit it if you want to use `finality` */,
    "finality": /* "latest" | "final" | "near-final" | omit it if you want to se `block_id` */,
    "changes_type": /* "account_changes" | "single_access_key_changes" | "all_access_key_changes" | "contract_code_changes" | "data_changes" */,
    /* extra fields based on `changes_type` */
}
```

the extra fields based on `changes_type` are the following:

* ` "account_changes"`:
    * `account_ids`
* `"single_access_key_changes"`:
    * `keys` a list of
        * `account_id`
        * `public_key`
* `"all_access_key_changes"`:
    * `account_ids`
* `"contract_code_changes`:
    * `account_ids`
* `"data_changes"`:
    * `account_ids`
    * `key_prefix_base64` (base64-encoded string of the key-prefix data saved from a smart contract)

### Example of Account changes

When an account gets modified (created, updated, removed), we can query the block which contains the receipts for the transaction:

```js
http post http://localhost:3030 jsonrpc=2.0 id=dontcare \
    method=EXPERIMENTAL_changes \
    'params:={
        "block_id": "DYHRzRbxUR1ANPdCQcgQE9g5zyYQoDZ1k8BJEQ3hDSgW"
        "changes_type": "account_changes",
        "account_ids": ["new-account"]
    }'
```

we observe the following:

```js
{
    "block_hash": "DYHRzRbxUR1ANPdCQcgQE9g5zyYQoDZ1k8BJEQ3hDSgW",
    "changes": [
        {
            "cause": {
                "type": "receipt_processing",
                "receipt_hash": "8rPN9tHY9MtT23TqBvvBGBQzwskA5fuZDjmiLpTobgRv"
            },
            "type": "account_update",
            "change": {
                "account_id": "new-account",
                "amount": "0",
                "locked": "0",
                "code_hash": "11111111111111111111111111111111",
                "storage_usage": 100,
                "storage_paid_at": 9
            }
        }
    ]
}
```

If the account was deleted:

```js
{
    "block_hash": "DYHRzRbxUR1ANPdCQcgQE9g5zyYQoDZ1k8BJEQ3hDSgW",
    "changes": [
        {
            "cause": {
                "type": "receipt_processing",
                "receipt_hash": "8rPN9tHY9MtT23TqBvvBGBQzwskA5fuZDjmiLpTobgRv"
            },
            "type": "account_deletion",
            "change": {
                "account_id": "new-account"
            }
        }
    ]
}
```

### Example of Data changes

When some key gets modified (created, updated, removed), we can query the block which contains the receipts for the transaction:

```js
http post http://localhost:3030 jsonrpc=2.0 id=dontcare \
    method=EXPERIMENTAL_changes \
    'params:={
        "block_id": "DYHRzRbxUR1ANPdCQcgQE9g5zyYQoDZ1k8BJEQ3hDSgW"
        "changes_type": "data_changes",
        "account_ids": ["new-account"],
        "key_prefix_base64": "bXlfa2V5"  /* base64-encoded "my_key" */
    }'
```

we observe the following (assume the key was modified twice in a single block, and then removed):

```js
{
    "block_hash": "DYHRzRbxUR1ANPdCQcgQE9g5zyYQoDZ1k8BJEQ3hDSgW",
    "changes": [
        {
            "cause": {
                "type": "receipt_processing",
                "receipt_hash": "111N9tHY9MtT23TqBvvBGBQzwskA5fuZDjmiLpTob111",
            },
            "type": "data_update",
            "change": {
                "account_id": "new-account",
                "key_base64": "bXlfa2V5",  /* base64-encoded "my_key" */
                "value_base64":  "bXlfdmFsdWVfMQ==" /* base64-encoded "my_value_1" */,
            }
        },
        {
            "cause": {
                "type": "receipt_processing",
                "receipt_hash": "222N9tHY9MtT23TqBvvBGBQzwskA5fuZDjmiLpTob222"
            },
            "type": "data_update",
            "change": {
                "account_id": "new-account",
                "key_base64": "bXlfa2V5",  /* base64-encoded "my_key" */
                "value_base64": "bXlfdmFsdWVfMg==" /* base64-encoded "my_value_2" */
            }
        },
        {
            "cause": {
                "type": "receipt_processing",
                "receipt_hash": "333N9tHY9MtT23TqBvvBGBQzwskA5fuZDjmiLpTob333"
            },
            "type": "data_deletion",
            "change": {
                "account_id": "new-account",
                "key_base64": "bXlfa2V5"  /* base64-encoded "my_key" */
            }
        }
    ]
}
```

## Test plan

* [x] Update the existing `pytest` suite (`sanity/rpc_state_changes.py`)
* [x] Add tests for an empty list of account ids
* [x] Add tests for a list of account ids which don't have any changes in the given block
* [x] Add tests for multiple account ids where some accounts don't have any changes in the given block