### PR TITLE
refactor: Applied Clippy suggestions

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2179,7 +2179,7 @@ impl<'a> ChainUpdate<'a> {
         block_economics_config: &'a BlockEconomicsConfig,
         doomslug_threshold_mode: DoomslugThresholdMode,
     ) -> Self {
-        let chain_store_update: ChainStoreUpdate = store.store_update();
+        let chain_store_update: ChainStoreUpdate<'_> = store.store_update();
         ChainUpdate {
             runtime_adapter,
             chain_store_update,

--- a/chain/chain/src/finality.rs
+++ b/chain/chain/src/finality.rs
@@ -28,7 +28,7 @@ impl FinalityGadget {
     pub fn process_approval(
         me: &Option<AccountId>,
         approval: &Approval,
-        chain_store_update: &mut ChainStoreUpdate,
+        chain_store_update: &mut ChainStoreUpdate<'_>,
     ) -> Result<(), Error> {
         // Approvals without reference hash are for doomslug / randomness only and are ignored by
         // the finality gadget

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -358,7 +358,7 @@ impl ChainStore {
         self.store.clone()
     }
 
-    pub fn store_update(&mut self) -> ChainStoreUpdate {
+    pub fn store_update(&mut self) -> ChainStoreUpdate<'_> {
         ChainStoreUpdate::new(self)
     }
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate log;
-
 use std::cmp;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -273,7 +271,7 @@ impl ShardsManager {
         );
     }
 
-    pub fn get_pool_iterator(&mut self, shard_id: ShardId) -> Option<PoolIteratorWrapper> {
+    pub fn get_pool_iterator(&mut self, shard_id: ShardId) -> Option<PoolIteratorWrapper<'_>> {
         self.tx_pools.get_mut(&shard_id).map(|pool| pool.pool_iterator())
     }
 
@@ -1040,7 +1038,7 @@ impl ShardsManager {
     pub fn persist_partial_chunk_for_data_availability(
         &self,
         chunk_entry: &EncodedChunksCacheEntry,
-        store_update: &mut ChainStoreUpdate,
+        store_update: &mut ChainStoreUpdate<'_>,
     ) {
         let prev_block_hash = chunk_entry.header.inner.prev_block_hash;
         let partial_chunk = PartialEncodedChunk {
@@ -1129,7 +1127,7 @@ impl ShardsManager {
         encoded_chunk: &EncodedShardChunk,
         merkle_paths: Vec<MerklePath>,
         outgoing_receipts: &Vec<Receipt>,
-        store_update: &mut ChainStoreUpdate,
+        store_update: &mut ChainStoreUpdate<'_>,
     ) {
         let shard_id = encoded_chunk.header.inner.shard_id;
         let outgoing_receipts_hashes =

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -32,7 +32,7 @@ pub enum Error {
 }
 
 impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Chain(err) => write!(f, "Chain: {}", err),
             Error::Chunk(err) => write!(f, "Chunk: {}", err),

--- a/chain/epoch_manager/src/types.rs
+++ b/chain/epoch_manager/src/types.rs
@@ -203,7 +203,7 @@ pub enum EpochError {
 impl std::error::Error for EpochError {}
 
 impl fmt::Debug for EpochError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EpochError::ThresholdError(stakes_sum, num_seats) => write!(
                 f,
@@ -218,7 +218,7 @@ impl fmt::Debug for EpochError {
 }
 
 impl fmt::Display for EpochError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EpochError::ThresholdError(stake, num_seats) => {
                 write!(f, "ThresholdError({}, {})", stake, num_seats)

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -196,7 +196,7 @@ impl JsonRpcClient {
     pub fn EXPERIMENTAL_genesis_records(
         &mut self,
         request: RpcGenesisRecordsRequest,
-    ) -> RpcRequest<GenesisRecordsView> {
+    ) -> RpcRequest<GenesisRecordsView<'_>> {
         call_method(&self.client, &self.server_addr, "EXPERIMENTAL_genesis_records", request)
     }
 

--- a/chain/jsonrpc/client/src/message.rs
+++ b/chain/jsonrpc/client/src/message.rs
@@ -33,7 +33,7 @@ impl<'de> Deserialize<'de> for Version {
         impl<'de> Visitor<'de> for VersionVisitor {
             type Value = Version;
 
-            fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
                 formatter.write_str("a version string")
             }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -132,7 +132,7 @@ pub enum ServerError {
 }
 
 impl Display for ServerError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             ServerError::TxExecutionError(e) => write!(f, "ServerError: {}", e),
             ServerError::Timeout => write!(f, "ServerError: Timeout"),

--- a/chain/network/src/peer_store.rs
+++ b/chain/network/src/peer_store.rs
@@ -155,7 +155,7 @@ impl PeerStore {
     }
 
     /// Return iterator over all known peers.
-    pub fn iter(&self) -> Iter<PeerId, KnownPeerState> {
+    pub fn iter(&self) -> Iter<'_, PeerId, KnownPeerState> {
         self.peer_states.iter()
     }
 
@@ -194,7 +194,7 @@ impl PeerStore {
 
 #[cfg(test)]
 mod test {
-    extern crate tempdir;
+    use tempdir;
 
     use near_crypto::{KeyType, SecretKey};
     use near_store::create_store;

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -63,7 +63,7 @@ impl PeerInfo {
 
 // Note, `Display` automatically implements `ToString` which must be reciprocal to `FromStr`.
 impl fmt::Display for PeerInfo {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.id)?;
         if let Some(addr) = &self.addr {
             write!(f, "@{}", addr)?;
@@ -412,7 +412,7 @@ pub enum PeerMessage {
 }
 
 impl fmt::Display for PeerMessage {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             PeerMessage::Handshake(_) => f.write_str("Handshake"),
             PeerMessage::HandshakeFailure(_, _) => f.write_str("HandshakeFailure"),

--- a/chain/pool/src/lib.rs
+++ b/chain/pool/src/lib.rs
@@ -59,7 +59,7 @@ impl TransactionPool {
     /// Returns a pool iterator wrapper that implements an iterator like trait to iterate over
     /// transaction groups in the proper order defined by the protocol.
     /// When the iterator is dropped, all remaining groups are inserted back into the pool.
-    pub fn pool_iterator(&mut self) -> PoolIteratorWrapper {
+    pub fn pool_iterator(&mut self) -> PoolIteratorWrapper<'_> {
         PoolIteratorWrapper::new(self)
     }
 

--- a/core/crypto/src/signature.rs
+++ b/core/crypto/src/signature.rs
@@ -21,7 +21,7 @@ pub enum KeyType {
 }
 
 impl Display for KeyType {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
             "{}",
@@ -71,7 +71,7 @@ fn split_key_type_data(value: &str) -> Result<(KeyType, &str), Box<dyn std::erro
 pub struct Secp256K1PublicKey([u8; 64]);
 
 impl std::fmt::Debug for Secp256K1PublicKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "{}", bs58::encode(&self.0.to_vec()).into_string())
     }
 }
@@ -100,7 +100,7 @@ impl Ord for Secp256K1PublicKey {
 pub struct ED25519PublicKey(pub [u8; ed25519_dalek::PUBLIC_KEY_LENGTH]);
 
 impl std::fmt::Debug for ED25519PublicKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "{}", bs58::encode(&self.0.to_vec()).into_string())
     }
 }
@@ -180,13 +180,13 @@ impl Hash for PublicKey {
 }
 
 impl Display for PublicKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "{}", String::from(self))
     }
 }
 
 impl Debug for PublicKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "{}", String::from(self))
     }
 }
@@ -307,7 +307,7 @@ impl PartialEq for ED25519SecretKey {
 }
 
 impl std::fmt::Debug for ED25519SecretKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(
             f,
             "{}",
@@ -393,7 +393,7 @@ impl SecretKey {
 }
 
 impl std::fmt::Display for SecretKey {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         let data = match self {
             SecretKey::ED25519(secret_key) => bs58::encode(&secret_key.0[..]).into_string(),
             SecretKey::SECP256K1(secret_key) => bs58::encode(&secret_key[..]).into_string(),
@@ -472,7 +472,7 @@ impl PartialEq for Secp256K1Signature {
 }
 
 impl Debug for Secp256K1Signature {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "{}", bs58::encode(&self.0.to_vec()).into_string())
     }
 }
@@ -573,7 +573,7 @@ impl BorshDeserialize for Signature {
 }
 
 impl Display for Signature {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         let data = match self {
             Signature::ED25519(signature) => {
                 bs58::encode(&signature.to_bytes().to_vec()).into_string()

--- a/core/crypto/src/traits.rs
+++ b/core/crypto/src/traits.rs
@@ -27,13 +27,13 @@ macro_rules! common_conversions {
         }
 
         impl ::std::fmt::Debug for $ty {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 f.write_str(to_str!(self))
             }
         }
 
         impl ::std::fmt::Display for $ty {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 f.write_str(to_str!(self))
             }
         }

--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -113,7 +113,9 @@ pub fn observe(histogram: &Result<Histogram>, value: f64) {
 
 /// Stops a timer created with `start_timer(..)`.
 pub fn stop_timer(timer: Option<HistogramTimer>) {
-    timer.map(|t| t.observe_duration());
+    if let Some(t) = timer {
+        t.observe_duration();
+    }
 }
 
 pub fn inc_counter(counter: &Result<IntCounter>) {

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -759,7 +759,7 @@ impl From<u64> for BlockScore {
 }
 
 impl std::fmt::Display for BlockScore {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.num)
     }
 }

--- a/core/primitives/src/errors.rs
+++ b/core/primitives/src/errors.rs
@@ -20,7 +20,7 @@ pub enum TxExecutionError {
 }
 
 impl Display for TxExecutionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             TxExecutionError::ActionError(e) => write!(f, "{}", e),
             TxExecutionError::InvalidTxError(e) => write!(f, "{}", e),
@@ -82,7 +82,7 @@ pub enum StorageError {
 }
 
 impl std::fmt::Display for StorageError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         f.write_str(&format!("{:?}", self))
     }
 }
@@ -200,7 +200,7 @@ pub enum ReceiptValidationError {
 }
 
 impl Display for ReceiptValidationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             ReceiptValidationError::InvalidPredecessorId { account_id } => {
                 write!(f, "The predecessor_id `{}` of a Receipt is not valid.", account_id)
@@ -232,7 +232,7 @@ impl Display for ReceiptValidationError {
 }
 
 impl Display for ActionsValidationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             ActionsValidationError::TotalPrepaidGasExceeded { total_prepaid_gas, limit } => {
                 write!(f, "The total prepaid gas {} exceeds the limit {}", total_prepaid_gas, limit)
@@ -355,7 +355,7 @@ impl From<ActionErrorKind> for ActionError {
 }
 
 impl Display for InvalidTxError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             InvalidTxError::InvalidSignerId { signer_id } => {
                 write!(f, "Invalid signer account ID {:?} according to requirements", signer_id)
@@ -406,7 +406,7 @@ impl From<InvalidAccessKeyError> for InvalidTxError {
 }
 
 impl Display for InvalidAccessKeyError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             InvalidAccessKeyError::AccessKeyNotFound { account_id, public_key } => write!(
                 f,
@@ -480,7 +480,7 @@ pub struct BalanceMismatchError {
 }
 
 impl Display for BalanceMismatchError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         // Using saturating add to avoid overflow in display
         let initial_balance = self
             .incoming_validator_rewards
@@ -565,13 +565,13 @@ impl From<InvalidTxError> for RuntimeError {
 }
 
 impl Display for ActionError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         write!(f, "Action #{}: {}", self.index.unwrap_or_default(), self.kind)
     }
 }
 
 impl Display for ActionErrorKind {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             ActionErrorKind::AccountAlreadyExists { account_id } => {
                 write!(f, "Can't create a new account {:?}, because it already exists", account_id)

--- a/core/primitives/src/hash.rs
+++ b/core/primitives/src/hash.rs
@@ -120,13 +120,13 @@ impl From<&CryptoHash> for Vec<u8> {
 }
 
 impl fmt::Debug for CryptoHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", pretty_hash(&String::from(self)))
     }
 }
 
 impl fmt::Display for CryptoHash {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", String::from(self))
     }
 }

--- a/core/primitives/src/network.rs
+++ b/core/primitives/src/network.rs
@@ -63,13 +63,13 @@ impl PartialEq for PeerId {
 }
 
 impl fmt::Display for PeerId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }
 
 impl fmt::Debug for PeerId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
     }
 }

--- a/core/primitives/src/receipt.rs
+++ b/core/primitives/src/receipt.rs
@@ -103,7 +103,7 @@ pub struct DataReceiver {
 }
 
 impl fmt::Debug for DataReceipt {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DataReceipt")
             .field("data_id", &self.data_id)
             .field("data", &format_args!("{}", logging::pretty_result(&self.data)))
@@ -121,7 +121,7 @@ pub struct ReceivedData {
 }
 
 impl fmt::Debug for ReceivedData {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ReceivedData")
             .field("data", &format_args!("{}", logging::pretty_result(&self.data)))
             .finish()

--- a/core/primitives/src/serialize.rs
+++ b/core/primitives/src/serialize.rs
@@ -130,7 +130,7 @@ pub mod vec_base_format {
     {
         type Value = Vec<T>;
 
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("an array with base58 in the first element")
         }
 

--- a/core/primitives/src/state_record.rs
+++ b/core/primitives/src/state_record.rs
@@ -87,7 +87,7 @@ impl StateRecord {
 }
 
 impl Display for StateRecord {
-    fn fmt(&self, f: &mut Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             StateRecord::Account { account_id, account } => {
                 write!(f, "Account {:?}: {:?}", account_id, account)

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -85,7 +85,7 @@ pub struct DeployContractAction {
 }
 
 impl fmt::Debug for DeployContractAction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DeployContractAction")
             .field("code", &format_args!("{}", logging::pretty_utf8(&self.code)))
             .finish()
@@ -101,7 +101,7 @@ pub struct FunctionCallAction {
 }
 
 impl fmt::Debug for FunctionCallAction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FunctionCallAction")
             .field("method_name", &format_args!("{}", &self.method_name))
             .field("args", &format_args!("{}", logging::pretty_utf8(&self.args)))
@@ -221,7 +221,7 @@ pub enum ExecutionStatus {
 }
 
 impl fmt::Debug for ExecutionStatus {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ExecutionStatus::Unknown => f.write_str("Unknown"),
             ExecutionStatus::Failure(e) => f.write_fmt(format_args!("Failure({})", e)),
@@ -280,7 +280,7 @@ impl ExecutionOutcome {
 }
 
 impl fmt::Debug for ExecutionOutcome {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ExecutionOutcome")
             .field("status", &self.status)
             .field("logs", &format_args!("{}", logging::pretty_vec(&self.logs)))

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -85,7 +85,7 @@ pub fn is_valid_sub_account_id(signer_id: &AccountId, sub_account_id: &AccountId
 pub struct DisplayOption<T>(pub Option<T>);
 
 impl<T: fmt::Display> fmt::Display for DisplayOption<T> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             Some(ref v) => write!(f, "Some({})", v),
             None => write!(f, "None"),

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -735,7 +735,7 @@ pub enum FinalExecutionStatus {
 }
 
 impl fmt::Debug for FinalExecutionStatus {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FinalExecutionStatus::NotStarted => f.write_str("NotStarted"),
             FinalExecutionStatus::Started => f.write_str("Started"),
@@ -775,7 +775,7 @@ pub enum ExecutionStatusView {
 }
 
 impl fmt::Debug for ExecutionStatusView {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ExecutionStatusView::Unknown => f.write_str("Unknown"),
             ExecutionStatusView::Failure(e) => f.write_fmt(format_args!("Failure({:?})", e)),
@@ -859,7 +859,7 @@ pub struct FinalExecutionOutcomeView {
 }
 
 impl fmt::Debug for FinalExecutionOutcomeView {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FinalExecutionOutcome")
             .field("status", &self.status)
             .field("transaction", &self.transaction)

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -11,7 +11,7 @@ use std::sync::RwLock;
 pub struct DBError(rocksdb::Error);
 
 impl std::fmt::Display for DBError {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         self.0.fmt(formatter)
     }
 }
@@ -88,7 +88,7 @@ pub enum DBCol {
 const NUM_COLS: usize = 39;
 
 impl std::fmt::Display for DBCol {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         let desc = match self {
             Self::ColBlockMisc => "miscellaneous block data",
             Self::ColBlock => "block data",

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -199,7 +199,7 @@ impl StoreUpdate {
 }
 
 impl fmt::Debug for StoreUpdate {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Store Update {{")?;
         for op in self.transaction.ops.iter() {
             match op {

--- a/core/store/src/trie/insert_delete.rs
+++ b/core/store/src/trie/insert_delete.rs
@@ -84,7 +84,7 @@ impl Trie {
         &self,
         memory: &mut NodesStorage,
         node: StorageHandle,
-        partial: NibbleSlice,
+        partial: NibbleSlice<'_>,
         value: Vec<u8>,
     ) -> Result<StorageHandle, StorageError> {
         let root_handle = node;
@@ -312,7 +312,7 @@ impl Trie {
         &self,
         memory: &mut NodesStorage,
         node: StorageHandle,
-        partial: NibbleSlice,
+        partial: NibbleSlice<'_>,
     ) -> Result<(StorageHandle, bool), StorageError> {
         let mut handle = node;
         let mut partial = partial;

--- a/core/store/src/trie/iterator.rs
+++ b/core/store/src/trie/iterator.rs
@@ -61,7 +61,10 @@ impl<'a> TrieIterator<'a> {
         self.seek_nibble_slice(NibbleSlice::new(key.as_ref()))
     }
 
-    pub(crate) fn seek_nibble_slice(&mut self, mut key: NibbleSlice) -> Result<(), StorageError> {
+    pub(crate) fn seek_nibble_slice(
+        &mut self,
+        mut key: NibbleSlice<'_>,
+    ) -> Result<(), StorageError> {
         self.trail.clear();
         self.key_nibbles.clear();
         let mut hash = NodeHandle::Hash(self.root);

--- a/core/store/src/trie/mod.rs
+++ b/core/store/src/trie/mod.rs
@@ -869,7 +869,7 @@ impl Trie {
     fn lookup(
         &self,
         root: &CryptoHash,
-        mut key: NibbleSlice,
+        mut key: NibbleSlice<'_>,
     ) -> Result<Option<(u32, CryptoHash)>, StorageError> {
         let mut hash = *root;
 

--- a/core/store/src/trie/nibble_slice.rs
+++ b/core/store/src/trie/nibble_slice.rs
@@ -54,8 +54,9 @@ pub struct NibbleSliceIterator<'a> {
     i: usize,
 }
 
-impl<'a> Iterator for NibbleSliceIterator<'a> {
+impl Iterator for NibbleSliceIterator<'_> {
     type Item = u8;
+
     fn next(&mut self) -> Option<u8> {
         self.i += 1;
         if self.i <= self.p.len() {
@@ -83,7 +84,7 @@ impl<'a> NibbleSlice<'a> {
     }
 
     /// Create a new nibble slice from the given HPE encoded data (e.g. output of `encoded()`).
-    pub fn from_encoded(data: &'a [u8]) -> (NibbleSlice<'_>, bool) {
+    pub fn from_encoded(data: &'a [u8]) -> (Self, bool) {
         (Self::new_offset(data, if data[0] & 16 == 16 { 1 } else { 2 }), data[0] & 32 == 32)
     }
 
@@ -109,7 +110,7 @@ impl<'a> NibbleSlice<'a> {
     }
 
     /// Return object which represents a view on to this slice (further) offset by `i` nibbles.
-    pub fn mid(&self, i: usize) -> NibbleSlice<'a> {
+    pub fn mid(&self, i: usize) -> Self {
         NibbleSlice { data: self.data, offset: self.offset + i }
     }
 
@@ -195,13 +196,13 @@ impl<'a> NibbleSlice<'a> {
     }
 }
 
-impl<'a> PartialEq for NibbleSlice<'a> {
+impl PartialEq for NibbleSlice<'_> {
     fn eq(&self, them: &Self) -> bool {
         self.len() == them.len() && self.starts_with(them)
     }
 }
 
-impl<'a> PartialOrd for NibbleSlice<'a> {
+impl PartialOrd for NibbleSlice<'_> {
     fn partial_cmp(&self, them: &Self) -> Option<Ordering> {
         let s = min(self.len(), them.len());
         for i in 0..s {
@@ -215,7 +216,7 @@ impl<'a> PartialOrd for NibbleSlice<'a> {
     }
 }
 
-impl<'a> fmt::Debug for NibbleSlice<'a> {
+impl fmt::Debug for NibbleSlice<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_empty() {
             return Ok(());

--- a/core/store/src/trie/nibble_slice.rs
+++ b/core/store/src/trie/nibble_slice.rs
@@ -83,7 +83,7 @@ impl<'a> NibbleSlice<'a> {
     }
 
     /// Create a new nibble slice from the given HPE encoded data (e.g. output of `encoded()`).
-    pub fn from_encoded(data: &'a [u8]) -> (NibbleSlice, bool) {
+    pub fn from_encoded(data: &'a [u8]) -> (NibbleSlice<'_>, bool) {
         (Self::new_offset(data, if data[0] & 16 == 16 { 1 } else { 2 }), data[0] & 32 == 32)
     }
 
@@ -216,7 +216,7 @@ impl<'a> PartialOrd for NibbleSlice<'a> {
 }
 
 impl<'a> fmt::Debug for NibbleSlice<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.is_empty() {
             return Ok(());
         }

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -69,7 +69,7 @@ impl TrieUpdate {
         self.trie.get(&self.root, &key)
     }
 
-    pub fn get_ref(&self, key: &TrieKey) -> Result<Option<TrieUpdateValuePtr>, StorageError> {
+    pub fn get_ref(&self, key: &TrieKey) -> Result<Option<TrieUpdateValuePtr<'_>>, StorageError> {
         let key = key.to_vec();
         if let Some(key_value) = self.prospective.get(&key) {
             return Ok(key_value.value.as_ref().map(TrieUpdateValuePtr::MemoryRef));
@@ -131,7 +131,7 @@ impl TrieUpdate {
     }
 
     /// Returns Error if the underlying storage fails
-    pub fn iter(&self, key_prefix: &[u8]) -> Result<TrieUpdateIterator, StorageError> {
+    pub fn iter(&self, key_prefix: &[u8]) -> Result<TrieUpdateIterator<'_>, StorageError> {
         TrieUpdateIterator::new(self, key_prefix, b"", None)
     }
 
@@ -140,7 +140,7 @@ impl TrieUpdate {
         prefix: &[u8],
         start: &[u8],
         end: &[u8],
-    ) -> Result<TrieUpdateIterator, StorageError> {
+    ) -> Result<TrieUpdateIterator<'_>, StorageError> {
         TrieUpdateIterator::new(self, prefix, start, Some(end))
     }
 

--- a/runtime/near-runtime-fees/src/lib.rs
+++ b/runtime/near-runtime-fees/src/lib.rs
@@ -118,6 +118,7 @@ pub struct StorageUsageConfig {
 
 impl Default for RuntimeFeesConfig {
     fn default() -> Self {
+        #[allow(clippy::unreadable_literal)]
         Self {
             action_receipt_creation_config: Fee {
                 send_sir: 924119500000,
@@ -214,7 +215,7 @@ impl RuntimeFeesConfig {
                     function_call_cost_per_byte: free.clone(),
                 },
                 delete_key_cost: free.clone(),
-                delete_account_cost: free.clone(),
+                delete_account_cost: free,
             },
             storage_usage_config: StorageUsageConfig {
                 num_bytes_account: 0,

--- a/runtime/near-vm-errors/src/lib.rs
+++ b/runtime/near-vm-errors/src/lib.rs
@@ -175,7 +175,7 @@ impl From<PrepareError> for VMError {
 }
 
 impl fmt::Display for PrepareError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         use PrepareError::*;
         match self {
             Serialization => write!(f, "Error happened while serializing the module."),
@@ -192,7 +192,7 @@ impl fmt::Display for PrepareError {
 }
 
 impl fmt::Display for FunctionCallError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             FunctionCallError::CompilationError(e) => e.fmt(f),
             FunctionCallError::MethodResolveError(e) => e.fmt(f),
@@ -204,7 +204,7 @@ impl fmt::Display for FunctionCallError {
 }
 
 impl fmt::Display for CompilationError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             CompilationError::CodeDoesNotExist { account_id } => {
                 write!(f, "cannot find contract code for account {}", account_id)
@@ -218,13 +218,13 @@ impl fmt::Display for CompilationError {
 }
 
 impl fmt::Display for MethodResolveError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         fmt::Debug::fmt(self, f)
     }
 }
 
 impl fmt::Display for VMError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
             VMError::FunctionCallError(err) => fmt::Display::fmt(err, f),
             VMError::ExternalError(_err) => write!(f, "Serialized ExternalError"),
@@ -234,7 +234,7 @@ impl fmt::Display for VMError {
 }
 
 impl std::fmt::Display for InconsistentStateError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         match self {
             InconsistentStateError::IntegerOverflow => write!(
                 f,
@@ -245,7 +245,7 @@ impl std::fmt::Display for InconsistentStateError {
 }
 
 impl std::fmt::Display for HostError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         use HostError::*;
         match self {
             BadUTF8 => write!(f, "String encoding is bad UTF-8 sequence."),

--- a/runtime/near-vm-logic/src/serde_with.rs
+++ b/runtime/near-vm-logic/src/serde_with.rs
@@ -82,7 +82,7 @@ pub mod vec_bytes_as_str {
     impl<'de> Visitor<'de> for VecBytesVisitor {
         type Value = Vec<Vec<u8>>;
 
-        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
             formatter.write_str("an array with string in the first element")
         }
 

--- a/runtime/near-vm-logic/tests/helpers.rs
+++ b/runtime/near-vm-logic/tests/helpers.rs
@@ -8,7 +8,7 @@ type Result<T> = ::std::result::Result<T, VMLogicError>;
 
 #[allow(dead_code)]
 pub fn promise_create(
-    logic: &mut VMLogic,
+    logic: &mut VMLogic<'_>,
     account_id: &[u8],
     amount: u128,
     gas: Gas,
@@ -29,7 +29,7 @@ pub fn promise_create(
 
 #[allow(dead_code)]
 pub fn promise_batch_action_function_call(
-    logic: &mut VMLogic,
+    logic: &mut VMLogic<'_>,
     promise_index: u64,
     amount: u128,
     gas: Gas,
@@ -50,7 +50,7 @@ pub fn promise_batch_action_function_call(
 
 #[allow(dead_code)]
 pub fn promise_batch_action_add_key_with_function_call(
-    logic: &mut VMLogic,
+    logic: &mut VMLogic<'_>,
     promise_index: u64,
     public_key: &[u8],
     nonce: u64,

--- a/runtime/near-vm-logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-logic/tests/vm_logic_builder.rs
@@ -27,7 +27,7 @@ impl Default for VMLogicBuilder {
 }
 
 impl VMLogicBuilder {
-    pub fn build(&mut self, context: VMContext) -> VMLogic {
+    pub fn build(&mut self, context: VMContext) -> VMLogic<'_> {
         VMLogic::new(
             &mut self.ext,
             context,

--- a/runtime/near-vm-runner/src/imports.rs
+++ b/runtime/near-vm-runner/src/imports.rs
@@ -14,12 +14,12 @@ macro_rules! wrapped_imports {
             $(
                 #[allow(unused_parens)]
                 fn $func( ctx: &mut Ctx, $( $arg_name: $arg_type ),* ) -> Result<($( $returns ),*)> {
-                    let logic: &mut VMLogic = unsafe { &mut *(ctx.data as *mut VMLogic) };
+                    let logic: &mut VMLogic<'_> = unsafe { &mut *(ctx.data as *mut VMLogic<'_>) };
                     logic.$func( $( $arg_name, )* )
                 }
             )*
 
-            pub(crate) fn build(memory: Memory, logic: &mut VMLogic) -> ImportObject {
+            pub(crate) fn build(memory: Memory, logic: &mut VMLogic<'_>) -> ImportObject {
                 let raw_ptr = logic as *mut _ as *mut c_void;
                 let import_reference = ImportReference(raw_ptr);
                 imports! {

--- a/runtime/runtime-params-estimator/src/ext_costs_generator.rs
+++ b/runtime/runtime-params-estimator/src/ext_costs_generator.rs
@@ -172,7 +172,7 @@ impl ExtCostsGenerator {
     }
 }
 impl std::fmt::Display for ExtCostsGenerator {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in &self.agg {
             writeln!(f, "{:?}\t\t\t\t{}", k, v)?;
         }

--- a/runtime/runtime-params-estimator/src/runtime_fees_generator.rs
+++ b/runtime/runtime-params-estimator/src/runtime_fees_generator.rs
@@ -119,7 +119,7 @@ impl RuntimeFeesGenerator {
 }
 
 impl std::fmt::Display for RuntimeFeesGenerator {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for (k, v) in self.compute() {
             writeln!(f, "{:?}\t\t\t\t{}", k, v)?;
         }

--- a/runtime/runtime-params-estimator/src/stats.rs
+++ b/runtime/runtime-params-estimator/src/stats.rs
@@ -185,7 +185,7 @@ impl DataStats {
 }
 
 impl std::fmt::Display for DataStats {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.mean.as_secs() > 100 {
             write!(
                 f,

--- a/test-utils/loadtester/src/main.rs
+++ b/test-utils/loadtester/src/main.rs
@@ -167,7 +167,7 @@ fn main() {
 
 pub const CONFIG_FILENAME: &str = "config.json";
 
-fn create_genesis(matches: &clap::ArgMatches) {
+fn create_genesis(matches: &clap::ArgMatches<'_>) {
     let n = value_t_or_exit!(matches, "accounts", u64) as u64;
     let v = value_t_or_exit!(matches, "validators", u64) as NumSeats;
     let s = value_t_or_exit!(matches, "shards", u64) as NumShards;
@@ -191,7 +191,7 @@ fn create_genesis(matches: &clap::ArgMatches) {
     }
 }
 
-fn load_state_dump(matches: &clap::ArgMatches) {
+fn load_state_dump(matches: &clap::ArgMatches<'_>) {
     let dir_buf = value_t_or_exit!(matches, "home", PathBuf);
     let state_dump_path = value_t_or_exit!(matches, "state_dump", PathBuf);
     let dir = dir_buf.as_path();
@@ -200,7 +200,7 @@ fn load_state_dump(matches: &clap::ArgMatches) {
     store.load_from_file(ColState, state_dump).expect("Failed to read state dump");
 }
 
-fn run(matches: &clap::ArgMatches) {
+fn run(matches: &clap::ArgMatches<'_>) {
     let n = value_t_or_exit!(matches, "accounts", u64);
     let prefix = value_t_or_exit!(matches, "prefix", String);
     let massive_accounts = matches.is_present("massive_accounts");

--- a/test-utils/loadtester/src/stats.rs
+++ b/test-utils/loadtester/src/stats.rs
@@ -20,7 +20,7 @@ pub struct Stats {
 }
 
 impl std::fmt::Display for Stats {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
         let from_height = self.from_height.unwrap();
         let to_height = self.to_height.unwrap();
         let blocks_passed = to_height - from_height + 1;

--- a/tools/rpctypegen/core/src/lib.rs
+++ b/tools/rpctypegen/core/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate proc_macro;
-extern crate proc_macro2;
-
 use std::collections::BTreeMap;
 use syn::{Data, DataEnum, DataStruct, DeriveInput, Fields, FieldsNamed, FieldsUnnamed};
 
@@ -27,7 +24,7 @@ fn error_type_name<'a>(
     name: String,
 ) -> &'a mut ErrorType {
     let error_type = ErrorType { name: name.clone(), ..Default::default() };
-    schema.entry(name.clone()).or_insert(error_type)
+    schema.entry(name).or_insert(error_type)
 }
 
 pub fn parse_error_type(schema: &mut BTreeMap<String, ErrorType>, input: &DeriveInput) {

--- a/tools/rpctypegen/macro/src/lib.rs
+++ b/tools/rpctypegen/macro/src/lib.rs
@@ -1,6 +1,3 @@
-extern crate proc_macro;
-extern crate proc_macro2;
-
 use near_rpc_error_core::{parse_error_type, ErrorType};
 use proc_macro::TokenStream;
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
It is mostly a result of:

```
cargo fix --workspace --all-features --allow-dirty --edition-idioms
```

In the absolute numbers, most of the changes are around explicit usage of an unnamed lifetime. I have no preference here. Should we use it or not?

The rest are unnecessary clones and unnecessary `extern crate`.