### PR TITLE
fix: Fixing skip_epoch.py

### DIFF
--- a/pytest/tests/sanity/skip_epoch.py
+++ b/pytest/tests/sanity/skip_epoch.py
@@ -17,17 +17,16 @@ TWENTY_FIVE = 25
 
 config = load_config()
 # give more stake to the bootnode so that it can produce the blocks alone
-near_root, node_dirs = init_cluster(2, 1, 2, config, [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 7], ["block_producer_kickout_threshold", 80], ["validators", 0, "amount", "60000000000000000000000000000000"], ["records", 0, "Account", "account", "locked", "60000000000000000000000000000000"]], {2: {"tracked_shards": [0, 1]}})
+near_root, node_dirs = init_cluster(4, 1, 4, config, [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 7], ["block_producer_kickout_threshold", 40]], {4: {"tracked_shards": [0, 1, 2, 3]}})
 
 started = time.time()
 
 boot_node = spin_up_node(config, near_root, node_dirs[0], 0, None, None)
-#node1 = spin_up_node(config, near_root, node_dirs[1], 1, boot_node.node_key.pk, boot_node.addr())
-observer = spin_up_node(config, near_root, node_dirs[2], 2, boot_node.node_key.pk, boot_node.addr())
+node3 = spin_up_node(config, near_root, node_dirs[2], 2, boot_node.node_key.pk, boot_node.addr())
+node4 = spin_up_node(config, near_root, node_dirs[3], 3, boot_node.node_key.pk, boot_node.addr())
+observer = spin_up_node(config, near_root, node_dirs[4], 4, boot_node.node_key.pk, boot_node.addr())
 
-# It takes a while for test2 account to appear
-ctx = TxContext([0, 0, 0], [boot_node, None, observer])
-print('ha')
+ctx = TxContext([0, 0, 0, 0, 0], [boot_node, None, node3, node4, observer])
 initial_balances = ctx.get_balances()
 total_supply = sum(initial_balances)
 
@@ -106,17 +105,17 @@ print(get_validators())
 
 # The stake for node2 must be higher than that of boot_node, so that it can produce blocks
 # after the boot_node is brought down
-tx = sign_staking_tx(node2.signer_key, node2.validator_key, 70000000000000000000000000000000, 20, base58.b58decode(hash_.encode('utf8')))
+tx = sign_staking_tx(node2.signer_key, node2.validator_key, 50000000000000000000000000000000, 20, base58.b58decode(hash_.encode('utf8')))
 boot_node.send_tx(tx)
 
-assert(get_validators() == set(["test0"]))
+assert(get_validators() == set(["test0", "test2", "test3"])), get_validators()
 
 while True:
     if time.time() - started > TIMEOUT:
         print(get_validators())
         assert False
 
-    if get_validators() == set(["test0", "test1"]):
+    if get_validators() == set(["test0", "test1", "test2", "test3"]):
         break
 
     time.sleep(1)
@@ -127,8 +126,8 @@ ctx.next_nonce = 100
 status = node2.get_status()
 last_height = status['sync_info']['latest_block_height']
 
-ctx.nodes = [boot_node, node2, observer]
-ctx.act_to_val = [1, 1, 1]
+ctx.nodes = [boot_node, node2, node3, node4, observer]
+ctx.act_to_val = [1, 1, 1, 1, 1]
 
 boot_node.kill()
 seen_boot_heights = set()


### PR DESCRIPTION
The test was relying on a single block producer being able to finalize
an epoch, which is not possible any longer. Fixing it by increasing the
number of block producers to four (with one offline the remaining three
can still finalize the epoch)

Fixes #2546