### PR TITLE
fix: gc test

### DIFF
--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -851,7 +851,8 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
         blocks.push(block);
     }
     for i in 1..=epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
-        if i <= epoch_length {
+        println!("height = {}", i);
+        if i < epoch_length {
             assert!(env.clients[0].chain.get_block(&blocks[i as usize - 1].hash()).is_err());
             assert!(env.clients[0]
                 .chain
@@ -870,8 +871,6 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
 }
 
 #[test]
-#[ignore]
-// TODO FIXME #2368
 fn test_gc_with_epoch_length() {
     for i in 2..20 {
         test_gc_with_epoch_length_common(i);

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -116,12 +116,12 @@ expensive nearcore test_cases_testnet_rpc test::test_delete_access_key_with_allo
 # expensive nearcore test_cases_testnet_rpc test::test_access_key_smart_contract_testnet
 
 # GC tests
-expensive near-chain gc tests::test_gc_remove_fork_large
-expensive near-chain gc tests::test_gc_not_remove_fork_large
-expensive near-chain gc tests::test_gc_boundaries_large
-expensive near-chain gc tests::test_gc_random_large
-expensive near-chain gc tests::test_gc_pine
-expensive near-chain gc tests::test_gc_star_large
+expensive --timeout=600 near-chain gc tests::test_gc_remove_fork_large
+expensive --timeout=600 near-chain gc tests::test_gc_not_remove_fork_large
+expensive --timeout=600 near-chain gc tests::test_gc_boundaries_large
+expensive --timeout=600 near-chain gc tests::test_gc_random_large
+expensive --timeout=600 near-chain gc tests::test_gc_pine
+expensive --timeout=600 near-chain gc tests::test_gc_star_large
 
 # other tests
 expensive nearcore test_simple test::test_2_10_multiple_nodes


### PR DESCRIPTION
Fixes `test_gc_with_epoch_length`. It failed because now `clear_block_data` clears the data on the previous block if the block is on the canonical chain. Also increases timeout on nightly gc tests. Resolves #2368.

Test plan
---------
Make sure that `test_gc_with_epoch_length` passes.