### PR TITLE
fix: validate genesis

### DIFF
--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -94,7 +94,7 @@ pub struct GenesisConfig {
     Serialize,
     Deserialize,
 )]
-pub struct GenesisRecords(Vec<StateRecord>);
+pub struct GenesisRecords(pub Vec<StateRecord>);
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Genesis {

--- a/neard/src/genesis_validate.rs
+++ b/neard/src/genesis_validate.rs
@@ -1,0 +1,100 @@
+use near_chain_configs::Genesis;
+use near_primitives::state_record::StateRecord;
+use std::collections::{HashMap, HashSet};
+
+/// Validate genesis config and records. Panics if genesis is ill-formed.
+pub fn validate_genesis(genesis: &Genesis) {
+    let validators = genesis
+        .config
+        .validators
+        .clone()
+        .into_iter()
+        .map(|account_info| (account_info.account_id, account_info.amount))
+        .collect::<HashMap<_, _>>();
+    assert_eq!(
+        validators.len(),
+        genesis.config.validators.len(),
+        "Duplicate account in validators"
+    );
+    assert!(!validators.is_empty(), "no validators in genesis");
+
+    let mut total_supply = 0;
+    let mut staked_accounts = HashMap::new();
+    let mut account_ids = HashSet::new();
+    for record in genesis.records.0.iter() {
+        if let StateRecord::Account { account_id, account } = record {
+            if account_ids.contains(account_id) {
+                panic!("Duplicate account id {} in genesis records", account_id);
+            }
+            total_supply += account.locked + account.amount;
+            account_ids.insert(account_id.clone());
+            if account.locked > 0 {
+                staked_accounts.insert(account_id.clone(), account.locked);
+            }
+        }
+    }
+    assert_eq!(total_supply, genesis.config.total_supply, "wrong total supply");
+    assert_eq!(validators, staked_accounts, "validator accounts do not match staked accounts");
+}
+
+#[cfg(test)]
+mod test {
+    use crate::genesis_validate::validate_genesis;
+    use near_chain_configs::{Genesis, GenesisRecords};
+    use near_crypto::{KeyType, PublicKey};
+    use near_primitives::state_record::StateRecord;
+    use near_primitives::types::AccountInfo;
+    use near_primitives::views::AccountView;
+
+    #[test]
+    #[should_panic(expected = "wrong total supply")]
+    fn test_total_supply_not_match() {
+        let mut genesis = Genesis::default();
+        genesis.config.validators = vec![AccountInfo {
+            account_id: "test".to_string(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            amount: 10,
+        }];
+        genesis.records = GenesisRecords(vec![StateRecord::Account {
+            account_id: "test".to_string(),
+            account: AccountView {
+                amount: 100,
+                locked: 10,
+                code_hash: Default::default(),
+                storage_usage: 0,
+                storage_paid_at: 0,
+            },
+        }]);
+        validate_genesis(&genesis);
+    }
+
+    #[test]
+    #[should_panic(expected = "validator accounts do not match staked accounts")]
+    fn test_validator_not_match() {
+        let mut genesis = Genesis::default();
+        genesis.config.validators = vec![AccountInfo {
+            account_id: "test".to_string(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            amount: 100,
+        }];
+        genesis.config.total_supply = 110;
+        genesis.records = GenesisRecords(vec![StateRecord::Account {
+            account_id: "test".to_string(),
+            account: AccountView {
+                amount: 100,
+                locked: 10,
+                code_hash: Default::default(),
+                storage_usage: 0,
+                storage_paid_at: 0,
+            },
+        }]);
+        validate_genesis(&genesis);
+    }
+
+    #[test]
+    #[should_panic(expected = "no validators in genesis")]
+    fn test_empty_validator() {
+        let mut genesis = Genesis::default();
+        validate_genesis(&genesis);
+    }
+}

--- a/neard/src/genesis_validate.rs
+++ b/neard/src/genesis_validate.rs
@@ -21,20 +21,48 @@ pub fn validate_genesis(genesis: &Genesis) {
     let mut total_supply = 0;
     let mut staked_accounts = HashMap::new();
     let mut account_ids = HashSet::new();
+    let mut access_key_account_ids = HashSet::new();
+    let mut contract_account_ids = HashSet::new();
     for record in genesis.records.0.iter() {
-        if let StateRecord::Account { account_id, account } = record {
-            if account_ids.contains(account_id) {
-                panic!("Duplicate account id {} in genesis records", account_id);
+        match record {
+            StateRecord::Account { account_id, account } => {
+                if account_ids.contains(account_id) {
+                    panic!("Duplicate account id {} in genesis records", account_id);
+                }
+                total_supply += account.locked + account.amount;
+                account_ids.insert(account_id.clone());
+                if account.locked > 0 {
+                    staked_accounts.insert(account_id.clone(), account.locked);
+                }
             }
-            total_supply += account.locked + account.amount;
-            account_ids.insert(account_id.clone());
-            if account.locked > 0 {
-                staked_accounts.insert(account_id.clone(), account.locked);
+            StateRecord::AccessKey { account_id, .. } => {
+                access_key_account_ids.insert(account_id.clone());
             }
+            StateRecord::Contract { account_id, .. } => {
+                if contract_account_ids.contains(account_id) {
+                    panic!("account {} has more than one contract deployed", account_id);
+                }
+                contract_account_ids.insert(account_id.clone());
+            }
+            _ => {}
         }
     }
     assert_eq!(total_supply, genesis.config.total_supply, "wrong total supply");
     assert_eq!(validators, staked_accounts, "validator accounts do not match staked accounts");
+    for account_id in access_key_account_ids {
+        assert!(
+            account_ids.contains(&account_id),
+            "access key account {} does not exist",
+            account_id
+        );
+    }
+    for account_id in contract_account_ids {
+        assert!(
+            account_ids.contains(&account_id),
+            "contract account {} does not exist",
+            account_id
+        );
+    }
 }
 
 #[cfg(test)]
@@ -42,9 +70,10 @@ mod test {
     use crate::genesis_validate::validate_genesis;
     use near_chain_configs::{Genesis, GenesisRecords};
     use near_crypto::{KeyType, PublicKey};
+    use near_primitives::serialize::to_base64;
     use near_primitives::state_record::StateRecord;
     use near_primitives::types::AccountInfo;
-    use near_primitives::views::AccountView;
+    use near_primitives::views::{AccessKeyPermissionView, AccessKeyView, AccountView};
 
     #[test]
     #[should_panic(expected = "wrong total supply")]
@@ -94,7 +123,67 @@ mod test {
     #[test]
     #[should_panic(expected = "no validators in genesis")]
     fn test_empty_validator() {
+        let genesis = Genesis::default();
+        validate_genesis(&genesis);
+    }
+
+    #[test]
+    #[should_panic(expected = "access key account test1 does not exist")]
+    fn test_access_key_with_nonexistent_account() {
         let mut genesis = Genesis::default();
+        genesis.config.validators = vec![AccountInfo {
+            account_id: "test".to_string(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            amount: 10,
+        }];
+        genesis.config.total_supply = 110;
+        genesis.records = GenesisRecords(vec![
+            StateRecord::Account {
+                account_id: "test".to_string(),
+                account: AccountView {
+                    amount: 100,
+                    locked: 10,
+                    code_hash: Default::default(),
+                    storage_usage: 0,
+                    storage_paid_at: 0,
+                },
+            },
+            StateRecord::AccessKey {
+                account_id: "test1".to_string(),
+                public_key: PublicKey::empty(KeyType::ED25519),
+                access_key: AccessKeyView {
+                    nonce: 0,
+                    permission: AccessKeyPermissionView::FullAccess,
+                },
+            },
+        ]);
+        validate_genesis(&genesis);
+    }
+
+    #[test]
+    #[should_panic(expected = "account test has more than one contract deployed")]
+    fn test_more_than_one_contract() {
+        let mut genesis = Genesis::default();
+        genesis.config.validators = vec![AccountInfo {
+            account_id: "test".to_string(),
+            public_key: PublicKey::empty(KeyType::ED25519),
+            amount: 10,
+        }];
+        genesis.config.total_supply = 110;
+        genesis.records = GenesisRecords(vec![
+            StateRecord::Account {
+                account_id: "test".to_string(),
+                account: AccountView {
+                    amount: 100,
+                    locked: 10,
+                    code_hash: Default::default(),
+                    storage_usage: 0,
+                    storage_paid_at: 0,
+                },
+            },
+            StateRecord::Contract { account_id: "test".to_string(), code: to_base64([1, 2, 3]) },
+            StateRecord::Contract { account_id: "test".to_string(), code: to_base64([1, 2, 3, 4]) },
+        ]);
         validate_genesis(&genesis);
     }
 }

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -17,6 +17,7 @@ pub use crate::config::{init_configs, load_config, load_test_config, NearConfig,
 pub use crate::runtime::NightshadeRuntime;
 
 pub mod config;
+pub mod genesis_validate;
 mod runtime;
 mod shard_tracker;
 

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -15,6 +15,7 @@ use tracing_subscriber::EnvFilter;
 use git_version::git_version;
 use near_primitives::types::Version;
 use neard::config::init_testnet_configs;
+use neard::genesis_validate::validate_genesis;
 use neard::{get_default_home, get_store_path, init_configs, load_config, start_with_config};
 
 fn init_logging(verbose: Option<&str>) {
@@ -146,6 +147,7 @@ fn main() {
         ("run", Some(args)) => {
             // Load configs from home.
             let mut near_config = load_config(home_dir);
+            validate_genesis(&near_config.genesis);
             // Set current version in client config.
             near_config.client_config.version = version;
             // Override some parameters from command line.


### PR DESCRIPTION
Validate genesis to check that various invariants hold before starting the node. Partially addresses #2435.

Test plan
---------
unit tests in `validate_genesis.rs`.