### PR TITLE
refactor(core): Fixed potentially dangerous implementation of parse_account_id_from_access_key_key

### DIFF
--- a/core/primitives/src/trie_key.rs
+++ b/core/primitives/src/trie_key.rs
@@ -261,8 +261,13 @@ pub mod trie_key_parsers {
         raw_key: &[u8],
     ) -> Result<AccountId, std::io::Error> {
         let account_id_prefix = parse_account_id_prefix(col::ACCESS_KEY, raw_key)?;
-        let public_key_position = if let Some(index) =
-            account_id_prefix.iter().enumerate().find(|(_, c)| **c == 2).map(|(index, _)| index)
+        // To simplify things, we assume that the data separator is a single byte.
+        debug_assert_eq!(col::ACCESS_KEY.len(), 1);
+        let public_key_position = if let Some(index) = account_id_prefix
+            .iter()
+            .enumerate()
+            .find(|(_, c)| **c == col::ACCESS_KEY[0])
+            .map(|(index, _)| index)
         {
             index
         } else {


### PR DESCRIPTION
*Resolves #2408*

I realized that I missed the fact that there is indeed a separator `col::ACCESS_KEY`, so the storage key is, essentially, constructed as `col::ACCESS_KEY + account_id + col::ACCESS_KEY + serialized_public_key`! I missed the fact that it is a constant there, which can be used instead of the magical `2`!

## Test Plan

No tests are needed, the magical `2` was the correct const.