### PR TITLE
fix(GC): removing Genesis Block from State

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -908,10 +908,6 @@ impl Chain {
 
         chain_store_update.commit()?;
 
-        // Fill the Trie with Genesis state
-        let (_, state_store_update, _) = self.runtime_adapter.genesis_state();
-        state_store_update.commit()?;
-
         Ok(())
     }
 

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1783,6 +1783,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 assert!(false);
             }
             // Don't clean Genesis Block
+            self.merge(store_update);
             return Ok(());
         }
 

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1739,15 +1739,6 @@ impl<'a> ChainStoreUpdate<'a> {
         mut block_hash: CryptoHash,
         gc_mode: GCMode,
     ) -> Result<(), Error> {
-        let header = self
-            .get_block_header(&block_hash)
-            .expect("block data is not expected to be already cleaned")
-            .clone();
-        if header.inner_lite.height == self.get_genesis_height() {
-            // Don't clean Genesis
-            return Ok(());
-        }
-
         let mut store_update = self.store().store_update();
 
         // 1. Apply revert insertions or deletions from ColTrieChanges for Trie
@@ -1791,6 +1782,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 // Broken GC prerequisites found
                 assert!(false);
             }
+            // Don't clean Genesis Block
             return Ok(());
         }
 


### PR DESCRIPTION
Currently, we're not using any data from Genesis Block in State. According to https://github.com/nearprotocol/nearcore/issues/2570, it's not enough to not erase Genesis data from State to keep it useful. So, it's better to remove Genesis data from State at all.

Fixes https://github.com/nearprotocol/nearcore/issues/2570

Plan to test: CI + sanity python tests (gc_after_sync, gc_sync_after_sync, gc_sync_after_sync swap_nodes).