### PR TITLE
fix(GC): refcount map compatibility with current GC

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1871,7 +1871,7 @@ impl<'a> ChainStoreUpdate<'a> {
 
             // 3. Delete block_hash-indexed data
             // 3a. Delete block (ColBlock) if not genesis
-            if height > 0 {
+            if height > self.get_genesis_height() {
                 store_update.delete(ColBlock, block_hash.as_ref());
                 self.chain_store.blocks.cache_remove(&block_hash.clone().into());
             }
@@ -1890,8 +1890,10 @@ impl<'a> ChainStoreUpdate<'a> {
             // 3g. Delete from ColBlocksToCatchup
             store_update.delete(ColBlocksToCatchup, block_hash.as_ref());
             // 3i. Delete from ColBlockRefCount
-            self.chain_store.block_refcounts.cache_remove(&block_hash.clone().into());
-            store_update.delete(ColBlockRefCount, block_hash.as_ref());
+            if height > self.get_genesis_height() {
+                store_update.delete(ColBlockRefCount, block_hash.as_ref());
+                self.chain_store.block_refcounts.cache_remove(&block_hash.clone().into());
+            }
         }
         // 4. Delete height-indexed data
         // 4a. Delete blocks with current height (ColBlockPerHeight)

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -228,8 +228,11 @@ impl Handler<NetworkClientMessages> for ClientActor {
                     NetworkAdversarialMessage::AdvCheckRefMap => {
                         info!(target: "adversary", "Check Block Reference Map");
                         match check_refcount_map(&mut self.client.chain) {
-                            Ok(_) => NetworkClientResponses::AdvResult(1), /* true */
-                            Err(_) => NetworkClientResponses::AdvResult(0), /* false */
+                            Ok(_) => NetworkClientResponses::AdvResult(1 /* true */),
+                            Err(e) => {
+                                error!(target: "client", "Block Reference Map is inconsistent: {:?}", e);
+                                NetworkClientResponses::AdvResult(0 /* false */)
+                            }
                         }
                     }
                     _ => panic!("invalid adversary message"),


### PR DESCRIPTION
<s>The reason of turning off checking refmap is to stop supporting legacy version of GC.
All necessary checks will be added after #2084.</s>

Refcount checks is fixed at current version of GC.

Also extends refcount error messages and adds some make ups.