### PR TITLE
feat: Disable creation of short top-level account ids

### DIFF
--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -49,6 +49,13 @@
         "size": ""
       }
     },
+    "Deprecated": {
+      "name": "Deprecated",
+      "subtypes": [],
+      "props": {
+        "method_name": ""
+      }
+    },
     "Deserialization": {
       "name": "Deserialization",
       "subtypes": [],
@@ -373,6 +380,7 @@
       "subtypes": [
         "AccountAlreadyExists",
         "AccountDoesNotExist",
+        "CreateAccountOnlyByRegistrar",
         "CreateAccountNotAllowed",
         "ActorNoPermission",
         "DeleteKeyDoesNotExist",
@@ -611,6 +619,13 @@
       ],
       "props": {}
     },
+    "UnsuitableStakingKey": {
+      "name": "UnsuitableStakingKey",
+      "subtypes": [],
+      "props": {
+        "public_key": ""
+      }
+    },
     "Closed": {
       "name": "Closed",
       "subtypes": [],
@@ -630,35 +645,21 @@
       "subtypes": [],
       "props": {}
     },
-    "UnsuitableStakingKey": {
-      "name": "UnsuitableStakingKey",
-      "subtypes": [],
-      "props": {
-        "public_key": ""
-      }
-    },
     "LackBalanceForState": {
       "name": "LackBalanceForState",
       "subtypes": [],
       "props": {
-        "amount": "",
-        "signer_id": "",
-        "account_id": ""
+        "account_id": "",
+        "amount": ""
       }
     },
-    "DeleteAccountHasEnoughBalance": {
-      "name": "DeleteAccountHasEnoughBalance",
+    "CreateAccountOnlyByRegistrar": {
+      "name": "CreateAccountOnlyByRegistrar",
       "subtypes": [],
       "props": {
         "account_id": "",
-        "balance": ""
-      }
-    },
-    "Deprecated": {
-      "name": "Deprecated",
-      "subtypes": [],
-      "props": {
-        "method_name": ""
+        "predecessor_id": "",
+        "registrar_account_id": ""
       }
     }
   }

--- a/chain/jsonrpc/res/rpc_errors_schema.json
+++ b/chain/jsonrpc/res/rpc_errors_schema.json
@@ -428,7 +428,6 @@
         "processed_delayed_receipts_balance": "",
         "total_balance_burnt": "",
         "total_balance_slashed": "",
-        "total_rent_paid": "",
         "total_validator_reward": ""
       }
     },
@@ -445,12 +444,13 @@
         "predecessor_id": ""
       }
     },
-    "DeleteAccountHasRent": {
-      "name": "DeleteAccountHasRent",
+    "CreateAccountOnlyByRegistrar": {
+      "name": "CreateAccountOnlyByRegistrar",
       "subtypes": [],
       "props": {
         "account_id": "",
-        "balance": ""
+        "predecessor_id": "",
+        "registrar_account_id": ""
       }
     },
     "DeleteAccountStaking": {
@@ -540,6 +540,14 @@
       ],
       "props": {}
     },
+    "LackBalanceForState": {
+      "name": "LackBalanceForState",
+      "subtypes": [],
+      "props": {
+        "account_id": "",
+        "amount": ""
+      }
+    },
     "MethodNameMismatch": {
       "name": "MethodNameMismatch",
       "subtypes": [],
@@ -572,14 +580,6 @@
       "props": {
         "ak_receiver": "",
         "tx_receiver": ""
-      }
-    },
-    "RentUnpaid": {
-      "name": "RentUnpaid",
-      "subtypes": [],
-      "props": {
-        "account_id": "",
-        "amount": ""
       }
     },
     "RequiresFullAccess": {
@@ -644,23 +644,6 @@
       "name": "Timeout",
       "subtypes": [],
       "props": {}
-    },
-    "LackBalanceForState": {
-      "name": "LackBalanceForState",
-      "subtypes": [],
-      "props": {
-        "account_id": "",
-        "amount": ""
-      }
-    },
-    "CreateAccountOnlyByRegistrar": {
-      "name": "CreateAccountOnlyByRegistrar",
-      "subtypes": [],
-      "props": {
-        "account_id": "",
-        "predecessor_id": "",
-        "registrar_account_id": ""
-      }
     }
   }
 }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -655,6 +655,18 @@ fn status_handler(
     response.boxed()
 }
 
+fn health_handler(
+    handler: web::Data<JsonRpcHandler>,
+) -> impl Future<Output = Result<HttpResponse, HttpError>> {
+    let response = async move {
+        match handler.health().await {
+            Ok(value) => Ok(HttpResponse::Ok().json(value)),
+            Err(_) => Ok(HttpResponse::ServiceUnavailable().finish()),
+        }
+    };
+    response.boxed()
+}
+
 fn network_info_handler(
     handler: web::Data<JsonRpcHandler>,
 ) -> impl Future<Output = Result<HttpResponse, HttpError>> {
@@ -718,6 +730,11 @@ pub fn start_http(
                 web::resource("/status")
                     .route(web::get().to(status_handler))
                     .route(web::head().to(status_handler)),
+            )
+            .service(
+                web::resource("/health")
+                    .route(web::get().to(health_handler))
+                    .route(web::head().to(health_handler)),
             )
             .service(web::resource("/network_info").route(web::get().to(network_info_handler)))
             .service(web::resource("/metrics").route(web::get().to(prometheus_handler)))

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -7,4 +7,4 @@ pub use genesis_config::{
 };
 
 /// Current latest version of the protocol
-pub const PROTOCOL_VERSION: u32 = 5;
+pub const PROTOCOL_VERSION: u32 = 6;

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -7,4 +7,4 @@ pub use genesis_config::{
 };
 
 /// Current latest version of the protocol
-pub const PROTOCOL_VERSION: u32 = 6;
+pub const PROTOCOL_VERSION: u32 = 7;

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -302,6 +302,12 @@ pub enum ActionErrorKind {
     AccountAlreadyExists { account_id: AccountId },
     /// Happens when TX receiver_id doesn't exist (but action is not Action::CreateAccount)
     AccountDoesNotExist { account_id: AccountId },
+    /// A newly created top-level account ID can only be created by registrar.
+    CreateAccountOnlyByRegistrar {
+        account_id: AccountId,
+        registrar_account_id: AccountId,
+        predecessor_id: AccountId,
+    },
     /// A newly created account must be under a namespace of the creator account
     CreateAccountNotAllowed { account_id: AccountId, predecessor_id: AccountId },
     /// Administrative actions like `DeployContract`, `Stake`, `AddKey`, `DeleteKey`. can be proceed only if sender=receiver
@@ -570,7 +576,6 @@ impl Display for ActionErrorKind {
             ActionErrorKind::AccountAlreadyExists { account_id } => {
                 write!(f, "Can't create a new account {:?}, because it already exists", account_id)
             }
-
             ActionErrorKind::AccountDoesNotExist { account_id } => write!(
                 f,
                 "Can't complete the action because account {:?} doesn't exist",
@@ -597,10 +602,15 @@ impl Display for ActionErrorKind {
             ActionErrorKind::UnsuitableStakingKey { public_key } => {
                 write!(f, "The staking key must be ED25519. {} is provided instead.", public_key)
             }
+            ActionErrorKind::CreateAccountOnlyByRegistrar { account_id, registrar_account_id, predecessor_id } => write!(
+                f,
+                "A new top-level account ID {:?} can't be created by {:?}, short top-level account IDs can only be created by {:?}",
+                account_id, predecessor_id, registrar_account_id,
+            ),
             ActionErrorKind::CreateAccountNotAllowed { account_id, predecessor_id } => write!(
                 f,
-                "The new account_id {:?} can't be created by {:?}",
-                account_id, predecessor_id
+                "A new sub-account ID {:?} can't be created by account {:?}",
+                account_id, predecessor_id,
             ),
             ActionErrorKind::DeleteKeyDoesNotExist { account_id, .. } => write!(
                 f,

--- a/core/runtime-configs/src/lib.rs
+++ b/core/runtime-configs/src/lib.rs
@@ -2,7 +2,7 @@
 use serde::{Deserialize, Serialize};
 
 use near_primitives::serialize::u128_dec_format;
-use near_primitives::types::Balance;
+use near_primitives::types::{AccountId, Balance};
 use near_runtime_fees::RuntimeFeesConfig;
 use near_vm_logic::VMConfig;
 
@@ -19,6 +19,8 @@ pub struct RuntimeConfig {
     pub transaction_costs: RuntimeFeesConfig,
     /// Config of wasm operations.
     pub wasm_config: VMConfig,
+    /// Config that defines rules for account creation.
+    pub account_creation_config: AccountCreationConfig,
 }
 
 impl Default for RuntimeConfig {
@@ -28,6 +30,7 @@ impl Default for RuntimeConfig {
             storage_amount_per_byte: 909 * 100_000_000_000_000_000,
             transaction_costs: RuntimeFeesConfig::default(),
             wasm_config: VMConfig::default(),
+            account_creation_config: AccountCreationConfig::default(),
         }
     }
 }
@@ -38,6 +41,29 @@ impl RuntimeConfig {
             storage_amount_per_byte: 0,
             transaction_costs: RuntimeFeesConfig::free(),
             wasm_config: VMConfig::free(),
+            account_creation_config: AccountCreationConfig {
+                min_allowed_top_level_account_length: 0,
+                registrar_account_id: AccountId::default(),
+            },
+        }
+    }
+}
+
+/// The structure describes configuration for creation of new accounts.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct AccountCreationConfig {
+    /// The minimum length of the top-level account ID that is allowed to be created by any account.
+    pub min_allowed_top_level_account_length: u8,
+    /// The account ID of the account registrar. This account ID allowed to create top-level
+    /// accounts of any valid length.
+    pub registrar_account_id: AccountId,
+}
+
+impl Default for AccountCreationConfig {
+    fn default() -> Self {
+        Self {
+            min_allowed_top_level_account_length: 11,
+            registrar_account_id: AccountId::from("registrar"),
         }
     }
 }

--- a/core/runtime-configs/src/lib.rs
+++ b/core/runtime-configs/src/lib.rs
@@ -41,10 +41,7 @@ impl RuntimeConfig {
             storage_amount_per_byte: 0,
             transaction_costs: RuntimeFeesConfig::free(),
             wasm_config: VMConfig::free(),
-            account_creation_config: AccountCreationConfig {
-                min_allowed_top_level_account_length: 0,
-                registrar_account_id: AccountId::default(),
-            },
+            account_creation_config: AccountCreationConfig::default(),
         }
     }
 }

--- a/near/res/testnet_genesis_config.json
+++ b/near/res/testnet_genesis_config.json
@@ -1,40 +1,25 @@
 {
-  "protocol_version": 5,
   "config_version": 1,
-  "genesis_height": 0,
-  "genesis_time": "2019-06-04T06:13:25Z",
-  "chain_id": "testnet",
+  "protocol_version": 7,
+  "genesis_time": "2020-03-31T21:27:57.474226Z",
+  "chain_id": "test-chain-IER4n",
+  "genesis_height": 21,
   "num_block_producer_seats": 50,
   "num_block_producer_seats_per_shard": [
-    7,
-    7,
-    6,
-    6,
-    6,
-    6,
-    6,
-    6
+    50
   ],
   "avg_hidden_validator_seats_per_shard": [
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
     0
   ],
   "dynamic_resharding": false,
-  "epoch_length": 600,
+  "epoch_length": 60,
   "gas_limit": 1000000000000000,
-  "min_gas_price": 5000,
-  "block_producer_kickout_threshold": 80,
+  "min_gas_price": "5000",
+  "block_producer_kickout_threshold": 90,
   "chunk_producer_kickout_threshold": 60,
   "gas_price_adjustment_rate": 1,
   "runtime_config": {
-    "storage_cost_byte_per_block": "1",
-    "poke_threshold": 60,
+    "poke_threshold": 0,
     "transaction_costs": {
       "action_receipt_creation_config": {
         "send_sir": 924119500000,
@@ -200,22 +185,26 @@
         "max_number_input_data_dependencies": 128
       }
     },
-    "account_length_baseline_cost_per_block": "6561"
+    "storage_amount_per_byte": "90949470177292823791",
+    "account_creation_config": {
+      "min_allowed_top_level_account_length": 11,
+      "registrar_account_id": "registrar"
+    }
   },
   "validators": [
     {
-      "account_id": "far",
-      "public_key": "ed25519:7rNEmDbkn8grQREdTt3PWhR1phNtsqJdgfV26XdR35QL",
-      "amount": "200000000000000000000000000000"
+      "account_id": "test.near",
+      "public_key": "ed25519:Fr9rU2jBF5dWfXJ9ewH7qAuirJMa2DKJ2QxV4DnizRnh",
+      "amount": "50000000000000000000000000000000"
     }
   ],
-  "records": [],
-  "transaction_validity_period": 1000,
+  "transaction_validity_period": 100,
   "developer_reward_percentage": 30,
   "protocol_reward_percentage": 10,
   "max_inflation_rate": 5,
-  "total_supply": 1633462267318535697189514651161,
+  "total_supply": "2050000000000000000000000000000000",
   "num_blocks_per_year": 31536000,
-  "protocol_treasury_account": "near",
-  "fishermen_threshold": "10000000000000000000"
+  "protocol_treasury_account": "test.near",
+  "fishermen_threshold": "10000000000000000000000000",
+  "records": []
 }

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -32,7 +32,7 @@ def compile_current():
     """ Compile current branch """
     branch = current_branch()
     try:
-        # Accommodate rename from near to neard 
+        # Accommodate rename from near to neard
         subprocess.check_output(['cargo', 'build', '-p', 'neard'])
     except:
         subprocess.check_output(['cargo', 'build', '-p', 'near'])
@@ -54,7 +54,7 @@ def download_binary(branch):
 
 def prepare_ab_test(other_branch):
     compile_current()
-    if other_branch in ['master', 'beta', 'stable']:
+    if os.environ.get('BUILDKITE') and other_branch in ['master', 'beta', 'stable']:
         download_binary(other_branch)
     else:
         compile_binary(other_branch)

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -296,9 +296,11 @@ impl Runtime {
                 near_metrics::inc_counter(&metrics::ACTION_CREATE_ACCOUNT_TOTAL);
                 action_create_account(
                     &self.config.transaction_costs,
+                    &self.config.account_creation_config,
                     account,
                     actor_id,
-                    receipt,
+                    &receipt.receiver_id,
+                    &receipt.predecessor_id,
                     &mut result,
                 );
             }

--- a/scripts/migrations/7-account-registrar.py
+++ b/scripts/migrations/7-account-registrar.py
@@ -39,12 +39,12 @@ for record in config['records']:
     if ('AccessKey' in record) and (record['AccessKey']['account_id'] == 'registrar'):
         continue
     if ('AccessKey' in record) and (record['AccessKey']['account_id'] == 'near'):
-        near_access_key_records.push(record['AccessKey'])
-    records.push(record)
+        near_access_key_records.append(record['AccessKey'])
+    records.append(record)
 
 assert(len(near_access_key_records) > 0)
 
-records.push({
+records.append({
     'Account': {
         'account': {
             # 1_000_000 N or 1e30
@@ -58,7 +58,7 @@ records.push({
 })
 
 for access_key_record in near_access_key_records:
-    records.push({
+    records.append({
         'AccessKey': {
             'access_key': access_key_record['access_key'],
             'public_key': access_key_record['public_key'],

--- a/scripts/migrations/7-account-registrar.py
+++ b/scripts/migrations/7-account-registrar.py
@@ -48,7 +48,7 @@ records.append({
     'Account': {
         'account': {
             # 1_000_000 N or 1e30
-            'amount': '1' + ('0' * 30),
+            'amount': str(10**30),
             'locked': '0',
             'code_hash': '11111111111111111111111111111111',
             'storage_usage': 100 + len(near_access_key_records) * 82,

--- a/scripts/migrations/7-account-registrar.py
+++ b/scripts/migrations/7-account-registrar.py
@@ -1,0 +1,72 @@
+"""
+This migration implements state staking spec change:
+https://github.com/nearprotocol/NEPs/pull/45
+
+Changes:
+ - Introduce `account_creation_config` in `RuntimeConfig`.
+ - Set `min_allowed_top_level_account_length` to 11. Means any top-level account ID with 10 chars or less
+   can only be created by `registrar`
+ - Set `registrar_account_id` to `registrar`.
+ - Creates a new `registrar` account with `near` access keys and 1M $N.
+"""
+
+import sys
+import os
+import json
+from collections import OrderedDict
+
+home = sys.argv[1]
+output_home = sys.argv[2]
+
+config = json.load(open(os.path.join(home, 'output.json')), object_pairs_hook=OrderedDict)
+
+assert config['protocol_version'] == 6
+
+config['protocol_version'] = 7
+config['runtime_config']['account_creation_config'] = {
+    'min_allowed_top_level_account_length': 11,
+    'registrar_account_id': 'registrar',
+}
+
+records = []
+
+near_access_key_records = []
+
+# Removing existing `registrar` account.
+for record in config['records']:
+    if ('Account' in record) and (record['Account']['account_id'] == 'registrar'):
+        continue
+    if ('AccessKey' in record) and (record['AccessKey']['account_id'] == 'registrar'):
+        continue
+    if ('AccessKey' in record) and (record['AccessKey']['account_id'] == 'near'):
+        near_access_key_records.push(record['AccessKey'])
+    records.push(record)
+
+assert(len(near_access_key_records) > 0)
+
+records.push({
+    'Account': {
+        'account': {
+            # 1_000_000 N or 1e30
+            'amount': '1' + ('0' * 30),
+            'locked': '0',
+            'code_hash': '11111111111111111111111111111111',
+            'storage_usage': 100 + len(near_access_key_records) * 82,
+        },
+        'account_id': 'registrar',
+    }
+})
+
+for access_key_record in near_access_key_records:
+    records.push({
+        'AccessKey': {
+            'access_key': access_key_record['access_key'],
+            'public_key': access_key_record['public_key'],
+            'account_id': 'registrar',
+        }
+    })
+
+
+config['records'] = records
+
+json.dump(config, open(os.path.join(output_home, 'output.json'), 'w'), indent=2)


### PR DESCRIPTION
Disabling creation of top-level account IDs shorted than 11 characters, except if created by `registrar`.
- Adding a new error that tells that the account has to be created by `registrar`
- Adding config to do this
- Adding migration script
- Bumping protocol version
- Adding `registrar` account

NEP: https://github.com/nearprotocol/NEPs/pull/45
Fixes #2292

## Test plan:
- CI
- State migration test
- Extra tests for account ID creation.