### PR TITLE
fix(nightly): rpc_state_changes

### DIFF
--- a/pytest/tests/sanity/rpc_state_changes.py
+++ b/pytest/tests/sanity/rpc_state_changes.py
@@ -354,7 +354,7 @@ def test_key_value_changes():
             contract_key.account_id,
             'setKeyValue',
             json.dumps({"key": "my_key", "value": "my_value_1"}).encode('utf-8'),
-            100000000000,
+            10000000000000000,
             100000000000,
             20,
             base58.b58decode(latest_block_hash.encode('utf8'))
@@ -368,7 +368,7 @@ def test_key_value_changes():
         contract_key.account_id,
         'setKeyValue',
         json.dumps({"key": "my_key", "value": "my_value_2"}).encode('utf-8'),
-        100000000000,
+        10000000000000000,
         100000000000,
         30,
         base58.b58decode(latest_block_hash.encode('utf8'))


### PR DESCRIPTION
rpc_state_changes.py fails because of the gas provided to function calls becomes insufficient after #2574.

Test plan
---------
Make sure `rpc_state_changes.py` pass locally.