### PR TITLE
fix: fix several issues around transaction and transaction query routing

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1931,10 +1931,7 @@ impl Chain {
         &mut self,
         hash: &CryptoHash,
     ) -> Result<ExecutionOutcomeWithIdView, Error> {
-        match self.get_execution_outcome(hash) {
-            Ok(result) => Ok(result.clone().into()),
-            Err(err) => return Err(err),
-        }
+        self.get_execution_outcome(hash).map(|r| r.clone().into())
     }
 
     fn get_recursive_transaction_results(

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -473,8 +473,10 @@ pub struct Tip {
     pub prev_block_hash: CryptoHash,
     /// The score on that fork
     pub score: BlockScore,
-    /// Previous epoch id. Used for getting validator info.
+    /// Current epoch id. Used for getting validator info.
     pub epoch_id: EpochId,
+    /// Next epoch id.
+    pub next_epoch_id: EpochId,
 }
 
 impl Tip {
@@ -486,6 +488,7 @@ impl Tip {
             prev_block_hash: header.prev_hash,
             score: header.inner_rest.score,
             epoch_id: header.inner_lite.epoch_id.clone(),
+            next_epoch_id: header.inner_lite.next_epoch_id.clone(),
         }
     }
 

--- a/neard/src/runtime.rs
+++ b/neard/src/runtime.rs
@@ -1367,6 +1367,7 @@ mod test {
                     height: 0,
                     epoch_id: EpochId::default(),
                     score: 0.into(),
+                    next_epoch_id: Default::default(),
                 },
                 state_roots,
                 last_receipts: HashMap::default(),
@@ -1434,6 +1435,7 @@ mod test {
                 height: self.head.height + 1,
                 epoch_id: self.runtime.get_epoch_id_from_prev_block(&new_hash).unwrap(),
                 score: self.head.score,
+                next_epoch_id: self.runtime.get_next_epoch_id_from_prev_block(&new_hash).unwrap(),
             };
         }
 


### PR DESCRIPTION
Fix several issues regarding transaction and tx status request routing:
* If a transaction is submitted through a nonvalidator, we don't consider the case where it is close to the epoch boundary and might forward to wrong validators.
* When a validator receives a transaction, they check whether they are an "active validator" without considering epoch boundary.
* https://github.com/nearprotocol/nearcore/pull/2494/ broke transaction status request routing. If the transaction has receipts that will be processed in some other shards, the validator will never request the receipt result.

Test plan
---------
`test_tx_forward_around_epoch_boundary` that tests transaction forwarding from nonvalidator works on epoch boundary.
`rpc_query.py` does not fail with transaction timeout.