### PR TITLE
fix: improve tx routing

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -65,6 +65,9 @@ const ACCEPTABLE_TIME_DIFFERENCE: i64 = 12 * 10;
 /// Over this block height delta in advance if we are not chunk producer - route tx to upcoming validators.
 pub const TX_ROUTING_HEIGHT_HORIZON: BlockHeightDelta = 4;
 
+/// We choose this number of chunk producers to forward transactions to, if necessary.
+pub const NUM_CHUNK_PRODUCERS_TO_FORWARD_TX: u64 = 2;
+
 /// Private constant for 1 NEAR (copy from near/config.rs) used for reporting.
 const NEAR_BASE: Balance = 1_000_000_000_000_000_000_000_000;
 
@@ -1948,9 +1951,10 @@ impl Chain {
         &self,
         epoch_id: &EpochId,
         shard_id: ShardId,
+        horizon: BlockHeight,
     ) -> Result<AccountId, Error> {
         let head = self.head()?;
-        let target_height = head.height + TX_ROUTING_HEIGHT_HORIZON - 1;
+        let target_height = head.height + horizon - 1;
         self.runtime_adapter.get_chunk_producer(&epoch_id, target_height, shard_id)
     }
 
@@ -1958,7 +1962,7 @@ impl Chain {
     pub fn find_validator_for_forwarding(&self, shard_id: ShardId) -> Result<AccountId, Error> {
         let head = self.head()?;
         let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(&head.last_block_hash)?;
-        self.find_chunk_producer_for_forwarding(&epoch_id, shard_id)
+        self.find_chunk_producer_for_forwarding(&epoch_id, shard_id, TX_ROUTING_HEIGHT_HORIZON)
     }
 }
 

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -249,7 +249,9 @@ impl Handler<NetworkClientMessages> for ClientActor {
                     _ => panic!("invalid adversary message"),
                 };
             }
-            NetworkClientMessages::Transaction(tx) => self.client.process_tx(tx),
+            NetworkClientMessages::Transaction(tx, is_forwarded) => {
+                self.client.process_tx(tx, is_forwarded)
+            }
             NetworkClientMessages::Block(block, peer_id, was_requested) => {
                 let blocks_at_height = self
                     .client

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -249,8 +249,8 @@ impl Handler<NetworkClientMessages> for ClientActor {
                     _ => panic!("invalid adversary message"),
                 };
             }
-            NetworkClientMessages::Transaction(tx, is_forwarded) => {
-                self.client.process_tx(tx, is_forwarded)
+            NetworkClientMessages::Transaction { transaction, is_forwarded } => {
+                self.client.process_tx(transaction, is_forwarded)
             }
             NetworkClientMessages::Block(block, peer_id, was_requested) => {
                 let blocks_at_height = self

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -918,7 +918,7 @@ impl TestEnv {
             100,
             self.clients[id].chain.head().unwrap().last_block_hash,
         );
-        self.clients[id].process_tx(tx)
+        self.clients[id].process_tx(tx, false)
     }
 
     pub fn restart(&mut self, id: usize) {

--- a/chain/client/tests/bug_repros.rs
+++ b/chain/client/tests/bug_repros.rs
@@ -99,6 +99,7 @@ fn repro_1183() {
                                         1,
                                         block.header.prev_hash,
                                     ),
+                                    false,
                                 ));
                             nonce_delta += 1
                         }

--- a/chain/client/tests/bug_repros.rs
+++ b/chain/client/tests/bug_repros.rs
@@ -90,8 +90,8 @@ fn repro_1183() {
                             connectors1.write().unwrap()
                                 [account_id_to_shard_id(&from.to_string(), 4) as usize]
                                 .0
-                                .do_send(NetworkClientMessages::Transaction(
-                                    SignedTransaction::send_money(
+                                .do_send(NetworkClientMessages::Transaction {
+                                    transaction: SignedTransaction::send_money(
                                         block.header.inner_lite.height * 16 + nonce_delta,
                                         from.to_string(),
                                         to.to_string(),
@@ -99,8 +99,8 @@ fn repro_1183() {
                                         1,
                                         block.header.prev_hash,
                                     ),
-                                    false,
-                                ));
+                                    is_forwarded: false,
+                                });
                             nonce_delta += 1
                         }
                     }

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -64,10 +64,12 @@ mod tests {
         block_hash: CryptoHash,
     ) {
         let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
-        connector.do_send(NetworkClientMessages::Transaction(
-            SignedTransaction::send_money(nonce, from, to, &signer, amount, block_hash),
-            false,
-        ));
+        connector.do_send(NetworkClientMessages::Transaction {
+            transaction: SignedTransaction::send_money(
+                nonce, from, to, &signer, amount, block_hash,
+            ),
+            is_forwarded: false,
+        });
     }
 
     enum ReceiptsSyncPhases {

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -64,9 +64,10 @@ mod tests {
         block_hash: CryptoHash,
     ) {
         let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
-        connector.do_send(NetworkClientMessages::Transaction(SignedTransaction::send_money(
-            nonce, from, to, &signer, amount, block_hash,
-        )));
+        connector.do_send(NetworkClientMessages::Transaction(
+            SignedTransaction::send_money(nonce, from, to, &signer, amount, block_hash),
+            false,
+        ));
     }
 
     enum ReceiptsSyncPhases {

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -375,14 +375,17 @@ fn test_verify_chunk_invalid_state_challenge() {
     let validator_signer = InMemoryValidatorSigner::from_seed("test0", KeyType::ED25519, "test0");
     let genesis_hash = env.clients[0].chain.genesis().hash();
     env.produce_block(0, 1);
-    env.clients[0].process_tx(SignedTransaction::send_money(
-        0,
-        "test0".to_string(),
-        "test1".to_string(),
-        &signer,
-        1000,
-        genesis_hash,
-    ));
+    env.clients[0].process_tx(
+        SignedTransaction::send_money(
+            0,
+            "test0".to_string(),
+            "test1".to_string(),
+            &signer,
+            1000,
+            genesis_hash,
+        ),
+        false,
+    );
     env.produce_block(0, 2);
 
     // Invalid chunk & block.
@@ -649,7 +652,7 @@ fn test_fishermen_challenge() {
         signer.public_key(),
         genesis_hash,
     );
-    env.clients[0].process_tx(stake_transaction);
+    env.clients[0].process_tx(stake_transaction, false);
     for i in 1..=11 {
         env.produce_block(0, i);
     }

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -222,13 +222,13 @@ fn chunks_produced_and_distributed_common(
             let connectors_ = connectors.write().unwrap();
             connectors_[0]
                 .0
-                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash), false));
+                .do_send(NetworkClientMessages::Transaction{transaction: SignedTransaction::empty(block_hash), is_forwarded:false});
             connectors_[1]
                 .0
-                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash), false));
+                .do_send(NetworkClientMessages::Transaction{transaction: SignedTransaction::empty(block_hash), is_forwarded:false});
             connectors_[2]
                 .0
-                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash), false));
+                .do_send(NetworkClientMessages::Transaction{transaction:SignedTransaction::empty(block_hash), is_forwarded:false});
             future::ready(())
         }));
     })

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -222,13 +222,13 @@ fn chunks_produced_and_distributed_common(
             let connectors_ = connectors.write().unwrap();
             connectors_[0]
                 .0
-                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash)));
+                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash), false));
             connectors_[1]
                 .0
-                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash)));
+                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash), false));
             connectors_[2]
                 .0
-                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash)));
+                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash), false));
             future::ready(())
         }));
     })

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -111,14 +111,17 @@ mod tests {
         actix::spawn(
             connectors.write().unwrap()[connector_ordinal]
                 .0
-                .send(NetworkClientMessages::Transaction(SignedTransaction::send_money(
-                    nonce,
-                    from.clone(),
-                    to.clone(),
-                    &signer,
-                    amount,
-                    block_hash,
-                )))
+                .send(NetworkClientMessages::Transaction(
+                    SignedTransaction::send_money(
+                        nonce,
+                        from.clone(),
+                        to.clone(),
+                        &signer,
+                        amount,
+                        block_hash,
+                    ),
+                    false,
+                ))
                 .then(move |x| {
                     match x.unwrap() {
                         NetworkClientResponses::NoResponse

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -111,8 +111,8 @@ mod tests {
         actix::spawn(
             connectors.write().unwrap()[connector_ordinal]
                 .0
-                .send(NetworkClientMessages::Transaction(
-                    SignedTransaction::send_money(
+                .send(NetworkClientMessages::Transaction {
+                    transaction: SignedTransaction::send_money(
                         nonce,
                         from.clone(),
                         to.clone(),
@@ -120,8 +120,8 @@ mod tests {
                         amount,
                         block_hash,
                     ),
-                    false,
-                ))
+                    is_forwarded: false,
+                })
                 .then(move |x| {
                     match x.unwrap() {
                         NetworkClientResponses::NoResponse

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -949,3 +949,15 @@ fn test_gc_block_skips() {
         }
     }
 }
+
+#[test]
+fn test_tx_forwarding() {
+    let mut chain_genesis = ChainGenesis::test();
+    chain_genesis.epoch_length = 100;
+    let mut env = TestEnv::new(chain_genesis, 50, 50);
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
+    let genesis_hash = genesis_block.hash();
+    // forward to 2 chunk producers
+    env.clients[0].process_tx(SignedTransaction::empty(genesis_hash));
+    assert_eq!(env.network_adapters[0].requests.read().unwrap().len(), 2);
+}

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -116,8 +116,10 @@ fn produce_blocks_with_tx() {
         actix::spawn(view_client.send(GetBlock::latest()).then(move |res| {
             let header: BlockHeader = res.unwrap().unwrap().header.into();
             let block_hash = header.hash;
-            client
-                .do_send(NetworkClientMessages::Transaction(SignedTransaction::empty(block_hash)));
+            client.do_send(NetworkClientMessages::Transaction(
+                SignedTransaction::empty(block_hash),
+                false,
+            ));
             future::ready(())
         }))
     })
@@ -648,7 +650,10 @@ fn test_process_invalid_tx() {
         },
     );
     produce_blocks(&mut client, 12);
-    assert_eq!(client.process_tx(tx), NetworkClientResponses::InvalidTx(InvalidTxError::Expired));
+    assert_eq!(
+        client.process_tx(tx, false),
+        NetworkClientResponses::InvalidTx(InvalidTxError::Expired)
+    );
     let tx2 = SignedTransaction::new(
         Signature::empty(KeyType::ED25519),
         Transaction {
@@ -660,7 +665,10 @@ fn test_process_invalid_tx() {
             actions: vec![],
         },
     );
-    assert_eq!(client.process_tx(tx2), NetworkClientResponses::InvalidTx(InvalidTxError::Expired));
+    assert_eq!(
+        client.process_tx(tx2, false),
+        NetworkClientResponses::InvalidTx(InvalidTxError::Expired)
+    );
 }
 
 /// If someone produce a block with Utc::now() + 1 min, we should produce a block with valid timestamp
@@ -958,6 +966,17 @@ fn test_tx_forwarding() {
     let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
     let genesis_hash = genesis_block.hash();
     // forward to 2 chunk producers
-    env.clients[0].process_tx(SignedTransaction::empty(genesis_hash));
+    env.clients[0].process_tx(SignedTransaction::empty(genesis_hash), false);
     assert_eq!(env.network_adapters[0].requests.read().unwrap().len(), 2);
+}
+
+#[test]
+fn test_tx_forwarding_no_double_forwarding() {
+    let mut chain_genesis = ChainGenesis::test();
+    chain_genesis.epoch_length = 100;
+    let mut env = TestEnv::new(chain_genesis, 50, 50);
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap();
+    let genesis_hash = genesis_block.hash();
+    env.clients[0].process_tx(SignedTransaction::empty(genesis_hash), true);
+    assert!(env.network_adapters[0].requests.read().unwrap().is_empty());
 }

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -116,10 +116,10 @@ fn produce_blocks_with_tx() {
         actix::spawn(view_client.send(GetBlock::latest()).then(move |res| {
             let header: BlockHeader = res.unwrap().unwrap().header.into();
             let block_hash = header.hash;
-            client.do_send(NetworkClientMessages::Transaction(
-                SignedTransaction::empty(block_hash),
-                false,
-            ));
+            client.do_send(NetworkClientMessages::Transaction {
+                transaction: SignedTransaction::empty(block_hash),
+                is_forwarded: false,
+            });
             future::ready(())
         }))
     })

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -230,7 +230,7 @@ impl JsonRpcHandler {
     async fn send_tx_async(&self, params: Option<Value>) -> Result<Value, RpcError> {
         let tx = parse_tx(params)?;
         let hash = (&tx.get_hash()).to_base();
-        actix::spawn(self.client_addr.send(NetworkClientMessages::Transaction(tx)).map(drop));
+        actix::spawn(self.client_addr.send(NetworkClientMessages::Transaction(tx, false)).map(drop));
         Ok(Value::String(hash))
     }
 
@@ -267,7 +267,7 @@ impl JsonRpcHandler {
         let signer_account_id = tx.transaction.signer_id.clone();
         let result = self
             .client_addr
-            .send(NetworkClientMessages::Transaction(tx))
+            .send(NetworkClientMessages::Transaction(tx, false))
             .map_err(|err| RpcError::server_error(Some(ServerError::from(err))))
             .await?;
         match result {

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -230,7 +230,11 @@ impl JsonRpcHandler {
     async fn send_tx_async(&self, params: Option<Value>) -> Result<Value, RpcError> {
         let tx = parse_tx(params)?;
         let hash = (&tx.get_hash()).to_base();
-        actix::spawn(self.client_addr.send(NetworkClientMessages::Transaction(tx, false)).map(drop));
+        actix::spawn(
+            self.client_addr
+                .send(NetworkClientMessages::Transaction { transaction: tx, is_forwarded: false })
+                .map(drop),
+        );
         Ok(Value::String(hash))
     }
 
@@ -267,7 +271,7 @@ impl JsonRpcHandler {
         let signer_account_id = tx.transaction.signer_id.clone();
         let result = self
             .client_addr
-            .send(NetworkClientMessages::Transaction(tx, false))
+            .send(NetworkClientMessages::Transaction { transaction: tx, is_forwarded: false })
             .map_err(|err| RpcError::server_error(Some(ServerError::from(err))))
             .await?;
         match result {

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -406,7 +406,7 @@ impl Peer {
             }
             PeerMessage::Transaction(transaction) => {
                 near_metrics::inc_counter(&metrics::PEER_TRANSACTION_RECEIVED_TOTAL);
-                NetworkClientMessages::Transaction(transaction, false)
+                NetworkClientMessages::Transaction { transaction, is_forwarded: false }
             }
             PeerMessage::BlockHeaders(headers) => {
                 NetworkClientMessages::BlockHeaders(headers, peer_id)
@@ -420,7 +420,7 @@ impl Peer {
                         NetworkClientMessages::BlockApproval(approval, peer_id)
                     }
                     RoutedMessageBody::ForwardTx(transaction) => {
-                        NetworkClientMessages::Transaction(transaction, true)
+                        NetworkClientMessages::Transaction { transaction, is_forwarded: true }
                     }
 
                     RoutedMessageBody::StateResponse(info) => {

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -406,7 +406,7 @@ impl Peer {
             }
             PeerMessage::Transaction(transaction) => {
                 near_metrics::inc_counter(&metrics::PEER_TRANSACTION_RECEIVED_TOTAL);
-                NetworkClientMessages::Transaction(transaction)
+                NetworkClientMessages::Transaction(transaction, false)
             }
             PeerMessage::BlockHeaders(headers) => {
                 NetworkClientMessages::BlockHeaders(headers, peer_id)
@@ -420,7 +420,7 @@ impl Peer {
                         NetworkClientMessages::BlockApproval(approval, peer_id)
                     }
                     RoutedMessageBody::ForwardTx(transaction) => {
-                        NetworkClientMessages::Transaction(transaction)
+                        NetworkClientMessages::Transaction(transaction, true)
                     }
 
                     RoutedMessageBody::StateResponse(info) => {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1136,7 +1136,7 @@ pub enum NetworkClientMessages {
     Adversarial(NetworkAdversarialMessage),
 
     /// Received transaction.
-    Transaction(SignedTransaction),
+    Transaction(SignedTransaction, bool),
     /// Received block, possibly requested.
     Block(Block, PeerId, bool),
     /// Received list of headers for syncing.

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1136,7 +1136,10 @@ pub enum NetworkClientMessages {
     Adversarial(NetworkAdversarialMessage),
 
     /// Received transaction.
-    Transaction(SignedTransaction, bool),
+    Transaction {
+        transaction: SignedTransaction,
+        is_forwarded: bool,
+    },
     /// Received block, possibly requested.
     Block(Block, PeerId, bool),
     /// Received list of headers for syncing.

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -107,7 +107,10 @@ fn test_stake_nodes() {
             test_nodes[1].genesis_hash,
         );
         actix::spawn(
-            test_nodes[0].client.send(NetworkClientMessages::Transaction(tx, false)).map(drop),
+            test_nodes[0]
+                .client
+                .send(NetworkClientMessages::Transaction { transaction: tx, is_forwarded: false })
+                .map(drop),
         );
 
         WaitOrTimeout::new(
@@ -184,7 +187,10 @@ fn test_validator_kickout() {
             actix::spawn(
                 test_node
                     .client
-                    .send(NetworkClientMessages::Transaction(stake_transaction, false))
+                    .send(NetworkClientMessages::Transaction {
+                        transaction: stake_transaction,
+                        is_forwarded: false,
+                    })
                     .map(drop),
             );
         }
@@ -333,13 +339,19 @@ fn test_validator_join() {
         actix::spawn(
             test_nodes[1]
                 .client
-                .send(NetworkClientMessages::Transaction(unstake_transaction, false))
+                .send(NetworkClientMessages::Transaction {
+                    transaction: unstake_transaction,
+                    is_forwarded: false,
+                })
                 .map(drop),
         );
         actix::spawn(
             test_nodes[0]
                 .client
-                .send(NetworkClientMessages::Transaction(stake_transaction, false))
+                .send(NetworkClientMessages::Transaction {
+                    transaction: stake_transaction,
+                    is_forwarded: false,
+                })
                 .map(drop),
         );
 

--- a/near/tests/stake_nodes.rs
+++ b/near/tests/stake_nodes.rs
@@ -106,7 +106,9 @@ fn test_stake_nodes() {
             test_nodes[1].config.validator_signer.as_ref().unwrap().public_key(),
             test_nodes[1].genesis_hash,
         );
-        actix::spawn(test_nodes[0].client.send(NetworkClientMessages::Transaction(tx)).map(drop));
+        actix::spawn(
+            test_nodes[0].client.send(NetworkClientMessages::Transaction(tx, false)).map(drop),
+        );
 
         WaitOrTimeout::new(
             Box::new(move |_ctx| {
@@ -182,7 +184,7 @@ fn test_validator_kickout() {
             actix::spawn(
                 test_node
                     .client
-                    .send(NetworkClientMessages::Transaction(stake_transaction))
+                    .send(NetworkClientMessages::Transaction(stake_transaction, false))
                     .map(drop),
             );
         }
@@ -331,13 +333,13 @@ fn test_validator_join() {
         actix::spawn(
             test_nodes[1]
                 .client
-                .send(NetworkClientMessages::Transaction(unstake_transaction))
+                .send(NetworkClientMessages::Transaction(unstake_transaction, false))
                 .map(drop),
         );
         actix::spawn(
             test_nodes[0]
                 .client
-                .send(NetworkClientMessages::Transaction(stake_transaction))
+                .send(NetworkClientMessages::Transaction(stake_transaction, false))
                 .map(drop),
         );
 

--- a/near/tests/sync_nodes.rs
+++ b/near/tests/sync_nodes.rs
@@ -241,7 +241,12 @@ fn sync_state_stake_change() {
             genesis_hash,
         );
         actix::spawn(
-            client1.send(NetworkClientMessages::Transaction(unstake_transaction, false)).map(drop),
+            client1
+                .send(NetworkClientMessages::Transaction {
+                    transaction: unstake_transaction,
+                    is_forwarded: false,
+                })
+                .map(drop),
         );
 
         let started = Arc::new(AtomicBool::new(false));

--- a/near/tests/sync_nodes.rs
+++ b/near/tests/sync_nodes.rs
@@ -241,7 +241,7 @@ fn sync_state_stake_change() {
             genesis_hash,
         );
         actix::spawn(
-            client1.send(NetworkClientMessages::Transaction(unstake_transaction)).map(drop),
+            client1.send(NetworkClientMessages::Transaction(unstake_transaction, false)).map(drop),
         );
 
         let started = Arc::new(AtomicBool::new(false));


### PR DESCRIPTION
Right now we only forward transaction to one chunk producer in 4 blocks. It is possible that 1) the chunk producer for that slot received the transaction after they already produced the chunk due to some network glitch and 2) the chunk producer wasn't able to produce the chunk because the previous block is skipped. To protect agains it, this PR changes it so that we route the transaction to both the chunk producer in 4 blocks and the chunk producers in 8 blocks. Since chunk producer would remove transactions from the mempool that are already in existing chunks, this shouldn't cause any harm other than more traffic in the network. Resolves #2357.

Test plan
---------
`test_tx_forwarding` that tests two forwarding requests are generated when tx routing happens.