### PR TITLE
fix: correctly count chunk produced

### DIFF
--- a/chain/epoch_manager/src/types.rs
+++ b/chain/epoch_manager/src/types.rs
@@ -167,11 +167,15 @@ impl BlockInfo {
     pub fn update_shard_tracker(
         &mut self,
         epoch_info: &EpochInfo,
+        prev_block_height: BlockHeight,
         mut prev_shard_tracker: HashMap<ShardId, HashMap<ValidatorId, ValidatorStats>>,
     ) {
         for (i, mask) in self.chunk_mask.iter().enumerate() {
-            let chunk_validator_id =
-                EpochManager::chunk_producer_from_info(epoch_info, self.height, i as ShardId);
+            let chunk_validator_id = EpochManager::chunk_producer_from_info(
+                epoch_info,
+                prev_block_height + 1,
+                i as ShardId,
+            );
             let tracker = prev_shard_tracker.entry(i as ShardId).or_insert_with(HashMap::new);
             tracker
                 .entry(chunk_validator_id)


### PR DESCRIPTION
The current way of counting expected number of chunks for a chunk producer is flawed. While I took into consideration that when a block is not produced, not chunk can be included in that block, I failed to realize that if block at height `h` is not produced, chunks at height `h` can be included in block `h+1`, if it is produced. Therefore, what we really need to count when processing a block is whether chunk producers for height `prev_block_height + 1` produced their chunks. Resolves #2534.

Test plan
---------
`test_expected_chunks_prev_block_not_produced` that tests when a chunk producer failed to produce a chunk due to the block at previous height not being produced, it does not get kicked out.
