### PR TITLE
fix(sync): fix state sync infinite loop

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -895,9 +895,11 @@ impl Chain {
             hashes.push(header.hash());
             current = self.get_previous_header(&header).map(|h| h.clone());
         }
+        let next_epoch_id =
+            self.get_block_header(&block_head.last_block_hash)?.inner_lite.next_epoch_id.clone();
 
-        // Don't run State Sync if epochs are the same
-        if block_head.epoch_id != header_head.epoch_id {
+        // Don't run State Sync if header head is not more than one epoch ahead.
+        if block_head.epoch_id != header_head.epoch_id && next_epoch_id != header_head.epoch_id {
             let sync_head = self.sync_head()?;
             if oldest_height < sync_head.height.saturating_sub(block_fetch_horizon) {
                 // Epochs are different and we are too far from horizon, State Sync is needed

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -201,6 +201,14 @@ fn default_header_sync_expected_height_per_second() -> u64 {
     10
 }
 
+fn default_sync_check_period() -> Duration {
+    Duration::from_secs(10)
+}
+
+fn default_sync_step_period() -> Duration {
+    Duration::from_millis(10)
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Consensus {
     /// Minimum number of peers to start syncing.
@@ -240,6 +248,12 @@ pub struct Consensus {
     /// Expected increase of header head weight per second during header sync
     #[serde(default = "default_header_sync_expected_height_per_second")]
     pub header_sync_expected_height_per_second: u64,
+    /// How frequently we check whether we need to sync
+    #[serde(default = "default_sync_check_period")]
+    pub sync_check_period: Duration,
+    /// During sync the time we wait before reentering the sync loop
+    #[serde(default = "default_sync_step_period")]
+    pub sync_step_period: Duration,
 }
 
 impl Default for Consensus {
@@ -262,6 +276,8 @@ impl Default for Consensus {
             header_sync_stall_ban_timeout: default_header_sync_stall_ban_timeout(),
             header_sync_expected_height_per_second: default_header_sync_expected_height_per_second(
             ),
+            sync_check_period: default_sync_check_period(),
+            sync_step_period: default_sync_step_period(),
         }
     }
 }
@@ -433,8 +449,8 @@ impl NearConfig {
                 reduce_wait_for_missing_block: config.consensus.reduce_wait_for_missing_block,
                 block_expected_weight: 1000,
                 skip_sync_wait: config.network.skip_sync_wait,
-                sync_check_period: Duration::from_secs(10),
-                sync_step_period: Duration::from_millis(10),
+                sync_check_period: config.consensus.sync_check_period,
+                sync_step_period: config.consensus.sync_step_period,
                 sync_height_threshold: 1,
                 header_sync_initial_timeout: config.consensus.header_sync_initial_timeout,
                 header_sync_progress_timeout: config.consensus.header_sync_progress_timeout,

--- a/pytest/tests/sanity/state_sync3.py
+++ b/pytest/tests/sanity/state_sync3.py
@@ -1,0 +1,48 @@
+# Spin up one validating node and make it produce blocks for more than one epoch
+# spin up another node that tracks the shard, make sure that it can state sync into the first node
+
+import sys, time
+import base58
+
+sys.path.append('lib')
+
+from cluster import start_cluster
+from transaction import sign_payment_tx
+
+EPOCH_LENGTH = 1000
+MAX_SYNC_WAIT = 120
+consensus_config0 = {"consensus": {"min_block_production_delay": {"secs": 0, "nanos": 100000000}}}
+consensus_config1 = {"consensus": {"sync_step_period": {"secs": 0, "nanos": 1000}}, "tracked_shards": [0]}
+nodes = start_cluster(1, 1, 1, None, [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10], ["chunk_producer_kickout_threshold", 10]], {0: consensus_config0, 1: consensus_config1})
+time.sleep(2)
+nodes[1].kill()
+
+print("step 1")
+
+node0_height = 0
+while node0_height <= EPOCH_LENGTH + 600:
+    status = nodes[0].get_status()
+    node0_height = status['sync_info']['latest_block_height']
+    time.sleep(5)
+nodes[1].start(nodes[1].node_key.pk, nodes[1].addr())
+time.sleep(2)
+
+print("step 2")
+synced = False
+node1_height = 0
+start_time = time.time()
+state_sync_done_time = None
+state_sync_done_height = None
+while node1_height <= node0_height:
+    if time.time() - start_time > MAX_SYNC_WAIT:
+        assert False, "state sync timed out"
+    status1 = nodes[1].get_status()
+    node1_height = status1['sync_info']['latest_block_height']
+    if node1_height >= EPOCH_LENGTH:
+        if state_sync_done_time is None:
+            state_sync_done_time = time.time()
+            state_sync_done_height = node1_height
+        elif time.time() - state_sync_done_time > 8:
+            assert node1_height > state_sync_done_height, "No progress after state sync is done"
+    time.sleep(2)
+


### PR DESCRIPTION
Currently there is a potential infinite loop in state sync: if the node that is syncing cares about the shard, it will not be able to process sync block immediately, which will likely cause the node to go back into state sync after it is done (unless the sync block is close to header head), and because sync block is already removed at this point, future state syncs will get stuck as well after they are done. This PR fixes the issue by relaxing the criterion of entering block sync to allow block sync even if the head is one epoch behind. This is harmless in most scenarios, as a node would first do state sync anyways, unless it is right in the range of (one epoch, two epochs) behind header head.
Fixes #2374.

Test plan
---------
`state_sync3.py` that tests the scenario described above.