### PR TITLE
fix(script): nightly after near->neard

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -79,7 +79,7 @@ expensive --timeout=2400 near-epoch-manager finality tests::test_fuzzy_safety
 expensive --timeout=1200 near-epoch-manager finality tests::test_fuzzy_light_client
 
 # state sync tests
-expensive near sync_state_nodes sync_state_nodes_multishard
+expensive neard sync_state_nodes sync_state_nodes_multishard
 
 # testnet rpc
 expensive nearcore test_tps_regression test::test_highload


### PR DESCRIPTION
Fix nightly after near->neard. Also a little rename happens in https://github.com/nearprotocol/nightly/commit/8e3640d8dc0aa851529c525d1e83cfb0381992c6

Test Plan
------------
Simulate nightly runner test run pytest locally