### PR TITLE
fix(pytest): fix rpc_state_changes.py

### DIFF
--- a/pytest/tests/sanity/rpc_state_changes.py
+++ b/pytest/tests/sanity/rpc_state_changes.py
@@ -15,7 +15,7 @@ from cluster import start_cluster, Key
 from utils import load_binary_file
 import transaction
 
-nodes = start_cluster(4, 0, 1, None, [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
+nodes = start_cluster(4, 0, 1, None, [["epoch_length", 1000], ["block_producer_kickout_threshold", 80]], {})
 
 def assert_changes_in_block_response(request, expected_response):
     for node_index, node in enumerate(nodes):


### PR DESCRIPTION
rpc_state_changes.py sometimes fails because on the first block of an epoch there is state change to validator accounts when reward is added. This PR fixes it by using an epoch length that is sufficiently long. Fixes #2541 

Test plan
---------
* `rpc_state_changes.py` passes.