### PR TITLE
fix(gc): increased tests timeout

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -117,7 +117,7 @@ expensive nearcore test_cases_testnet_rpc test::test_delete_access_key_with_allo
 
 # GC tests
 expensive --timeout=600 near-chain gc tests::test_gc_remove_fork_large
-expensive --timeout=600 near-chain gc tests::test_gc_not_remove_fork_large
+expensive --timeout=1200 near-chain gc tests::test_gc_not_remove_fork_large
 expensive --timeout=600 near-chain gc tests::test_gc_boundaries_large
 expensive --timeout=600 near-chain gc tests::test_gc_random_large
 expensive --timeout=600 near-chain gc tests::test_gc_pine


### PR DESCRIPTION
`test_gc_not_remove_fork_large` needs more time to execute