### PR TITLE
fix(pytest): fix restaked

### DIFF
--- a/pytest/tests/sanity/restaked.py
+++ b/pytest/tests/sanity/restaked.py
@@ -49,7 +49,8 @@ nodes[0].kill()
 while time.time() - started < TIMEOUT:
     status = nodes[1].get_status()
     height = status['sync_info']['latest_block_height']
-    if height > EPOCH_LENGTH * 5:
+    # epoch boundary may have shifted due to validator being offline
+    if height > EPOCH_LENGTH * 5 + 5:
         # 5 epochs later.
         validators = nodes[1].get_validators()['result']
         present = False


### PR DESCRIPTION
`restaked.py` failed because epoch boundary is now shifted a bit if a validator is offline. Fixes #2542 

Test plan
---------
`restaked.py` passes locally.