### PR TITLE
feat(runtime costs): simplify cost computations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3026,6 +3026,7 @@ dependencies = [
  "near-vm-runner 0.8.0",
  "neard 0.4.13",
  "node-runtime 0.0.1",
+ "num-rational 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -15,6 +15,7 @@ csv = "1.1.1"
 clap = "2.33"
 
 borsh = "0.6.1"
+num-rational = "0.2.4"
 
 near-runtime-fees = { path = "../../runtime/near-runtime-fees" }
 near-crypto = { path = "../../core/crypto" }

--- a/runtime/runtime-params-estimator/src/cases.rs
+++ b/runtime/runtime-params-estimator/src/cases.rs
@@ -603,7 +603,8 @@ fn get_ext_costs_config(measurement: &Measurements) -> ExtCostsConfig {
         storage_iter_next_key_byte: 0,
         storage_iter_next_value_byte: 0,
         // TODO: Actually compute it once our storage is complete.
-        touching_trie_node: 1,
+        // TODO: temporary value, as suggested by @nearmax, divisor is log_16(20000) ~ 3.57 ~ 7/2.
+        touching_trie_node: measured_to_gas(metric, &measured, storage_read_base) * 2 / 7,
         promise_and_base: measured_to_gas(metric, &measured, promise_and_base),
         promise_and_per_promise: measured_to_gas(metric, &measured, promise_and_per_promise),
         promise_return: measured_to_gas(metric, &measured, promise_return),

--- a/runtime/runtime-params-estimator/src/cases.rs
+++ b/runtime/runtime-params-estimator/src/cases.rs
@@ -486,8 +486,7 @@ fn ratio_to_gas(gas_metric: &GasMetric, value: Ratio<u64>) -> u64 {
         GasMetric::ICount => 8u64,
         GasMetric::Time => 1u64,
     };
-    Ratio::<u64>::new(*value.numer() * GAS_IN_MEASURE_UNIT, *value.denom() * divisor)
-        .to_integer()
+    Ratio::<u64>::new(*value.numer() * GAS_IN_MEASURE_UNIT, *value.denom() * divisor).to_integer()
 }
 
 /// Converts cost of a certain action to a fee, spliting it evenly between send and execution fee.

--- a/runtime/runtime-params-estimator/src/cases.rs
+++ b/runtime/runtime-params-estimator/src/cases.rs
@@ -5,6 +5,8 @@ use std::convert::TryInto;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 
+use num_rational::Ratio;
+
 use near_crypto::{InMemorySigner, KeyType, PublicKey};
 use near_primitives::account::{AccessKey, AccessKeyPermission, FunctionCallPermission};
 use near_primitives::hash::CryptoHash;
@@ -17,8 +19,9 @@ use crate::ext_costs_generator::ExtCostsGenerator;
 use crate::runtime_fees_generator::RuntimeFeesGenerator;
 use crate::stats::Measurements;
 use crate::testbed::RuntimeTestbed;
+use crate::testbed_runners::GasMetric;
 use crate::testbed_runners::{get_account_id, measure_actions, measure_transactions, Config};
-use crate::wasmer_estimator::nanosec_per_op;
+use crate::wasmer_estimator::cost_per_op;
 use near_runtime_fees::{
     AccessKeyCreationConfig, ActionCreationConfig, DataReceiptCreationConfig, Fee,
     RuntimeFeesConfig,
@@ -27,7 +30,7 @@ use near_vm_logic::{ExtCosts, ExtCostsConfig, VMConfig, VMLimitConfig};
 use node_runtime::config::RuntimeConfig;
 
 /// How much gas there is in a nanosecond worth of computation.
-const GAS_IN_NANOS: f64 = 1_000_000f64;
+const GAS_IN_MEASURE_UNIT: u64 = 1_000_000u64;
 
 fn measure_function(
     metric: Metric,
@@ -476,93 +479,120 @@ pub fn run(mut config: Config) -> RuntimeConfig {
     //    m.plot(PathBuf::from(&config.state_dump_path).as_path());
 }
 
-/// Converts time of a certain action to a fee, spliting it evenly between send and execution fee.
-fn f64_to_fee(value: f64) -> Fee {
-    let value = if value >= 0f64 { value } else { 0f64 };
-    let value: u64 = (value * GAS_IN_NANOS) as u64;
+fn ratio_to_gas(gas_metric: &GasMetric, value: Ratio<u64>) -> u64 {
+    let divisor = match gas_metric {
+        // We use factor of 8 to approximately match the price of SHA256 operation between
+        // time-based and icount-based metric as measured on 3.2Ghz Core i5.
+        GasMetric::ICount => 8u64,
+        GasMetric::Time => 1u64,
+    };
+    Ratio::<u64>::new(*value.numer() * GAS_IN_MEASURE_UNIT, *value.denom() * divisor)
+        .to_integer()
+}
+
+/// Converts cost of a certain action to a fee, spliting it evenly between send and execution fee.
+fn measured_to_fee(gas_metric: &GasMetric, value: Ratio<u64>) -> Fee {
+    let value = ratio_to_gas(gas_metric, value);
     Fee { send_sir: value / 2, send_not_sir: value / 2, execution: value / 2 }
 }
 
-fn f64_to_gas(value: f64) -> u64 {
-    let value = if value >= 0f64 { value } else { 0f64 };
-    (value * GAS_IN_NANOS) as u64
+fn measured_to_gas(
+    gas_metric: &GasMetric,
+    measured: &BTreeMap<ExtCosts, Ratio<u64>>,
+    cost: ExtCosts,
+) -> u64 {
+    match measured.get(&cost) {
+        Some(value) => ratio_to_gas(gas_metric, *value),
+        None => panic!("cost {} not found", cost as u32),
+    }
 }
 
 fn get_runtime_fees_config(measurement: &Measurements) -> RuntimeFeesConfig {
-    use crate::runtime_fees_generator::ReceiptFeesFloat::*;
+    use crate::runtime_fees_generator::ReceiptFees::*;
     let generator = RuntimeFeesGenerator::new(measurement);
-    let pure = generator.compute();
+    let measured = generator.compute();
+    let metric = &measurement.gas_metric;
     RuntimeFeesConfig {
-        action_receipt_creation_config: f64_to_fee(pure[&ActionReceiptCreation]),
+        action_receipt_creation_config: measured_to_fee(metric, measured[&ActionReceiptCreation]),
         data_receipt_creation_config: DataReceiptCreationConfig {
-            base_cost: f64_to_fee(pure[&DataReceiptCreationBase]),
-            cost_per_byte: f64_to_fee(pure[&DataReceiptCreationPerByte]),
+            base_cost: measured_to_fee(metric, measured[&DataReceiptCreationBase]),
+            cost_per_byte: measured_to_fee(metric, measured[&DataReceiptCreationPerByte]),
         },
         action_creation_config: ActionCreationConfig {
-            create_account_cost: f64_to_fee(pure[&ActionCreateAccount]),
-            deploy_contract_cost: f64_to_fee(pure[&ActionDeployContractBase]),
-            deploy_contract_cost_per_byte: f64_to_fee(pure[&ActionDeployContractPerByte]),
-            function_call_cost: f64_to_fee(pure[&ActionFunctionCallBase]),
-            function_call_cost_per_byte: f64_to_fee(pure[&ActionFunctionCallPerByte]),
-            transfer_cost: f64_to_fee(pure[&ActionTransfer]),
-            stake_cost: f64_to_fee(pure[&ActionStake]),
+            create_account_cost: measured_to_fee(metric, measured[&ActionCreateAccount]),
+            deploy_contract_cost: measured_to_fee(metric, measured[&ActionDeployContractBase]),
+            deploy_contract_cost_per_byte: measured_to_fee(
+                metric,
+                measured[&ActionDeployContractPerByte],
+            ),
+            function_call_cost: measured_to_fee(metric, measured[&ActionFunctionCallBase]),
+            function_call_cost_per_byte: measured_to_fee(
+                metric,
+                measured[&ActionFunctionCallPerByte],
+            ),
+            transfer_cost: measured_to_fee(metric, measured[&ActionTransfer]),
+            stake_cost: measured_to_fee(metric, measured[&ActionStake]),
             add_key_cost: AccessKeyCreationConfig {
-                full_access_cost: f64_to_fee(pure[&ActionAddFullAccessKey]),
-                function_call_cost: f64_to_fee(pure[&ActionAddFunctionAccessKeyBase]),
-                function_call_cost_per_byte: f64_to_fee(pure[&ActionAddFunctionAccessKeyPerByte]),
+                full_access_cost: measured_to_fee(metric, measured[&ActionAddFullAccessKey]),
+                function_call_cost: measured_to_fee(
+                    metric,
+                    measured[&ActionAddFunctionAccessKeyBase],
+                ),
+                function_call_cost_per_byte: measured_to_fee(
+                    metric,
+                    measured[&ActionAddFunctionAccessKeyPerByte],
+                ),
             },
-            delete_key_cost: f64_to_fee(pure[&ActionDeleteKey]),
-            delete_account_cost: f64_to_fee(pure[&ActionDeleteAccount]),
+            delete_key_cost: measured_to_fee(metric, measured[&ActionDeleteKey]),
+            delete_account_cost: measured_to_fee(metric, measured[&ActionDeleteAccount]),
         },
         ..Default::default()
     }
 }
 
-fn cost_as_gas(pure: &BTreeMap<ExtCosts, f64>, cost: ExtCosts) -> u64 {
-    match pure.get(&cost) {
-        Some(value) => f64_to_gas(*value),
-        None => panic!("cost {} not found", cost as u32),
-    }
-}
-
 fn get_ext_costs_config(measurement: &Measurements) -> ExtCostsConfig {
     let mut generator = ExtCostsGenerator::new(measurement);
-    let pure = generator.compute();
+    let measured = generator.compute();
+    let metric = &measurement.gas_metric;
     use ExtCosts::*;
     ExtCostsConfig {
-        base: cost_as_gas(&pure, base),
-        read_memory_base: cost_as_gas(&pure, read_memory_base),
-        read_memory_byte: cost_as_gas(&pure, read_memory_byte),
-        write_memory_base: cost_as_gas(&pure, write_memory_base),
-        write_memory_byte: cost_as_gas(&pure, write_memory_byte),
-        read_register_base: cost_as_gas(&pure, read_register_base),
-        read_register_byte: cost_as_gas(&pure, read_register_byte),
-        write_register_base: cost_as_gas(&pure, write_register_base),
-        write_register_byte: cost_as_gas(&pure, write_register_byte),
-        utf8_decoding_base: cost_as_gas(&pure, utf8_decoding_base),
-        utf8_decoding_byte: cost_as_gas(&pure, utf8_decoding_byte),
-        utf16_decoding_base: cost_as_gas(&pure, utf16_decoding_base),
-        utf16_decoding_byte: cost_as_gas(&pure, utf16_decoding_byte),
-        sha256_base: cost_as_gas(&pure, sha256_base),
-        sha256_byte: cost_as_gas(&pure, sha256_byte),
-        keccak256_base: cost_as_gas(&pure, keccak256_base),
-        keccak256_byte: cost_as_gas(&pure, keccak256_byte),
-        keccak512_base: cost_as_gas(&pure, keccak512_base),
-        keccak512_byte: cost_as_gas(&pure, keccak512_byte),
-        log_base: cost_as_gas(&pure, log_base),
-        log_byte: cost_as_gas(&pure, log_byte),
-        storage_write_base: cost_as_gas(&pure, storage_write_base),
-        storage_write_key_byte: cost_as_gas(&pure, storage_write_key_byte),
-        storage_write_value_byte: cost_as_gas(&pure, storage_write_value_byte),
-        storage_write_evicted_byte: cost_as_gas(&pure, storage_write_evicted_byte),
-        storage_read_base: cost_as_gas(&pure, storage_read_base),
-        storage_read_key_byte: cost_as_gas(&pure, storage_read_key_byte),
-        storage_read_value_byte: cost_as_gas(&pure, storage_read_value_byte),
-        storage_remove_base: cost_as_gas(&pure, storage_remove_base),
-        storage_remove_key_byte: cost_as_gas(&pure, storage_remove_key_byte),
-        storage_remove_ret_value_byte: cost_as_gas(&pure, storage_remove_ret_value_byte),
-        storage_has_key_base: cost_as_gas(&pure, storage_has_key_base),
-        storage_has_key_byte: cost_as_gas(&pure, storage_has_key_byte),
+        base: measured_to_gas(metric, &measured, base),
+        read_memory_base: measured_to_gas(metric, &measured, read_memory_base),
+        read_memory_byte: measured_to_gas(metric, &measured, read_memory_byte),
+        write_memory_base: measured_to_gas(metric, &measured, write_memory_base),
+        write_memory_byte: measured_to_gas(metric, &measured, write_memory_byte),
+        read_register_base: measured_to_gas(metric, &measured, read_register_base),
+        read_register_byte: measured_to_gas(metric, &measured, read_register_byte),
+        write_register_base: measured_to_gas(metric, &measured, write_register_base),
+        write_register_byte: measured_to_gas(metric, &measured, write_register_byte),
+        utf8_decoding_base: measured_to_gas(metric, &measured, utf8_decoding_base),
+        utf8_decoding_byte: measured_to_gas(metric, &measured, utf8_decoding_byte),
+        utf16_decoding_base: measured_to_gas(metric, &measured, utf16_decoding_base),
+        utf16_decoding_byte: measured_to_gas(metric, &measured, utf16_decoding_byte),
+        sha256_base: measured_to_gas(metric, &measured, sha256_base),
+        sha256_byte: measured_to_gas(metric, &measured, sha256_byte),
+        keccak256_base: measured_to_gas(metric, &measured, keccak256_base),
+        keccak256_byte: measured_to_gas(metric, &measured, keccak256_byte),
+        keccak512_base: measured_to_gas(metric, &measured, keccak512_base),
+        keccak512_byte: measured_to_gas(metric, &measured, keccak512_byte),
+        log_base: measured_to_gas(metric, &measured, log_base),
+        log_byte: measured_to_gas(metric, &measured, log_byte),
+        storage_write_base: measured_to_gas(metric, &measured, storage_write_base),
+        storage_write_key_byte: measured_to_gas(metric, &measured, storage_write_key_byte),
+        storage_write_value_byte: measured_to_gas(metric, &measured, storage_write_value_byte),
+        storage_write_evicted_byte: measured_to_gas(metric, &measured, storage_write_evicted_byte),
+        storage_read_base: measured_to_gas(metric, &measured, storage_read_base),
+        storage_read_key_byte: measured_to_gas(metric, &measured, storage_read_key_byte),
+        storage_read_value_byte: measured_to_gas(metric, &measured, storage_read_value_byte),
+        storage_remove_base: measured_to_gas(metric, &measured, storage_remove_base),
+        storage_remove_key_byte: measured_to_gas(metric, &measured, storage_remove_key_byte),
+        storage_remove_ret_value_byte: measured_to_gas(
+            metric,
+            &measured,
+            storage_remove_ret_value_byte,
+        ),
+        storage_has_key_base: measured_to_gas(metric, &measured, storage_has_key_base),
+        storage_has_key_byte: measured_to_gas(metric, &measured, storage_has_key_byte),
         // TODO: storage_iter_* operations below are deprecated, so just hardcode zero price,
         // and remove those operations ASAP.
         storage_iter_create_prefix_base: 0,
@@ -575,9 +605,9 @@ fn get_ext_costs_config(measurement: &Measurements) -> ExtCostsConfig {
         storage_iter_next_value_byte: 0,
         // TODO: Actually compute it once our storage is complete.
         touching_trie_node: 1,
-        promise_and_base: cost_as_gas(&pure, promise_and_base),
-        promise_and_per_promise: cost_as_gas(&pure, promise_and_per_promise),
-        promise_return: cost_as_gas(&pure, promise_return),
+        promise_and_base: measured_to_gas(metric, &measured, promise_and_base),
+        promise_and_per_promise: measured_to_gas(metric, &measured, promise_and_per_promise),
+        promise_return: measured_to_gas(metric, &measured, promise_return),
     }
 }
 
@@ -587,7 +617,7 @@ fn get_vm_config(measurement: &Measurements) -> VMConfig {
         // TODO: Figure out whether we need this fee at all. If we do what should be the memory
         // growth cost.
         grow_mem_cost: 1,
-        regular_op_cost: f64_to_gas(nanosec_per_op()) as u32,
+        regular_op_cost: cost_per_op(&measurement.gas_metric) as u32,
         limit_config: VMLimitConfig::default(),
     }
 }

--- a/runtime/runtime-params-estimator/src/ext_costs_generator.rs
+++ b/runtime/runtime-params-estimator/src/ext_costs_generator.rs
@@ -41,8 +41,9 @@ impl ExtCostsGenerator {
         self.extract(write_memory_10b_10k, write_memory_base);
         self.extract(write_memory_1Mib_10k, write_memory_byte);
 
-        self.result.insert(log_base, Ratio::<u64>::new(0, 1));
-        self.result.insert(log_byte, Ratio::<u64>::new(0, 1));
+        self.extract(utf16_log_10b_10k, log_base);
+        self.extract(utf16_log_10kib_10k, log_byte);
+
         self.extract(utf8_log_10b_10k, utf8_decoding_base);
         // Charge the maximum between non-nul-terminated and nul-terminated costs.
         let utf8_byte = self.extract_value(utf8_log_10kib_10k, utf8_decoding_byte);

--- a/runtime/runtime-params-estimator/src/ext_costs_generator.rs
+++ b/runtime/runtime-params-estimator/src/ext_costs_generator.rs
@@ -1,11 +1,12 @@
 use crate::cases::Metric;
 use crate::stats::{DataStats, Measurements};
 use near_vm_logic::ExtCosts;
+use num_rational::Ratio;
 use std::collections::BTreeMap;
 
 pub struct ExtCostsGenerator {
     agg: BTreeMap<Metric, DataStats>,
-    result: BTreeMap<ExtCosts, f64>,
+    result: BTreeMap<ExtCosts, Ratio<u64>>,
 }
 
 impl ExtCostsGenerator {
@@ -14,132 +15,71 @@ impl ExtCostsGenerator {
         Self { agg: aggregated, result: Default::default() }
     }
 
-    fn extract_value(
-        &mut self,
-        metric: Metric,
-        ext_cost: ExtCosts,
-        ignore_costs: &[ExtCosts],
-    ) -> f64 {
-        let Self { agg, result } = self;
+    fn extract_value(&mut self, metric: Metric, ext_cost: ExtCosts) -> Ratio<u64> {
+        let Self { agg, result: _ } = self;
         let agg = &agg[&metric];
-        let mut res = agg.upper() as f64;
-        let mut multiplier = None;
-        for (k, v) in &agg.ext_costs {
-            if ignore_costs.contains(k) || k == &ExtCosts::touching_trie_node {
-                continue;
-            }
-            if k == &ext_cost {
-                multiplier = Some(*v);
-                continue;
-            }
-            res -= match result.get(k) {
-                Some(x) => x * (*v),
-                None => panic!(
-                    "While extracting {:?} cost from {:?} metric, {:?} cost was not computed yet",
-                    ext_cost, metric, k
-                ),
-            };
-        }
-        match multiplier {
-            Some(x) => res /= x,
-            None => panic!(
-                "While extracting {:?} cost from {:?} metric the cost was not found",
-                ext_cost, metric
-            ),
-        };
-        res
+        let multiplier = agg.ext_costs[&ext_cost];
+        Ratio::<u64>::new(agg.upper(), multiplier)
     }
 
-    fn extract(&mut self, metric: Metric, ext_cost: ExtCosts, ignore_costs: &[ExtCosts]) {
-        let value = self.extract_value(metric, ext_cost, ignore_costs);
+    fn extract(&mut self, metric: Metric, ext_cost: ExtCosts) {
+        let value = self.extract_value(metric, ext_cost);
         self.result.insert(ext_cost, value);
     }
 
-    pub fn compute(&mut self) -> BTreeMap<ExtCosts, f64> {
+    pub fn compute(&mut self) -> BTreeMap<ExtCosts, Ratio<u64>> {
         self.result.clear();
         use ExtCosts::*;
         use Metric::*;
-        self.extract(base_1M, base, &[]);
-        self.extract(read_memory_10b_10k, read_memory_base, &[read_memory_byte]);
-        self.extract(read_memory_1Mib_10k, read_memory_byte, &[]);
-        self.extract(write_register_10b_10k, write_register_base, &[write_register_byte]);
-        self.extract(write_register_1Mib_10k, write_register_byte, &[]);
-        self.extract(read_register_10b_10k, read_register_base, &[read_register_byte]);
-        self.extract(read_register_1Mib_10k, read_register_byte, &[]);
-        self.extract(write_memory_10b_10k, write_memory_base, &[write_memory_byte]);
-        self.extract(write_memory_1Mib_10k, write_memory_byte, &[]);
+        self.extract(base_1M, base);
+        self.extract(read_memory_10b_10k, read_memory_base);
+        self.extract(read_memory_1Mib_10k, read_memory_byte);
+        self.extract(write_register_10b_10k, write_register_base);
+        self.extract(write_register_1Mib_10k, write_register_byte);
+        self.extract(read_register_10b_10k, read_register_base);
+        self.extract(read_register_1Mib_10k, read_register_byte);
+        self.extract(write_memory_10b_10k, write_memory_base);
+        self.extract(write_memory_1Mib_10k, write_memory_byte);
 
-        self.result.insert(log_base, 0f64);
-        self.result.insert(log_byte, 0f64);
-        self.extract(utf8_log_10b_10k, utf8_decoding_base, &[utf8_decoding_byte]);
+        self.result.insert(log_base, Ratio::<u64>::new(0, 1));
+        self.result.insert(log_byte, Ratio::<u64>::new(0, 1));
+        self.extract(utf8_log_10b_10k, utf8_decoding_base);
         // Charge the maximum between non-nul-terminated and nul-terminated costs.
-        let utf8_byte = self.extract_value(utf8_log_10kib_10k, utf8_decoding_byte, &[]);
-        let nul_utf8_byte = self.extract_value(nul_utf8_log_10kib_10k, utf8_decoding_byte, &[]);
+        let utf8_byte = self.extract_value(utf8_log_10kib_10k, utf8_decoding_byte);
+        let nul_utf8_byte = self.extract_value(nul_utf8_log_10kib_10k, utf8_decoding_byte);
         self.result.insert(utf8_decoding_byte, utf8_byte.max(nul_utf8_byte));
-        self.extract(utf16_log_10b_10k, utf16_decoding_base, &[utf16_decoding_byte]);
+        self.extract(utf16_log_10b_10k, utf16_decoding_base);
         // Charge the maximum between non-nul-terminated and nul-terminated costs.
-        let utf16_byte = self.extract_value(utf16_log_10kib_10k, utf16_decoding_byte, &[]);
-        let nul_utf16_byte = self.extract_value(nul_utf16_log_10kib_10k, utf16_decoding_byte, &[]);
+        let utf16_byte = self.extract_value(utf16_log_10kib_10k, utf16_decoding_byte);
+        let nul_utf16_byte = self.extract_value(nul_utf16_log_10kib_10k, utf16_decoding_byte);
         self.result.insert(utf16_decoding_byte, utf16_byte.max(nul_utf16_byte));
 
-        self.extract(sha256_10b_10k, sha256_base, &[sha256_byte]);
-        self.extract(sha256_10kib_10k, sha256_byte, &[]);
+        self.extract(sha256_10b_10k, sha256_base);
+        self.extract(sha256_10kib_10k, sha256_byte);
 
-        self.extract(keccak256_10b_10k, keccak256_base, &[keccak256_byte]);
-        self.extract(keccak256_10kib_10k, keccak256_byte, &[]);
+        self.extract(keccak256_10b_10k, keccak256_base);
+        self.extract(keccak256_10kib_10k, keccak256_byte);
 
-        self.extract(keccak512_10b_10k, keccak512_base, &[keccak512_byte]);
-        self.extract(keccak512_10kib_10k, keccak512_byte, &[]);
+        self.extract(keccak512_10b_10k, keccak512_base);
+        self.extract(keccak512_10kib_10k, keccak512_byte);
 
         // TODO: Redo storage costs once we have counting of nodes and we have size peek.
-        self.extract(
-            storage_write_10b_key_10b_value_1k,
-            storage_write_base,
-            &[storage_write_key_byte, storage_write_value_byte, storage_write_evicted_byte],
-        );
-        self.extract(
-            storage_write_10kib_key_10b_value_1k,
-            storage_write_key_byte,
-            &[storage_write_value_byte, storage_write_evicted_byte],
-        );
-        self.extract(
-            storage_write_10b_key_10kib_value_1k,
-            storage_write_value_byte,
-            &[storage_write_evicted_byte],
-        );
-        self.extract(storage_write_10b_key_10kib_value_1k_evict, storage_write_evicted_byte, &[]);
-        self.extract(
-            storage_read_10b_key_10b_value_1k,
-            storage_read_base,
-            &[storage_read_key_byte, storage_read_value_byte],
-        );
-        self.extract(
-            storage_read_10kib_key_10b_value_1k,
-            storage_read_key_byte,
-            &[storage_read_value_byte],
-        );
-        self.extract(storage_read_10b_key_10kib_value_1k, storage_read_value_byte, &[]);
-        self.extract(
-            storage_remove_10b_key_10b_value_1k,
-            storage_remove_base,
-            &[storage_remove_key_byte, storage_remove_ret_value_byte],
-        );
-        self.extract(
-            storage_remove_10kib_key_10b_value_1k,
-            storage_remove_key_byte,
-            &[storage_remove_ret_value_byte],
-        );
-        self.extract(storage_remove_10b_key_10kib_value_1k, storage_remove_ret_value_byte, &[]);
-        self.extract(
-            storage_has_key_10b_key_10b_value_1k,
-            storage_has_key_base,
-            &[storage_has_key_byte],
-        );
-        self.extract(storage_has_key_10kib_key_10b_value_1k, storage_has_key_byte, &[]);
+        self.extract(storage_write_10b_key_10b_value_1k, storage_write_base);
+        self.extract(storage_write_10kib_key_10b_value_1k, storage_write_key_byte);
+        self.extract(storage_write_10b_key_10kib_value_1k, storage_write_value_byte);
+        self.extract(storage_write_10b_key_10kib_value_1k_evict, storage_write_evicted_byte);
+        self.extract(storage_read_10b_key_10b_value_1k, storage_read_base);
+        self.extract(storage_read_10kib_key_10b_value_1k, storage_read_key_byte);
+        self.extract(storage_read_10b_key_10kib_value_1k, storage_read_value_byte);
+        self.extract(storage_remove_10b_key_10b_value_1k, storage_remove_base);
+        self.extract(storage_remove_10kib_key_10b_value_1k, storage_remove_key_byte);
+        self.extract(storage_remove_10b_key_10kib_value_1k, storage_remove_ret_value_byte);
+        self.extract(storage_has_key_10b_key_10b_value_1k, storage_has_key_base);
+        self.extract(storage_has_key_10kib_key_10b_value_1k, storage_has_key_byte);
 
-        self.extract(promise_and_100k, promise_and_base, &[promise_and_per_promise]);
-        self.extract(promise_and_100k_on_1k_and, promise_and_per_promise, &[]);
-        self.extract(promise_return_100k, promise_return, &[]);
+        self.extract(promise_and_100k, promise_and_base);
+        self.extract(promise_and_100k_on_1k_and, promise_and_per_promise);
+        self.extract(promise_return_100k, promise_return);
         self.result.clone()
     }
 }

--- a/runtime/runtime-params-estimator/src/runtime_fees_generator.rs
+++ b/runtime/runtime-params-estimator/src/runtime_fees_generator.rs
@@ -1,14 +1,15 @@
 use crate::cases::Metric;
 use crate::stats::{DataStats, Measurements};
+use num_rational::Ratio;
 use std::collections::BTreeMap;
 
 pub struct RuntimeFeesGenerator {
     aggregated: BTreeMap<Metric, DataStats>,
 }
 
-/// Fees for receipts and actions expressed in micros as floats.
+/// Fees for receipts and actions.
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, PartialOrd, Ord)]
-pub enum ReceiptFeesFloat {
+pub enum ReceiptFees {
     ActionReceiptCreation,
     DataReceiptCreationBase,
     DataReceiptCreationPerByte,
@@ -32,88 +33,77 @@ impl RuntimeFeesGenerator {
         Self { aggregated }
     }
 
-    /// Compute fees for receipts and actions in microseconds as floats.
-    pub fn compute(&self) -> BTreeMap<ReceiptFeesFloat, f64> {
-        let mut res: BTreeMap<ReceiptFeesFloat, f64> = Default::default();
+    /// Compute fees for receipts and actions in measurment units, keeps result as rational.
+    pub fn compute(&self) -> BTreeMap<ReceiptFees, Ratio<u64>> {
+        let mut res: BTreeMap<ReceiptFees, Ratio<u64>> = Default::default();
         res.insert(
-            ReceiptFeesFloat::ActionReceiptCreation,
-            self.aggregated[&Metric::Receipt].upper() as f64,
+            ReceiptFees::ActionReceiptCreation,
+            Ratio::new(self.aggregated[&Metric::Receipt].upper(), 1),
         );
         res.insert(
-            ReceiptFeesFloat::DataReceiptCreationBase,
-            self.aggregated[&Metric::data_receipt_10b_1000].upper() as f64 / 1000f64,
+            ReceiptFees::DataReceiptCreationBase,
+            Ratio::new(self.aggregated[&Metric::data_receipt_10b_1000].upper(), 1000),
         );
         res.insert(
-            ReceiptFeesFloat::DataReceiptCreationPerByte,
-            self.aggregated[&Metric::data_receipt_100kib_1000].upper() as f64
-                / (1000f64 * 100f64 * 1024f64),
+            ReceiptFees::DataReceiptCreationPerByte,
+            Ratio::new(
+                self.aggregated[&Metric::data_receipt_100kib_1000].upper(),
+                1000 * 100 * 1024,
+            ),
         );
         res.insert(
-            ReceiptFeesFloat::ActionCreateAccount,
-            (self.aggregated[&Metric::ActionCreateAccount].upper() as i64
-                - self.aggregated[&Metric::Receipt].upper() as i64) as f64,
+            ReceiptFees::ActionCreateAccount,
+            Ratio::new(self.aggregated[&Metric::ActionCreateAccount].upper(), 1),
         );
         res.insert(
-            ReceiptFeesFloat::ActionDeployContractBase,
+            ReceiptFees::ActionDeployContractBase,
             // TODO: This is a base cost, so we should not be charging for bytes here.
             // We ignore the fact that this includes 10K contract.
-            (self.aggregated[&Metric::ActionDeploy10K].upper() as i64
-                - self.aggregated[&Metric::Receipt].upper() as i64) as f64,
+            Ratio::new(self.aggregated[&Metric::ActionDeploy10K].upper(), 1),
         );
         res.insert(
-            ReceiptFeesFloat::ActionDeployContractPerByte,
-            ((self.aggregated[&Metric::ActionDeploy1M].upper() as i64
-                - self.aggregated[&Metric::ActionDeploy100K].upper() as i64) as f64)
-                / (1024f64 * 1024f64 - 100f64 * 1024f64),
+            ReceiptFees::ActionDeployContractPerByte,
+            Ratio::new(self.aggregated[&Metric::ActionDeploy1M].upper(), 1024 * 1024),
         );
         res.insert(
-            ReceiptFeesFloat::ActionFunctionCallBase,
-            (self.aggregated[&Metric::noop].upper() - self.aggregated[&Metric::Receipt].upper())
-                as f64,
+            ReceiptFees::ActionFunctionCallBase,
+            Ratio::new(self.aggregated[&Metric::noop].upper(), 1),
         );
         res.insert(
-            ReceiptFeesFloat::ActionFunctionCallPerByte,
-            (self.aggregated[&Metric::noop_1MiB].upper() as i64
-                - self.aggregated[&Metric::noop].upper() as i64) as f64
-                / (1024f64 * 1024f64),
+            ReceiptFees::ActionFunctionCallPerByte,
+            Ratio::new(self.aggregated[&Metric::noop_1MiB].upper(), 1024 * 1024),
         );
         res.insert(
-            ReceiptFeesFloat::ActionTransfer,
-            (self.aggregated[&Metric::ActionTransfer].upper() as i64
-                - self.aggregated[&Metric::Receipt].upper() as i64) as f64,
+            ReceiptFees::ActionTransfer,
+            Ratio::new(self.aggregated[&Metric::ActionTransfer].upper(), 1),
         );
         res.insert(
-            ReceiptFeesFloat::ActionStake,
-            (self.aggregated[&Metric::ActionStake].upper() as i64
-                - self.aggregated[&Metric::Receipt].upper() as i64) as f64,
+            ReceiptFees::ActionStake,
+            Ratio::new(self.aggregated[&Metric::ActionStake].upper(), 1),
         );
         res.insert(
-            ReceiptFeesFloat::ActionAddFullAccessKey,
-            (self.aggregated[&Metric::ActionAddFullAccessKey].upper() as i64
-                - self.aggregated[&Metric::Receipt].upper() as i64) as f64,
+            ReceiptFees::ActionAddFullAccessKey,
+            Ratio::new(self.aggregated[&Metric::ActionAddFullAccessKey].upper(), 1),
         );
         res.insert(
-            ReceiptFeesFloat::ActionAddFunctionAccessKeyBase,
-            (self.aggregated[&Metric::ActionAddFunctionAccessKey1Method].upper() as i64
-                - self.aggregated[&Metric::Receipt].upper() as i64) as f64,
+            ReceiptFees::ActionAddFunctionAccessKeyBase,
+            Ratio::new(self.aggregated[&Metric::ActionAddFunctionAccessKey1Method].upper(), 1),
         );
         res.insert(
-            ReceiptFeesFloat::ActionAddFunctionAccessKeyPerByte,
+            ReceiptFees::ActionAddFunctionAccessKeyPerByte,
             // These are 1k methods each 10bytes long.
-            (self.aggregated[&Metric::ActionAddFunctionAccessKey1000Methods].upper() as i64
-                - self.aggregated[&Metric::ActionAddFunctionAccessKey1Method].upper() as i64)
-                as f64
-                / (1000f64 * 10f64),
+            Ratio::new(
+                self.aggregated[&Metric::ActionAddFunctionAccessKey1000Methods].upper() * 1024,
+                10,
+            ),
         );
         res.insert(
-            ReceiptFeesFloat::ActionDeleteKey,
-            (self.aggregated[&Metric::ActionDeleteAccessKey].upper() as i64
-                - self.aggregated[&Metric::Receipt].upper() as i64) as f64,
+            ReceiptFees::ActionDeleteKey,
+            Ratio::new(self.aggregated[&Metric::ActionDeleteAccessKey].upper(), 1),
         );
         res.insert(
-            ReceiptFeesFloat::ActionDeleteAccount,
-            (self.aggregated[&Metric::ActionDeleteAccount].upper() as i64
-                - self.aggregated[&Metric::Receipt].upper() as i64) as f64,
+            ReceiptFees::ActionDeleteAccount,
+            Ratio::new(self.aggregated[&Metric::ActionDeleteAccount].upper(), 1),
         );
         res
     }

--- a/runtime/runtime-params-estimator/src/runtime_fees_generator.rs
+++ b/runtime/runtime-params-estimator/src/runtime_fees_generator.rs
@@ -92,10 +92,7 @@ impl RuntimeFeesGenerator {
         res.insert(
             ReceiptFees::ActionAddFunctionAccessKeyPerByte,
             // These are 1k methods each 10bytes long.
-            Ratio::new(
-                self.aggregated[&Metric::ActionAddFunctionAccessKey1000Methods].upper() * 1024,
-                10,
-            ),
+            Ratio::new(self.aggregated[&Metric::ActionAddFunctionAccessKey1000Methods].upper(), 10),
         );
         res.insert(
             ReceiptFees::ActionDeleteKey,

--- a/runtime/runtime-params-estimator/src/testbed_runners.rs
+++ b/runtime/runtime-params-estimator/src/testbed_runners.rs
@@ -25,7 +25,7 @@ fn warmup_total_transactions(config: &Config) -> usize {
     config.block_sizes.iter().sum::<usize>() * config.warmup_iters_per_block
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum GasMetric {
     // If we measure gas in number of executed instructions, must run under simulator.
     ICount,
@@ -113,7 +113,7 @@ pub unsafe fn syscall3(mut n: usize, a1: usize, a2: usize, a3: usize) -> usize {
 
 const CATCH_BASE: usize = 0xcafebabe;
 
-enum Consumed {
+pub enum Consumed {
     Instant(Instant),
     None,
 }
@@ -155,14 +155,14 @@ fn end_count_time(consumed: &Consumed) -> u64 {
     }
 }
 
-fn start_count(metric: &GasMetric) -> Consumed {
+pub fn start_count(metric: &GasMetric) -> Consumed {
     return match *metric {
         GasMetric::ICount => start_count_instructions(),
         GasMetric::Time => start_count_time(),
     };
 }
 
-fn end_count(metric: &GasMetric, consumed: &Consumed) -> u64 {
+pub fn end_count(metric: &GasMetric, consumed: &Consumed) -> u64 {
     return match metric {
         GasMetric::ICount => end_count_instructions(),
         GasMetric::Time => end_count_time(consumed),

--- a/runtime/runtime-params-estimator/src/wasmer_estimator.rs
+++ b/runtime/runtime-params-estimator/src/wasmer_estimator.rs
@@ -1,10 +1,12 @@
+use crate::testbed_runners::end_count;
+use crate::testbed_runners::start_count;
+use crate::testbed_runners::GasMetric;
 use near_runtime_fees::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::MockedExternal;
 use near_vm_logic::{VMConfig, VMContext, VMOutcome};
 use near_vm_runner::VMError;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::time::Instant;
 
 const CURRENT_ACCOUNT_ID: &str = "alice";
 const SIGNER_ACCOUNT_ID: &str = "bob";
@@ -56,17 +58,17 @@ fn call() -> (Option<VMOutcome>, Option<VMError>) {
     )
 }
 
-const NUM_ITERATIONS: usize = 10;
+const NUM_ITERATIONS: u64 = 10;
 
-/// Amount of nanosec it takes to execute the most CPU demanding operation.
-pub fn nanosec_per_op() -> f64 {
+/// Cost of the most CPU demanding operation.
+pub fn cost_per_op(gas_metric: &GasMetric) -> u64 {
     // Call once for the warmup.
     let (outcome, _) = call();
     let outcome = outcome.unwrap();
-    let start = Instant::now();
+    let start = start_count(&gas_metric);
     for _ in 0..NUM_ITERATIONS {
         call();
     }
-    let duration = Instant::now().duration_since(start).as_nanos() as f64;
-    duration / (outcome.burnt_gas as f64 * NUM_ITERATIONS as f64)
+    let cost = end_count(&gas_metric, &start);
+    cost / (outcome.burnt_gas * NUM_ITERATIONS)
 }


### PR DESCRIPTION
Switch to using rational numbers when computing runtime costs,
and avoid attempts to deduce the cost of the compound computations.

Test Plan
------------
Run cost estimators in both time and icount modes.