### PR TITLE
Bump runtime versions to 0.7.0

### DIFF
--- a/runtime/near-runtime-fees/Cargo.toml
+++ b/runtime/near-runtime-fees/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-runtime-fees"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-errors/Cargo.toml
+++ b/runtime/near-vm-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-errors"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-logic"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -17,8 +17,8 @@ byteorder = "1.2"
 bs58 = "0.3"
 base64 = "0.11"
 serde = { version = "1.0", features = ["derive"] }
-near-runtime-fees = { path = "../near-runtime-fees", version = "0.6.1" }
-near-vm-errors = { path = "../near-vm-errors", version = "0.6.1" }
+near-runtime-fees = { path = "../near-runtime-fees", version = "0.7.0" }
+near-vm-errors = { path = "../near-vm-errors", version = "0.7.0" }
 
 [dev-dependencies]
 serde_json = {version= "1.0", features= ["preserve_order"]}

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner-standalone"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -21,6 +21,6 @@ to make sure it has expected behavior once deployed to the blockchain.
 [dependencies]
 serde_json = "1.0"
 clap = "2.33.0"
-near-vm-logic = { path = "../near-vm-logic", version = "0.6.1"}
-near-vm-runner = { path = "../near-vm-runner", version = "0.6.1" }
-near-runtime-fees = { path = "../near-runtime-fees", version = "0.6.1" }
+near-vm-logic = { path = "../near-vm-logic", version = "0.7.0"}
+near-vm-runner = { path = "../near-vm-runner", version = "0.7.0" }
+near-runtime-fees = { path = "../near-runtime-fees", version = "0.7.0" }

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner"
-version = "0.6.1"
+version = "0.7.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,9 +16,9 @@ This crate implements the specification of the interface that Near blockchain ex
 cached = "0.12.0"
 wasmer-runtime = { version = "0.13.1", features = ["default-backend-singlepass"], default-features = false }
 wasmer-runtime-core = { version = "0.13.1" }
-near-runtime-fees = { path="../near-runtime-fees", version = "0.6.1" }
-near-vm-logic = { path="../near-vm-logic", version = "0.6.1", default-features = false, features = []}
-near-vm-errors = { path = "../near-vm-errors", version = "0.6.1" }
+near-runtime-fees = { path="../near-runtime-fees", version = "0.7.0" }
+near-vm-logic = { path="../near-vm-logic", version = "0.7.0", default-features = false, features = []}
+near-vm-errors = { path = "../near-vm-errors", version = "0.7.0" }
 pwasm-utils = "0.12.0"
 parity-wasm = "0.41.0"
 wasmparser = "0.44"


### PR DESCRIPTION
The current versions of the runtime are outdated and are breaking CI on near-sdk-rs