### PR TITLE
fix(test): skip when run in nightly runner

### DIFF
--- a/tests/test_rejoin.rs
+++ b/tests/test_rejoin.rs
@@ -15,12 +15,14 @@ mod test {
     use testlib::test_helpers::{heavy_test, wait, wait_for_catchup};
 
     fn warmup() {
-        Command::new("cargo")
-            .args(&["build", "-p", "neard"])
-            .spawn()
-            .expect("warmup failed")
-            .wait()
-            .unwrap();
+        if let Err(_) = std::env::var("NIGHTLY_RUNNER") {
+            Command::new("cargo")
+                .args(&["build", "-p", "neard"])
+                .spawn()
+                .expect("warmup failed")
+                .wait()
+                .unwrap();
+        }
     }
 
     // DISCLAIMER. These tests are very heavy and somehow manage to interfere with each other.


### PR DESCRIPTION
cargo isn't available when run nightly tests in parallel containers.

Test Plan
------------
run test with NIGHT_RUNNER defined, cargo build should be skipped. run test directly cargo build should not be skipped.