### PR TITLE
fix: tail should be updated when there are skips

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -644,8 +644,6 @@ impl Chain {
                 }
                 debug_assert_eq!(blocks_current_height.len(), 1);
                 chain_store_update.clear_block_data(trie.clone(), *block_hash, false)?;
-            } else {
-                debug_assert!(false, "all block hashes should not be empty")
             }
             chain_store_update.update_tail(height);
         }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -625,7 +625,10 @@ impl Chain {
                     Ok(blocks_current_height) => {
                         blocks_current_height.values().flatten().cloned().collect()
                     }
-                    _ => continue,
+                    _ => {
+                        chain_store_update.update_tail(height);
+                        continue;
+                    }
                 };
             if let Some(block_hash) = blocks_current_height.first() {
                 let prev_hash = chain_store_update.get_block_header(block_hash)?.prev_hash;
@@ -641,6 +644,8 @@ impl Chain {
                 }
                 debug_assert_eq!(blocks_current_height.len(), 1);
                 chain_store_update.clear_block_data(trie.clone(), *block_hash, false)?;
+            } else {
+                debug_assert!(false, "all block hashes should not be empty")
             }
             chain_store_update.update_tail(height);
         }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -620,30 +620,26 @@ impl Chain {
 
         // Canonical Chain Clearing
         for height in tail + 1..gc_stop_height {
-            let blocks_current_height: Vec<CryptoHash> =
-                match chain_store_update.get_all_block_hashes_by_height(height) {
-                    Ok(blocks_current_height) => {
-                        blocks_current_height.values().flatten().cloned().collect()
+            if let Ok(blocks_current_height) =
+                chain_store_update.get_all_block_hashes_by_height(height)
+            {
+                let blocks_current_height =
+                    blocks_current_height.values().flatten().cloned().collect::<Vec<_>>();
+                if let Some(block_hash) = blocks_current_height.first() {
+                    let prev_hash = chain_store_update.get_block_header(block_hash)?.prev_hash;
+                    let prev_block_refcount = *chain_store_update.get_block_refcount(&prev_hash)?;
+                    // break when there is a fork
+                    if prev_block_refcount > 1 {
+                        break;
+                    } else if prev_block_refcount == 0 {
+                        return Err(ErrorKind::GCError(
+                            "block on canonical chain shouldn't have refcount 0".into(),
+                        )
+                        .into());
                     }
-                    _ => {
-                        chain_store_update.update_tail(height);
-                        continue;
-                    }
-                };
-            if let Some(block_hash) = blocks_current_height.first() {
-                let prev_hash = chain_store_update.get_block_header(block_hash)?.prev_hash;
-                let prev_block_refcount = *chain_store_update.get_block_refcount(&prev_hash)?;
-                // break when there is a fork
-                if prev_block_refcount > 1 {
-                    break;
-                } else if prev_block_refcount == 0 {
-                    return Err(ErrorKind::GCError(
-                        "block on canonical chain shouldn't have refcount 0".into(),
-                    )
-                    .into());
+                    debug_assert_eq!(blocks_current_height.len(), 1);
+                    chain_store_update.clear_block_data(trie.clone(), *block_hash, false)?;
                 }
-                debug_assert_eq!(blocks_current_height.len(), 1);
-                chain_store_update.clear_block_data(trie.clone(), *block_hash, false)?;
             }
             chain_store_update.update_tail(height);
         }

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -1013,3 +1013,46 @@ fn test_not_resync_old_blocks() {
         assert_eq!(env.clients[0].chain.orphans_len(), 0);
     }
 }
+
+#[test]
+fn test_gc_tail_update() {
+    let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
+    let epoch_length = 2;
+    genesis.config.epoch_length = epoch_length;
+    let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![
+        Arc::new(neard::NightshadeRuntime::new(
+            Path::new("."),
+            create_test_store(),
+            Arc::new(genesis.clone()),
+            vec![],
+            vec![],
+        )),
+        Arc::new(neard::NightshadeRuntime::new(
+            Path::new("."),
+            create_test_store(),
+            Arc::new(genesis),
+            vec![],
+            vec![],
+        )),
+    ];
+    let mut chain_genesis = ChainGenesis::test();
+    chain_genesis.epoch_length = epoch_length;
+    let mut env = TestEnv::new_with_runtime(chain_genesis, 2, 1, runtimes);
+    let mut blocks = vec![];
+    for i in 1..=epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+        let block = env.clients[0].produce_block(i).unwrap().unwrap();
+        env.process_block(0, block.clone(), Provenance::PRODUCED);
+        blocks.push(block);
+    }
+    let headers = blocks.clone().into_iter().map(|b| b.header).collect::<Vec<_>>();
+    env.clients[1].sync_block_headers(headers).unwrap();
+    // simulate save sync hash block
+    let sync_block = blocks[blocks.len() - 2].clone();
+    env.clients[1].chain.save_block(&sync_block).unwrap();
+    env.clients[1]
+        .chain
+        .reset_heads_post_state_sync(&None, sync_block.hash(), |_| {}, |_| {}, |_| {})
+        .unwrap();
+    env.process_block(1, blocks.pop().unwrap(), Provenance::NONE);
+    assert_eq!(env.clients[1].chain.store().tail().unwrap(), epoch_length);
+}


### PR DESCRIPTION
Currently in `clear_data`, if there is no blocks between tail and gc_stop_height, we would just run through the entire loop without updating tail, which leads to gc getting stuck. This PR fixes it by updating the tail even when there is no block at some height. Notice that this means that tail height doesn't necessarily imply the existence of a block at that height, but given that we only use it for gc purposes, I think it is fine.

Test plan
---------
`test_gc_tail_update` passes.