### PR TITLE
fix(network): Fix issue on handshake.

### DIFF
--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -520,10 +520,13 @@ impl Actor for Peer {
         near_metrics::dec_gauge(&metrics::PEER_CONNECTIONS_TOTAL);
         debug!(target: "network", "{:?}: Peer {} disconnected.", self.node_info.id, self.peer_info);
         if let Some(peer_info) = self.peer_info.as_ref() {
-            if self.peer_status == PeerStatus::Ready {
-                self.peer_manager_addr.do_send(Unregister { peer_id: peer_info.id.clone() })
-            } else if let PeerStatus::Banned(ban_reason) = self.peer_status {
+            if let PeerStatus::Banned(ban_reason) = self.peer_status {
                 self.peer_manager_addr.do_send(Ban { peer_id: peer_info.id.clone(), ban_reason });
+            } else {
+                self.peer_manager_addr.do_send(Unregister {
+                    peer_id: peer_info.id.clone(),
+                    peer_type: self.peer_type,
+                })
             }
         }
         Running::Stop

--- a/chain/network/src/peer_store.rs
+++ b/chain/network/src/peer_store.rs
@@ -143,8 +143,6 @@ impl PeerStore {
 
     /// Return healthy known peers up to given amount.
     pub fn healthy_peers(&self, max_count: u32) -> Vec<PeerInfo> {
-        // TODO: better healthy peer definition here.
-        //  Discussion: wdyt about using reachable peers in the current routing table?
         self.find_peers(
             |p| match p.status {
                 KnownPeerStatus::Banned(_, _) => false,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -864,6 +864,7 @@ pub enum ConsolidateResponse {
 #[rtype(result = "()")]
 pub struct Unregister {
     pub peer_id: PeerId,
+    pub peer_type: PeerType,
 }
 
 pub struct PeerList {

--- a/chain/network/tests/churn_attack.rs
+++ b/chain/network/tests/churn_attack.rs
@@ -1,6 +1,4 @@
-use actix::System;
-
-pub use runner::{Action, Runner};
+pub use runner::*;
 
 mod runner;
 
@@ -10,23 +8,18 @@ mod runner;
 /// a connection among them.
 #[test]
 fn churn_attack() {
-    System::run(|| {
-        let mut runner = Runner::new(4, 4).enable_outbound().max_peer(2);
+    let mut runner = Runner::new(4, 4).enable_outbound().max_peer(2);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(2, 3));
-        runner.push(Action::AddEdge(3, 0));
-        runner.push(Action::AddEdge(1, 2));
-        runner
-            .push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (3, vec![3]), (2, vec![1, 3])]));
-        runner
-            .push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (3, vec![3]), (0, vec![1, 3])]));
-        runner.push(Action::Stop(1));
-        runner.push(Action::Stop(3));
-        runner.push(Action::CheckRoutingTable(0, vec![(2, vec![2])]));
-        runner.push(Action::CheckRoutingTable(2, vec![(0, vec![0])]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(2, 3));
+    runner.push(Action::AddEdge(3, 0));
+    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (3, vec![3]), (2, vec![1, 3])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (3, vec![3]), (0, vec![1, 3])]));
+    runner.push(Action::Stop(1));
+    runner.push(Action::Stop(3));
+    runner.push(Action::CheckRoutingTable(0, vec![(2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(0, vec![0])]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }

--- a/chain/network/tests/full_network.rs
+++ b/chain/network/tests/full_network.rs
@@ -1,0 +1,73 @@
+pub use runner::*;
+use std::cmp::min;
+
+mod runner;
+
+/// Check that a node is able to connect to the network, even if the number
+/// of active peers of every node is high.
+///
+/// Spawn a network with `num_node` nodes and with top connections allowed
+/// for every peer `max_peers`. Wait until every peer has `expected_connections`
+/// active peers and start new node. Wait until new node is connected.
+pub fn connect_at_max_capacity(
+    num_node: usize,
+    max_peers: u32,
+    expected_connections: usize,
+    extra_nodes: usize,
+) {
+    // Use at most 4 boot nodes
+    let total_boot_nodes = min(num_node, 4);
+
+    let boot_nodes = (0..total_boot_nodes).collect::<Vec<_>>();
+
+    let mut runner = Runner::new(num_node + extra_nodes, num_node)
+        .enable_outbound()
+        .max_peer(max_peers)
+        .use_boot_nodes(boot_nodes);
+
+    let total_nodes = num_node + extra_nodes;
+
+    // Stop all extra nodes
+    for node_id in num_node..total_nodes {
+        runner.push(Action::Stop(node_id));
+    }
+
+    // Wait until all running nodes have expected connections
+    for node_id in 0..num_node {
+        runner.push_action(check_expected_connections(node_id, expected_connections));
+    }
+
+    // Restart stopped nodes
+    for node_id in num_node..total_nodes {
+        runner.push_action(restart(node_id));
+    }
+
+    // Wait until all nodes have expected connections
+    for node_id in 0..total_nodes {
+        runner.push_action(check_expected_connections(node_id, expected_connections));
+    }
+
+    start_test(runner);
+}
+
+/// Check that two nodes are able to connect if they only know themselves from boot list.
+#[test]
+fn simple_network() {
+    connect_at_max_capacity(2, 1, 1, 0);
+}
+
+/// Start 4 nodes and connect them all with each other.
+/// Create new node, it should be able to connect since max allowed peers is 4.
+#[test]
+fn connect_on_almost_full_network() {
+    connect_at_max_capacity(4, 4, 1, 1);
+}
+
+/// Start 4 nodes and connect them all with each other.
+/// Create new node, it should be able to connect even if max allowed peers is 3.
+/// TODO: Fix it.
+#[test]
+#[ignore]
+fn connect_on_full_network() {
+    connect_at_max_capacity(4, 3, 1, 1);
+}

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -1,145 +1,115 @@
-use actix::System;
-
-pub use runner::{Action, Runner};
+pub use runner::*;
 
 mod runner;
 
 #[test]
 fn simple() {
-    System::run(|| {
-        let mut runner = Runner::new(2, 1);
+    let mut runner = Runner::new(2, 1);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
-        runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn from_boot_nodes() {
-    System::run(|| {
-        let mut runner = Runner::new(2, 1).use_boot_nodes(vec![0]).enable_outbound();
+    let mut runner = Runner::new(2, 1).use_boot_nodes(vec![0]).enable_outbound();
 
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
-        runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn three_nodes_path() {
-    System::run(|| {
-        let mut runner = Runner::new(3, 2);
+    let mut runner = Runner::new(3, 2);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(1, 2));
-        runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
-        runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn three_nodes_star() {
-    System::run(|| {
-        let mut runner = Runner::new(3, 2);
+    let mut runner = Runner::new(3, 2);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(1, 2));
-        runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
-        runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
-        runner.push(Action::AddEdge(0, 2));
-        runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
-        runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
+    runner.push(Action::AddEdge(0, 2));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn join_components() {
-    System::run(|| {
-        let mut runner = Runner::new(4, 4);
+    let mut runner = Runner::new(4, 4);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(2, 3));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
-        runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
-        runner.push(Action::CheckRoutingTable(2, vec![(3, vec![3])]));
-        runner.push(Action::CheckRoutingTable(3, vec![(2, vec![2])]));
-        runner.push(Action::AddEdge(0, 2));
-        runner.push(Action::AddEdge(3, 1));
-        runner
-            .push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2]), (3, vec![1, 2])]));
-        runner
-            .push(Action::CheckRoutingTable(3, vec![(1, vec![1]), (2, vec![2]), (0, vec![1, 2])]));
-        runner
-            .push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (3, vec![3]), (2, vec![0, 3])]));
-        runner
-            .push(Action::CheckRoutingTable(2, vec![(0, vec![0]), (3, vec![3]), (1, vec![0, 3])]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(2, 3));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(3, vec![3])]));
+    runner.push(Action::CheckRoutingTable(3, vec![(2, vec![2])]));
+    runner.push(Action::AddEdge(0, 2));
+    runner.push(Action::AddEdge(3, 1));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2]), (3, vec![1, 2])]));
+    runner.push(Action::CheckRoutingTable(3, vec![(1, vec![1]), (2, vec![2]), (0, vec![1, 2])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (3, vec![3]), (2, vec![0, 3])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(0, vec![0]), (3, vec![3]), (1, vec![0, 3])]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn account_propagation() {
-    System::run(|| {
-        let mut runner = Runner::new(3, 2);
+    let mut runner = Runner::new(3, 2);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::CheckAccountId(1, vec![0, 1]));
-        runner.push(Action::AddEdge(0, 2));
-        runner.push(Action::CheckAccountId(2, vec![0, 1]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::CheckAccountId(1, vec![0, 1]));
+    runner.push(Action::AddEdge(0, 2));
+    runner.push(Action::CheckAccountId(2, vec![0, 1]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn ping_simple() {
-    System::run(|| {
-        let mut runner = Runner::new(2, 2);
+    let mut runner = Runner::new(2, 2);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
-        runner.push(Action::PingTo(0, 0, 1));
-        runner.push(Action::CheckPingPong(1, vec![(0, 0)], vec![]));
-        runner.push(Action::CheckPingPong(0, vec![], vec![(0, 1)]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
+    runner.push(Action::PingTo(0, 0, 1));
+    runner.push(Action::CheckPingPong(1, vec![(0, 0)], vec![]));
+    runner.push(Action::CheckPingPong(0, vec![], vec![(0, 1)]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn ping_jump() {
-    System::run(|| {
-        let mut runner = Runner::new(3, 2);
+    let mut runner = Runner::new(3, 2);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(1, 2));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
-        runner.push(Action::PingTo(0, 0, 2));
-        runner.push(Action::CheckPingPong(2, vec![(0, 0)], vec![]));
-        runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2)]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
+    runner.push(Action::PingTo(0, 0, 2));
+    runner.push(Action::CheckPingPong(2, vec![(0, 0)], vec![]));
+    runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2)]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 /// Test routed messages are not dropped if have enough TTL.
@@ -152,19 +122,16 @@ fn ping_jump() {
 /// Check Ping arrive at node 2 and later Pong arrive at node 0.
 #[test]
 fn test_dont_drop_after_ttl() {
-    System::run(|| {
-        let mut runner = Runner::new(3, 1).routed_message_ttl(2);
+    let mut runner = Runner::new(3, 1).routed_message_ttl(2);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(1, 2));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
-        runner.push(Action::PingTo(0, 0, 2));
-        runner.push(Action::CheckPingPong(2, vec![(0, 0)], vec![]));
-        runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2)]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
+    runner.push(Action::PingTo(0, 0, 2));
+    runner.push(Action::CheckPingPong(2, vec![(0, 0)], vec![]));
+    runner.push(Action::CheckPingPong(0, vec![], vec![(0, 2)]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 /// Test routed messages are dropped if don't have enough TTL.
@@ -177,122 +144,101 @@ fn test_dont_drop_after_ttl() {
 /// Check none of Ping and Pong arrived.
 #[test]
 fn test_drop_after_ttl() {
-    System::run(|| {
-        let mut runner = Runner::new(3, 1).routed_message_ttl(1);
+    let mut runner = Runner::new(3, 1).routed_message_ttl(1);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(1, 2));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
-        runner.push(Action::PingTo(0, 0, 2));
-        runner.push(Action::Wait(100));
-        runner.push(Action::CheckPingPong(2, vec![], vec![]));
-        runner.push(Action::CheckPingPong(0, vec![], vec![]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
+    runner.push(Action::PingTo(0, 0, 2));
+    runner.push(Action::Wait(100));
+    runner.push(Action::CheckPingPong(2, vec![], vec![]));
+    runner.push(Action::CheckPingPong(0, vec![], vec![]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn simple_remove() {
-    System::run(|| {
-        let mut runner = Runner::new(3, 3);
+    let mut runner = Runner::new(3, 3);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(1, 2));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
-        runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
-        runner.push(Action::Stop(1));
-        runner.push(Action::CheckRoutingTable(0, vec![]));
-        runner.push(Action::CheckRoutingTable(2, vec![]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![1])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![1])]));
+    runner.push(Action::Stop(1));
+    runner.push(Action::CheckRoutingTable(0, vec![]));
+    runner.push(Action::CheckRoutingTable(2, vec![]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn square() {
-    System::run(|| {
-        let mut runner = Runner::new(4, 4);
+    let mut runner = Runner::new(4, 4);
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(1, 2));
-        runner.push(Action::AddEdge(2, 3));
-        runner.push(Action::AddEdge(3, 0));
-        runner
-            .push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (3, vec![3]), (2, vec![1, 3])]));
-        runner.push(Action::Stop(1));
-        runner.push(Action::CheckRoutingTable(0, vec![(3, vec![3]), (2, vec![3])]));
-        runner.push(Action::CheckRoutingTable(2, vec![(3, vec![3]), (0, vec![3])]));
-        runner.push(Action::CheckRoutingTable(3, vec![(2, vec![2]), (0, vec![0])]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::AddEdge(2, 3));
+    runner.push(Action::AddEdge(3, 0));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (3, vec![3]), (2, vec![1, 3])]));
+    runner.push(Action::Stop(1));
+    runner.push(Action::CheckRoutingTable(0, vec![(3, vec![3]), (2, vec![3])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(3, vec![3]), (0, vec![3])]));
+    runner.push(Action::CheckRoutingTable(3, vec![(2, vec![2]), (0, vec![0])]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn blacklist_01() {
-    System::run(|| {
-        let mut runner = Runner::new(2, 2).add_to_blacklist(0, Some(1)).use_boot_nodes(vec![0]);
+    let mut runner = Runner::new(2, 2).add_to_blacklist(0, Some(1)).use_boot_nodes(vec![0]);
 
-        runner.push(Action::Wait(100));
-        runner.push(Action::CheckRoutingTable(1, vec![]));
-        runner.push(Action::CheckRoutingTable(0, vec![]));
+    runner.push(Action::Wait(100));
+    runner.push(Action::CheckRoutingTable(1, vec![]));
+    runner.push(Action::CheckRoutingTable(0, vec![]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn blacklist_10() {
-    System::run(|| {
-        let mut runner = Runner::new(2, 2).add_to_blacklist(1, Some(0)).use_boot_nodes(vec![0]);
+    let mut runner = Runner::new(2, 2).add_to_blacklist(1, Some(0)).use_boot_nodes(vec![0]);
 
-        runner.push(Action::Wait(100));
-        runner.push(Action::CheckRoutingTable(1, vec![]));
-        runner.push(Action::CheckRoutingTable(0, vec![]));
+    runner.push(Action::Wait(100));
+    runner.push(Action::CheckRoutingTable(1, vec![]));
+    runner.push(Action::CheckRoutingTable(0, vec![]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }
 
 #[test]
 fn blacklist_all() {
-    System::run(|| {
-        let mut runner = Runner::new(2, 2).add_to_blacklist(0, None).use_boot_nodes(vec![0]);
+    let mut runner = Runner::new(2, 2).add_to_blacklist(0, None).use_boot_nodes(vec![0]);
 
-        runner.push(Action::Wait(100));
-        runner.push(Action::CheckRoutingTable(1, vec![]));
-        runner.push(Action::CheckRoutingTable(0, vec![]));
-        runner.run();
-    })
-    .unwrap();
+    runner.push(Action::Wait(100));
+    runner.push(Action::CheckRoutingTable(1, vec![]));
+    runner.push(Action::CheckRoutingTable(0, vec![]));
+
+    start_test(runner);
 }
 
 /// Spawn 4 nodes with max peers required equal 2. Connect first three peers in a triangle.
 /// Try to connect peer3 to peer0 and see it fail since first three peer are at max capacity.
 #[test]
 fn max_peer_limit() {
-    System::run(|| {
-        let mut runner = Runner::new(4, 4).max_peer(2).enable_outbound();
+    let mut runner = Runner::new(4, 4).max_peer(2).enable_outbound();
 
-        runner.push(Action::AddEdge(0, 1));
-        runner.push(Action::AddEdge(1, 2));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
-        runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
-        runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
-        runner.push(Action::AddEdge(3, 0));
-        runner.push(Action::Wait(100));
-        runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
-        runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
-        runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
-        runner.push(Action::CheckRoutingTable(3, vec![]));
+    runner.push(Action::AddEdge(0, 1));
+    runner.push(Action::AddEdge(1, 2));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
+    runner.push(Action::AddEdge(3, 0));
+    runner.push(Action::Wait(100));
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1]), (2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0]), (2, vec![2])]));
+    runner.push(Action::CheckRoutingTable(2, vec![(1, vec![1]), (0, vec![0])]));
+    runner.push(Action::CheckRoutingTable(3, vec![]));
 
-        runner.run();
-    })
-    .unwrap();
+    start_test(runner);
 }


### PR DESCRIPTION
There was an issue on handshake when two nodes tried to
connect to each other, in which they were not removed successfully
from outgoing list, and were unable to make progress.

There was another issue uncovered by the fix of previous issue
that in the scenario when A and B try to connect to each other,
when B drop its outgoing connection to A, it also drops the inbound
connection.

We introduce a test for #2395. This test is still failing and will
be fixed on a future PR. (connect_on_full_network)

Test plan
=========
There are two regression test for fixed issues that verify handshake
is performed properly. (simple_network & peer_handshake) Notice the
latter test already existed, and was important in detecting the
second uncovered issue.