### PR TITLE
fix(sync): Stop requesting headers from banned peer

### DIFF
--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -182,12 +182,16 @@ impl HeaderSync {
                                 if now > *stalling_ts + self.stall_ban_timeout
                                     && *highest_height == peer.chain_info.height
                                 {
-                                    info!(target: "sync", "Sync: ban a fraudulent peer: {}, claimed height: {}, score: {}",
+                                    info!(target: "sync", "Sync: ban a fraudulent peer: {}, claimed height: {}, score: {}", 
                                         peer.peer_info, peer.chain_info.height, peer.chain_info.score);
                                     self.network_adapter.do_send(NetworkRequests::BanPeer {
                                         peer_id: peer.peer_info.id.clone(),
                                         ban_reason: ReasonForBan::HeightFraud,
                                     });
+                                    // This peer is fraudulent, let's skip this beat and wait for
+                                    // the next one when this peer is not in the list anymore.
+                                    self.syncing_peer = None;
+                                    return false;
                                 }
                             }
                             _ => (),

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -402,7 +402,7 @@ impl PeerManagerActor {
         future::try_join_all(requests)
             .into_actor(self)
             .map(|x, _, _| {
-                let _ignore = x.map_err(|e| error!("Failed sending broadcast message: {}", e));
+                let _ignore = x.map_err(|e| error!(target: "network", "Failed sending broadcast message(query_active_peers): {}", e));
             })
             .spawn(ctx);
     }
@@ -496,7 +496,7 @@ impl PeerManagerActor {
                 .addr
                 .send(QueryPeerStats {})
                 .into_actor(self)
-                .map(|result, _, _| result.map_err(|err| error!("Failed sending message: {}", err)))
+                .map(|result, _, _| result.map_err(|err| error!(target: "network", "Failed sending message(monitor_peer_stats): {}", err)))
                 .map(move |res, act, _| {
                     let _ignore = res.map(|res| {
                         if res.is_abusive {
@@ -579,7 +579,7 @@ impl PeerManagerActor {
 
         future::try_join_all(requests)
             .into_actor(self)
-            .map(|res, _, _| res.map_err(|e| error!("Failed sending broadcast message: {}", e)))
+            .map(|res, _, _| res.map_err(|e| error!(target: "network", "Failed sending broadcast message(broadcast_message): {}", e)))
             .map(|_, _, _| ())
             .spawn(ctx);
     }
@@ -604,11 +604,12 @@ impl PeerManagerActor {
         message: PeerMessage,
     ) -> bool {
         if let Some(active_peer) = self.active_peers.get(&peer_id) {
+            let msg_kind = format!("{}", message);
             active_peer
                 .addr
                 .send(SendMessage { message })
                 .into_actor(self)
-                .map(|res, _, _| res.map_err(|e| error!("Failed sending message: {}", e)))
+                .map(move |res, _, _| res.map_err(|e| error!(target: "network", "Failed sending message(send_message, {}): {}", msg_kind, e)))
                 .map(|_, _, _| ())
                 .spawn(ctx);
             true
@@ -939,7 +940,7 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                 if let Some(peer) = self.active_peers.get(&peer_id) {
                     let _ = peer.addr.do_send(PeerManagerRequest::BanPeer(ban_reason));
                 } else {
-                    warn!(target: "network", "Try to ban a disconnected peer: {:?}", peer_id);
+                    warn!(target: "network", "Try to ban a disconnected peer for {:?}: {:?}", ban_reason, peer_id);
                     // Call `ban_peer` in peer manager to trigger action that persists information
                     // of ban in disk.
                     self.ban_peer(ctx, &peer_id, ban_reason);

--- a/near/src/config.rs
+++ b/near/src/config.rs
@@ -405,7 +405,7 @@ impl NearConfig {
                 sync_height_threshold: 1,
                 header_sync_initial_timeout: Duration::from_secs(10),
                 header_sync_progress_timeout: Duration::from_secs(2),
-                header_sync_stall_ban_timeout: Duration::from_secs(40),
+                header_sync_stall_ban_timeout: Duration::from_secs(120),
                 header_sync_expected_height_per_second: 10,
                 min_num_peers: config.consensus.min_num_peers,
                 log_summary_period: Duration::from_secs(10),


### PR DESCRIPTION
Also:
 - make header sync parameters read from config (and some that were already from config but were not used).
 - increase default timeout for stalling in header sync to 120s.
 - don't report error about failing to send message when peer is not active any more as it's expected that message doesn't go.

Fix #2305

Test Plan
---------
Run nodes on slow network and see that it doesn't get banned.
With lower header sync limit, observe that it doesn't try to re-request from banned peer.