### PR TITLE
fix(test): increase always timeout tests timeout in parallel nightly

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -79,7 +79,7 @@ expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_w
 expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_2
 
 # consensus tests
-expensive --timeout=1500 near-chain doomslug tests::test_fuzzy_doomslug_liveness_and_safety
+expensive --timeout=3000 near-chain doomslug tests::test_fuzzy_doomslug_liveness_and_safety
 expensive --timeout=500 near-client consensus tests::test_consensus_with_epoch_switches
 
 # state sync tests
@@ -121,7 +121,7 @@ expensive nearcore test_cases_testnet_rpc test::test_delete_access_key_with_allo
 # GC tests
 expensive --timeout=600 near-chain gc tests::test_gc_remove_fork_large
 expensive --timeout=1200 near-chain gc tests::test_gc_not_remove_fork_large
-expensive --timeout=600 near-chain gc tests::test_gc_boundaries_large
+expensive --timeout=1200 near-chain gc tests::test_gc_boundaries_large
 expensive --timeout=600 near-chain gc tests::test_gc_random_large
 expensive --timeout=600 near-chain gc tests::test_gc_pine
 expensive --timeout=600 near-chain gc tests::test_gc_star_large


### PR DESCRIPTION
In nightly fail now, this two test fails because it needs about 10% to 20% more time when run in parallel nightly:
https://nightly.neartest.com/test/expensive/expensive_near-chain_doomslug_tests__test_fuzzy_doomslug_liveness_and_safety
https://nightly.neartest.com/test/expensive/expensive_near-chain_gc_tests__test_gc_boundaries_large

This two test passed before parallel nightly is deployed (~May 8th), now they timeout but generate no error stdout 10% smaller than before May 8th, so giving it 10%-20% time it should pass. To ensure I give double time.

Test Plan
------------
This two test passed when i submit a modified nightly.txt: NIGHTLY_TXT_URL="https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nightly/output/master_fc193cfe563d21580da1f3673f5fed840887f8ef_20200513_194903/fails.txt"
https://buildkite.com/nearprotocol/nightly/builds/16#7cb24c16-1237-42ba-a7c3-73c35fe0e54a