### PR TITLE
fix: resolve Reed Solomon memory leak by occasionally reinstantiating

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -8,7 +8,6 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Utc};
 use log::{debug, error, warn};
 use rand::seq::SliceRandom;
-use reed_solomon_erasure::galois_8::ReedSolomon;
 
 use near_chain::validate::validate_chunk_proofs;
 use near_chain::{
@@ -24,7 +23,7 @@ use near_primitives::merkle::{merklize, verify_path, MerklePath};
 use near_primitives::receipt::Receipt;
 use near_primitives::sharding::{
     ChunkHash, EncodedShardChunk, PartialEncodedChunk, PartialEncodedChunkPart, ReceiptProof,
-    ShardChunkHeader, ShardChunkHeaderInner, ShardProof,
+    ReedSolomonWrapper, ShardChunkHeader, ShardChunkHeaderInner, ShardProof,
 };
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{
@@ -674,7 +673,10 @@ impl ShardsManager {
         });
     }
 
-    pub fn check_chunk_complete(chunk: &mut EncodedShardChunk, rs: &ReedSolomon) -> ChunkStatus {
+    pub fn check_chunk_complete(
+        chunk: &mut EncodedShardChunk,
+        rs: &mut ReedSolomonWrapper,
+    ) -> ChunkStatus {
         let data_parts = rs.data_shard_count();
         if chunk.content.num_fetched_parts() >= data_parts {
             if let Ok(_) = chunk.content.reconstruct(rs) {
@@ -714,7 +716,7 @@ impl ShardsManager {
         &mut self,
         mut encoded_chunk: EncodedShardChunk,
         chain_store: &mut ChainStore,
-        rs: &ReedSolomon,
+        rs: &mut ReedSolomonWrapper,
     ) -> Result<bool, Error> {
         match ShardsManager::check_chunk_complete(&mut encoded_chunk, rs) {
             ChunkStatus::Complete(merkle_paths) => {
@@ -734,7 +736,7 @@ impl ShardsManager {
         &mut self,
         partial_encoded_chunk: PartialEncodedChunk,
         chain_store: &mut ChainStore,
-        rs: &ReedSolomon,
+        rs: &mut ReedSolomonWrapper,
     ) -> Result<ProcessPartialEncodedChunkResult, Error> {
         // Check validity first
 
@@ -1003,7 +1005,7 @@ impl ShardsManager {
         outgoing_receipts_root: CryptoHash,
         tx_root: CryptoHash,
         signer: &dyn ValidatorSigner,
-        rs: &ReedSolomon,
+        rs: &mut ReedSolomonWrapper,
     ) -> Result<(EncodedShardChunk, Vec<MerklePath>), Error> {
         EncodedShardChunk::new(
             prev_block_hash,

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -8,7 +8,6 @@ use std::time::Instant;
 use cached::{Cached, SizedCache};
 use chrono::Utc;
 use log::{debug, error, info, warn};
-use reed_solomon_erasure::galois_8::ReedSolomon;
 
 use near_chain::chain::TX_ROUTING_HEIGHT_HORIZON;
 use near_chain::test_utils::format_hash;
@@ -25,7 +24,9 @@ use near_primitives::challenge::{Challenge, ChallengeBody};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, MerklePath};
 use near_primitives::receipt::Receipt;
-use near_primitives::sharding::{EncodedShardChunk, PartialEncodedChunk, ShardChunkHeader};
+use near_primitives::sharding::{
+    EncodedShardChunk, PartialEncodedChunk, ReedSolomonWrapper, ShardChunkHeader,
+};
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeight, ChunkExtra, EpochId, ShardId};
 use near_primitives::unwrap_or_return;
@@ -70,7 +71,7 @@ pub struct Client {
     /// List of currently accumulated challenges.
     pub challenges: HashMap<CryptoHash, Challenge>,
     /// A ReedSolomon instance to reconstruct shard.
-    pub rs: ReedSolomon,
+    rs: ReedSolomonWrapper,
     /// Blocks that have been re-broadcast recently. They should not be broadcast again.
     rebroadcasted_blocks: SizedCache<CryptoHash, ()>,
 }
@@ -139,7 +140,7 @@ impl Client {
             block_sync,
             state_sync,
             challenges: Default::default(),
-            rs: ReedSolomon::new(data_parts, parity_parts).unwrap(),
+            rs: ReedSolomonWrapper::new(data_parts, parity_parts),
             rebroadcasted_blocks: SizedCache::with_size(NUM_REBROADCAST_BLOCKS),
         })
     }
@@ -529,7 +530,7 @@ impl Client {
             outgoing_receipts_root,
             tx_root,
             &*validator_signer,
-            &self.rs,
+            &mut self.rs,
         )?;
 
         debug!(
@@ -676,7 +677,7 @@ impl Client {
         let process_result = self.shards_mgr.process_partial_encoded_chunk(
             partial_encoded_chunk.clone(),
             self.chain.mut_store(),
-            &self.rs,
+            &mut self.rs,
         )?;
 
         match process_result {

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -4,7 +4,6 @@ use std::path::Path;
 use std::sync::Arc;
 
 use borsh::BorshSerialize;
-use reed_solomon_erasure::galois_8::ReedSolomon;
 
 use near::config::{GenesisExt, FISHERMEN_THRESHOLD};
 use near::NightshadeRuntime;
@@ -26,7 +25,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, MerklePath};
 use near_primitives::receipt::Receipt;
 use near_primitives::serialize::BaseDecode;
-use near_primitives::sharding::EncodedShardChunk;
+use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper};
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::StateRoot;
@@ -153,7 +152,7 @@ fn create_chunk(
         let data_parts = client.chain.runtime_adapter.num_data_parts();
         let decoded_chunk = chunk.decode_chunk(data_parts).unwrap();
         let parity_parts = total_parts - data_parts;
-        let rs = ReedSolomon::new(data_parts, parity_parts).unwrap();
+        let mut rs = ReedSolomonWrapper::new(data_parts, parity_parts);
 
         let (tx_root, _) = merklize(&transactions);
         let signer = client.validator_signer.as_ref().unwrap().clone();
@@ -163,7 +162,7 @@ fn create_chunk(
             chunk.header.inner.outcome_root,
             chunk.header.inner.height_created,
             chunk.header.inner.shard_id,
-            &rs,
+            &mut rs,
             chunk.header.inner.gas_used,
             chunk.header.inner.gas_limit,
             chunk.header.inner.rent_paid,
@@ -392,7 +391,7 @@ fn test_verify_chunk_invalid_state_challenge() {
     let total_parts = env.clients[0].runtime_adapter.num_total_parts();
     let data_parts = env.clients[0].runtime_adapter.num_data_parts();
     let parity_parts = total_parts - data_parts;
-    let rs = ReedSolomon::new(data_parts, parity_parts).unwrap();
+    let mut rs = ReedSolomonWrapper::new(data_parts, parity_parts);
     let (mut invalid_chunk, merkle_paths) = env.clients[0]
         .shards_mgr
         .create_encoded_shard_chunk(
@@ -412,7 +411,7 @@ fn test_verify_chunk_invalid_state_challenge() {
             last_block.chunks[0].inner.outgoing_receipts_root,
             CryptoHash::default(),
             &validator_signer,
-            &rs,
+            &mut rs,
         )
         .unwrap();
 

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -2,7 +2,6 @@ use std::cmp::{max, Ordering};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use chrono::{DateTime, Utc};
-use reed_solomon_erasure::galois_8::ReedSolomon;
 use serde::Serialize;
 
 use near_crypto::{KeyType, PublicKey, Signature};
@@ -10,7 +9,9 @@ use near_crypto::{KeyType, PublicKey, Signature};
 use crate::challenge::{Challenges, ChallengesResult};
 use crate::hash::{hash, CryptoHash};
 use crate::merkle::{combine_hash, merklize, verify_path, MerklePath};
-use crate::sharding::{ChunkHashHeight, EncodedShardChunk, ShardChunk, ShardChunkHeader};
+use crate::sharding::{
+    ChunkHashHeight, EncodedShardChunk, ReedSolomonWrapper, ShardChunk, ShardChunkHeader,
+};
 use crate::types::{
     AccountId, Balance, BlockHeight, EpochId, Gas, MerkleHash, NumShards, StateRoot, ValidatorStake,
 };
@@ -409,7 +410,7 @@ pub fn genesis_chunks(
     genesis_height: BlockHeight,
 ) -> Vec<ShardChunk> {
     assert!(state_roots.len() == 1 || state_roots.len() == (num_shards as usize));
-    let rs = ReedSolomon::new(1, 2).unwrap();
+    let mut rs = ReedSolomonWrapper::new(1, 2);
 
     (0..num_shards)
         .map(|i| {
@@ -419,7 +420,7 @@ pub fn genesis_chunks(
                 CryptoHash::default(),
                 genesis_height,
                 i,
-                &rs,
+                &mut rs,
                 0,
                 initial_gas_limit,
                 0,

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use reed_solomon_erasure::galois_8::ReedSolomon;
+use reed_solomon_erasure::galois_8::{Field, ReedSolomon};
 use serde::Serialize;
 
 use near_crypto::Signature;
@@ -10,6 +10,7 @@ use crate::receipt::Receipt;
 use crate::transaction::SignedTransaction;
 use crate::types::{Balance, BlockHeight, Gas, MerkleHash, ShardId, StateRoot, ValidatorStake};
 use crate::validator_signer::ValidatorSigner;
+use reed_solomon_erasure::ReconstructShard;
 
 #[derive(
     BorshSerialize, BorshDeserialize, Serialize, Hash, Eq, PartialEq, Clone, Debug, Default,
@@ -186,7 +187,10 @@ impl EncodedShardChunkBody {
     }
 
     /// Returns true if reconstruction was successful
-    pub fn reconstruct(&mut self, rs: &ReedSolomon) -> Result<(), reed_solomon_erasure::Error> {
+    pub fn reconstruct(
+        &mut self,
+        rs: &mut ReedSolomonWrapper,
+    ) -> Result<(), reed_solomon_erasure::Error> {
         rs.reconstruct(self.parts.as_mut_slice())
     }
 
@@ -215,7 +219,7 @@ impl EncodedShardChunk {
         outcome_root: CryptoHash,
         height: BlockHeight,
         shard_id: ShardId,
-        rs: &ReedSolomon,
+        rs: &mut ReedSolomonWrapper,
         gas_used: Gas,
         gas_limit: Gas,
         rent_paid: Balance,
@@ -292,7 +296,7 @@ impl EncodedShardChunk {
         encoded_length: u64,
         parts: Vec<Option<Box<[u8]>>>,
 
-        rs: &ReedSolomon,
+        rs: &mut ReedSolomonWrapper,
 
         signer: &dyn ValidatorSigner,
     ) -> (Self, Vec<MerklePath>) {
@@ -369,5 +373,43 @@ impl EncodedShardChunk {
             transactions: transaction_receipts.0,
             receipts: transaction_receipts.1,
         })
+    }
+}
+
+/// An reed solomon instance should not consume more than 500MB of memory.
+const RS_MAX_MEMORY: u64 = 500 * 1024 * 1024;
+
+pub struct ReedSolomonWrapper {
+    rs: ReedSolomon,
+    ttl: u64,
+}
+
+impl ReedSolomonWrapper {
+    pub fn new(data_shards: usize, parity_shards: usize) -> Self {
+        ReedSolomonWrapper {
+            rs: ReedSolomon::new(data_shards, parity_shards).unwrap(),
+            ttl: RS_MAX_MEMORY / (data_shards * data_shards) as u64,
+        }
+    }
+
+    pub fn reconstruct<T: ReconstructShard<Field>>(
+        &mut self,
+        slices: &mut [T],
+    ) -> Result<(), reed_solomon_erasure::Error> {
+        let res = self.rs.reconstruct(slices);
+        self.ttl -= 1;
+        if self.ttl == 0 {
+            *self =
+                ReedSolomonWrapper::new(self.rs.data_shard_count(), self.rs.parity_shard_count());
+        }
+        res
+    }
+
+    pub fn data_shard_count(&self) -> usize {
+        self.rs.data_shard_count()
+    }
+
+    pub fn total_shard_count(&self) -> usize {
+        self.rs.total_shard_count()
     }
 }

--- a/core/primitives/src/sharding.rs
+++ b/core/primitives/src/sharding.rs
@@ -376,9 +376,12 @@ impl EncodedShardChunk {
     }
 }
 
-/// An reed solomon instance should not consume more than 500MB of memory.
-const RS_MAX_MEMORY: u64 = 500 * 1024 * 1024;
+/// An reed solomon instance should not consume more than 20MB of memory.
+const RS_MAX_MEMORY: u64 = 20 * 1024 * 1024;
 
+/// Wrapper around reed solomon which occasionally resets the underlying
+/// reed solomon instead to work around the memory leak in reed solomon
+/// implementation https://github.com/darrenldl/reed-solomon-erasure/issues/74.
 pub struct ReedSolomonWrapper {
     rs: ReedSolomon,
     ttl: u64,
@@ -388,7 +391,7 @@ impl ReedSolomonWrapper {
     pub fn new(data_shards: usize, parity_shards: usize) -> Self {
         ReedSolomonWrapper {
             rs: ReedSolomon::new(data_shards, parity_shards).unwrap(),
-            ttl: RS_MAX_MEMORY / (data_shards * data_shards) as u64,
+            ttl: RS_MAX_MEMORY / (data_shards * data_shards) as u64 + 1,
         }
     }
 


### PR DESCRIPTION
There is a memory leak in the reed solomon code that we use https://github.com/darrenldl/reed-solomon-erasure/issues/74 which results in our nodes crashing after reaching about 100k blocks. This PR fixes it by occasionally reinstantiating the reed solomon instance and cap its memory usage at 500MB.

Test plan
---------
Make sure existing tests pass.