### PR TITLE
fix(script): nightly test

### DIFF
--- a/pytest/empty-contract-rs/Cargo.toml
+++ b/pytest/empty-contract-rs/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-near-bindgen = { git = "https://github.com/nearprotocol/near-bindgen", branch = "master"}
+near-sdk = { git = "https://github.com/near/near-sdk-rs", branch = "master"}
 borsh = "0.6.1"
 wee_alloc = "0.4.5"
 

--- a/pytest/empty-contract-rs/src/lib.rs
+++ b/pytest/empty-contract-rs/src/lib.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use near_bindgen::{env, metadata, near_bindgen};
+use near_sdk::{env, metadata, near_bindgen};
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -70,7 +70,7 @@ class Key(object):
 
 
 class BaseNode(object):
-    def _get_command_line(self, near_root, node_dir, boot_key, boot_node_addr, binary_name='near'):
+    def _get_command_line(self, near_root, node_dir, boot_key, boot_node_addr, binary_name='neard'):
         if boot_key is None:
             assert boot_node_addr is None
             return [os.path.join(near_root, binary_name), "--verbose", "", "--home", node_dir, "run"]
@@ -186,7 +186,7 @@ class RpcNode(BaseNode):
 
 
 class LocalNode(BaseNode):
-    def __init__(self, port, rpc_port, near_root, node_dir, blacklist, binary_name='near'):
+    def __init__(self, port, rpc_port, near_root, node_dir, blacklist, binary_name='neard'):
         super(LocalNode, self).__init__()
         self.port = port
         self.rpc_port = rpc_port
@@ -528,7 +528,7 @@ def start_cluster(num_nodes, num_observers, num_shards, config, genesis_config_c
     return ret
 
 
-DEFAULT_CONFIG = {'local': True, 'near_root': '../target/debug/', 'binary_name': 'near'}
+DEFAULT_CONFIG = {'local': True, 'near_root': '../target/debug/', 'binary_name': 'neard'}
 CONFIG_ENV_VAR = 'NEAR_PYTEST_CONFIG'
 
 

--- a/pytest/tests/contracts/deploy_call_smart_contract.py
+++ b/pytest/tests/contracts/deploy_call_smart_contract.py
@@ -51,6 +51,6 @@ time.sleep(3)
 status4 = nodes[3].get_status()
 hash_4 = status4['sync_info']['latest_block_hash']
 hash_4 = base58.b58decode(hash_4.encode('utf8'))
-tx4 = sign_function_call_tx(nodes[2].signer_key, nodes[2].signer_key.account_id, 'log_world', [], 100000000000, 100000000000, 20, hash_4)
+tx4 = sign_function_call_tx(nodes[2].signer_key, nodes[2].signer_key.account_id, 'log_world', [], 100000000000, 0, 20, hash_4)
 res = nodes[3].send_tx_and_wait(tx4, 10)
 assert res['result']['receipts_outcome'][0]['outcome']['logs'][0] == 'world'

--- a/pytest/tests/sanity/state_sync2.py
+++ b/pytest/tests/sanity/state_sync2.py
@@ -4,16 +4,22 @@
 # and sync
 
 import sys, time
+import fcntl
 
 sys.path.append('lib')
 
 from cluster import start_cluster
 from utils import LogTracker
 
+fcntl.fcntl(1, fcntl.F_SETFL, 0) # no cache when execute from nightly runner
+
+print('start state sync2')
+print('start state sync2', file=sys.stderr)
 TIMEOUT = 600
 BLOCKS = 105 # should be enough to trigger state sync for node 1 later, see comments there
 
 nodes = start_cluster(2, 0, 2, None, [["num_block_producer_seats", 199], ["num_block_producer_seats_per_shard", [24, 25, 25, 25, 25, 25, 25, 25]], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
+print('cluster started')
 
 started = time.time()
 


### PR DESCRIPTION
https://nightly.neartest.com/run/c1ba86d68438f22d25235ba66e2254439d55e9c4_200406_171929/expensive/expensive_near_sync_state_nodes_sync_state_nodes_multishard/stderr
: fixed in #2401 
https://nightly.neartest.com/run/c1ba86d68438f22d25235ba66e2254439d55e9c4_200406_171929/pytest/pytest_contracts_deploy_call_smart_contract_py/stderr: fixed here
0 stdout and 0 stderr of state_sync2: Possibly fixed using the same trick used the parallel_run_test.py. Also If still no output, added print to ensure it's stdout cached instead of there's really no output

Test Plan
------------
deploy_call_smart_contract passed locally