### PR TITLE
fix: Disable top-level registrar requirement

### DIFF
--- a/core/runtime-configs/src/lib.rs
+++ b/core/runtime-configs/src/lib.rs
@@ -59,7 +59,7 @@ pub struct AccountCreationConfig {
 impl Default for AccountCreationConfig {
     fn default() -> Self {
         Self {
-            min_allowed_top_level_account_length: 11,
+            min_allowed_top_level_account_length: 0,
             registrar_account_id: AccountId::from("registrar"),
         }
     }

--- a/near/res/testnet_genesis_config.json
+++ b/near/res/testnet_genesis_config.json
@@ -187,7 +187,7 @@
     },
     "storage_amount_per_byte": "90949470177292823791",
     "account_creation_config": {
-      "min_allowed_top_level_account_length": 11,
+      "min_allowed_top_level_account_length": 0,
       "registrar_account_id": "registrar"
     }
   },

--- a/runtime/runtime/src/actions.rs
+++ b/runtime/runtime/src/actions.rs
@@ -509,6 +509,7 @@ mod tests {
     fn test_action_create_account(
         account_id: AccountId,
         predecessor_id: AccountId,
+        length: u8,
     ) -> ActionResult {
         let mut account = None;
         let mut actor_id = predecessor_id.clone();
@@ -516,7 +517,7 @@ mod tests {
         action_create_account(
             &RuntimeFeesConfig::default(),
             &AccountCreationConfig {
-                min_allowed_top_level_account_length: 11,
+                min_allowed_top_level_account_length: length,
                 registrar_account_id: AccountId::from("registrar"),
             },
             &mut account,
@@ -538,7 +539,7 @@ mod tests {
     fn test_create_account_valid_top_level_long() {
         let account_id = AccountId::from("bob_near_long_name");
         let predecessor_id = AccountId::from("alice.near");
-        let action_result = test_action_create_account(account_id, predecessor_id);
+        let action_result = test_action_create_account(account_id, predecessor_id, 11);
         assert!(action_result.result.is_ok());
     }
 
@@ -546,7 +547,7 @@ mod tests {
     fn test_create_account_valid_top_level_by_registrar() {
         let account_id = AccountId::from("bob");
         let predecessor_id = AccountId::from("registrar");
-        let action_result = test_action_create_account(account_id, predecessor_id);
+        let action_result = test_action_create_account(account_id, predecessor_id, 11);
         assert!(action_result.result.is_ok());
     }
 
@@ -554,7 +555,7 @@ mod tests {
     fn test_create_account_valid_sub_account() {
         let account_id = AccountId::from("alice.near");
         let predecessor_id = AccountId::from("near");
-        let action_result = test_action_create_account(account_id, predecessor_id);
+        let action_result = test_action_create_account(account_id, predecessor_id, 11);
         assert!(action_result.result.is_ok());
     }
 
@@ -562,7 +563,8 @@ mod tests {
     fn test_create_account_invalid_sub_account() {
         let account_id = AccountId::from("alice.near");
         let predecessor_id = AccountId::from("bob");
-        let action_result = test_action_create_account(account_id.clone(), predecessor_id.clone());
+        let action_result =
+            test_action_create_account(account_id.clone(), predecessor_id.clone(), 11);
         assert_eq!(
             action_result.result,
             Err(ActionError {
@@ -579,7 +581,8 @@ mod tests {
     fn test_create_account_invalid_short_top_level() {
         let account_id = AccountId::from("bob");
         let predecessor_id = AccountId::from("near");
-        let action_result = test_action_create_account(account_id.clone(), predecessor_id.clone());
+        let action_result =
+            test_action_create_account(account_id.clone(), predecessor_id.clone(), 11);
         assert_eq!(
             action_result.result,
             Err(ActionError {
@@ -591,5 +594,14 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn test_create_account_valid_short_top_level_len_allowed() {
+        let account_id = AccountId::from("bob");
+        let predecessor_id = AccountId::from("near");
+        let action_result =
+            test_action_create_account(account_id.clone(), predecessor_id.clone(), 0);
+        assert!(action_result.result.is_ok());
     }
 }

--- a/scripts/migrations/7-account-registrar.py
+++ b/scripts/migrations/7-account-registrar.py
@@ -4,8 +4,7 @@ https://github.com/nearprotocol/NEPs/pull/45
 
 Changes:
  - Introduce `account_creation_config` in `RuntimeConfig`.
- - Set `min_allowed_top_level_account_length` to 11. Means any top-level account ID with 10 chars or less
-   can only be created by `registrar`
+ - Set `min_allowed_top_level_account_length` to 0. Means any top-level account ID can still be created by anyone.
  - Set `registrar_account_id` to `registrar`.
  - Creates a new `registrar` account with `near` access keys and 1M $N.
 """
@@ -24,7 +23,7 @@ assert config['protocol_version'] == 6
 
 config['protocol_version'] = 7
 config['runtime_config']['account_creation_config'] = {
-    'min_allowed_top_level_account_length': 11,
+    'min_allowed_top_level_account_length': 0,
     'registrar_account_id': 'registrar',
 }
 


### PR DESCRIPTION
Disables requirement to create top-level accounts with `registrar`.
By setting min allowed length to 0. It will allow testing of app-layer when `registrar` requirements are needed.

## Test plan:
- Added unit-test to verify
- CI