### PR TITLE
fix(pytest): fix state_sync2.py

### DIFF
--- a/pytest/tests/sanity/state_sync2.py
+++ b/pytest/tests/sanity/state_sync2.py
@@ -18,7 +18,7 @@ print('start state sync2', file=sys.stderr)
 TIMEOUT = 600
 BLOCKS = 105 # should be enough to trigger state sync for node 1 later, see comments there
 
-nodes = start_cluster(2, 0, 2, None, [["num_block_producer_seats", 199], ["num_block_producer_seats_per_shard", [24, 25, 25, 25, 25, 25, 25, 25]], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
+nodes = start_cluster(2, 0, 2, None, [["num_block_producer_seats", 199], ["num_block_producer_seats_per_shard", [99, 100]], ["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
 print('cluster started')
 
 started = time.time()
@@ -39,6 +39,7 @@ nodes[0].kill()
 nodes[0].reset_data()
 tracker = LogTracker(nodes[0])
 nodes[0].start(nodes[1].node_key.pk, nodes[1].addr())
+time.sleep(3)
 
 while True:
     assert time.time() - started < TIMEOUT


### PR DESCRIPTION
`state_sync2.py` was not written correctly. The number of shards specified does not match the number specified in `num_block_producer_seats_per_shard`. Resolves #2548 

Test plan
---------
Make sure `state_sync2.py` works locally.