### PR TITLE
fix(test): run in nightly container has no cargo

### DIFF
--- a/test-utils/testlib/src/node/process_node.rs
+++ b/test-utils/testlib/src/node/process_node.rs
@@ -116,17 +116,7 @@ impl ProcessNode {
     /// Side effect: writes chain spec file
     pub fn get_start_node_command(&self) -> Command {
         let mut command = Command::new("cargo");
-        command.args(&[
-            "run",
-            "-p",
-            "neard",
-            "--bin",
-            "neard",
-            "--",
-            "--home",
-            &self.work_dir,
-            "run",
-        ]);
+        command.args(&["target/debug/neard", "--home", &self.work_dir, "run"]);
         command
     }
 }

--- a/test-utils/testlib/src/node/process_node.rs
+++ b/test-utils/testlib/src/node/process_node.rs
@@ -115,9 +115,25 @@ impl ProcessNode {
 
     /// Side effect: writes chain spec file
     pub fn get_start_node_command(&self) -> Command {
-        let mut command = Command::new("cargo");
-        command.args(&["target/debug/neard", "--home", &self.work_dir, "run"]);
-        command
+        if let Err(_) = std::env::var("NIGHTLY_RUNNER") {
+            let mut command = Command::new("cargo");
+            command.args(&[
+                "run",
+                "-p",
+                "neard",
+                "--bin",
+                "neard",
+                "--",
+                "--home",
+                &self.work_dir,
+                "run",
+            ]);
+            command
+        } else {
+            let mut command = Command::new("target/debug/neard");
+            command.args(&["--home", &self.work_dir, "run"]);
+            command
+        }
     }
 }
 


### PR DESCRIPTION
When run locally, `fn warmup` will compile neard binary. When run in nightly, binary is prebuilt by script. 

Test Plan
------------
```
docker run --rm -u $UID:$UID -w /home/bo/workspace/nearcore2 -e NIGHTLY_RUNNER=1 -e CARGO_MANIFEST_DIR=/home/bo/workspace/nearcore2/test-utils/testlib -v /home/bo/workspace/nearcore2/target/debug/deps/cross_shard_tx-779ceb73f76760d6:/home/bo/workspace/nearcore2/target/debug/deps/cross_shard_tx-779ceb73f76760d6 -v /home/bo/workspace/nearcore2/runtime/near-vm-runner/tests/res/test_contract_rs.wasm:/home/bo/workspace/nearcore2/runtime/near-vm-runner/tests/res/test_contract_rs.wasm -w /home/bo/workspace/nearcore2 -it ubuntu:19.04 /home/bo/workspace/nearcore2/target/debug/deps/cross_shard_tx-779ceb73f76760d6
```
to simulate parallel nightly