### PR TITLE
fix(script): avoid buildkite manual build use HEAD as version

### DIFF
--- a/scripts/binary-release.sh
+++ b/scripts/binary-release.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 branch=${BUILDKITE_BRANCH:-${GITHUB_REF##*/}}
 commit=${BUILDKITE_COMMIT:-${GITHUB_SHA}}
+if [[ ${commit} == "HEAD" ]]; then
+    commit=$(git rev-parse HEAD)
+fi
 os=$(uname)
 
 make release

--- a/scripts/docker-release.sh
+++ b/scripts/docker-release.sh
@@ -3,6 +3,9 @@ set -euo pipefail
 
 branch=${BUILDKITE_BRANCH}
 commit=${BUILDKITE_COMMIT}
+if [[ ${commit} == "HEAD" ]]; then
+    commit=$(git rev-parse HEAD)
+fi
 
 make
 # Here we don't check master, beta and stable criteria, they have to be checked in buildkite pipeline


### PR DESCRIPTION
buildkite use HEAD as commit when trigger a manual build on ui. This isn't a problem for most task but is problematic for binary and docker release. This one tag docker image and name binary to HEAD:  https://buildkite.com/nearprotocol/nearcore/builds/596#35b319ac-a0e9-45e5-816a-24263ee11388 

Test Plan
------------
Locally set BUILDKITE_BRANCH, set BUILDKITE_COMMIT to HEAD and echo