### PR TITLE
Revert "disabling State Sync Clearing optimization (#2484)"

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -1081,8 +1081,7 @@ impl ClientActor {
                     .collect();
 
                 if !self.client.config.archive {
-                    // TODO #2464 enable it
-                    //unwrap_or_run_later!(self.client.chain.reset_data_pre_state_sync(sync_hash));
+                    unwrap_or_run_later!(self.client.chain.reset_data_pre_state_sync(sync_hash));
                 }
 
                 match unwrap_or_run_later!(self.client.state_sync.run(


### PR DESCRIPTION
This reverts commit 601c8d72811bd12d38a29046a1f53e8844640e0a.
Fixes #2464.