### PR TITLE
fix: do not rebroadcast very old blocks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2128,7 +2128,7 @@ impl<'a> ChainUpdate<'a> {
     {
         debug!(target: "chain", "Process block header: {} at {}", header.hash(), header.inner_lite.height);
 
-        self.check_header_known(header)?;
+        self.check_known(&header.hash)?;
         self.validate_header(header, &Provenance::NONE, on_challenge)?;
         Ok(())
     }
@@ -2522,7 +2522,7 @@ impl<'a> ChainUpdate<'a> {
         debug!(target: "chain", "Process block {} at {}, approvals: {}, me: {:?}", block.hash(), block.header.inner_lite.height, block.header.num_approvals(), me);
 
         // Check if we have already processed this block previously.
-        self.check_known(&block)?;
+        self.check_known(&block.header.hash)?;
 
         // Delay hitting the db for current chain head until we know this block is not already known.
         let head = self.chain_store_update.head()?;
@@ -3042,25 +3042,24 @@ impl<'a> ChainUpdate<'a> {
         {
             return Err(ErrorKind::Unfit("header already known".to_string()).into());
         }
-        self.check_known_store(header)
+        self.check_known_store(&header.hash)
     }
 
     /// Quick in-memory check for fast-reject any block handled recently.
-    fn check_known_head(&self, header: &BlockHeader) -> Result<(), Error> {
+    fn check_known_head(&self, block_hash: &CryptoHash) -> Result<(), Error> {
         let head = self.chain_store_update.head()?;
-        let bh = header.hash();
-        if bh == head.last_block_hash || bh == head.prev_block_hash {
+        if block_hash == &head.last_block_hash || block_hash == &head.prev_block_hash {
             return Err(ErrorKind::Unfit("already known in head".to_string()).into());
         }
         Ok(())
     }
 
     /// Check if this block is in the set of known orphans.
-    fn check_known_orphans(&self, header: &BlockHeader) -> Result<(), Error> {
-        if self.orphans.contains(&header.hash()) {
+    fn check_known_orphans(&self, block_hash: &CryptoHash) -> Result<(), Error> {
+        if self.orphans.contains(block_hash) {
             return Err(ErrorKind::Unfit("already known in orphans".to_string()).into());
         }
-        if self.blocks_with_missing_chunks.contains(&header.hash()) {
+        if self.blocks_with_missing_chunks.contains(block_hash) {
             return Err(ErrorKind::Unfit(
                 "already known in blocks with missing chunks".to_string(),
             )
@@ -3070,8 +3069,8 @@ impl<'a> ChainUpdate<'a> {
     }
 
     /// Check if this block is in the store already.
-    fn check_known_store(&self, header: &BlockHeader) -> Result<(), Error> {
-        match self.chain_store_update.block_exists(&header.hash()) {
+    fn check_known_store(&self, block_hash: &CryptoHash) -> Result<(), Error> {
+        match self.chain_store_update.block_exists(block_hash) {
             Ok(true) => Err(ErrorKind::Unfit("already known in store".to_string()).into()),
             Ok(false) => {
                 // Not yet processed this block, we can proceed.
@@ -3081,28 +3080,11 @@ impl<'a> ChainUpdate<'a> {
         }
     }
 
-    /// Check if header is known: head, orphan or in store.
-    #[allow(dead_code)]
-    fn is_header_known(&self, header: &BlockHeader) -> Result<bool, Error> {
-        let check = || {
-            self.check_known_head(header)?;
-            self.check_known_orphans(header)?;
-            self.check_known_store(header)
-        };
-        match check() {
-            Ok(()) => Ok(false),
-            Err(err) => match err.kind() {
-                ErrorKind::Unfit(_) => Ok(true),
-                kind => Err(kind.into()),
-            },
-        }
-    }
-
     /// Check if block is known: head, orphan or in store.
-    fn check_known(&self, block: &Block) -> Result<(), Error> {
-        self.check_known_head(&block.header)?;
-        self.check_known_orphans(&block.header)?;
-        self.check_known_store(&block.header)?;
+    fn check_known(&self, block_hash: &CryptoHash) -> Result<(), Error> {
+        self.check_known_head(&block_hash)?;
+        self.check_known_orphans(&block_hash)?;
+        self.check_known_store(&block_hash)?;
         Ok(())
     }
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -697,15 +697,6 @@ impl Client {
         }
     }
 
-    pub fn process_block_header(&mut self, header: &BlockHeader) -> Result<(), near_chain::Error> {
-        let challenges = Arc::new(RwLock::new(vec![]));
-        self.chain.process_block_header(header, |challenge| {
-            challenges.write().unwrap().push(challenge)
-        })?;
-        self.send_challenges(challenges);
-        Ok(())
-    }
-
     pub fn sync_block_headers(
         &mut self,
         headers: Vec<BlockHeader>,

--- a/chain/client/tests/bug_repros.rs
+++ b/chain/client/tests/bug_repros.rs
@@ -15,6 +15,8 @@ use near_network::{NetworkClientMessages, NetworkRequests, NetworkResponses, Pee
 use near_primitives::block::Block;
 use near_primitives::test_utils::init_test_logger;
 use near_primitives::transaction::SignedTransaction;
+use std::cmp::max;
+use std::collections::HashMap;
 
 #[test]
 fn repro_1183() {
@@ -46,7 +48,7 @@ fn repro_1183() {
             false,
             5,
             false,
-            false,
+            vec![false; validators.iter().map(|x| x.len()).sum()],
             Arc::new(RwLock::new(Box::new(move |_account_id: String, msg: &NetworkRequests| {
                 if let NetworkRequests::Block { block } = msg {
                     let mut last_block = last_block.write().unwrap();
@@ -125,6 +127,103 @@ fn repro_1183() {
         *connectors.write().unwrap() = conn;
 
         near_network::test_utils::wait_or_panic(60000);
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_sync_from_achival_node() {
+    init_test_logger();
+    let validators = vec![vec!["test1", "test2", "test3", "test4"]];
+    let key_pairs =
+        vec![PeerInfo::random(), PeerInfo::random(), PeerInfo::random(), PeerInfo::random()];
+    let largest_height = Arc::new(RwLock::new(0));
+    let blocks = Arc::new(RwLock::new(HashMap::new()));
+    let epoch_length = 4;
+
+    System::run(move || {
+        let network_mock: Arc<
+            RwLock<Box<dyn FnMut(String, &NetworkRequests) -> (NetworkResponses, bool)>>,
+        > = Arc::new(RwLock::new(Box::new(|_: String, _: &NetworkRequests| {
+            (NetworkResponses::NoResponse, true)
+        })));
+        let (_, conns) = setup_mock_all_validators(
+            validators.clone(),
+            key_pairs,
+            1,
+            true,
+            100,
+            false,
+            false,
+            epoch_length,
+            false,
+            vec![true, false, false, false],
+            network_mock.clone(),
+        );
+        let mut block_counter = 0;
+        *network_mock.write().unwrap() =
+            Box::new(move |_: String, msg: &NetworkRequests| -> (NetworkResponses, bool) {
+                if let NetworkRequests::Block { block } = msg {
+                    let mut largest_height = largest_height.write().unwrap();
+                    *largest_height = max(block.header.inner_lite.height, *largest_height);
+                }
+                if *largest_height.read().unwrap() >= 50 {
+                    System::current().stop();
+                }
+                if *largest_height.read().unwrap() <= 30 {
+                    match msg {
+                        NetworkRequests::Block { block } => {
+                            for (i, (client, _)) in conns.clone().into_iter().enumerate() {
+                                if i != 3 {
+                                    client.do_send(NetworkClientMessages::Block(
+                                        block.clone(),
+                                        PeerInfo::random().id,
+                                        false,
+                                    ))
+                                }
+                            }
+                            if block.header.inner_lite.height <= 10 {
+                                blocks.write().unwrap().insert(block.hash(), block.clone());
+                            }
+                            (NetworkResponses::NoResponse, false)
+                        }
+                        NetworkRequests::Approval { approval_message } => {
+                            for (i, (client, _)) in conns.clone().into_iter().enumerate() {
+                                if i != 3 {
+                                    client.do_send(NetworkClientMessages::BlockApproval(
+                                        approval_message.approval.clone(),
+                                        PeerInfo::random().id,
+                                    ))
+                                }
+                            }
+                            (NetworkResponses::NoResponse, false)
+                        }
+                        _ => (NetworkResponses::NoResponse, true),
+                    }
+                } else {
+                    if block_counter > 10 {
+                        panic!("incorrect rebroadcasting of blocks");
+                    }
+                    for (_, block) in blocks.write().unwrap().drain() {
+                        conns[3].0.do_send(NetworkClientMessages::Block(
+                            block,
+                            PeerInfo::random().id,
+                            false,
+                        ));
+                    }
+                    match msg {
+                        NetworkRequests::Block { block } => {
+                            if block.header.inner_lite.height <= 10 {
+                                block_counter += 1;
+                            }
+                            (NetworkResponses::NoResponse, true)
+                        }
+                        _ => (NetworkResponses::NoResponse, true),
+                    }
+                }
+            });
+
+        near_network::test_utils::wait_or_panic(20000);
     })
     .unwrap();
 }

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -141,7 +141,7 @@ mod tests {
                 false,
                 5,
                 false,
-                true,
+                vec![true; validators.iter().map(|x| x.len()).sum()],
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
                         let account_from = "test3.3".to_string();
@@ -437,7 +437,7 @@ mod tests {
                 false,
                 5,
                 false,
-                false,
+                vec![false; validators.iter().map(|x| x.len()).sum()],
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
                         let mut seen_heights_same_block = seen_heights_same_block.write().unwrap();
@@ -662,7 +662,7 @@ mod tests {
                 false,
                 5,
                 false,
-                false,
+                vec![false; validators.iter().map(|x| x.len()).sum()],
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
                         if let NetworkRequests::Block { block } = msg {
@@ -725,7 +725,7 @@ mod tests {
                 false,
                 5,
                 true,
-                false,
+                vec![false; validators.iter().map(|x| x.len()).sum()],
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
                         let propagate = if let NetworkRequests::Block { block } = msg {
@@ -798,7 +798,7 @@ mod tests {
                 false,
                 5,
                 false,
-                false,
+                vec![false; validators.iter().map(|x| x.len()).sum()],
                 Arc::new(RwLock::new(Box::new(
                     move |sender_account_id: String, msg: &NetworkRequests| {
                         let mut grieving_chunk_hash = grieving_chunk_hash.write().unwrap();
@@ -961,7 +961,7 @@ mod tests {
                 false,
                 epoch_length,
                 false,
-                false,
+                vec![false; validators.iter().map(|x| x.len()).sum()],
                 Arc::new(RwLock::new(Box::new(
                     move |sender_account_id: String, msg: &NetworkRequests| {
                         let mut seen_chunk_same_sender = seen_chunk_same_sender.write().unwrap();

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -119,7 +119,7 @@ fn chunks_produced_and_distributed_common(
             false,
             5,
             true,
-            false,
+            vec![false; validators.iter().map(|x| x.len()).sum()],
             Arc::new(RwLock::new(Box::new(move |from_whom: String, msg: &NetworkRequests| {
                 match msg {
                     NetworkRequests::Block { block } => {

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -35,7 +35,7 @@ fn test_keyvalue_runtime_balances() {
             false,
             5,
             false,
-            false,
+            vec![false; validators.iter().map(|x| x.len()).sum()],
             Arc::new(RwLock::new(Box::new(move |_account_id: String, _msg: &NetworkRequests| {
                 (NetworkResponses::NoResponse, true)
             }))),
@@ -418,7 +418,7 @@ mod tests {
                 !test_doomslug,
                 20,
                 test_doomslug,
-                true,
+                vec![true; validators.iter().map(|x| x.len()).sum()],
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, _msg: &NetworkRequests| {
                         (NetworkResponses::NoResponse, true)

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -377,7 +377,7 @@ fn produce_block_with_approvals_arrived_early() {
             false,
             100,
             true,
-            false,
+            vec![false; validators.iter().map(|x| x.len()).sum()],
             network_mock.clone(),
         );
         *network_mock.write().unwrap() =


### PR DESCRIPTION
When a node is syncing from peers, it might obtain blocks that are garbage collected for a normal node from an archival node. When this happens, the node can rebroadcast the block to its peers. However, since we do not have any check for old blocks that might have been garbage collected, all peers that are not archival node will consider this block "new" and rebroadcast again. Since in `process_block_header`, this causes an infinite loop of rebroadcasting and therefore the network crash. This PR fixes both issues by 1) checking orphan pool in `process_block_headers` and 2) have a check for blocks that are older than one epoch.

Test plan
---------
* Integration test `test_sync_from_achival_node` that tests the scenario mentioned above. Notice that due to a timing issue, it is very hard to reproduce the exact scenario without first making nodes produce a lot of blocks, I simplify the test by manually injecting blocks to a node at a certain point.