### PR TITLE
fix(network): Remove address when nodes goes off.

### DIFF
--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -94,7 +94,8 @@ mod test {
         let peer_info = PeerInfo::random();
         let fake_handshake = Handshake {
             version: 1,
-            peer_id: peer_info.id,
+            peer_id: peer_info.id.clone(),
+            target_peer_id: peer_info.id,
             listen_port: None,
             chain_info: PeerChainInfo {
                 genesis_id: Default::default(),

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1397,9 +1397,8 @@ impl Handler<PeersResponse> for PeerManagerActor {
 
     fn handle(&mut self, msg: PeersResponse, _ctx: &mut Self::Context) {
         unwrap_or_error!(
-            self.peer_store.add_peers(
-                msg.peers.into_iter().filter(|peer_info| peer_info.id != self.peer_id).collect(),
-                TrustLevel::Indirect,
+            self.peer_store.add_indirect_peers(
+                msg.peers.into_iter().filter(|peer_info| peer_info.id != self.peer_id).collect()
             ),
             "Fail to update peer store"
         );
@@ -1467,7 +1466,7 @@ impl Handler<PeerRequest> for PeerManagerActor {
                 PeerResponse::NoResponse
             }
             PeerRequest::UpdatePeerInfo(peer_info) => {
-                if let Err(err) = self.peer_store.add_peers(vec![peer_info], TrustLevel::Direct) {
+                if let Err(err) = self.peer_store.add_trusted_peer(peer_info, TrustLevel::Direct) {
                     error!(target: "network", "Fail to update peer store: {}", err);
                 }
                 PeerResponse::NoResponse

--- a/chain/network/src/recorder.rs
+++ b/chain/network/src/recorder.rs
@@ -41,7 +41,6 @@ impl SentReceived {
     }
 }
 
-// TODO(MarX): Use more compact debug. Right now it will print all known hashes.
 #[derive(Default, Debug, Deserialize, Clone)]
 struct HashAggregator {
     total: usize,

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -9,8 +9,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use byteorder::LittleEndian;
 use byteorder::WriteBytesExt;
 use cached::{Cached, SizedCache};
-use log::warn;
-use log::{debug, trace};
+use log::{debug, trace, warn};
 
 use near_crypto::{SecretKey, Signature};
 use near_metrics;

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -77,10 +77,14 @@ impl NetworkConfig {
     }
 }
 
+pub fn peer_id_from_seed(seed: &str) -> PeerId {
+    SecretKey::from_seed(KeyType::ED25519, seed).public_key().into()
+}
+
 pub fn convert_boot_nodes(boot_nodes: Vec<(&str, u16)>) -> Vec<PeerInfo> {
     let mut result = vec![];
     for (peer_seed, port) in boot_nodes {
-        let id = SecretKey::from_seed(KeyType::ED25519, peer_seed).public_key();
+        let id = peer_id_from_seed(peer_seed);
         result.push(PeerInfo::new(id.into(), format!("127.0.0.1:{}", port).parse().unwrap()))
     }
     result

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -159,6 +159,8 @@ pub struct Handshake {
     pub version: u32,
     /// Sender's peer id.
     pub peer_id: PeerId,
+    /// Receiver's peer id.
+    pub target_peer_id: PeerId,
     /// Sender's listening addr.
     pub listen_port: Option<u16>,
     /// Peer's chain information.
@@ -170,11 +172,19 @@ pub struct Handshake {
 impl Handshake {
     pub fn new(
         peer_id: PeerId,
+        target_peer_id: PeerId,
         listen_port: Option<u16>,
         chain_info: PeerChainInfo,
         edge_info: EdgeInfo,
     ) -> Self {
-        Handshake { version: PROTOCOL_VERSION, peer_id, listen_port, chain_info, edge_info }
+        Handshake {
+            version: PROTOCOL_VERSION,
+            peer_id,
+            target_peer_id,
+            listen_port,
+            chain_info,
+            edge_info,
+        }
     }
 }
 
@@ -190,6 +200,7 @@ pub struct AnnounceAccountRoute {
 pub enum HandshakeFailureReason {
     ProtocolVersionMismatch(u32),
     GenesisMismatch(GenesisId),
+    InvalidTarget,
 }
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, PartialEq, Eq, Clone, Debug)]
@@ -760,7 +771,7 @@ impl FromStr for PatternAddr {
 }
 
 /// Status of the known peers.
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Eq, PartialEq, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Eq, PartialEq, Debug, Clone)]
 pub enum KnownPeerStatus {
     Unknown,
     NotConnected,
@@ -778,7 +789,7 @@ impl KnownPeerStatus {
 }
 
 /// Information node stores about known peers.
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone)]
 pub struct KnownPeerState {
     pub peer_info: PeerInfo,
     pub status: KnownPeerStatus,
@@ -884,6 +895,7 @@ pub struct PeerList {
 pub enum PeerRequest {
     UpdateEdge((PeerId, u64)),
     RouteBack(RoutedMessageBody, CryptoHash),
+    UpdatePeerInfo(PeerInfo),
 }
 
 impl Message for PeerRequest {

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -14,8 +14,8 @@ use near_chain_configs::ClientConfig;
 use near_client::{ClientActor, ViewClientActor};
 use near_crypto::KeyType;
 use near_network::test_utils::{
-    convert_boot_nodes, expected_routing_tables, open_port, BanPeerSignal, GetInfo, StopSignal,
-    WaitOrTimeout,
+    convert_boot_nodes, expected_routing_tables, open_port, peer_id_from_seed, BanPeerSignal,
+    GetInfo, StopSignal, WaitOrTimeout,
 };
 use near_network::types::{OutboundTcpConnect, ROUTED_MESSAGE_TTL};
 use near_network::utils::blacklist_from_vec;
@@ -606,15 +606,32 @@ impl Actor for Runner {
 
 #[derive(Message)]
 #[rtype(result = "()")]
-struct StartNode(usize);
+enum RunnerMessage {
+    StartNode(usize),
+    ChangeAccountId(usize, String),
+}
 
-impl Handler<StartNode> for Runner {
+impl Handler<RunnerMessage> for Runner {
     type Result = ();
-    fn handle(&mut self, msg: StartNode, _ctx: &mut Self::Context) -> Self::Result {
-        let node_id = msg.0;
-        let pm = self.setup_node(node_id);
-        let info = self.info.as_ref().cloned().unwrap();
-        (*info.write().unwrap()).pm_addr[node_id] = pm;
+    fn handle(&mut self, msg: RunnerMessage, _ctx: &mut Self::Context) -> Self::Result {
+        match msg {
+            RunnerMessage::StartNode(node_id) => {
+                let pm = self.setup_node(node_id);
+                let info = self.info.as_ref().cloned().unwrap();
+                let mut write_info = info.write().unwrap();
+                write_info.pm_addr[node_id] = pm;
+            }
+            RunnerMessage::ChangeAccountId(node_id, account_id) => {
+                self.accounts_id.as_mut().unwrap()[node_id] = account_id.clone();
+                let info = self.info.as_ref().cloned().unwrap();
+                let mut write_info = info.write().unwrap();
+
+                write_info.peers_info[node_id].id = peer_id_from_seed(account_id.as_str());
+                if write_info.peers_info[node_id].account_id.is_some() {
+                    write_info.peers_info[node_id].account_id = Some(account_id);
+                }
+            }
+        }
     }
 }
 
@@ -646,7 +663,7 @@ pub fn check_expected_connections(node_id: usize, expected_connections: usize) -
     )
 }
 
-// Restart a node that was already stopped
+/// Restart a node that was already stopped.
 pub fn restart(node_id: usize) -> ActionFn {
     Box::new(
         move |_info: SharedRunningInfo,
@@ -655,7 +672,7 @@ pub fn restart(node_id: usize) -> ActionFn {
               runner: Addr<Runner>| {
             actix::spawn(
                 runner
-                    .send(StartNode(node_id))
+                    .send(RunnerMessage::StartNode(node_id))
                     .map_err(|_| ())
                     .and_then(move |_| {
                         flag.store(true, Ordering::Relaxed);
@@ -667,6 +684,7 @@ pub fn restart(node_id: usize) -> ActionFn {
     )
 }
 
+/// Ban peer `banned_peer` from perspective of `target_peer`.
 pub fn ban_peer(target_peer: usize, banned_peer: usize) -> ActionFn {
     Box::new(
         move |info: SharedRunningInfo,
@@ -680,6 +698,28 @@ pub fn ban_peer(target_peer: usize, banned_peer: usize) -> ActionFn {
                     .get(target_peer)
                     .unwrap()
                     .send(BanPeerSignal::new(banned_peer_id))
+                    .map_err(|_| ())
+                    .and_then(move |_| {
+                        flag.store(true, Ordering::Relaxed);
+                        future::ok(())
+                    })
+                    .map(drop),
+            );
+        },
+    )
+}
+
+/// Change account id from a stopped peer. Notice this will also change its peer id, since
+/// peer_id is derived from account id with NetworkConfig::from_seed
+pub fn change_account_id(node_id: usize, account_id: String) -> ActionFn {
+    Box::new(
+        move |_info: SharedRunningInfo,
+              flag: Arc<AtomicBool>,
+              _ctx: &mut Context<WaitOrTimeout>,
+              runner: Addr<Runner>| {
+            actix::spawn(
+                runner
+                    .send(RunnerMessage::ChangeAccountId(node_id, account_id.clone()))
                     .map_err(|_| ())
                     .and_then(move |_| {
                         flag.store(true, Ordering::Relaxed);


### PR DESCRIPTION
Currently if peer_id A goes offline and in the same address
a new peer_id B appears, nodes will try to connect to B as if it were
A, receiving a lot of invalid handshakes.
Also check that we don't try to connect to ourself.

This solution introduce some complexity on how PeerStore is handled,
since now we need to know about address associated with each peer id
and updated properly, and at the same time protect against malicious
actors that tries to manipulate this mapping. Fix #2456 

Test plan
=========
It was created a test that replicated the issue, by creating two
nodes A and B, taking down B, changing it identity, and spawning it
again at the same address. A and B are able to connect again, since
A was able to learn the new identity from B.

Also a lot of small test were created to test PeerStore handling.