### PR TITLE
fix(script): Do not telemetry in 100 node

### DIFF
--- a/pytest/tests/stress/hundred_nodes/start_100_nodes.py
+++ b/pytest/tests/stress/hundred_nodes/start_100_nodes.py
@@ -44,6 +44,9 @@ client_config_changes = {
             "secs": 6 * block_production_time,
             "nanos": 0,
         },
+    },
+    "telemetry": {
+        "endpoints": [],
     }
 }
 


### PR DESCRIPTION
Do not telemetry in 100 node

Test Plan
-------------
commented create machine part locally, only generate 100 node configs. check they're updated correctly 