### PR TITLE
fix(pytest): fix gc_sync_after_sync

### DIFF
--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -13,22 +13,19 @@ if "swap_nodes" in sys.argv:
 from cluster import start_cluster
 
 TARGET_HEIGHT_1 = 60
-TARGET_HEIGHT_2 = 150
+TARGET_HEIGHT_2 = 160
 TARGET_HEIGHT_3 = 250
 TIMEOUT = 300
 
-consensus_config = {"consensus": {"min_block_production_delay": {"secs": 0, "nanos": 100000000}, "max_block_production_delay": {"secs": 0, "nanos": 400000000}, "max_block_wait_delay": {"secs": 0, "nanos": 400000000}, "block_fetch_horizon": 20, "block_header_fetch_horizon": 20}}
+consensus_config = {"consensus": {"block_fetch_horizon": 20, "block_header_fetch_horizon": 20}}
 
 nodes = start_cluster(
-    2, 0, 1, None,
+    5, 0, 1, None,
     [
         ["epoch_length", 10],
-        ["num_block_producer_seats", 10], ["num_block_producer_seats_per_shard", [10]],
-        ["validators", 0, "amount", "250000000000000000000000000000000"],
-        ["records", 0, "Account", "account", "locked", "250000000000000000000000000000000"],
-        ["total_supply", "3200000000000000000000000000000000"]
+        ["num_block_producer_seats", 10], ["num_block_producer_seats_per_shard", [10]]
     ],
-    {0: consensus_config, 1: consensus_config}
+    {1: consensus_config}
 )
 
 print('Kill node 1')


### PR DESCRIPTION
The previous fix for `gc_sync_after_sync.py` fails when `swap` is enabled because of the asymmetry in stake distribution and if the nodes are swapped, blocks cannot be produced. Fixes #2540 

Test plan
---------
`gc_sync_after_sync.py` and `gc_sync_after_sync.py swap` both pass locally.