### PR TITLE
fix: display correct sync status

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1170,6 +1170,7 @@ impl ClientActor {
             };
 
             act.info_helper.info(
+                act.client.chain.store().get_genesis_height(),
                 &head,
                 &act.client.sync_status,
                 &act.node_id,

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -161,7 +161,7 @@ fn display_sync_status(
         SyncStatus::AwaitingPeers => format!("#{:>8} Waiting for peers", head.height),
         SyncStatus::NoSync => format!("#{:>8} {:>44}", head.height, head.last_block_hash),
         SyncStatus::HeaderSync { current_height, highest_height } => {
-            let percent = if *highest_height == genesis_height {
+            let percent = if *highest_height <= genesis_height {
                 0
             } else {
                 (min(current_height, highest_height) - genesis_height) * 100
@@ -170,7 +170,7 @@ fn display_sync_status(
             format!("#{:>8} Downloading headers {}%", head.height, percent)
         }
         SyncStatus::BodySync { current_height, highest_height } => {
-            let percent = if *highest_height == 0 {
+            let percent = if *highest_height <= genesis_height {
                 0
             } else {
                 (current_height - genesis_height) * 100 / (highest_height - genesis_height)


### PR DESCRIPTION
Currently the sync status is off because we use 0 instead of genesis height as the base.

Test plan
---------
Manually test it with betanet to check that the displayed information makes sense.