### PR TITLE
fix(nightly): fix some nightly tests

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -13,7 +13,7 @@ pytest --timeout=600 sanity/state_sync.py manytx 250
 pytest sanity/state_sync.py onetx 30
 pytest --timeout=600 sanity/state_sync.py onetx 250
 pytest --timeout=240 sanity/state_sync1.py
-pytest --timeout=600 sanity/state_sync2.py
+pytest --timeout=900 sanity/state_sync2.py
 pytest --timeout=900 sanity/state_sync3.py
 pytest --timeout=600 sanity/state_sync_routed.py manytx 100
 pytest --timeout=300 sanity/state_sync_late.py notx

--- a/pytest/tests/sanity/block_sync.py
+++ b/pytest/tests/sanity/block_sync.py
@@ -15,7 +15,14 @@ TIMEOUT = 25
 consensus_config0 = {"consensus": {"block_fetch_horizon": 30, "block_header_fetch_horizon": 30}}
 consensus_config1 = {"consensus": {"min_block_production_delay": {"secs": 100, "nanos": 0}, "max_block_production_delay": {"secs": 200, "nanos": 0}, "max_block_wait_delay": {"secs": 1000, "nanos": 0}}}
 # give more stake to the bootnode so that it can produce the blocks alone
-nodes = start_cluster(2, 0, 4, None, [["epoch_length", 100], ["validators", 0, "amount", "60000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"]], {0: consensus_config0, 1: consensus_config1})
+nodes = start_cluster(
+    2, 0, 4, None,
+    [
+        ["epoch_length", 100], ["validators", 0, "amount", "60000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"],
+        ["total_supply", "3010000000000000000000000000000000"]
+    ],
+    {0: consensus_config0, 1: consensus_config1}
+)
 time.sleep(3)
 
 node0_height = 0

--- a/pytest/tests/sanity/garbage_collection.py
+++ b/pytest/tests/sanity/garbage_collection.py
@@ -15,7 +15,10 @@ consensus_config = {"consensus": {"min_block_production_delay": {"secs": 0, "nan
 
 nodes = start_cluster(
     2, 0, 1, None,
-    [["epoch_length", 10], ["num_block_producer_seats", 5], ["num_block_producer_seats_per_shard", [5]], ["validators", 0, "amount", "60000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"]],
+    [
+        ["epoch_length", 10], ["num_block_producer_seats", 5], ["num_block_producer_seats_per_shard", [5]], ["validators", 0, "amount", "60000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"],
+        ["total_supply", "3010000000000000000000000000000000"]
+    ],
     {0: consensus_config, 1: consensus_config}
 )
 

--- a/pytest/tests/sanity/garbage_collection1.py
+++ b/pytest/tests/sanity/garbage_collection1.py
@@ -17,7 +17,10 @@ consensus_config = {"consensus": {"min_block_production_delay": {"secs": 0, "nan
 
 nodes = start_cluster(
     3, 0, 1, None,
-    [["epoch_length", 10], ["num_block_producer_seats", 5], ["num_block_producer_seats_per_shard", [5]], ["validators", 0, "amount", "110000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "110000000000000000000000000000000"]],
+    [
+        ["epoch_length", 10], ["num_block_producer_seats", 5], ["num_block_producer_seats_per_shard", [5]],
+        ["total_supply", "4060000000000000000000000000000000"], ["validators", 0, "amount", "110000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "110000000000000000000000000000000"]
+    ],
     {0: consensus_config, 1: consensus_config, 2: consensus_config}
 )
 

--- a/pytest/tests/sanity/gc_after_sync.py
+++ b/pytest/tests/sanity/gc_after_sync.py
@@ -16,7 +16,13 @@ consensus_config = {"consensus": {"min_block_production_delay": {"secs": 0, "nan
 
 nodes = start_cluster(
     3, 0, 1, None,
-    [["epoch_length", 10], ["num_block_producer_seats_per_shard", [5]], ["validators", 0, "amount", "60000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"]],
+    [
+        ["epoch_length", 10],
+        ["num_block_producer_seats_per_shard", [5]],
+        ["validators", 0, "amount", "60000000000000000000000000000000"],
+        ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"],
+        ["total_supply", "4010000000000000000000000000000000"]
+    ],
     {0: consensus_config, 1: consensus_config, 2: consensus_config}
 )
 
@@ -55,8 +61,8 @@ while True:
 # all fresh data should be synced
 blocks_count = 0
 for height in range(node1_height - 10, node1_height):
-    block0 = nodes[0].json_rpc('block', [height])
-    block1 = nodes[1].json_rpc('block', [height])
+    block0 = nodes[0].json_rpc('block', [height], timeout=15)
+    block1 = nodes[1].json_rpc('block', [height], timeout=15)
     assert block0 == block1
     if 'result' in block0:
         blocks_count += 1
@@ -66,8 +72,8 @@ time.sleep(1)
 # all old data should be GCed
 blocks_count = 0
 for height in range(1, 60):
-    block0 = nodes[0].json_rpc('block', [height])
-    block1 = nodes[1].json_rpc('block', [height])
+    block0 = nodes[0].json_rpc('block', [height], timeout=15)
+    block1 = nodes[1].json_rpc('block', [height], timeout=15)
     assert block0 == block1
     if 'result' in block0:
         blocks_count += 1

--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -21,7 +21,13 @@ consensus_config = {"consensus": {"min_block_production_delay": {"secs": 0, "nan
 
 nodes = start_cluster(
     3, 0, 1, None,
-    [["epoch_length", 10], ["num_block_producer_seats_per_shard", [5]], ["validators", 0, "amount", "60000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"]],
+    [
+        ["epoch_length", 10],
+        ["num_block_producer_seats_per_shard", [5]],
+        ["validators", 0, "amount", "60000000000000000000000000000000"],
+        ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"],
+        ["total_supply", "4010000000000000000000000000000000"]
+    ],
     {0: consensus_config, 1: consensus_config, 2: consensus_config}
 )
 

--- a/pytest/tests/sanity/one_val.py
+++ b/pytest/tests/sanity/one_val.py
@@ -16,7 +16,16 @@ TIMEOUT = 240
 
 
 # give more stake to the bootnode so that it can produce the blocks alone
-nodes = start_cluster(2, 1, 8, None, [["num_block_producer_seats", 199], ["num_block_producer_seats_per_shard", [24, 25, 25, 25, 25, 25, 25, 25]], ["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 10], ["block_producer_kickout_threshold", 70], ["validators", 0, "amount", "60000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"]], {})
+nodes = start_cluster(
+    2, 1, 8, None,
+    [
+        ["num_block_producer_seats", 199], ["num_block_producer_seats_per_shard", [24, 25, 25, 25, 25, 25, 25, 25]],
+        ["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 10], ["block_producer_kickout_threshold", 70],
+        ["validators", 0, "amount", "60000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"],
+        ["total_supply", "4010000000000000000000000000000000"]
+    ],
+    {}
+)
 time.sleep(3)
 nodes[1].kill()
 

--- a/test-utils/testlib/src/node/process_node.rs
+++ b/test-utils/testlib/src/node/process_node.rs
@@ -116,7 +116,17 @@ impl ProcessNode {
     /// Side effect: writes chain spec file
     pub fn get_start_node_command(&self) -> Command {
         let mut command = Command::new("cargo");
-        command.args(&["run", "-p", "near", "--", "--home", &self.work_dir, "run"]);
+        command.args(&[
+            "run",
+            "-p",
+            "neard",
+            "--bin",
+            "neard",
+            "--",
+            "--home",
+            &self.work_dir,
+            "run",
+        ]);
         command
     }
 }

--- a/tests/test_rejoin.rs
+++ b/tests/test_rejoin.rs
@@ -16,7 +16,7 @@ mod test {
 
     fn warmup() {
         Command::new("cargo")
-            .args(&["build", "-p", "near"])
+            .args(&["build", "-p", "neard"])
             .spawn()
             .expect("warmup failed")
             .wait()


### PR DESCRIPTION
Fix two kinds of failures on nightly:
* Since we now do not calculate total supply at deserialization time, some tests fail because they modify some records but not the total supply.
* `test_4_20_kill1` and `test_4_20_kill1` failed because of the neard binary change.

Test plan
---------
Running tests locally and see that they pass.