### PR TITLE
[refactor]: Move network parameters to config.

### DIFF
--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -386,20 +386,20 @@ impl PeerManagerActor {
     /// Check if it is needed to create a new outbound connection.
     /// If the number of active connections is less than `ideal_connections_lo` or
     /// (the number of outgoing connections is less than `minimum_outbound_peers`
-    ///     and the total connections is less than `max_peer`)
+    ///     and the total connections is less than `max_num_peers`)
     fn is_outbound_bootstrap_needed(&self) -> bool {
         let total_connections = self.active_peers.len() + self.outgoing_peers.len();
         let potential_outgoing_connections =
             self.num_active_outgoing_peers() + self.outgoing_peers.len();
 
         (total_connections < self.config.ideal_connections_lo as usize
-            || (total_connections < self.config.max_peer as usize
+            || (total_connections < self.config.max_num_peers as usize
                 && potential_outgoing_connections < self.config.minimum_outbound_peers as usize))
             && !self.config.outbound_disabled
     }
 
     fn is_inbound_allowed(&self) -> bool {
-        self.active_peers.len() + self.outgoing_peers.len() < self.config.max_peer as usize
+        self.active_peers.len() + self.outgoing_peers.len() < self.config.max_num_peers as usize
     }
 
     /// Returns single random peer with close to the highest height
@@ -919,7 +919,7 @@ impl PeerManagerActor {
                 .map(|a| a.full_peer_info.clone())
                 .collect::<Vec<_>>(),
             num_active_peers: self.num_active_peers(),
-            peer_max_count: self.config.max_peer,
+            peer_max_count: self.config.max_num_peers,
             highest_height_peers: self.highest_height_peers(),
             sent_bytes_per_sec,
             received_bytes_per_sec,

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -386,7 +386,7 @@ impl PeerManagerActor {
     /// Check if it is needed to create a new outbound connection.
     /// If the number of active connections is less than `ideal_connections_lo` or
     /// (the number of outgoing connections is less than `minimum_outbound_peers`
-    ///     and the total connections is less than `max_peers`)
+    ///     and the total connections is less than `max_peer`)
     fn is_outbound_bootstrap_needed(&self) -> bool {
         let total_connections = self.active_peers.len() + self.outgoing_peers.len();
         let potential_outgoing_connections =

--- a/chain/network/src/test_utils.rs
+++ b/chain/network/src/test_utils.rs
@@ -61,7 +61,7 @@ impl NetworkConfig {
             handshake_timeout: Duration::from_secs(60),
             reconnect_delay: Duration::from_secs(60),
             bootstrap_peers_period: Duration::from_millis(100),
-            max_peer: 10,
+            max_num_peers: 10,
             minimum_outbound_peers: 5,
             ideal_connections_lo: 30,
             ideal_connections_hi: 35,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -707,7 +707,7 @@ pub struct NetworkConfig {
     pub reconnect_delay: Duration,
     pub bootstrap_peers_period: Duration,
     /// Maximum number of active peers. Hard limit.
-    pub max_peer: u32,
+    pub max_num_peers: u32,
     /// Minimum outbound connections a peer should have to avoid eclipse attacks.
     pub minimum_outbound_peers: u32,
     /// Lower bound of the ideal number of connections.
@@ -755,24 +755,24 @@ impl NetworkConfig {
     pub fn verify(&self) {
         if self.ideal_connections_lo + 1 >= self.ideal_connections_hi {
             error!(target: "network",
-            "Invalid IDEAL_CONNECTIONS values. LO({}) > HI({})",
+            "Invalid ideal_connections values. lo({}) > hi({}).",
             self.ideal_connections_lo, self.ideal_connections_hi);
         }
 
-        if self.ideal_connections_hi >= self.max_peer {
+        if self.ideal_connections_hi >= self.max_num_peers {
             error!(target: "network",
-                "Inestable IDEAL_CONNECTIONS_HI({}) compared with MAX_PEER({})",
-                self.ideal_connections_hi, self.max_peer
+                "max_num_peers({}) is below ideal_connections_hi({}) which may lead to connection saturation and declining new connections.",
+                self.max_num_peers, self.ideal_connections_hi
             );
         }
 
         if self.outbound_disabled {
-            warn!(target: "network", "Outbound connections are disabled");
+            warn!(target: "network", "Outbound connections are disabled.");
         }
 
         if self.safe_set_size <= self.minimum_outbound_peers {
             error!(target: "network",
-                "SAFE_SET_SIZE({}) must be larger than MINIMUM_OUTBOUND_PEERS({})",
+                "safe_set_size({}) must be larger than minimum_outbound_peers({}).",
                 self.safe_set_size,
                 self.minimum_outbound_peers
             );
@@ -781,7 +781,7 @@ impl NetworkConfig {
         if UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE * 2 > self.peer_recent_time_window {
             error!(
                 target: "network",
-                "Very short PEER_RECENT_TIME_WINDOW({}). It should be at least twice UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE({})",
+                "Very short peer_recent_time_window({}). it should be at least twice update_interval_last_time_received_message({}).",
                 self.peer_recent_time_window.as_secs(), UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE.as_secs()
             );
         }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -753,21 +753,17 @@ pub struct NetworkConfig {
 
 impl NetworkConfig {
     pub fn verify(&self) {
-        let mut some_error = false;
-
         if self.ideal_connections_lo + 1 >= self.ideal_connections_hi {
             error!(target: "network",
             "Invalid IDEAL_CONNECTIONS values. LO({}) > HI({})",
             self.ideal_connections_lo, self.ideal_connections_hi);
-            some_error = true;
         }
 
         if self.ideal_connections_hi >= self.max_peer {
             error!(target: "network",
-                "Inestable IDEAL_CONNECTIONS_HI({}) compared with MAX_PEERS({})",
+                "Inestable IDEAL_CONNECTIONS_HI({}) compared with MAX_PEER({})",
                 self.ideal_connections_hi, self.max_peer
             );
-            some_error = true;
         }
 
         if self.outbound_disabled {
@@ -780,7 +776,6 @@ impl NetworkConfig {
                 self.safe_set_size,
                 self.minimum_outbound_peers
             );
-            some_error = true;
         }
 
         if UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE * 2 > self.peer_recent_time_window {
@@ -789,11 +784,6 @@ impl NetworkConfig {
                 "Very short PEER_RECENT_TIME_WINDOW({}). It should be at least twice UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE({})",
                 self.peer_recent_time_window.as_secs(), UPDATE_INTERVAL_LAST_TIME_RECEIVED_MESSAGE.as_secs()
             );
-            some_error = true;
-        }
-
-        if some_error {
-            panic!("Invalid network configuration. See logs for more details.");
         }
     }
 }

--- a/chain/network/tests/churn_attack.rs
+++ b/chain/network/tests/churn_attack.rs
@@ -8,7 +8,7 @@ mod runner;
 /// a connection among them.
 #[test]
 fn churn_attack() {
-    let mut runner = Runner::new(4, 4).enable_outbound().max_peer(2);
+    let mut runner = Runner::new(4, 4).enable_outbound().max_num_peers(2);
 
     runner.push(Action::AddEdge(0, 1));
     runner.push(Action::AddEdge(2, 3));

--- a/chain/network/tests/full_network.rs
+++ b/chain/network/tests/full_network.rs
@@ -7,13 +7,13 @@ mod runner;
 /// of active peers of every node is high.
 ///
 /// Spawn a network with `num_node` nodes and with top connections allowed
-/// for every peer `max_peers`. Wait until every peer has `expected_connections`
+/// for every peer `max_peer`. Wait until every peer has `expected_connections`
 /// active peers and start new node. Wait until new node is connected.
 pub fn connect_at_max_capacity(
     num_node: usize,
     ideal_lo: u32,
     ideal_hi: u32,
-    max_peers: u32,
+    max_peer: u32,
     expected_connections: usize,
     extra_nodes: usize,
 ) {
@@ -24,7 +24,7 @@ pub fn connect_at_max_capacity(
 
     let mut runner = Runner::new(num_node + extra_nodes, num_node)
         .enable_outbound()
-        .max_peer(max_peers)
+        .max_peer(max_peer)
         .use_boot_nodes(boot_nodes)
         .safe_set_size(0)
         .minimum_outbound_peers(0)

--- a/chain/network/tests/full_network.rs
+++ b/chain/network/tests/full_network.rs
@@ -7,13 +7,13 @@ mod runner;
 /// of active peers of every node is high.
 ///
 /// Spawn a network with `num_node` nodes and with top connections allowed
-/// for every peer `max_peer`. Wait until every peer has `expected_connections`
+/// for every peer `max_num_peers`. Wait until every peer has `expected_connections`
 /// active peers and start new node. Wait until new node is connected.
 pub fn connect_at_max_capacity(
     num_node: usize,
     ideal_lo: u32,
     ideal_hi: u32,
-    max_peer: u32,
+    max_num_peers: u32,
     expected_connections: usize,
     extra_nodes: usize,
 ) {
@@ -24,7 +24,7 @@ pub fn connect_at_max_capacity(
 
     let mut runner = Runner::new(num_node + extra_nodes, num_node)
         .enable_outbound()
-        .max_peer(max_peer)
+        .max_num_peers(max_num_peers)
         .use_boot_nodes(boot_nodes)
         .safe_set_size(0)
         .minimum_outbound_peers(0)

--- a/chain/network/tests/infinite_loop.rs
+++ b/chain/network/tests/infinite_loop.rs
@@ -26,7 +26,7 @@ pub fn make_peer_manager(
     let store = create_test_store();
     let mut config = NetworkConfig::from_seed(seed, port);
     config.boot_nodes = convert_boot_nodes(boot_nodes);
-    config.max_peer = peer_max_count;
+    config.max_num_peers = peer_max_count;
     let counter = Arc::new(AtomicUsize::new(0));
     let counter1 = counter.clone();
     let client_addr = ClientMock::mock(Box::new(move |_msg, _ctx| {

--- a/chain/network/tests/peer_handshake.rs
+++ b/chain/network/tests/peer_handshake.rs
@@ -27,7 +27,7 @@ fn make_peer_manager(
     let store = create_test_store();
     let mut config = NetworkConfig::from_seed(seed, port);
     config.boot_nodes = convert_boot_nodes(boot_nodes);
-    config.max_peer = peer_max_count;
+    config.max_num_peers = peer_max_count;
     let client_addr = ClientMock::mock(Box::new(move |_msg, _ctx| {
         Box::new(Some(NetworkClientResponses::NoResponse))
     }))

--- a/chain/network/tests/routing.rs
+++ b/chain/network/tests/routing.rs
@@ -225,8 +225,8 @@ fn blacklist_all() {
 /// Spawn 4 nodes with max peers required equal 2. Connect first three peers in a triangle.
 /// Try to connect peer3 to peer0 and see it fail since first three peer are at max capacity.
 #[test]
-fn max_peer_limit() {
-    let mut runner = Runner::new(4, 4).max_peer(2).enable_outbound();
+fn max_num_peers_limit() {
+    let mut runner = Runner::new(4, 4).max_num_peers(2).enable_outbound();
 
     runner.push(Action::AddEdge(0, 1));
     runner.push(Action::AddEdge(1, 2));

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -359,7 +359,7 @@ impl StateMachine {
 }
 
 struct TestConfig {
-    max_peer: u32,
+    max_num_peers: u32,
     routed_message_ttl: u8,
     boot_nodes: Vec<usize>,
     blacklist: HashSet<Option<usize>>,
@@ -373,7 +373,7 @@ struct TestConfig {
 impl TestConfig {
     fn new() -> Self {
         Self {
-            max_peer: 100,
+            max_num_peers: 100,
             routed_message_ttl: ROUTED_MESSAGE_TTL,
             boot_nodes: vec![],
             blacklist: HashSet::new(),
@@ -463,9 +463,9 @@ impl Runner {
         self
     }
 
-    pub fn max_peer(mut self, max_peer: u32) -> Self {
+    pub fn max_num_peers(mut self, max_num_peers: u32) -> Self {
         self.apply_all(move |test_config| {
-            test_config.max_peer = max_peer;
+            test_config.max_num_peers = max_num_peers;
         });
         self
     }
@@ -544,7 +544,7 @@ impl Runner {
             NetworkConfig::from_seed(accounts_id[node_id].as_str(), ports[node_id].clone());
 
         network_config.ban_window = test_config.ban_window;
-        network_config.max_peer = test_config.max_peer;
+        network_config.max_num_peers = test_config.max_num_peers;
         network_config.ttl_account_id_router = Duration::from_secs(5);
         network_config.routed_message_ttl = test_config.routed_message_ttl;
         network_config.blacklist = blacklist;

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -157,8 +157,8 @@ fn default_ideal_connections_hi() -> u32 {
     35
 }
 /// Peers which last message is was within this period of time are considered active recent peers.
-fn default_peer_recent_time_window() -> u64 {
-    600
+fn default_peer_recent_time_window() -> Duration {
+    Duration::from_secs(600)
 }
 /// Number of peers to keep while removing a connection.
 /// Used to avoid disconnecting from peers we have been connected since long time.
@@ -189,7 +189,7 @@ pub struct Network {
     pub ideal_connections_hi: u32,
     /// Peers which last message is was within this period of time are considered active recent peers (in seconds).
     #[serde(default = "default_peer_recent_time_window")]
-    pub peer_recent_time_window: u64,
+    pub peer_recent_time_window: Duration,
     /// Number of peers to keep while removing a connection.
     /// Used to avoid disconnecting from peers we have been connected since long time.
     #[serde(default = "default_safe_set_size")]
@@ -214,12 +214,12 @@ impl Default for Network {
             addr: "0.0.0.0:24567".to_string(),
             external_address: "".to_string(),
             boot_nodes: "".to_string(),
-            max_num_peers: 40,
-            minimum_outbound_peers: 5,
-            ideal_connections_lo: 30,
-            ideal_connections_hi: 35,
-            peer_recent_time_window: 600,
-            safe_set_size: 20,
+            max_num_peers: default_max_num_peers(),
+            minimum_outbound_peers: default_minimum_outbound_connections(),
+            ideal_connections_lo: default_ideal_connections_lo(),
+            ideal_connections_hi: default_ideal_connections_hi(),
+            peer_recent_time_window: default_peer_recent_time_window(),
+            safe_set_size: default_safe_set_size(),
             handshake_timeout: Duration::from_secs(20),
             reconnect_delay: Duration::from_secs(60),
             skip_sync_wait: false,
@@ -550,9 +550,7 @@ impl NearConfig {
                 minimum_outbound_peers: config.network.minimum_outbound_peers,
                 ideal_connections_lo: config.network.ideal_connections_lo,
                 ideal_connections_hi: config.network.ideal_connections_hi,
-                peer_recent_time_window: Duration::from_secs(
-                    config.network.peer_recent_time_window,
-                ),
+                peer_recent_time_window: config.network.peer_recent_time_window,
                 safe_set_size: config.network.safe_set_size,
                 ban_window: config.network.ban_window,
                 max_send_peers: 512,

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -140,6 +140,32 @@ lazy_static! {
     pub static ref MAX_INFLATION_RATE: Rational = Rational::new(5, 100);
 }
 
+/// Maximum number of active peers. Hard limit.
+fn default_max_num_peers() -> u32 {
+    40
+}
+/// Minimum outbound connections a peer should have to avoid eclipse attacks.
+fn default_minimum_outbound_connections() -> u32 {
+    5
+}
+/// Lower bound of the ideal number of connections.
+fn default_ideal_connections_lo() -> u32 {
+    30
+}
+/// Upper bound of the ideal number of connections.
+fn default_ideal_connections_hi() -> u32 {
+    35
+}
+/// Peers which last message is was within this period of time are considered active recent peers.
+fn default_peer_recent_time_window() -> u64 {
+    600
+}
+/// Number of peers to keep while removing a connection.
+/// Used to avoid disconnecting from peers we have been connected since long time.
+fn default_safe_set_size() -> u32 {
+    20
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Network {
     /// Address to listen for incoming connections.
@@ -150,17 +176,23 @@ pub struct Network {
     /// Comma separated list of nodes to connect to.
     pub boot_nodes: String,
     /// Maximum number of active peers. Hard limit.
-    pub max_peers: u32,
+    #[serde(default = "default_max_num_peers")]
+    pub max_num_peers: u32,
     /// Minimum outbound connections a peer should have to avoid eclipse attacks.
+    #[serde(default = "default_minimum_outbound_connections")]
     pub minimum_outbound_peers: u32,
     /// Lower bound of the ideal number of connections.
+    #[serde(default = "default_ideal_connections_lo")]
     pub ideal_connections_lo: u32,
     /// Upper bound of the ideal number of connections.
+    #[serde(default = "default_ideal_connections_hi")]
     pub ideal_connections_hi: u32,
     /// Peers which last message is was within this period of time are considered active recent peers (in seconds).
+    #[serde(default = "default_peer_recent_time_window")]
     pub peer_recent_time_window: u64,
     /// Number of peers to keep while removing a connection.
     /// Used to avoid disconnecting from peers we have been connected since long time.
+    #[serde(default = "default_safe_set_size")]
     pub safe_set_size: u32,
     /// Handshake timeout.
     pub handshake_timeout: Duration,
@@ -182,7 +214,7 @@ impl Default for Network {
             addr: "0.0.0.0:24567".to_string(),
             external_address: "".to_string(),
             boot_nodes: "".to_string(),
-            max_peers: 40,
+            max_num_peers: 40,
             minimum_outbound_peers: 5,
             ideal_connections_lo: 30,
             ideal_connections_hi: 35,
@@ -514,7 +546,7 @@ impl NearConfig {
                 handshake_timeout: config.network.handshake_timeout,
                 reconnect_delay: config.network.reconnect_delay,
                 bootstrap_peers_period: Duration::from_secs(60),
-                max_peer: config.network.max_peers,
+                max_num_peers: config.network.max_num_peers,
                 minimum_outbound_peers: config.network.minimum_outbound_peers,
                 ideal_connections_lo: config.network.ideal_connections_lo,
                 ideal_connections_hi: config.network.ideal_connections_hi,


### PR DESCRIPTION
All network parameters can be manipulated from config file.
Invalid network arguments won't  lead to panic anymore,
but only error message will be displayed.

Fix #2521 