### PR TITLE
feat(script): add compile necessary binary for nearup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,12 @@
 docker-nearcore:
 	DOCKER_BUILDKIT=1 docker build -t nearcore -f Dockerfile .
+
+release:
+	cargo build -p near --release
+	cargo build -p keypair-generator --release
+	cargo build -p genesis-csv-to-json --release
+
+debug:
+	cargo build -p near
+	cargo build -p keypair-generator
+	cargo build -p genesis-csv-to-json


### PR DESCRIPTION
[nearup](https://github.com/nearprotocol/nearup) uses `--binary-path` to run near with both binary compiled from ci and binary compiled locally. It's therefore easier for local dev to just `make release`/`make debug` and `nearup`

Test Plan
------------
Run `make release` and `make debug` locally