### PR TITLE
fix(chain): Fixing several nightly failures

### DIFF
--- a/chain/chain/tests/doomslug.rs
+++ b/chain/chain/tests/doomslug.rs
@@ -179,17 +179,7 @@ mod tests {
                         let num_blocks_to_produce = if bp_ord < 3 { 2 } else { 1 };
 
                         for block_ord in 0..num_blocks_to_produce {
-                            let parent_hash = if (bp_ord == 1 || bp_ord == 2)
-                                && target_height == ds.get_tip().1 + 1
-                                && target_height > 2
-                                && thread_rng().gen_bool(0.5)
-                            {
-                                // For the second and third malicious actor occasionally create blocks
-                                // with different parents
-                                block_hash(target_height - 1, thread_rng().gen_range(0, 2))
-                            } else {
-                                ds.get_tip().0
-                            };
+                            let parent_hash = ds.get_tip().0;
 
                             let prev_height = hash_to_block_info.get(&parent_hash).unwrap().0;
                             let prev_prev_height = if prev_height <= 1 {

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -79,8 +79,8 @@ expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_w
 expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_2
 
 # consensus tests
-expensive --timeout=900 near-chain doomslug tests::test_fuzzy_doomslug_liveness_and_safety
-expensive --timeout=350 near-client consensus tests::test_consensus_with_epoch_switches
+expensive --timeout=1500 near-chain doomslug tests::test_fuzzy_doomslug_liveness_and_safety
+expensive --timeout=500 near-client consensus tests::test_consensus_with_epoch_switches
 
 # state sync tests
 expensive neard sync_state_nodes sync_state_nodes_multishard


### PR DESCRIPTION
Two doomslug-related tests had timeouts slightly lower than needed;

`test_fuzzy_doomslug_liveness_and_safety` had a way to create short
forks by malicious actors, but those forks were violating doomslug
invariants (specifically, blocks that did not have enough endorsements
could be produced), and under certain conditions the test would find a
situation in which one such block is not built on top of a final block.
Removing that logic from the test;

Fixes #2553