### PR TITLE
fix: test_sync_from_achival_node

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -628,18 +628,10 @@ impl Chain {
                     _ => continue,
                 };
             if let Some(block_hash) = blocks_current_height.first() {
-                if blocks_current_height.len() > 1 {
-                    // Fork is here
-                    break;
-                }
                 let prev_hash = chain_store_update.get_block_header(block_hash)?.prev_hash;
-                if *chain_store_update.get_block_refcount(&prev_hash)? != 1 {
-                    return Err(ErrorKind::GCError(format!(
-                        "invalid refcount for {:?}, expected 1, found {:?}",
-                        block_hash,
-                        chain_store_update.get_block_refcount(&prev_hash).unwrap()
-                    ))
-                    .into());
+                // break when there is a fork
+                if *chain_store_update.get_block_refcount(&prev_hash)? > 1 {
+                    break;
                 }
                 chain_store_update.clear_block_data(trie.clone(), *block_hash, false)?;
             }

--- a/chain/client/tests/bug_repros.rs
+++ b/chain/client/tests/bug_repros.rs
@@ -133,8 +133,6 @@ fn repro_1183() {
 }
 
 #[test]
-#[ignore]
-// TODO FIXME #2366
 fn test_sync_from_achival_node() {
     init_test_logger();
     let validators = vec![vec!["test1", "test2", "test3", "test4"]];


### PR DESCRIPTION
When we clear block data in gc the way to tell whether there is a fork is wrong. We should look at block refcount instead of whether there are multiple blocks at a height, since there can be a fork with heads on different heights. However, this doesn't fix the deeper issue #2386. Resolves #2366.

Test plan
---------
`test_sync_from_achival_node` passes 