### PR TITLE
fix(script): fix verbose flag not work in docker node

### DIFF
--- a/scripts/run_docker.sh
+++ b/scripts/run_docker.sh
@@ -3,23 +3,13 @@ set -e
 
 export NEAR_HOME=/srv/near
 
-if [[ -z {INIT} ]]
-then
-    near --home=${NEAR_HOME} init --chain-id=${CHAIN_ID} --account-id=${ACCOUNT_ID}
-fi
-
-if [[ -z {NODE_KEY} ]]
-then
-
-    cat << EOF > ${NEAR_HOME}/node_key.json
-{"account_id": "", "public_key": "", "secret_key": "$NODE_KEY"}
-EOF
-
-fi
-
 ulimit -c unlimited
 
 echo "Telemetry: ${TELEMETRY_URL}"
 echo "Bootnodes: ${BOOT_NODES}"
 
-near --home=${NEAR_HOME} run --telemetry-url=${TELEMETRY_URL} --boot-nodes=${BOOT_NODES}
+if [[ -z "${VERBOSE}" ]]; then
+    verbose="--verbose ''"
+fi
+
+near --home=${NEAR_HOME} run --telemetry-url=${TELEMETRY_URL} --boot-nodes=${BOOT_NODES} ${verbose}


### PR DESCRIPTION
This is to fix https://github.com/near/nearup/issues/11. nearup relies on run_docker.sh to take VERBOSE env. I think it might be better to depreciated run_docker.sh and use near as entry point. And nearup pass all args to near.

Test Plan
------------
local docker image works