### PR TITLE
feat(chain): Make a separate error kind for a missing (not available) block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1932,6 +1932,7 @@ dependencies = [
  "rocksdb 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tracing 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -17,6 +17,7 @@ serde_derive = "1.0"
 cached = "0.12.0"
 lazy_static = "1.4"
 num-rational = "0.2.4"
+tracing = "0.1.13"
 
 borsh = "0.6.1"
 

--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -5,6 +5,7 @@ use chrono::{DateTime, Utc};
 use failure::{Backtrace, Context, Fail};
 
 use near_primitives::challenge::{ChunkProofs, ChunkState};
+use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::types::ShardId;
 
@@ -21,7 +22,11 @@ pub enum ErrorKind {
     /// Orphan block.
     #[fail(display = "Orphan")]
     Orphan,
-    #[fail(display = "Chunk Missing: {:?}", _0)]
+    /// Block is not availiable (e.g. garbage collected)
+    #[fail(display = "Block Missing (unavailable on the node): {}", _0)]
+    BlockMissing(CryptoHash),
+    /// Chunk is missing.
+    #[fail(display = "Chunk Missing (unavailable on the node): {:?}", _0)]
     ChunkMissing(ChunkHash),
     /// Chunks missing with header info.
     #[fail(display = "Chunks Missing: {:?}", _0)]
@@ -204,6 +209,7 @@ impl Error {
         match self.kind() {
             ErrorKind::Unfit(_)
             | ErrorKind::Orphan
+            | ErrorKind::BlockMissing(_)
             | ErrorKind::ChunkMissing(_)
             | ErrorKind::ChunksMissing(_)
             | ErrorKind::InvalidChunkHeight

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -7,6 +7,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use cached::{Cached, SizedCache};
 use chrono::Utc;
 use serde::Serialize;
+use tracing::debug;
 
 use near_primitives::block::{Approval, BlockScore};
 use near_primitives::errors::InvalidTxError;
@@ -564,10 +565,20 @@ impl ChainStoreAccess for ChainStore {
                         Ok(Some(_)) => Err(ErrorKind::BlockMissing(h.clone()).into()),
                         Ok(None) => Err(e),
                         Err(header_error) => {
-                            unreachable!(
-                                "If the block was not found, the block header may either exist or not found as well, but {:?}",
+                            debug_assert!(
+                                false,
+                                "If the block was not found, the block header may either \
+                                exist or not found as well, instead the error was returned {:?}",
                                 header_error
                             );
+                            debug!(
+                                target: "store",
+                                "If the block was not found, the block header may either \
+                                exist or not found as well, instead the error was returned {:?}. \
+                                This is not expected to happen, but it is not a fatal error.",
+                                header_error
+                            );
+                            Err(e)
                         }
                     }
                 }

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -546,10 +546,34 @@ impl ChainStoreAccess for ChainStore {
 
     /// Get full block.
     fn get_block(&mut self, h: &CryptoHash) -> Result<&Block, Error> {
-        option_to_not_found(
+        let block_result = option_to_not_found(
             read_with_cache(&*self.store, ColBlock, &mut self.blocks, h.as_ref()),
             &format!("BLOCK: {}", h),
-        )
+        );
+        match block_result {
+            Ok(block) => Ok(block),
+            Err(e) => match e.kind() {
+                ErrorKind::DBNotFoundErr(_) => {
+                    let block_header_result = read_with_cache(
+                        &*self.store,
+                        ColBlockHeader,
+                        &mut self.headers,
+                        h.as_ref(),
+                    );
+                    match block_header_result {
+                        Ok(Some(_)) => Err(ErrorKind::BlockMissing(h.clone()).into()),
+                        Ok(None) => Err(e),
+                        Err(header_error) => {
+                            unreachable!(
+                                "If the block was not found, the block header may either exist or not found as well, but {:?}",
+                                header_error
+                            );
+                        }
+                    }
+                }
+                _ => Err(e),
+            },
+        }
     }
 
     /// Get full chunk.


### PR DESCRIPTION
*Resolves #2319*

The missing block is detected based on the availability of the block header. The block headers persist over garbage collection.

## Test Plan

* [x] Add tests to the GC testing suite to make sure that querying via either block hash or height results in the BlockMissing error