### PR TITLE
fix(primitives): Fixed serialization of balances in ValidatorKickoutReason

### DIFF
--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -529,7 +529,12 @@ pub enum ValidatorKickoutReason {
     /// Validator unstaked themselves.
     Unstaked,
     /// Validator stake is now below threshold
-    NotEnoughStake { stake: Balance, threshold: Balance },
+    NotEnoughStake {
+        #[serde(with = "u128_dec_format", rename = "stake_u128")]
+        stake: Balance,
+        #[serde(with = "u128_dec_format", rename = "threshold_u128")]
+        threshold: Balance,
+    },
     /// Enough stake but is not chosen because of seat limits.
     DidNotGetASeat,
 }


### PR DESCRIPTION
Sometimes we notice the following error from RPC:

```json
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32000,
        "message": "Server error",
        "data": "u128 is not supported"
    },
    "id": "dontcare"
}
```