### PR TITLE
feat(storage): Storage Consistency Test Infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,7 @@ dependencies = [
  "elastic-array 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-literal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-chain-configs 0.1.0",
  "near-crypto 0.1.0",
  "near-primitives 0.1.0",
  "num_cpus 1.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3333,6 +3334,27 @@ dependencies = [
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "store-validator"
+version = "0.1.0"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "borsh 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "near-chain 0.1.0",
+ "near-chain-configs 0.1.0",
+ "near-client 0.1.0",
+ "near-crypto 0.1.0",
+ "near-logger-utils 0.1.0",
+ "near-network 0.1.0",
+ "near-primitives 0.1.0",
+ "near-store 0.1.0",
+ "neard 0.4.13",
+ "node-runtime 0.0.1",
+ "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
+ "testlib 0.1.0",
+]
 
 [[package]]
 name = "stream-cipher"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3345,13 +3345,10 @@ dependencies = [
  "near-chain 0.1.0",
  "near-chain-configs 0.1.0",
  "near-client 0.1.0",
- "near-crypto 0.1.0",
  "near-logger-utils 0.1.0",
- "near-network 0.1.0",
  "near-primitives 0.1.0",
  "near-store 0.1.0",
  "neard 0.4.13",
- "node-runtime 0.0.1",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "testlib 0.1.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "test-utils/testlib",
     "test-utils/loadtester",
     "test-utils/state-viewer",
+    "test-utils/store-validator",
     "neard/",
     "tools/rpctypegen/core",
     "tools/rpctypegen/macro",

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ release:
 	cargo build -p genesis-csv-to-json --release
 	cargo build -p near-vm-runner-standalone --release
 	cargo build -p state-viewer --release
+	cargo build -p store-validator --release
 
 debug:
 	cargo build -p neard
@@ -14,3 +15,4 @@ debug:
 	cargo build -p genesis-csv-to-json
 	cargo build -p near-vm-runner-standalone
 	cargo build -p state-viewer
+	cargo build -p store-validator

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2340,6 +2340,7 @@ mod tests {
 
     use cached::Cached;
 
+    use near_chain_configs::GenesisConfig;
     use near_crypto::KeyType;
     use near_primitives::block::Block;
     use near_primitives::errors::InvalidTxError;
@@ -2348,6 +2349,7 @@ mod tests {
     use near_primitives::utils::index_to_bytes;
     use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
     use near_store::test_utils::create_test_store;
+    use near_store::StoreValidator;
 
     use crate::chain::{check_refcount_map, MAX_HEIGHTS_TO_CLEAR};
     use crate::store::{ChainStoreAccess, GCMode};
@@ -2738,6 +2740,11 @@ mod tests {
                 }
             }
             assert!(check_refcount_map(&mut chain).is_ok());
+            let mut genesis = GenesisConfig::default();
+            genesis.genesis_height = 0;
+            let mut store_validator = StoreValidator::default();
+            store_validator.validate(&*chain.store().owned_store(), &genesis);
+            assert!(!store_validator.is_failed());
         }
     }
 }

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -34,20 +34,14 @@ use near_store::{
     ColIncomingReceipts, ColInvalidChunks, ColLastBlockWithNewChunk, ColNextBlockHashes,
     ColNextBlockWithNewChunk, ColOutgoingReceipts, ColPartialChunks, ColReceiptIdToShardId,
     ColState, ColStateChanges, ColStateDlInfos, ColStateHeaders, ColTransactionResult,
-    ColTransactions, ColTrieChanges, KeyForStateChanges, ShardTries, Store, StoreUpdate,
-    TrieChanges, WrappedTrieChanges,
+    ColTransactions, ColTrieChanges, KeyForStateChanges, Store, StoreUpdate, Trie, TrieChanges,
+    WrappedTrieChanges, HEADER_HEAD_KEY, HEAD_KEY, LARGEST_TARGET_HEIGHT_KEY, LATEST_KNOWN_KEY,
+    SYNC_HEAD_KEY, TAIL_KEY,
 };
 
 use crate::byzantine_assert;
 use crate::error::{Error, ErrorKind};
 use crate::types::{Block, BlockHeader, LatestKnown, ReceiptProofResponse, ReceiptResponse, Tip};
-
-const HEAD_KEY: &[u8; 4] = b"HEAD";
-const TAIL_KEY: &[u8; 4] = b"TAIL";
-const SYNC_HEAD_KEY: &[u8; 9] = b"SYNC_HEAD";
-const HEADER_HEAD_KEY: &[u8; 11] = b"HEADER_HEAD";
-const LATEST_KNOWN_KEY: &[u8; 12] = b"LATEST_KNOWN";
-const LARGEST_TARGET_HEIGHT_KEY: &[u8; 21] = b"LARGEST_TARGET_HEIGHT";
 
 /// lru cache size
 const CACHE_SIZE: usize = 100;

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -34,9 +34,9 @@ use near_store::{
     ColIncomingReceipts, ColInvalidChunks, ColLastBlockWithNewChunk, ColNextBlockHashes,
     ColNextBlockWithNewChunk, ColOutgoingReceipts, ColPartialChunks, ColReceiptIdToShardId,
     ColState, ColStateChanges, ColStateDlInfos, ColStateHeaders, ColTransactionResult,
-    ColTransactions, ColTrieChanges, KeyForStateChanges, Store, StoreUpdate, Trie, TrieChanges,
-    WrappedTrieChanges, HEADER_HEAD_KEY, HEAD_KEY, LARGEST_TARGET_HEIGHT_KEY, LATEST_KNOWN_KEY,
-    SYNC_HEAD_KEY, TAIL_KEY,
+    ColTransactions, ColTrieChanges, KeyForStateChanges, ShardTries, Store, StoreUpdate,
+    TrieChanges, WrappedTrieChanges, HEADER_HEAD_KEY, HEAD_KEY, LARGEST_TARGET_HEIGHT_KEY,
+    LATEST_KNOWN_KEY, SYNC_HEAD_KEY, TAIL_KEY,
 };
 
 use crate::byzantine_assert;

--- a/chain/chain/tests/gc.rs
+++ b/chain/chain/tests/gc.rs
@@ -6,13 +6,14 @@ mod tests {
     use near_chain::test_utils::KeyValueRuntime;
     use near_chain::types::Tip;
     use near_chain::DoomslugThresholdMode;
+    use near_chain_configs::GenesisConfig;
     use near_crypto::KeyType;
     use near_primitives::block::Block;
     use near_primitives::merkle::PartialMerkleTree;
     use near_primitives::types::{NumBlocks, StateRoot};
     use near_primitives::validator_signer::InMemoryValidatorSigner;
     use near_store::test_utils::{create_test_store, gen_changes};
-    use near_store::{ShardTries, StoreUpdate, Trie, WrappedTrieChanges};
+    use near_store::{ShardTries, StoreUpdate, StoreValidator, Trie, WrappedTrieChanges};
     use rand::Rng;
 
     fn get_chain(num_shards: u64) -> Chain {
@@ -251,6 +252,13 @@ mod tests {
             }
             start_index += simple_chain.length;
         }
+        let mut genesis = GenesisConfig::default();
+        genesis.genesis_height = 0;
+        let mut store_validator = StoreValidator::default();
+        store_validator.validate(&*chain1.store().owned_store(), &genesis);
+        assert!(!store_validator.is_failed());
+        store_validator.validate(&*chain2.store().owned_store(), &genesis);
+        assert!(!store_validator.is_failed());
     }
 
     // from is an index in blocks array, length is the number of blocks in a chain on top of blocks[from],

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -18,6 +18,8 @@ use near_chain::{
     RuntimeAdapter,
 };
 use near_chain_configs::ClientConfig;
+#[cfg(feature = "adversarial")]
+use near_chain_configs::GenesisConfig;
 use near_crypto::Signature;
 #[cfg(feature = "metric_recorder")]
 use near_network::recorder::MetricRecorder;
@@ -46,6 +48,8 @@ use crate::types::{
     StatusSyncInfo, SyncStatus,
 };
 use crate::StatusResponse;
+#[cfg(feature = "adversarial")]
+use near_store::StoreValidator;
 
 /// Multiplier on `max_block_time` to wait until deciding that chain stalled.
 const STATUS_WAIT_TIME_MULTIPLIER: u64 = 10;
@@ -250,6 +254,19 @@ impl Handler<NetworkClientMessages> for ClientActor {
                                 error!(target: "client", "Block Reference Map is inconsistent: {:?}", e);
                                 NetworkClientResponses::AdvResult(0 /* false */)
                             }
+                        }
+                    }
+                    NetworkAdversarialMessage::AdvCheckStorageConsistency => {
+                        info!(target: "adversary", "Check Storage Consistency");
+                        let mut genesis = GenesisConfig::default();
+                        genesis.genesis_height = self.client.chain.store().get_genesis_height();
+                        let mut store_validator = StoreValidator::default();
+                        store_validator.validate(self.client.chain.store().store(), &genesis);
+                        if store_validator.is_failed() {
+                            error!(target: "client", "Storage Validation failed, {:?}", store_validator.errors);
+                            NetworkClientResponses::AdvResult(0)
+                        } else {
+                            NetworkClientResponses::AdvResult(store_validator.tests_done())
                         }
                     }
                     _ => panic!("invalid adversary message"),

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -201,6 +201,7 @@ impl JsonRpcHandler {
                 "adv_switch_to_height" => Some(self.adv_switch_to_height(params).await),
                 "adv_get_saved_blocks" => Some(self.adv_get_saved_blocks(params).await),
                 "adv_check_refmap" => Some(self.adv_check_refmap(params).await),
+                "adv_check_store" => Some(self.adv_check_store(params).await),
                 _ => None,
             };
 
@@ -692,6 +693,22 @@ impl JsonRpcHandler {
         match self
             .client_addr
             .send(NetworkClientMessages::Adversarial(NetworkAdversarialMessage::AdvCheckRefMap))
+            .await
+        {
+            Ok(result) => match result {
+                NetworkClientResponses::AdvResult(value) => jsonify(Ok(Ok(value))),
+                _ => Err(RpcError::server_error::<String>(None)),
+            },
+            _ => Err(RpcError::server_error::<String>(None)),
+        }
+    }
+
+    async fn adv_check_store(&self, _params: Option<Value>) -> Result<Value, RpcError> {
+        match self
+            .client_addr
+            .send(NetworkClientMessages::Adversarial(
+                NetworkAdversarialMessage::AdvCheckStorageConsistency,
+            ))
             .await
         {
             Ok(result) => match result {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1212,6 +1212,7 @@ pub enum NetworkAdversarialMessage {
     AdvDisableDoomslug,
     AdvGetSavedBlocks,
     AdvCheckRefMap,
+    AdvCheckStorageConsistency,
     AdvSetSyncInfo(u64),
 }
 

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -18,6 +18,7 @@ rand = "0.7.2"
 
 borsh = "0.6.1"
 
+near-chain-configs = { path = "../chain-configs" }
 near-crypto = { path = "../crypto" }
 near-primitives = { path = "../primitives" }
 

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -133,6 +133,13 @@ impl std::fmt::Display for DBCol {
     }
 }
 
+pub const HEAD_KEY: &[u8; 4] = b"HEAD";
+pub const TAIL_KEY: &[u8; 4] = b"TAIL";
+pub const SYNC_HEAD_KEY: &[u8; 9] = b"SYNC_HEAD";
+pub const HEADER_HEAD_KEY: &[u8; 11] = b"HEADER_HEAD";
+pub const LATEST_KNOWN_KEY: &[u8; 12] = b"LATEST_KNOWN";
+pub const LARGEST_TARGET_HEIGHT_KEY: &[u8; 21] = b"LARGEST_TARGET_HEIGHT";
+
 pub struct DBTransaction {
     pub ops: Vec<DBOp>,
 }

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -9,6 +9,9 @@ use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use cached::{Cached, SizedCache};
 
 pub use db::DBCol::{self, *};
+pub use db::{
+    HEADER_HEAD_KEY, HEAD_KEY, LARGEST_TARGET_HEIGHT_KEY, LATEST_KNOWN_KEY, SYNC_HEAD_KEY, TAIL_KEY,
+};
 use near_crypto::PublicKey;
 use near_primitives::account::{AccessKey, Account};
 use near_primitives::contract::ContractCode;
@@ -18,6 +21,7 @@ use near_primitives::receipt::{Receipt, ReceivedData};
 use near_primitives::serialize::to_base;
 use near_primitives::trie_key::{trie_key_parsers, TrieKey};
 use near_primitives::types::AccountId;
+pub use validate::StoreValidator;
 
 use crate::db::{DBOp, DBTransaction, Database, RocksDB};
 pub use crate::trie::{
@@ -29,6 +33,7 @@ pub use crate::trie::{
 mod db;
 pub mod test_utils;
 mod trie;
+mod validate;
 
 pub struct Store {
     storage: Arc<dyn Database>,

--- a/core/store/src/validate.rs
+++ b/core/store/src/validate.rs
@@ -121,14 +121,13 @@ fn chunk_hash_validity(
 
 fn block_of_chunk_exists(
     store: &Store,
-    _config: &GenesisConfig,
+    config: &GenesisConfig,
     _key: &[u8],
     value: &[u8],
 ) -> Result<(), String> {
     let shard_chunk = ShardChunk::try_from_slice(value).unwrap();
     let height = shard_chunk.header.height_included;
-    if height == 0 {
-        // TODO discuss - non-accepted chunk found?
+    if height == config.genesis_height {
         return Ok(());
     }
     match store.get_ser::<HashMap<EpochId, HashSet<CryptoHash>>>(
@@ -151,8 +150,8 @@ fn block_of_chunk_exists(
             }
             err!(format!("No Block on height {:?} accepts ShardChunk {:?}", height, shard_chunk))
         }
-        Ok(None) => err!(format!("Map not found on height {:?}", height)),
-        Err(e) => err!(format!("Can't get Map from storage on height {:?}, {:?}", height, e)),
+        Ok(None) => err!(format!("Map not found on height {:?}, no one is responsible for ShardChunk {:?}", height, shard_chunk)),
+        Err(e) => err!(format!("Can't get Map from storage on height {:?}, no one is responsible for ShardChunk {:?}, {:?}", height, shard_chunk, e)),
     }
 }
 

--- a/core/store/src/validate.rs
+++ b/core/store/src/validate.rs
@@ -22,7 +22,7 @@ use crate::{
     TAIL_KEY,
 };
 
-macro_rules! function {
+macro_rules! get_parent_function_name {
     () => {{
         fn f() {}
         fn type_name_of<T>(_: T) -> &'static str {
@@ -33,7 +33,7 @@ macro_rules! function {
     }};
 }
 
-macro_rules! err(($x:expr) => (Err(format!("{}: {}", function!(), $x))));
+macro_rules! err(($x:expr) => (Err(format!("{}: {}", get_parent_function_name!(), $x))));
 
 // All validations start here
 //
@@ -212,7 +212,7 @@ impl StoreValidator {
     pub fn is_failed(&self) -> bool {
         self.tests == 0 || self.errors.len() > 0
     }
-    pub fn failed(&self) -> u64 {
+    pub fn num_failed(&self) -> u64 {
         self.errors.len() as u64
     }
     pub fn tests_done(&self) -> u64 {

--- a/core/store/src/validate.rs
+++ b/core/store/src/validate.rs
@@ -1,0 +1,260 @@
+use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
+
+use borsh::BorshDeserialize;
+
+use near_chain_configs::GenesisConfig;
+use near_primitives::block::{Block, BlockHeader};
+use near_primitives::hash::CryptoHash;
+use near_primitives::sharding::{ChunkHash, ShardChunk};
+use near_primitives::types::{BlockHeight, EpochId};
+use near_primitives::utils::index_to_bytes;
+
+#[allow(unused)]
+use crate::{
+    read_with_cache, ColBlock, ColBlockExtra, ColBlockHeader, ColBlockHeight, ColBlockMisc,
+    ColBlockPerHeight, ColBlockRefCount, ColBlocksToCatchup, ColChallengedBlocks, ColChunkExtra,
+    ColChunkPerHeightShard, ColChunks, ColEpochLightClientBlocks, ColIncomingReceipts,
+    ColInvalidChunks, ColLastBlockWithNewChunk, ColNextBlockHashes, ColNextBlockWithNewChunk,
+    ColOutgoingReceipts, ColPartialChunks, ColReceiptIdToShardId, ColState, ColStateChanges,
+    ColStateDlInfos, ColStateHeaders, ColTransactionResult, ColTransactions, ColTrieChanges, DBCol,
+    KeyForStateChanges, Store, StoreUpdate, Trie, TrieChanges, TrieIterator, WrappedTrieChanges,
+    TAIL_KEY,
+};
+
+macro_rules! function {
+    () => {{
+        fn f() {}
+        fn type_name_of<T>(_: T) -> &'static str {
+            std::any::type_name::<T>()
+        }
+        let name = type_name_of(f);
+        &name[..name.len() - 3]
+    }};
+}
+
+macro_rules! err(($x:expr) => (Err(format!("{}: {}", function!(), $x))));
+
+// All validations start here
+//
+
+fn nothing(
+    _store: &Store,
+    _config: &GenesisConfig,
+    _key: &[u8],
+    _value: &[u8],
+) -> Result<(), String> {
+    // Make sure that validation is executed
+    Ok(())
+}
+
+fn block_header_validity(
+    _store: &Store,
+    _config: &GenesisConfig,
+    key: &[u8],
+    value: &[u8],
+) -> Result<(), String> {
+    let block_hash = CryptoHash::try_from(key.as_ref()).unwrap();
+    match BlockHeader::try_from_slice(value) {
+        Ok(header) => {
+            if header.hash() != block_hash {
+                err!(format!("Invalid Block Header hash stored, {:?}", block_hash))
+            } else {
+                Ok(())
+            }
+        }
+        Err(e) => err!(format!("Can't get Block Header from storage, {:?}, {:?}", block_hash, e)),
+    }
+}
+
+fn block_hash_validity(
+    _store: &Store,
+    _config: &GenesisConfig,
+    key: &[u8],
+    value: &[u8],
+) -> Result<(), String> {
+    let block_hash = CryptoHash::try_from(key.as_ref()).unwrap();
+    match Block::try_from_slice(value) {
+        Ok(block) => {
+            if block.hash() != block_hash {
+                err!(format!("Invalid Block hash stored, {:?}", block_hash))
+            } else {
+                Ok(())
+            }
+        }
+        Err(e) => err!(format!("Can't get Block Header from storage, {:?}, {:?}", block_hash, e)),
+    }
+}
+
+fn block_header_exists(
+    store: &Store,
+    _config: &GenesisConfig,
+    key: &[u8],
+    _value: &[u8],
+) -> Result<(), String> {
+    let block_hash = CryptoHash::try_from(key.as_ref()).unwrap();
+    match store.get_ser::<BlockHeader>(ColBlockHeader, block_hash.as_ref()) {
+        Ok(Some(_header)) => Ok(()),
+        Ok(None) => err!(format!("Block Header not found, {:?}", block_hash)),
+        Err(e) => err!(format!("Can't get Block Header from storage, {:?}, {:?}", block_hash, e)),
+    }
+}
+
+fn chunk_hash_validity(
+    _store: &Store,
+    _config: &GenesisConfig,
+    key: &[u8],
+    value: &[u8],
+) -> Result<(), String> {
+    let chunk_hash = ChunkHash::try_from_slice(key.as_ref()).unwrap();
+    match ShardChunk::try_from_slice(value) {
+        Ok(shard_chunk) => {
+            if shard_chunk.chunk_hash != chunk_hash {
+                err!(format!("Invalid ShardChunk hash stored, {:?}", chunk_hash))
+            } else {
+                Ok(())
+            }
+        }
+        Err(e) => err!(format!("Can't get ShardChunk from storage, {:?}, {:?}", chunk_hash, e)),
+    }
+}
+
+fn block_of_chunk_exists(
+    store: &Store,
+    _config: &GenesisConfig,
+    _key: &[u8],
+    value: &[u8],
+) -> Result<(), String> {
+    let shard_chunk = ShardChunk::try_from_slice(value).unwrap();
+    let height = shard_chunk.header.height_included;
+    if height == 0 {
+        // TODO discuss - non-accepted chunk found?
+        return Ok(());
+    }
+    match store.get_ser::<HashMap<EpochId, HashSet<CryptoHash>>>(
+        ColBlockPerHeight,
+        &index_to_bytes(height),
+    ) {
+        Ok(Some(map)) => {
+            for (_, set) in map {
+                for block_hash in set {
+                    match store.get_ser::<Block>(ColBlock, block_hash.as_ref()) {
+                        Ok(Some(block)) => {
+                            if block.chunks.contains(&shard_chunk.header) {
+                                // Block for ShardChunk is found
+                                return Ok(());
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            err!(format!("No Block on height {:?} accepts ShardChunk {:?}", height, shard_chunk))
+        }
+        Ok(None) => err!(format!("Map not found on height {:?}", height)),
+        Err(e) => err!(format!("Can't get Map from storage on height {:?}, {:?}", height, e)),
+    }
+}
+
+fn block_height_cmp_tail(
+    store: &Store,
+    config: &GenesisConfig,
+    key: &[u8],
+    value: &[u8],
+) -> Result<(), String> {
+    let block_hash = CryptoHash::try_from(key.as_ref()).unwrap();
+    let tail = match store.get_ser::<BlockHeight>(ColBlockMisc, TAIL_KEY) {
+        Ok(Some(tail)) => tail,
+        Ok(None) => config.genesis_height,
+        Err(_) => return err!("Can't get Tail from storage"),
+    };
+    match Block::try_from_slice(value) {
+        Ok(block) => {
+            if block.header.inner_lite.height < tail
+                && block.header.inner_lite.height != config.genesis_height
+            {
+                err!(format!(
+                    "Invalid block height stored: {:?}, tail: {:?}",
+                    block.header.inner_lite.height, tail
+                ))
+            } else {
+                Ok(())
+            }
+        }
+        Err(e) => {
+            err!(format!("Can't get Block from storage, {:?}, {:?}", block_hash.to_string(), e))
+        }
+    }
+}
+
+//
+// All validations end here
+
+#[derive(Debug)]
+pub struct ErrorMessage {
+    pub col: DBCol,
+    pub msg: String,
+}
+
+impl ErrorMessage {
+    fn new(col: DBCol, msg: String) -> Self {
+        Self { col, msg }
+    }
+}
+
+#[derive(Default, BorshDeserialize)]
+pub struct StoreValidator {
+    #[borsh_skip]
+    pub errors: Vec<ErrorMessage>,
+    tests: u64,
+}
+
+impl StoreValidator {
+    pub fn is_failed(&self) -> bool {
+        self.tests == 0 || self.errors.len() > 0
+    }
+    pub fn failed(&self) -> u64 {
+        self.errors.len() as u64
+    }
+    pub fn tests_done(&self) -> u64 {
+        self.tests
+    }
+    pub fn validate(&mut self, store: &Store, config: &GenesisConfig) {
+        self.check(&nothing, store, config, &[0], &[0], ColBlockMisc);
+        for (key, value) in store.iter(ColBlockHeader) {
+            // Block Header Hash is valid
+            self.check(&block_header_validity, store, config, &key, &value, ColBlockHeader);
+        }
+        for (key, value) in store.iter(ColBlock) {
+            // Block Hash is valid
+            self.check(&block_hash_validity, store, config, &key, &value, ColBlock);
+            // Block Header for current Block exists
+            self.check(&block_header_exists, store, config, &key, &value, ColBlock);
+            // Block Height is greater or equal to tail, or to Genesis Height
+            self.check(&block_height_cmp_tail, store, config, &key, &value, ColBlock);
+        }
+        for (key, value) in store.iter(ColChunks) {
+            // Chunk Hash is valid
+            self.check(&chunk_hash_validity, store, config, &key, &value, ColChunks);
+            // Block for current Chunk exists
+            self.check(&block_of_chunk_exists, store, config, &key, &value, ColChunks);
+        }
+    }
+
+    fn check(
+        &mut self,
+        f: &dyn Fn(&Store, &GenesisConfig, &[u8], &[u8]) -> Result<(), String>,
+        store: &Store,
+        config: &GenesisConfig,
+        key: &[u8],
+        value: &[u8],
+        col: DBCol,
+    ) {
+        let result = f(store, config, key, value);
+        self.tests += 1;
+        match result {
+            Ok(_) => {}
+            Err(msg) => self.errors.push(ErrorMessage::new(col, msg)),
+        }
+    }
+}

--- a/scripts/binary-release.sh
+++ b/scripts/binary-release.sh
@@ -20,3 +20,4 @@ upload_binary keypair-generator
 upload_binary genesis-csv-to-json
 upload_binary near-vm-runner-standalone
 upload_binary state-viewer
+upload_binary store-validator

--- a/test-utils/store-validator/Cargo.toml
+++ b/test-utils/store-validator/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "store-validator"
+version = "0.1.0"
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2018"
+
+[dependencies]
+ansi_term = "0.11"
+clap = "2.33"
+
+borsh = "0.5.0"
+
+near-chain-configs = { path = "../../core/chain-configs" }
+near-crypto = { path = "../../core/crypto" }
+near-logger-utils = {path = "../../test-utils/logger"}
+near-primitives = { path = "../../core/primitives" }
+near-store = { path = "../../core/store" }
+node-runtime = { path = "../../runtime/runtime" }
+near-chain = { path = "../../chain/chain" }
+near-network = { path = "../../chain/network" }
+neard = { path = "../../neard" }
+
+[dev-dependencies]
+testlib = { path = "../../test-utils/testlib" }
+serde_json = "1"
+near-client = { path = "../../chain/client" }

--- a/test-utils/store-validator/Cargo.toml
+++ b/test-utils/store-validator/Cargo.toml
@@ -11,13 +11,10 @@ clap = "2.33"
 borsh = "0.5.0"
 
 near-chain-configs = { path = "../../core/chain-configs" }
-near-crypto = { path = "../../core/crypto" }
 near-logger-utils = {path = "../../test-utils/logger"}
 near-primitives = { path = "../../core/primitives" }
 near-store = { path = "../../core/store" }
-node-runtime = { path = "../../runtime/runtime" }
 near-chain = { path = "../../chain/chain" }
-near-network = { path = "../../chain/network" }
 neard = { path = "../../neard" }
 
 [dev-dependencies]

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -1,0 +1,117 @@
+use std::path::Path;
+use std::process;
+use std::sync::Arc;
+
+use ansi_term::Color::{Green, Red};
+use clap::{App, Arg, SubCommand};
+
+use near_chain::{ChainStore, ChainStoreAccess};
+use near_logger_utils::init_integration_logger;
+use near_primitives::block::BlockHeader;
+use near_primitives::types::{BlockHeight, StateRoot};
+use near_store::{create_store, Store, StoreValidator};
+use neard::{get_default_home, get_store_path, load_config, NearConfig, NightshadeRuntime};
+
+#[allow(unused)]
+fn load_trie(
+    store: Arc<Store>,
+    home_dir: &Path,
+    near_config: &NearConfig,
+) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
+    load_trie_stop_at_height(store, home_dir, near_config, None)
+}
+
+fn load_trie_stop_at_height(
+    store: Arc<Store>,
+    home_dir: &Path,
+    near_config: &NearConfig,
+    stop_height: Option<BlockHeight>,
+) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
+    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
+
+    let runtime = NightshadeRuntime::new(
+        &home_dir,
+        store,
+        Arc::clone(&near_config.genesis),
+        near_config.client_config.tracked_accounts.clone(),
+        near_config.client_config.tracked_shards.clone(),
+    );
+    let head = chain_store.head().unwrap();
+    let last_block = match stop_height {
+        Some(height) => {
+            // find the first final block whose height is at least `height`.
+            let mut cur_height = height + 1;
+            loop {
+                if cur_height >= head.height {
+                    panic!("No final block with height >= {} exists", height);
+                }
+                let cur_block_hash = match chain_store.get_block_hash_by_height(cur_height) {
+                    Ok(hash) => hash,
+                    Err(_) => {
+                        cur_height += 1;
+                        continue;
+                    }
+                };
+                let last_final_block_hash = chain_store
+                    .get_block_header(&cur_block_hash)
+                    .unwrap()
+                    .inner_rest
+                    .last_final_block;
+                let last_final_block = chain_store.get_block(&last_final_block_hash).unwrap();
+                if last_final_block.header.inner_lite.height >= height {
+                    break last_final_block.clone();
+                } else {
+                    cur_height += 1;
+                    continue;
+                }
+            }
+        }
+        None => chain_store.get_block(&head.last_block_hash).unwrap().clone(),
+    };
+    let state_roots = last_block.chunks.iter().map(|chunk| chunk.inner.prev_state_root).collect();
+    (runtime, state_roots, last_block.header)
+}
+
+fn main() {
+    init_integration_logger();
+
+    let default_home = get_default_home();
+    let matches = App::new("store-validator")
+        .arg(
+            Arg::with_name("home")
+                .long("home")
+                .default_value(&default_home)
+                .help("Directory for config and data (default \"~/.near\")")
+                .takes_value(true),
+        )
+        .subcommand(SubCommand::with_name("validate"))
+        .get_matches();
+
+    let home_dir = matches.value_of("home").map(|dir| Path::new(dir)).unwrap();
+    let near_config = load_config(home_dir);
+
+    let store = create_store(&get_store_path(&home_dir));
+
+    //let (runtime, state_roots, header) = load_trie(store.clone(), &home_dir, &near_config);
+    //println!("Storage roots are {:?}, block height is {}", state_roots, header.inner_lite.height);
+    let mut store_validator = StoreValidator::default();
+    store_validator.validate(&*store, &near_config.genesis.config);
+
+    if store_validator.tests_done() == 0 {
+        println!("{}", Red.bold().paint("No conditions has been validated"));
+        process::exit(1);
+    }
+    println!(
+        "Conditions validated: {}",
+        Green.bold().paint(store_validator.tests_done().to_string())
+    );
+    for error in store_validator.errors.iter() {
+        println!("{}: {}", Red.bold().paint(&error.col.to_string()), error.msg);
+    }
+    if store_validator.is_failed() {
+        println!("Errors found: {}", Red.bold().paint(store_validator.failed().to_string()));
+        process::exit(1);
+    } else {
+        println!("{}", Green.bold().paint("No errors found"));
+    }
+}

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
         println!("{}: {}", Red.bold().paint(&error.col.to_string()), error.msg);
     }
     if store_validator.is_failed() {
-        println!("Errors found: {}", Red.bold().paint(store_validator.failed().to_string()));
+        println!("Errors found: {}", Red.bold().paint(store_validator.num_failed().to_string()));
         process::exit(1);
     } else {
         println!("{}", Green.bold().paint("No errors found"));

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -1,76 +1,12 @@
 use std::path::Path;
 use std::process;
-use std::sync::Arc;
 
 use ansi_term::Color::{Green, Red};
 use clap::{App, Arg, SubCommand};
 
-use near_chain::{ChainStore, ChainStoreAccess};
 use near_logger_utils::init_integration_logger;
-use near_primitives::block::BlockHeader;
-use near_primitives::types::{BlockHeight, StateRoot};
-use near_store::{create_store, Store, StoreValidator};
-use neard::{get_default_home, get_store_path, load_config, NearConfig, NightshadeRuntime};
-
-#[allow(unused)]
-fn load_trie(
-    store: Arc<Store>,
-    home_dir: &Path,
-    near_config: &NearConfig,
-) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
-    load_trie_stop_at_height(store, home_dir, near_config, None)
-}
-
-fn load_trie_stop_at_height(
-    store: Arc<Store>,
-    home_dir: &Path,
-    near_config: &NearConfig,
-    stop_height: Option<BlockHeight>,
-) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
-    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
-
-    let runtime = NightshadeRuntime::new(
-        &home_dir,
-        store,
-        Arc::clone(&near_config.genesis),
-        near_config.client_config.tracked_accounts.clone(),
-        near_config.client_config.tracked_shards.clone(),
-    );
-    let head = chain_store.head().unwrap();
-    let last_block = match stop_height {
-        Some(height) => {
-            // find the first final block whose height is at least `height`.
-            let mut cur_height = height + 1;
-            loop {
-                if cur_height >= head.height {
-                    panic!("No final block with height >= {} exists", height);
-                }
-                let cur_block_hash = match chain_store.get_block_hash_by_height(cur_height) {
-                    Ok(hash) => hash,
-                    Err(_) => {
-                        cur_height += 1;
-                        continue;
-                    }
-                };
-                let last_final_block_hash = chain_store
-                    .get_block_header(&cur_block_hash)
-                    .unwrap()
-                    .inner_rest
-                    .last_final_block;
-                let last_final_block = chain_store.get_block(&last_final_block_hash).unwrap();
-                if last_final_block.header.inner_lite.height >= height {
-                    break last_final_block.clone();
-                } else {
-                    cur_height += 1;
-                    continue;
-                }
-            }
-        }
-        None => chain_store.get_block(&head.last_block_hash).unwrap().clone(),
-    };
-    let state_roots = last_block.chunks.iter().map(|chunk| chunk.inner.prev_state_root).collect();
-    (runtime, state_roots, last_block.header)
-}
+use near_store::{create_store, StoreValidator};
+use neard::{get_default_home, get_store_path, load_config};
 
 fn main() {
     init_integration_logger();
@@ -92,8 +28,6 @@ fn main() {
 
     let store = create_store(&get_store_path(&home_dir));
 
-    //let (runtime, state_roots, header) = load_trie(store.clone(), &home_dir, &near_config);
-    //println!("Storage roots are {:?}, block height is {}", state_roots, header.inner_lite.height);
     let mut store_validator = StoreValidator::default();
     store_validator.validate(&*store, &near_config.genesis.config);
 


### PR DESCRIPTION
Resolves https://github.com/nearprotocol/nearcore/issues/2649

This PR introduces `store-validator` utility. It may be executed:
- As a separate binary which checks the storage:
<img width="929" alt="Screen Shot 2020-05-15 at 5 14 48 PM" src="https://user-images.githubusercontent.com/5685493/82060128-9b880200-96cf-11ea-83e1-7ca61c62b401.png">
- As a part of python tests infrastructure, it executes automatically:
<img width="434" alt="Screen Shot 2020-05-15 at 5 16 01 PM" src="https://user-images.githubusercontent.com/5685493/82060245-cb370a00-96cf-11ea-99a0-3a0f843a03d0.png">
- As an adversarial method `AdvCheckStorageConsistency` anywhere in CI / expensive tests or debugging