### PR TITLE
feat(chain): Improve RPC APIs around returning enums with empty variants

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1817,10 +1817,10 @@ impl Chain {
             .find_map(|outcome_with_id| {
                 if outcome_with_id.id == looking_for_id {
                     match &outcome_with_id.outcome.status {
-                        ExecutionStatusView::Unknown if num_outcomes == 1 => {
+                        ExecutionStatusView::Unknown {} if num_outcomes == 1 => {
                             Some(FinalExecutionStatus::NotStarted)
                         }
-                        ExecutionStatusView::Unknown => Some(FinalExecutionStatus::Started),
+                        ExecutionStatusView::Unknown {} => Some(FinalExecutionStatus::Started),
                         ExecutionStatusView::Failure(e) => {
                             Some(FinalExecutionStatus::Failure(e.clone()))
                         }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -83,7 +83,7 @@ pub enum AccessKeyPermissionView {
         receiver_id: AccountId,
         method_names: Vec<String>,
     },
-    FullAccess,
+    FullAccess {},
 }
 
 impl From<AccessKeyPermission> for AccessKeyPermissionView {
@@ -94,7 +94,7 @@ impl From<AccessKeyPermission> for AccessKeyPermissionView {
                 receiver_id: func_call.receiver_id,
                 method_names: func_call.method_names,
             },
-            AccessKeyPermission::FullAccess => AccessKeyPermissionView::FullAccess,
+            AccessKeyPermission::FullAccess => AccessKeyPermissionView::FullAccess {},
         }
     }
 }
@@ -109,7 +109,7 @@ impl From<AccessKeyPermissionView> for AccessKeyPermission {
                     method_names,
                 })
             }
-            AccessKeyPermissionView::FullAccess => AccessKeyPermission::FullAccess,
+            AccessKeyPermissionView::FullAccess {} => AccessKeyPermission::FullAccess,
         }
     }
 }
@@ -594,7 +594,7 @@ impl ChunkView {
 
 #[derive(Serialize, Deserialize, Clone, Debug, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub enum ActionView {
-    CreateAccount,
+    CreateAccount {},
     DeployContract {
         code: String,
     },
@@ -629,7 +629,7 @@ pub enum ActionView {
 impl From<Action> for ActionView {
     fn from(action: Action) -> Self {
         match action {
-            Action::CreateAccount(_) => ActionView::CreateAccount,
+            Action::CreateAccount(_) => ActionView::CreateAccount {},
             Action::DeployContract(action) => {
                 ActionView::DeployContract { code: to_base64(&hash(&action.code)) }
             }
@@ -660,7 +660,7 @@ impl TryFrom<ActionView> for Action {
 
     fn try_from(action_view: ActionView) -> Result<Self, Self::Error> {
         Ok(match action_view {
-            ActionView::CreateAccount => Action::CreateAccount(CreateAccountAction {}),
+            ActionView::CreateAccount {} => Action::CreateAccount(CreateAccountAction {}),
             ActionView::DeployContract { code } => {
                 Action::DeployContract(DeployContractAction { code: from_base64(&code)? })
             }
@@ -762,7 +762,7 @@ pub enum ServerError {
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Deserialize, PartialEq, Eq, Clone)]
 pub enum ExecutionStatusView {
     /// The execution is pending or unknown.
-    Unknown,
+    Unknown {},
     /// The execution has failed.
     Failure(TxExecutionError),
     /// The final action succeeded and returned some value or an empty vec encoded in base64.
@@ -775,7 +775,7 @@ pub enum ExecutionStatusView {
 impl fmt::Debug for ExecutionStatusView {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ExecutionStatusView::Unknown => f.write_str("Unknown"),
+            ExecutionStatusView::Unknown {} => f.write_str("Unknown"),
             ExecutionStatusView::Failure(e) => f.write_fmt(format_args!("Failure({:?})", e)),
             ExecutionStatusView::SuccessValue(v) => f.write_fmt(format_args!(
                 "SuccessValue({})",
@@ -791,7 +791,7 @@ impl fmt::Debug for ExecutionStatusView {
 impl From<ExecutionStatus> for ExecutionStatusView {
     fn from(outcome: ExecutionStatus) -> Self {
         match outcome {
-            ExecutionStatus::Unknown => ExecutionStatusView::Unknown,
+            ExecutionStatus::Unknown => ExecutionStatusView::Unknown {},
             ExecutionStatus::Failure(e) => ExecutionStatusView::Failure(e),
             ExecutionStatus::SuccessValue(v) => ExecutionStatusView::SuccessValue(to_base64(&v)),
             ExecutionStatus::SuccessReceiptId(receipt_id) => {

--- a/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
+++ b/genesis-tools/genesis-csv-to-json/src/csv_parser.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use near_crypto::{KeyType, PublicKey};
 use near_network::PeerInfo;
+use near_primitives::account::AccessKey;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::receipt::{ActionReceipt, Receipt, ReceiptEnum};
 use near_primitives::serialize::to_base64;
@@ -233,7 +234,7 @@ fn account_records(row: &Row, gas_price: Balance) -> Vec<StateRecord> {
         res.push(StateRecord::AccessKey {
             account_id: row.account_id.clone(),
             public_key: pk,
-            access_key: AccessKeyView { nonce: 0, permission: AccessKeyPermissionView::FullAccess },
+            access_key: AccessKey::full_access().into(),
         })
     }
 

--- a/test-utils/testlib/src/user/runtime_user.rs
+++ b/test-utils/testlib/src/user/runtime_user.rs
@@ -146,10 +146,10 @@ impl RuntimeUser {
             .find_map(|outcome_with_id| {
                 if outcome_with_id.id == looking_for_id {
                     match &outcome_with_id.outcome.status {
-                        ExecutionStatusView::Unknown if num_outcomes == 1 => {
+                        ExecutionStatusView::Unknown {} if num_outcomes == 1 => {
                             Some(FinalExecutionStatus::NotStarted)
                         }
-                        ExecutionStatusView::Unknown => Some(FinalExecutionStatus::Started),
+                        ExecutionStatusView::Unknown {} => Some(FinalExecutionStatus::Started),
                         ExecutionStatusView::Failure(e) => {
                             Some(FinalExecutionStatus::Failure(e.clone()))
                         }


### PR DESCRIPTION
*Resolves #2176*

Currently, Actions in Transaction and Permissions in Access Key APIs are serialized into a list of `string` or `object` depending on whether the enum variant has anything inside:

https://github.com/nearprotocol/nearcore/blob/a031e4f670c70ae362244ef68cf1ed3235a78f4f/core/primitives/src/views.rs#L68-L76

Which leads to inconsistency like:

```js
    "keys": [
      {
        "access_key": {
          "nonce": 1,
          "permission": "FullAccess"   // <-- it is a string
        },
        "public_key": "ed25519:4Ynh6YmogjUYc5V9VqtQ1pRnZ4KuJSAJdkuj9hLj4a2p"
      },
      {
        "access_key": {
          "nonce": 0,
          "permission": {   // <-- it is an object
            "FunctionCall": {
              "allowance": "100000000",
              "method_names": [],
              "receiver_id": "studio-d4zxn4xdu"
            }
          }
        },
```

To always serialize it to an object, you should use empty object notation for the empty enum variants (https://github.com/serde-rs/json/issues/602):

```js
    "keys": [
      {
        "access_key": {
          "nonce": 1,
          "permission": {  // <-- it would be consistent if it is an object as well
            "FullAccess": {}
          }
        },
        "public_key": "ed25519:4Ynh6YmogjUYc5V9VqtQ1pRnZ4KuJSAJdkuj9hLj4a2p"
      },
      {
        "access_key": {
          "nonce": 0,
          "permission": {   // <-- it is an object
            "FunctionCall": {
              "allowance": "100000000",
              "method_names": [],
              "receiver_id": "studio-d4zxn4xdu"
            }
          }
        },
```

While the above transition can be treated as a breaking change, it provides consistency for the future. Later, we should migrate to [tagged enum representation](https://serde.rs/enum-representations.html).

This actually breaks genesis records since they store access key permissions, and those are serialized as `"FullAccess"` string. :thinking: /cc @bowenwang1996 @ailisp 

## Motivation

This inconsistency leads to hacks in the Applayer (Explorer, Wallet, and misterwhite) projects.

## Test plan

* [ ] Run a node and join devnet:
  * [ ] genesis_records.json can be handled correctly
  * [ ] the node runs and responses to RPC calls
* [ ] Check the output of the following endpoints:
  * [ ] query access key with FullAccess
  * [ ] transaction details with CreateAccount action
* [ ] Update near-api-js