### PR TITLE
fix: Further harnessing skip_epoch.py

### DIFF
--- a/pytest/tests/sanity/skip_epoch.py
+++ b/pytest/tests/sanity/skip_epoch.py
@@ -61,6 +61,10 @@ while True:
 # 2. Spin up the second node and make sure it gets to 25 as well, and doesn't diverge
 node2 = spin_up_node(config, near_root, node_dirs[1], 1, boot_node.node_key.pk, boot_node.addr())
 
+status = boot_node.get_status()
+new_height = status['sync_info']['latest_block_height']
+seen_boot_heights.add(new_height)
+
 while True:
     assert time.time() - started < TIMEOUT
 


### PR DESCRIPTION
Locally it was still flaky if ran 100 times. With the extra check for
the seen heights haven't reproduced the failure.

Posting the correct way to fix into the #2546, in case it starts
behaving flaky again