### PR TITLE
fix(pytest): fix block_sync.py

### DIFF
--- a/pytest/tests/sanity/block_sync.py
+++ b/pytest/tests/sanity/block_sync.py
@@ -18,7 +18,8 @@ consensus_config1 = {"consensus": {"min_block_production_delay": {"secs": 100, "
 nodes = start_cluster(
     2, 0, 4, None,
     [
-        ["epoch_length", 100], ["validators", 0, "amount", "110000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "110000000000000000000000000000000"],
+        ["epoch_length", 100], ["num_block_producer_seats", 100], ["num_block_producer_seats_per_shard", [25, 25, 25, 25]],
+        ["validators", 0, "amount", "110000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "110000000000000000000000000000000"],
         ["total_supply", "3060000000000000000000000000000000"]
     ],
     {0: consensus_config0, 1: consensus_config1}


### PR DESCRIPTION
bloc_sync.py failed because on each shard there is only one chunk producer and therefore when the chunk producer cleared data, it has no way to recover the chunks and therefore cannot process synced blocks. Fixes #2543 

Test plan
---------
`block_sync.py` passes locally.