### PR TITLE
fix: pass correct gas price to runtime

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2560,7 +2560,7 @@ impl<'a> ChainUpdate<'a> {
                             &receipts,
                             &chunk.transactions,
                             &chunk.header.inner.validator_proposals,
-                            block.header.inner_rest.gas_price,
+                            prev_block.header.inner_rest.gas_price,
                             chunk.header.inner.gas_limit,
                             &block.header.inner_rest.challenges_result,
                         )

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -440,8 +440,6 @@ impl RuntimeAdapter for KeyValueRuntime {
 
     fn validate_tx(
         &self,
-        _block_height: BlockHeight,
-        _block_timestamp: u64,
         _gas_price: Balance,
         _state_update: StateRoot,
         _transaction: &SignedTransaction,
@@ -451,8 +449,6 @@ impl RuntimeAdapter for KeyValueRuntime {
 
     fn prepare_transactions(
         &self,
-        _block_height: BlockHeight,
-        _block_timestamp: u64,
         _gas_price: Balance,
         _gas_limit: Gas,
         _state_root: StateRoot,

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -134,8 +134,6 @@ pub trait RuntimeAdapter: Send + Sync {
     /// `RuntimeError::StorageError`.
     fn validate_tx(
         &self,
-        block_height: BlockHeight,
-        block_timestamp: u64,
         gas_price: Balance,
         state_root: StateRoot,
         transaction: &SignedTransaction,
@@ -150,8 +148,6 @@ pub trait RuntimeAdapter: Send + Sync {
     /// `RuntimeError::StorageError`.
     fn prepare_transactions(
         &self,
-        block_height: BlockHeight,
-        block_timestamp: u64,
         gas_price: Balance,
         gas_limit: Gas,
         state_root: StateRoot,

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -144,7 +144,6 @@ fn create_chunk(
             last_block.chunks[0].clone(),
             2,
             0,
-            0,
         )
         .unwrap()
         .unwrap();

--- a/core/chain-configs/src/lib.rs
+++ b/core/chain-configs/src/lib.rs
@@ -7,4 +7,4 @@ pub use genesis_config::{
 };
 
 /// Current latest version of the protocol
-pub const PROTOCOL_VERSION: u32 = 9;
+pub const PROTOCOL_VERSION: u32 = 10;

--- a/neard/res/genesis_config.json
+++ b/neard/res/genesis_config.json
@@ -1,6 +1,6 @@
 {
   "config_version": 1,
-  "protocol_version": 9,
+  "protocol_version": 10,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -217,7 +217,7 @@ impl Runtime {
         match verify_and_charge_transaction(
             &self.config,
             state_update,
-            apply_state,
+            apply_state.gas_price,
             signed_transaction,
         ) {
             Ok(verification_result) => {

--- a/scripts/migrations/10-gas-price-fix.py
+++ b/scripts/migrations/10-gas-price-fix.py
@@ -1,0 +1,20 @@
+"""
+Fixes a bug related to gas price computation. No state migration needed for this change
+
+"""
+
+import sys
+import os
+import json
+from collections import OrderedDict
+
+home = sys.argv[1]
+output_home = sys.argv[2]
+
+config = json.load(open(os.path.join(home, 'output.json')), object_pairs_hook=OrderedDict)
+
+assert config['protocol_version'] == 9
+
+config['protocol_version'] = 10
+
+json.dump(config, open(os.path.join(output_home, 'output.json'), 'w'), indent=2)


### PR DESCRIPTION
There is an off-by-one error that can cause a transaction which is valid when it is included in a chunk later becomes invalid when it is applied due to a change in gas price. This PR also refactors `verify_and_charge_transaction` to take `gas_price` instead of `apply_state` as an argument so that we don't pass a lot of unnecessary arguments around and make it easier to understand what the function requires.

Test plan
---------
* Make sure that `test_gas_price_change`, which reproduces the failure we had, passes.