### PR TITLE
fix(network): Don't allow connections from banned peers.

### DIFF
--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -273,6 +273,7 @@ impl Peer {
     fn ban_peer(&mut self, ctx: &mut Context<Peer>, ban_reason: ReasonForBan) {
         info!(target: "network", "Banning peer {} for {:?}", self.peer_info, ban_reason);
         self.peer_status = PeerStatus::Banned(ban_reason);
+        // On stopping Banned signal will be sent to PeerManager
         ctx.stop();
     }
 

--- a/chain/network/src/peer_store.rs
+++ b/chain/network/src/peer_store.rs
@@ -55,6 +55,12 @@ impl PeerStore {
         self.peer_states.is_empty()
     }
 
+    pub fn is_banned(&self, peer_id: &PeerId) -> bool {
+        self.peer_states
+            .get(&peer_id)
+            .map_or(false, |known_peer_state| known_peer_state.status.is_banned())
+    }
+
     pub fn peer_connected(
         &mut self,
         peer_info: &FullPeerInfo,

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -14,7 +14,7 @@ use near_primitives::network::PeerId;
 use near_primitives::types::EpochId;
 use near_primitives::utils::index_to_bytes;
 
-use crate::types::{NetworkConfig, NetworkInfo, PeerInfo, ROUTED_MESSAGE_TTL};
+use crate::types::{NetworkConfig, NetworkInfo, PeerInfo, ReasonForBan, ROUTED_MESSAGE_TTL};
 use crate::{NetworkAdapter, NetworkRequests, NetworkResponses, PeerManagerActor};
 use futures::future::BoxFuture;
 use std::sync::{Arc, Mutex, RwLock};
@@ -243,6 +243,28 @@ impl Handler<StopSignal> for PeerManagerActor {
         } else {
             ctx.stop();
         }
+    }
+}
+
+#[derive(Message)]
+#[rtype(result = "()")]
+pub struct BanPeerSignal {
+    pub peer_id: PeerId,
+    pub ban_reason: ReasonForBan,
+}
+
+impl BanPeerSignal {
+    pub fn new(peer_id: PeerId) -> Self {
+        Self { peer_id, ban_reason: ReasonForBan::None }
+    }
+}
+
+impl Handler<BanPeerSignal> for PeerManagerActor {
+    type Result = ();
+
+    fn handle(&mut self, msg: BanPeerSignal, ctx: &mut Self::Context) -> Self::Result {
+        debug!(target: "network", "Ban peer: {:?}", msg.peer_id);
+        self.try_ban_peer(ctx, &msg.peer_id, msg.ban_reason);
     }
 }
 

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -768,6 +768,15 @@ pub enum KnownPeerStatus {
     Banned(ReasonForBan, u64),
 }
 
+impl KnownPeerStatus {
+    pub fn is_banned(&self) -> bool {
+        match self {
+            KnownPeerStatus::Banned(_, _) => true,
+            _ => false,
+        }
+    }
+}
+
 /// Information node stores about known peers.
 #[derive(BorshSerialize, BorshDeserialize, Serialize, Debug)]
 pub struct KnownPeerState {
@@ -929,6 +938,8 @@ pub enum ReasonForBan {
     InvalidEdge = 10,
 }
 
+/// Banning signal sent from Peer instance to PeerManager
+/// just before Peer instance is stopped.
 #[derive(Message)]
 #[rtype(result = "()")]
 pub struct Ban {

--- a/chain/network/tests/ban_peers.rs
+++ b/chain/network/tests/ban_peers.rs
@@ -1,0 +1,53 @@
+pub use runner::*;
+use std::time::Duration;
+
+mod runner;
+
+/// Check we don't try to connect to a banned peer and we don't accept
+/// incoming connection from it.
+#[test]
+fn dont_connect_to_banned_peer() {
+    let mut runner = Runner::new(2, 2)
+        .enable_outbound()
+        .use_boot_nodes(vec![0, 1])
+        .ban_window(Duration::from_secs(60));
+
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
+
+    runner.push_action(ban_peer(0, 1));
+    // It needs to wait a large timeout so we are sure both peer don't establish a connection.
+    runner.push(Action::Wait(1000));
+
+    runner.push(Action::CheckRoutingTable(0, vec![]));
+    runner.push(Action::CheckRoutingTable(1, vec![]));
+
+    start_test(runner);
+}
+
+/// Check two peers are able to connect again after one peers is banned and unbanned.
+#[test]
+fn connect_to_unbanned_peer() {
+    let mut runner = Runner::new(2, 2)
+        .enable_outbound()
+        .use_boot_nodes(vec![0, 1])
+        .ban_window(Duration::from_secs(2));
+
+    // Check both peers are connected
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
+
+    // Ban peer 1
+    runner.push_action(ban_peer(0, 1));
+
+    runner.push(Action::Wait(1000));
+    // During two seconds peer is banned so no connection is possible.
+    runner.push(Action::CheckRoutingTable(0, vec![]));
+    runner.push(Action::CheckRoutingTable(1, vec![]));
+
+    // After two seconds peer is unbanned and they should be able to connect again.
+    runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
+    runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
+
+    start_test(runner);
+}


### PR DESCRIPTION
Previously if a banned peer tried to connect it was allowed. Fix #2455 

Test plan
=========
Start two nodes, check they connect to each other. Ban one of them.
Wait until they disconnect. After some timeout they shoud remain
disconnected i.e. don't allow incomming connection from banned peers.
After larger timeout (ban_windows) peers should be able to reconnect.

Because first `timeout` might be fuzzy I set large timeout (1 second)
and also test by hand that without the change introduced in the PR
this test fails.