### PR TITLE
fix(pytest): fix gc_sync_after_sync swap_nodes

### DIFF
--- a/pytest/tests/sanity/gc_sync_after_sync.py
+++ b/pytest/tests/sanity/gc_sync_after_sync.py
@@ -20,9 +20,14 @@ TIMEOUT = 300
 consensus_config = {"consensus": {"block_fetch_horizon": 20, "block_header_fetch_horizon": 20}}
 
 nodes = start_cluster(
-    5, 0, 1, None,
+    4, 0, 1, None,
     [
         ["epoch_length", 10],
+        ["validators", 0, "amount", "12500000000000000000000000000000"],
+        ["records", 0, "Account", "account", "locked", "12500000000000000000000000000000"],
+        ["validators", 1, "amount", "12500000000000000000000000000000"],
+        ["records", 2, "Account", "account", "locked", "12500000000000000000000000000000"],
+        ['total_supply', "4925000000000000000000000000000000"],
         ["num_block_producer_seats", 10], ["num_block_producer_seats_per_shard", [10]]
     ],
     {1: consensus_config}


### PR DESCRIPTION
The test fails because when swap happens, there are two nodes not producing blocks and the rest cannot produce blocks due to not having enough stake. I didn't notice it previously because I for some reason think the argument is `swap` instead of `swap_nodes`.

Test plan
---------
`gc_sync_after_sync.py swap_nodes` passes