### PR TITLE
Fix(script): docker build should not show version modified

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,6 @@
-.dockerignore
-Dockerfile
 .idea/
+.vscode/
 
-docs/
 docker/
 !docker/scripts/
 ops/


### PR DESCRIPTION
Currently all docker build has "-modified" in its version (e.g. nearup devnet) it's because some file isn't send to docker daemon.

Test Plan
------------
`make` and `docker run nearcore near --version` should not show modified.