### PR TITLE
fix(state dump): delayed receipts

### DIFF
--- a/core/primitives/src/state_record.rs
+++ b/core/primitives/src/state_record.rs
@@ -95,6 +95,7 @@ impl StateRecord {
                 let receipt = Receipt::try_from_slice(&value).unwrap();
                 Some(StateRecord::DelayedReceipt(Box::new(receipt)))
             }
+            col::DELAYED_RECEIPT_INDICES => None,
             _ => unreachable!(),
         }
     }

--- a/test-utils/state-viewer/src/state_dump.rs
+++ b/test-utils/state-viewer/src/state_dump.rs
@@ -246,4 +246,63 @@ mod test {
         let _ =
             state_dump(runtime2, state_roots.clone(), last_block.header.clone(), &genesis.config);
     }
+
+    #[test]
+    fn test_dump_state_with_delayed_receipt() {
+        let epoch_length = 4;
+        let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
+        genesis.config.num_block_producer_seats = 2;
+        genesis.config.num_block_producer_seats_per_shard = vec![2];
+        genesis.config.epoch_length = epoch_length;
+        let store = create_test_store();
+        let nightshade_runtime = NightshadeRuntime::new(
+            Path::new("."),
+            store.clone(),
+            Arc::new(genesis.clone()),
+            vec![],
+            vec![],
+        );
+        let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![Arc::new(nightshade_runtime)];
+        let mut chain_genesis = ChainGenesis::test();
+        chain_genesis.epoch_length = epoch_length;
+        let mut env = TestEnv::new_with_runtime(chain_genesis, 1, 2, runtimes);
+        let genesis_hash = env.clients[0].chain.genesis().hash();
+        let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
+        let tx = SignedTransaction::stake(
+            1,
+            "test1".to_string(),
+            &signer,
+            TESTING_INIT_STAKE,
+            signer.public_key.clone(),
+            genesis_hash,
+        );
+        env.clients[0].process_tx(tx, false);
+        for i in 1..=epoch_length * 2 + 1 {
+            env.produce_block(0, i);
+        }
+        let head = env.clients[0].chain.head().unwrap();
+        let last_block_hash = head.last_block_hash;
+        let cur_epoch_id = head.epoch_id;
+        let block_producers = env.clients[0]
+            .runtime_adapter
+            .get_epoch_block_producers_ordered(&cur_epoch_id, &last_block_hash)
+            .unwrap();
+        assert_eq!(
+            block_producers.into_iter().map(|(r, _)| r.account_id).collect::<HashSet<_>>(),
+            HashSet::from_iter(vec!["test0".to_string(), "test1".to_string()])
+        );
+        let last_block = env.clients[0].chain.get_block(&head.last_block_hash).unwrap().clone();
+        let state_roots =
+            last_block.chunks.iter().map(|chunk| chunk.inner.prev_state_root).collect();
+        let runtime = NightshadeRuntime::new(
+            Path::new("."),
+            store.clone(),
+            Arc::new(genesis.clone()),
+            vec![],
+            vec![],
+        );
+        let new_genesis = state_dump(runtime, state_roots, last_block.header, &genesis.config);
+        assert_eq!(new_genesis.config.validators.len(), 2);
+        validate_genesis(&new_genesis);
+    }
 }


### PR DESCRIPTION
Fix the error of entering `unreachable` when encountering `DELAYED_RECEIPT_INDICES`. @evgenykuzyakov please let me know if it makes sense to ignore delayed receipt indices.

Test plan
---------
`test_dump_state_with_delayed_receipt` that tests dumping state with delayed receipt.