### PR TITLE
fix(network): Avoid peers connecting to itself.

### DIFF
--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -8,7 +8,7 @@ pub use types::{
 };
 
 mod codec;
-mod metrics;
+pub mod metrics;
 mod peer;
 mod peer_manager;
 pub mod peer_store;

--- a/chain/network/src/metrics.rs
+++ b/chain/network/src/metrics.rs
@@ -87,6 +87,7 @@ lazy_static! {
             "drop_message_unreachable_peer",
             "Total messages dropped because target peer is not reachable"
         );
+    pub static ref RECEIVED_INFO_ABOUT_ITSELF: near_metrics::Result<IntCounter> = try_create_int_counter("received_info_about_itself", "Number of times a peer tried to connect to itself");
 }
 
 type_messages!(HANDSHAKE_RECEIVED_TOTAL, HANDSHAKE_RECEIVED_BYTES);

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -642,6 +642,7 @@ impl StreamHandler<Vec<u8>> for Peer {
                 }
 
                 if handshake.peer_id == self.node_info.id {
+                    near_metrics::inc_counter(&metrics::RECEIVED_INFO_ABOUT_ITSELF);
                     debug!(target: "network", "Received info about itself. Disconnecting this peer.");
                     ctx.stop();
                     return;

--- a/chain/network/src/peer_store.rs
+++ b/chain/network/src/peer_store.rs
@@ -1,4 +1,4 @@
-use std::collections::{hash_map::Iter, HashMap, HashSet};
+use std::collections::{hash_map::Iter, HashMap};
 use std::convert::TryInto;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -192,11 +192,11 @@ impl PeerStore {
 
     /// Return unconnected or peers with unknown status that we can try to connect to.
     /// Peers with unknown addresses are filtered out.
-    pub fn unconnected_peers(&self, ignore_list: &HashSet<PeerId>) -> Vec<PeerInfo> {
+    pub fn unconnected_peers(&self, ignore_fn: impl Fn(&KnownPeerState) -> bool) -> Vec<PeerInfo> {
         self.find_peers(
             |p| {
                 (p.status == KnownPeerStatus::NotConnected || p.status == KnownPeerStatus::Unknown)
-                    && !ignore_list.contains(&p.peer_info.id)
+                    && !ignore_fn(p)
                     && p.peer_info.addr.is_some()
             },
             0,

--- a/chain/network/tests/peer_handshake.rs
+++ b/chain/network/tests/peer_handshake.rs
@@ -209,5 +209,12 @@ fn check_connection_with_new_identity() {
     runner.push(Action::CheckRoutingTable(0, vec![(1, vec![1])]));
     runner.push(Action::CheckRoutingTable(1, vec![(0, vec![0])]));
 
+    runner.push(Action::Wait(2000));
+
+    // Check the no node tried to connect to itself in this process.
+    runner.push_action(wait_for(|| {
+        near_metrics::get_counter(&near_network::metrics::RECEIVED_INFO_ABOUT_ITSELF) == Ok(0)
+    }));
+
     start_test(runner);
 }

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -770,3 +770,20 @@ pub fn change_account_id(node_id: usize, account_id: String) -> ActionFn {
         },
     )
 }
+
+/// Wait for predicate to return True.
+pub fn wait_for<T>(predicate: T) -> ActionFn
+where
+    T: 'static + Fn() -> bool,
+{
+    Box::new(
+        move |_info: SharedRunningInfo,
+              flag: Arc<AtomicBool>,
+              _ctx: &mut Context<WaitOrTimeout>,
+              _runner: Addr<Runner>| {
+            if predicate() {
+                flag.store(true, Ordering::Relaxed);
+            }
+        },
+    )
+}

--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -126,6 +126,15 @@ pub fn inc_counter(counter: &Result<IntCounter>) {
     }
 }
 
+pub fn get_counter(counter: &Result<IntCounter>) -> std::result::Result<i64, ()> {
+    if let Ok(counter) = counter {
+        Ok(counter.get())
+    } else {
+        error!(target: "metrics", "Failed to fetch counter");
+        Err(())
+    }
+}
+
 pub fn inc_counter_by(counter: &Result<IntCounter>, value: i64) {
     if let Ok(counter) = counter {
         counter.inc_by(value);

--- a/core/metrics/src/lib.rs
+++ b/core/metrics/src/lib.rs
@@ -126,12 +126,11 @@ pub fn inc_counter(counter: &Result<IntCounter>) {
     }
 }
 
-pub fn get_counter(counter: &Result<IntCounter>) -> std::result::Result<i64, ()> {
+pub fn get_counter(counter: &Result<IntCounter>) -> std::result::Result<i64, String> {
     if let Ok(counter) = counter {
         Ok(counter.get())
     } else {
-        error!(target: "metrics", "Failed to fetch counter");
-        Err(())
+        Err("Failed to fetch counter".to_string())
     }
 }
 


### PR DESCRIPTION
If a node receives info about itself from other nodes
it was possible it tries to establish connection with itself.

Fix #2601 