### PR TITLE
test: Adding backward compatibility & state migration tests

### DIFF
--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -1,0 +1,27 @@
+
+import os
+import subprocess
+
+
+def current_branch():
+    return subprocess.check_output([
+        "git", "rev-parse", "--abbrev-ref", "HEAD"]).strip().decode()
+
+
+def compile_binary(branch):
+    """For given branch, compile binary."""
+    # TODO: download pre-compiled binary from github for beta/stable?
+    prev_branch = current_branch()
+    subprocess.call(['git', 'checkout', branch])
+    subprocess.call(['cargo', 'build', '-p', 'near'])
+    subprocess.call(['cargo', 'build', '-p', 'state-viewer'])
+    os.rename('../target/debug/near', '../target/debug/near-%s' % branch)
+    os.rename('../target/debug/state-viewer', '../target/debug/state-viewer-%s' % branch)
+    subprocess.call(['git', 'checkout', prev_branch])
+
+
+def prepare_ab_test(other_branch):
+    name = current_branch()
+    compile_binary(name)
+    compile_binary(other_branch)
+    return '../target/debug', [other_branch, name]

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -9,15 +9,21 @@ def current_branch():
 
 
 def compile_binary(branch):
-    """For given branch, compile binary."""
+    """For given branch, compile binary.
+
+    Stashes current changes, switches branch and then returns everything back.
+    """
     # TODO: download pre-compiled binary from github for beta/stable?
     prev_branch = current_branch()
+    stash_output = subprocess.check_output(['git', 'stash'])
     subprocess.call(['git', 'checkout', branch])
     subprocess.call(['cargo', 'build', '-p', 'near'])
     subprocess.call(['cargo', 'build', '-p', 'state-viewer'])
     os.rename('../target/debug/near', '../target/debug/near-%s' % branch)
     os.rename('../target/debug/state-viewer', '../target/debug/state-viewer-%s' % branch)
     subprocess.call(['git', 'checkout', prev_branch])
+    if stash_output != b"No local changes to save\n":
+        subprocess.call(['git', 'stash', 'pop'])
 
 
 def prepare_ab_test(other_branch):

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -24,4 +24,4 @@ def prepare_ab_test(other_branch):
     name = current_branch()
     compile_binary(name)
     compile_binary(other_branch)
-    return '../target/debug', [other_branch, name]
+    return '../target/debug/', [other_branch, name]

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -176,10 +176,11 @@ class LocalNode(BaseNode):
         self.near_root = near_root
         self.node_dir = node_dir
         self.binary_name = binary_name
+        self.cleaned = False
         with open(os.path.join(node_dir, "config.json")) as f:
             config_json = json.loads(f.read())
-        assert config_json['network']['addr'] == '0.0.0.0:24567', config_json['network']['addr']
-        assert config_json['rpc']['addr'] == '0.0.0.0:3030', config_json['rpc']['addr']
+        # assert config_json['network']['addr'] == '0.0.0.0:24567', config_json['network']['addr']
+        # assert config_json['rpc']['addr'] == '0.0.0.0:3030', config_json['rpc']['addr']
         # just a sanity assert that the setting name didn't change
         assert 0 <= config_json['consensus']['min_num_peers'] <= 3, config_json['consensus']['min_num_peers']
         config_json['network']['addr'] = '0.0.0.0:%s' % port
@@ -226,12 +227,15 @@ class LocalNode(BaseNode):
         shutil.rmtree(os.path.join(self.node_dir, "data"))
 
     def cleanup(self):
+        if self.cleaned:
+            return
         self.kill()
         # move the node dir to avoid weird interactions with multiple serial test invocations
         target_path = self.node_dir + '_finished'
         if os.path.exists(target_path) and os.path.isdir(target_path):
             shutil.rmtree(target_path)
         os.rename(self.node_dir, target_path)
+        self.cleaned = True
 
     def stop_network(self):
         print("Stopping network for process %s" % self.pid.value)

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -69,14 +69,14 @@ class Key(object):
 
 
 class BaseNode(object):
-    def _get_command_line(self, near_root, node_dir, boot_key, boot_node_addr):
+    def _get_command_line(self, near_root, node_dir, boot_key, boot_node_addr, binary_name='near'):
         if boot_key is None:
             assert boot_node_addr is None
-            return [os.path.join(near_root, 'near'), "--verbose", "", "--home", node_dir, "run"]
+            return [os.path.join(near_root, binary_name), "--verbose", "", "--home", node_dir, "run"]
         else:
             assert boot_node_addr is not None
             boot_key = boot_key.split(':')[1]
-            return [os.path.join(near_root, 'near'), "--verbose", "", "--home", node_dir, "run", '--boot-nodes', "%s@%s:%s" % (boot_key, boot_node_addr[0], boot_node_addr[1])]
+            return [os.path.join(near_root, binary_name), "--verbose", "", "--home", node_dir, "run", '--boot-nodes', "%s@%s:%s" % (boot_key, boot_node_addr[0], boot_node_addr[1])]
 
     def wait_for_rpc(self, timeout=1):
         retrying.retry(lambda: self.get_status(), timeout=timeout)
@@ -169,12 +169,13 @@ class RpcNode(BaseNode):
 
 
 class LocalNode(BaseNode):
-    def __init__(self, port, rpc_port, near_root, node_dir, blacklist):
+    def __init__(self, port, rpc_port, near_root, node_dir, blacklist, binary_name='near'):
         super(LocalNode, self).__init__()
         self.port = port
         self.rpc_port = rpc_port
         self.near_root = near_root
         self.node_dir = node_dir
+        self.binary_name = binary_name
         with open(os.path.join(node_dir, "config.json")) as f:
             config_json = json.loads(f.read())
         assert config_json['network']['addr'] == '0.0.0.0:24567', config_json['network']['addr']
@@ -197,10 +198,10 @@ class LocalNode(BaseNode):
         atexit.register(atexit_cleanup, self)
 
     def addr(self):
-        return ("0.0.0.0", self.port)
+        return ("127.0.0.1", self.port)
 
     def rpc_addr(self):
-        return ("0.0.0.0", self.rpc_port)
+        return ("127.0.0.1", self.rpc_port)
 
     def start(self, boot_key, boot_node_addr):
         env = os.environ.copy()
@@ -211,7 +212,7 @@ class LocalNode(BaseNode):
         self.stdout = open(self.stdout_name, 'a')
         self.stderr = open(self.stderr_name, 'a')
         cmd = self._get_command_line(
-            self.near_root, self.node_dir, boot_key, boot_node_addr)
+            self.near_root, self.node_dir, boot_key, boot_node_addr, self.binary_name)
         self.pid.value = subprocess.Popen(
             cmd, stdout=self.stdout, stderr=self.stderr, env=env).pid
         self.wait_for_rpc(5)
@@ -358,7 +359,7 @@ def spin_up_node(config, near_root, node_dir, ordinal, boot_key, boot_addr, blac
     if is_local:
         blacklist = ["127.0.0.1:%s" % (24567 + 10 + bl_ordinal) for bl_ordinal in blacklist]
         node = LocalNode(24567 + 10 + ordinal, 3030 +
-                         10 + ordinal, near_root, node_dir, blacklist)
+                         10 + ordinal, near_root, node_dir, blacklist, config['binary_name'])
     else:
         # TODO: Figure out how to know IP address beforehand for remote deployment.
         assert len(blacklist) == 0, "Blacklist is only supported in LOCAL deployment."
@@ -493,7 +494,7 @@ def start_cluster(num_nodes, num_observers, num_shards, config, genesis_config_c
     return ret
 
 
-DEFAULT_CONFIG = {'local': True, 'near_root': '../target/debug/'}
+DEFAULT_CONFIG = {'local': True, 'near_root': '../target/debug/', 'binary_name': 'near'}
 CONFIG_ENV_VAR = 'NEAR_PYTEST_CONFIG'
 
 

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+"""
+This script runs node from stable branch and from current branch and makes
+sure they are backward compatible.
+"""
+
+import sys
+import os
+import subprocess
+import time
+
+sys.path.append('lib')
+
+import cluster
+
+
+def compile_binary(branch):
+    """For given branch, compile binary."""
+    subprocess.call(['git', 'checkout', branch])
+    subprocess.call(['cargo', 'build', '-p', 'near'])
+    os.rename('../target/debug/near', '../target/debug/near-%s' % branch)
+
+
+def main():
+    stable_branch = "beta"
+    current_branch = subprocess.check_output([
+        "git", "rev-parse", "--abbrev-ref", "HEAD"]).strip().decode()
+    compile_binary(current_branch)
+    # TODO: download pre-compiled binary from github for beta/stable?
+    compile_binary(stable_branch)
+
+    # Setup local network.
+    near_root = "../target/debug/"
+    node_root = "backward"
+    subprocess.call(["%snear-%s" % (near_root, stable_branch), "--home=%s" % node_root, "testnet", "--v", "2", "--prefix", "test"])
+
+    # Run both binaries at the same time.
+    config = {"local": True, 'near_root': near_root, 'binary_name': 'near-%s' % stable_branch }
+    stable_node = cluster.spin_up_node(config, near_root, os.path.join(node_root, "test0"), 0, None, None)
+    config["binary_name"] = "near-%s" % current_branch
+    current_node = cluster.spin_up_node(config, near_root, os.path.join(node_root, "test1"), 1, stable_node.node_key.pk, stable_node.addr())
+
+    # Check it all works.
+    # TODO: we should run for at least 2 epochs.
+    BLOCKS = 20
+    TIMEOUT = 150
+    max_height = 0
+    started = time.time()
+    while max_height < BLOCKS:
+        assert time.time() - started < TIMEOUT
+        status = current_node.get_status()
+        max_height = status['sync_info']['latest_block_height']
+
+
+
+if __name__ == "__main__":
+    main()
+

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -12,37 +12,26 @@ import time
 
 sys.path.append('lib')
 
+import branches
 import cluster
 
 
-def compile_binary(branch):
-    """For given branch, compile binary."""
-    subprocess.call(['git', 'checkout', branch])
-    subprocess.call(['cargo', 'build', '-p', 'near'])
-    os.rename('../target/debug/near', '../target/debug/near-%s' % branch)
-
-
 def main():
-    stable_branch = "beta"
-    current_branch = subprocess.check_output([
-        "git", "rev-parse", "--abbrev-ref", "HEAD"]).strip().decode()
-    compile_binary(current_branch)
-    # TODO: download pre-compiled binary from github for beta/stable?
-    compile_binary(stable_branch)
+    node_root = "backward"
+    near_root, (stable_branch, current_branch) = branches.prepare_ab_test("beta")
 
     # Setup local network.
-    near_root = "../target/debug/"
-    node_root = "backward"
     subprocess.call(["%snear-%s" % (near_root, stable_branch), "--home=%s" % node_root, "testnet", "--v", "2", "--prefix", "test"])
 
     # Run both binaries at the same time.
-    config = {"local": True, 'near_root': near_root, 'binary_name': 'near-%s' % stable_branch }
+    config = {"local": True, 'near_root': near_root, 'binary_name': "near-%s" % stable_branch }
     stable_node = cluster.spin_up_node(config, near_root, os.path.join(node_root, "test0"), 0, None, None)
     config["binary_name"] = "near-%s" % current_branch
     current_node = cluster.spin_up_node(config, near_root, os.path.join(node_root, "test1"), 1, stable_node.node_key.pk, stable_node.addr())
 
     # Check it all works.
     # TODO: we should run for at least 2 epochs.
+    # TODO: send some transactions to test that runtime works the same.
     BLOCKS = 20
     TIMEOUT = 150
     max_height = 0
@@ -53,7 +42,5 @@ def main():
         max_height = status['sync_info']['latest_block_height']
 
 
-
 if __name__ == "__main__":
     main()
-

--- a/pytest/tests/sanity/state_migration.py
+++ b/pytest/tests/sanity/state_migration.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+"""
+Spins up stable node, runs it for a few blocks and stops it.
+Dump state via the stable state-viewer.
+Run migrations from stable version's genesis to the latest version.
+Spin up current node with migrated genesis and verify that it can keep producing blocks.
+"""
+
+import os
+import sys
+import time
+import json
+
+sys.path.append('lib')
+
+import branches
+import cluster
+
+
+def wait_for_blocks_or_timeout(node, num_blocks, timeout):
+    max_height = 0
+    started = time.time()
+    while max_height < num_blocks:
+        assert time.time() - started < timeout
+        status = node.get_status()
+        max_height = status['sync_info']['latest_block_height']
+
+
+def main():
+    node_root = 'state_migration'
+    near_root, (stable_branch, current_branch) = branches.prepare_ab_test("beta")
+
+    # Run stable node for few blocks.
+    subprocess.call(["%snear-%s" % (near_root, stable_branch), "--home=%s/test0" % node_root, "init", "--fast"])
+    config = {"local": True, 'near_root': near_root, 'binary_name': "near-%s" % stable_branch }
+    stable_node = cluster.spin_up_node(config, near_root, os.path.join(node_root, "test0"), 0, None, None)
+
+    wait_for_blocks_or_timeout(stable_node, 20, 100)
+    # TODO: we should make state more interesting to migrate by sending some tx / contracts.
+    stable_node.kill()
+
+    # Dump state.
+    subprocess.call(["%sstate-viewer-%s" % (near_root, stable_branch), "--home", node_root, "dump_state"])
+
+    # Migrate.
+    genesis = json.load(open(os.path.join(node_root, "output.json")), object_pairs_hook=OrderedDict)
+    # TODO: ???
+    json.dump(genesis, open(os.path.expanduser(node_root, "genesis.json"), "w"), indent=2)
+
+    # Run new node and verify it runs for a few more blocks.
+    config["binary_name"] = "near-%s" % current_branch
+    current_node = cluster.spin_up_node(config, near_root, os.path.join(node_root, "test0"), 0, None, None)
+
+    wait_for_blocks_or_timeout(current_node, 20, 100)
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest/tests/sanity/state_migration.py
+++ b/pytest/tests/sanity/state_migration.py
@@ -55,13 +55,14 @@ def main():
     # Migrate.
     migrations_home = '../scripts/migrations'
     all_migrations = sorted(os.listdir(migrations_home))
-    # TODO: currently migrations don't support multiple in a row due to output formats.
     for fname in all_migrations:
         m = re.match('([0-9]+)\-.*', fname)
         if m:
             version = int(m.groups()[0])
             if version > stable_protocol_version:
                 subprocess.call(['python', os.path.join(migrations_home, fname), '%s/test0' % node_root, '%s/test0' % node_root])
+
+    os.rename(os.path.join(node_root, 'output.json'), os.path.join(node_root, 'genesis.json'))
 
     # Run new node and verify it runs for a few more blocks.
     config["binary_name"] = "near-%s" % current_branch

--- a/scripts/migrations/5-preserve-height.py
+++ b/scripts/migrations/5-preserve-height.py
@@ -1,0 +1,21 @@
+import sys
+import os
+import json
+from collections import OrderedDict
+
+home = sys.argv[1]
+output_home = sys.argv[2]
+
+config = json.load(open(os.path.join(home, 'output_config.json')), object_pairs_hook=OrderedDict)
+records_fname = [filename for filename in os.listdir(home) if filename.startswith('output_records_')]
+assert len(records_fname) == 1, "Not found records file or found too many"
+
+records = json.load(open(os.path.join(home, records_fname[0])))
+
+assert config['protocol_version'] == 4
+
+config['genesis_height'] = 0
+config['records'] = records
+
+json.dump(config, open(os.path.join(output_home, 'genesis.json'), 'w'), indent=2)
+

--- a/scripts/migrations/5-preserve-height.py
+++ b/scripts/migrations/5-preserve-height.py
@@ -17,5 +17,5 @@ assert config['protocol_version'] == 4
 config['genesis_height'] = 0
 config['records'] = records
 
-json.dump(config, open(os.path.join(output_home, 'genesis.json'), 'w'), indent=2)
+json.dump(config, open(os.path.join(output_home, 'output.json'), 'w'), indent=2)
 


### PR DESCRIPTION
This adds to new python tests:
- Run `beta` branch binary and current branch binaries together as two validating nodes. Ref #1573
- Run `beta` branch binary, dump state, migrate and start current branch from the dumped state.

TODO: add sending transactions and also running for few epochs to catch other issues between version for both tests.

TODO: @ailisp please add:
 - we should be calling `state_migration.py` for all changes on CI.
 - calling `backward_compatible.py` test as a separate non-blocking step to the CI. 

This way we will always know when we broken something in the PR.

Also if we are publishing binaries for beta/stable -> can you also add it there instead of re-compiling?