### PR TITLE
Upload also vm standalone and state-viewer binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,12 @@ release:
 	cargo build -p near --release
 	cargo build -p keypair-generator --release
 	cargo build -p genesis-csv-to-json --release
+	cargo build -p near-vm-runner-standalone --release
+	cargo build -p state-viewer --release
 
 debug:
 	cargo build -p near
 	cargo build -p keypair-generator
 	cargo build -p genesis-csv-to-json
+	cargo build -p near-vm-runner-standalone
+	cargo build -p state-viewer

--- a/scripts/binary-release.sh
+++ b/scripts/binary-release.sh
@@ -5,13 +5,15 @@ branch=${BUILDKITE_BRANCH}
 commit=${BUILDKITE_COMMIT}
 os=$(uname)
 
-cargo build -p near --release
-cargo build -p keypair-generator --release
-cargo build -p genesis-csv-to-json --release
+make release
 
-aws s3 cp --acl public-read target/release/near s3://build.nearprotocol.com/nearcore/${os}/${branch}/near
-aws s3 cp --acl public-read target/release/near s3://build.nearprotocol.com/nearcore/${os}/${branch}/${commit}/near
-aws s3 cp --acl public-read target/release/keypair-generator s3://build.nearprotocol.com/nearcore/${os}/${branch}/keypair-generator
-aws s3 cp --acl public-read target/release/keypair-generator s3://build.nearprotocol.com/nearcore/${os}/${branch}/${commit}/keypair-generator
-aws s3 cp --acl public-read target/release/genesis-csv-to-json s3://build.nearprotocol.com/nearcore/${os}/${branch}/genesis-csv-to-json
-aws s3 cp --acl public-read target/release/genesis-csv-to-json s3://build.nearprotocol.com/nearcore/${os}/${branch}/${commit}/genesis-csv-to-json
+function upload_binary {
+    aws s3 cp --acl public-read target/release/near s3://build.nearprotocol.com/nearcore/${os}/${branch}/$1
+    aws s3 cp --acl public-read target/release/near s3://build.nearprotocol.com/nearcore/${os}/${branch}/${commit}/$1
+}
+
+upload_binary near
+upload_binary keypair-generator
+upload_binary genesis-csv-to-json
+upload_binary near-vm-runner-standalone
+upload_binary state-viewer


### PR DESCRIPTION
vm standalone is useful in near-runtime-ts ci and state-viewer is in automate betanet/testnet state upgrade

Test Plans
-------------
Run manually