### PR TITLE
fix(rpc): Fix returning missing tx error

### DIFF
--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -6,7 +6,7 @@ pub use crate::client_actor::ClientActor;
 pub use crate::types::{
     Error, GetBlock, GetChunk, GetGasPrice, GetNetworkInfo, GetNextLightClientBlock,
     GetStateChanges, GetStateChangesInBlock, GetValidatorInfo, Query, Status, StatusResponse,
-    SyncStatus, TxStatus,
+    SyncStatus, TxStatus, TxStatusError,
 };
 pub use crate::view_client::ViewClientActor;
 

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -97,6 +97,7 @@ pub fn setup(
         archive,
     );
     let view_client = ViewClientActor::new(
+        Some(signer.validator_id().clone()),
         &chain_genesis,
         runtime.clone(),
         network_adapter.clone(),

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -236,6 +236,8 @@ pub struct TxStatus {
 pub enum TxStatusError {
     ChainError(near_chain::Error),
     MissingTransaction(CryptoHash),
+    InternalError,
+    TimeoutError,
 }
 
 impl From<TxStatusError> for String {
@@ -245,6 +247,8 @@ impl From<TxStatusError> for String {
             TxStatusError::MissingTransaction(tx_hash) => {
                 format!("Transaction {} doesn't exist", tx_hash)
             }
+            TxStatusError::InternalError => format!("Internal error"),
+            TxStatusError::TimeoutError => format!("Timeout error"),
         }
     }
 }

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -233,8 +233,24 @@ pub struct TxStatus {
     pub signer_account_id: AccountId,
 }
 
+pub enum TxStatusError {
+    ChainError(near_chain::Error),
+    MissingTransaction(CryptoHash),
+}
+
+impl From<TxStatusError> for String {
+    fn from(error: TxStatusError) -> Self {
+        match error {
+            TxStatusError::ChainError(err) => format!("Chain error: {}", err),
+            TxStatusError::MissingTransaction(tx_hash) => {
+                format!("Transaction {} doesn't exist", tx_hash)
+            }
+        }
+    }
+}
+
 impl Message for TxStatus {
-    type Result = Result<Option<FinalExecutionOutcomeView>, String>;
+    type Result = Result<Option<FinalExecutionOutcomeView>, TxStatusError>;
 }
 
 pub struct GetValidatorInfo {

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -257,7 +257,7 @@ impl JsonRpcHandler {
                             break jsonify(tx_status_result.map(|x| x.map_err(|x| x.into())));
                         }
                     },
-                    Ok(Err(ref _err)) => {
+                    Ok(Err(_)) => {
                         break jsonify(tx_status_result.map(|x| x.map_err(|x| x.into())));
                     }
                     _ => {}

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -195,7 +195,7 @@ fn test_tx_status_missing_tx() {
         match client.tx(to_base(&CryptoHash::default()), "test1".to_string()).await {
             Err(e) => {
                 let s = serde_json::to_string(&e.data.unwrap()).unwrap();
-                assert_eq!(s, "\"Transaction 11111111111111111111111111111111 doesn't exist.\"");
+                assert_eq!(s, "\"Transaction 11111111111111111111111111111111 doesn't exist\"");
             }
             Ok(_) => panic!("transaction should not succeed"),
         }

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -188,3 +188,16 @@ fn test_tx_status_invalid_account_id() {
         };
     });
 }
+
+#[test]
+fn test_tx_status_missing_tx() {
+    test_with_client!(test_utils::NodeType::Validator, client, async move {
+        match client.tx(to_base(&CryptoHash::default()), "test1".to_string()).await {
+            Err(e) => {
+                let s = serde_json::to_string(&e.data.unwrap()).unwrap();
+                assert_eq!(s, "\"Transaction 11111111111111111111111111111111 doesn't exist.\"");
+            }
+            Ok(_) => panic!("transaction should not succeed"),
+        }
+    });
+}

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -89,6 +89,7 @@ pub fn setup_network_node(
         .unwrap()
         .start();
         let view_client_actor = ViewClientActor::new(
+            config.account_id.clone(),
             &chain_genesis,
             runtime.clone(),
             network_adapter.clone(),

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -68,6 +68,7 @@ pub fn start_with_config(
     let node_id = config.network_config.public_key.clone().into();
     let network_adapter = Arc::new(NetworkRecipient::new());
     let view_client = ViewClientActor::new(
+        config.validator_signer.as_ref().map(|signer| signer.validator_id().clone()),
         &chain_genesis,
         runtime.clone(),
         network_adapter.clone(),


### PR DESCRIPTION
Return if tx status is missing on the node that track this shard. Fixes #2488 

CC @frol `tx` rpc actually is not having proper typed errors. I'm not fixing it here, but it's worth reviewing that.

Test Plan
----
Add a test that for a single node if query missing transaction, it returns error right away instead of Timeout.