### PR TITLE
fix(script): typo in binary-release

### DIFF
--- a/scripts/binary-release.sh
+++ b/scripts/binary-release.sh
@@ -8,8 +8,8 @@ os=$(uname)
 make release
 
 function upload_binary {
-    aws s3 cp --acl public-read target/release/near s3://build.nearprotocol.com/nearcore/${os}/${branch}/$1
-    aws s3 cp --acl public-read target/release/near s3://build.nearprotocol.com/nearcore/${os}/${branch}/${commit}/$1
+    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os}/${branch}/$1
+    aws s3 cp --acl public-read target/release/$1 s3://build.nearprotocol.com/nearcore/${os}/${branch}/${commit}/$1
 }
 
 upload_binary near


### PR DESCRIPTION
Fix a stupid typo i did yesterday

Test Plans
-------------
Run script locally. Next time I need to be more careful on script change