### PR TITLE
feat: Network indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1392,9 +1392,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1407,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1417,15 +1417,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1434,15 +1434,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1452,21 +1452,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
 
 [[package]]
 name = "futures-task"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "futures-util"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1475,6 +1478,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
+ "pin-project",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1812,6 +1816,17 @@ name = "if_chain"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3360c7b59e5ffa2653671fb74b4741a5d343c03f331c0a4aeda42b5c2b0ec7d"
+
+[[package]]
+name = "indexer-example"
+version = "0.1.0"
+dependencies = [
+ "actix",
+ "near-indexer",
+ "serde_json",
+ "tokio",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "indexmap"
@@ -2416,6 +2431,20 @@ dependencies = [
  "serde",
  "serde_json",
  "smart-default",
+]
+
+[[package]]
+name = "near-indexer"
+version = "0.1.0"
+dependencies = [
+ "actix",
+ "futures",
+ "near-client",
+ "near-crypto",
+ "near-primitives",
+ "neard",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3722,9 +3751,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da07b57ee2623368351e9a0488bb0b261322a15a6e0ae53e243cbdc0f4208da9"
+checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "chain/pool",
     "chain/client",
     "chain/network",
+    "chain/indexer",
     "chain/jsonrpc",
     "chain/jsonrpc/client",
     "chain/jsonrpc/test-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,8 @@ members = [
     "genesis-tools/genesis-csv-to-json",
     "genesis-tools/genesis-populate",
     "genesis-tools/keypair-generator",
-    "tools/restaked"
+    "tools/restaked",
+    "tools/indexer/example"
 ]
 
 [dependencies]

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "near-indexer"
+version = "0.1.0"
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2018"
+
+[dependencies]
+actix = "0.9"
+tracing = "0.1.13"
+futures = "0.3.5"
+tokio = { version = "0.2", features = ["time", "sync"] }
+
+neard = { path = "../../neard" }
+near-client = { path = "../client" }
+near-crypto = { path = "../../core/crypto" }
+near-primitives = { path = "../../core/primitives" }

--- a/chain/indexer/README.md
+++ b/chain/indexer/README.md
@@ -1,0 +1,91 @@
+# NEAR Indexer
+
+NEAR Indexer is a micro-framework, which provides you with a stream of blocks that are recorded on NEAR network.
+
+
+NEAR Indexer is useful to handle real-time "events" on the chain.
+
+
+NEAR Indexer is going to be used to build NEAR Explorer, augment NEAR Wallet, and provide overview of events in Rainbow Bridge.
+
+
+See the [example](https://github.com/nearprotocol/nearcore/tree/master/tools/indexer/example) for further details.
+
+
+## How to set up and test NEAR Indexer
+
+Assuming you have all necessary tools installed (Python, Rust, Cargo etc.)
+
+### Localnet
+
+Clone [nearcore](https://github.com/nearprotocol/nearcore)
+
+```bash
+$ git clone git@github.com:nearprotocol/nearcore.git
+$ cd nearcore
+$ cargo run --package neard --bin neard init
+```
+
+The above commands should initialize necessary configs and keys to run localnet
+
+```bash
+$ cd tools/indexer/example
+$ cargo run
+```
+
+After that you should see logs of every block produced by your localnet
+
+
+### Betanet
+
+
+Clone [nearcore](https://github.com/nearprotocol/nearcore)
+
+```bash
+$ git clone git@github.com:nearprotocol/nearcore.git
+$ cd nearcore
+$ make release
+```
+
+This will take awhile to build `nearcore` (we are building `release` as it works a bit faster than debug)
+
+To connect to Betanet we need to have a proper configs and keys.
+
+Clone [nearup](https://github.com/near/nearup)
+
+```bash
+$ git clone git@github.com:near/nearup.git
+$ cd nearup
+$ ./nearup betanet --nodocker --binary-path path/to/nearcore/target/release
+```
+
+After that you will be asked for your validator account ID, you can leave it empty as we are not going to validate.
+
+After some time you'll see a success message that says the node is running.
+
+Now we need to stop the node.
+
+```bash
+$ ./nearup stop
+```
+
+Configs for beta net are in the `~/.near/betanet` folder. We need to ensure `"tracked_shards"` parameter in `~/.near/betaneta/config.json` set up properly.
+
+It has to be
+
+```
+...
+"tracked_shards": [0],
+...
+```
+
+After that we can run NEAR Indexer.
+
+Follow back to `nearcore` folder.
+
+```bash
+$ cd nearcore/tools/indexer/example
+$ cargo run
+```
+
+After that you should see logs of every block produced by Betanet

--- a/chain/indexer/README.md
+++ b/chain/indexer/README.md
@@ -17,7 +17,7 @@ See the [example](https://github.com/nearprotocol/nearcore/tree/master/tools/ind
 Before you proceed, make sure you have the following software installed:
 * [rustup](https://rustup.rs/) or Rust version that is mentioned in `rust-toolchain` file in the root of nearcore project.
 
-### Localnet
+### localnet
 
 Clone [nearcore](https://github.com/nearprotocol/nearcore)
 
@@ -45,7 +45,7 @@ $ env NEAR_ENV=local near --keyPath ~/.near/localnet/validator_key.json create_a
 
 ### betanet
 
-To run the NEAR Indexer connected to Betanet we need to have configs and keys prepopulated, you can get them with the [nearup](https://github.com/near/nearup). Clone it and follow the instruction to run non-validating node (leaving account ID empty).
+To run the NEAR Indexer connected to betanet we need to have configs and keys prepopulated, you can get them with the [nearup](https://github.com/near/nearup). Clone it and follow the instruction to run non-validating node (leaving account ID empty).
 
 Configs for betanet are in the `~/.near/betanet` folder. We need to ensure that NEAR Indexer follows all the necessary shards, so `"tracked_shards"` parameter in `~/.near/betaneta/config.json` needs to be configured properly. For example, with a single shared network, you just add the shard #0 to the list:
 

--- a/chain/indexer/README.md
+++ b/chain/indexer/README.md
@@ -14,7 +14,7 @@ See the [example](https://github.com/nearprotocol/nearcore/tree/master/tools/ind
 
 ## How to set up and test NEAR Indexer
 
-Assuming you have all necessary tools installed (Python, Rust, Cargo etc.)
+Assuming you have all necessary tools installed (Rust, Cargo etc.)
 
 ### Localnet
 
@@ -38,36 +38,7 @@ After that you should see logs of every block produced by your localnet
 
 ### Betanet
 
-
-Clone [nearcore](https://github.com/nearprotocol/nearcore)
-
-```bash
-$ git clone git@github.com:nearprotocol/nearcore.git
-$ cd nearcore
-$ make release
-```
-
-This will take awhile to build `nearcore` (we are building `release` as it works a bit faster than debug)
-
-To connect to Betanet we need to have a proper configs and keys.
-
-Clone [nearup](https://github.com/near/nearup)
-
-```bash
-$ git clone git@github.com:near/nearup.git
-$ cd nearup
-$ ./nearup betanet --nodocker --binary-path path/to/nearcore/target/release
-```
-
-After that you will be asked for your validator account ID, you can leave it empty as we are not going to validate.
-
-After some time you'll see a success message that says the node is running.
-
-Now we need to stop the node.
-
-```bash
-$ ./nearup stop
-```
+To run the NEAR Indexer connected to Betanet we need to have configs and keys prepopulated, you can get them with the [nearup](https://github.com/near/nearup). Clone it and follow the instruction to run non-validating node (leaving account ID empty).
 
 Configs for beta net are in the `~/.near/betanet` folder. We need to ensure `"tracked_shards"` parameter in `~/.near/betaneta/config.json` set up properly.
 
@@ -81,11 +52,11 @@ It has to be
 
 After that we can run NEAR Indexer.
 
-Follow back to `nearcore` folder.
+Follow to `nearcore` folder.
 
 ```bash
 $ cd nearcore/tools/indexer/example
-$ cargo run
+$ cargo run --release
 ```
 
 After that you should see logs of every block produced by Betanet

--- a/chain/indexer/README.md
+++ b/chain/indexer/README.md
@@ -14,7 +14,8 @@ See the [example](https://github.com/nearprotocol/nearcore/tree/master/tools/ind
 
 ## How to set up and test NEAR Indexer
 
-Assuming you have all necessary tools installed (Rust, Cargo etc.)
+Before you proceed, make sure you have the following software installed:
+* [rustup](https://rustup.rs/) or Rust version that is mentioned in `rust-toolchain` file in the root of nearcore project.
 
 ### Localnet
 
@@ -30,7 +31,7 @@ The above commands should initialize necessary configs and keys to run localnet
 
 ```bash
 $ cd tools/indexer/example
-$ cargo run
+$ cargo run --release
 ```
 
 After that you should see logs of every block produced by your localnet
@@ -57,4 +58,4 @@ $ cd nearcore/tools/indexer/example
 $ cargo run --release
 ```
 
-After that you should see logs of every block produced by Betanet
+After the network is synced, you should see logs of every block produced in Betanet. Get back to the code to implement any custom handling of the data flowing into the indexer.

--- a/chain/indexer/README.md
+++ b/chain/indexer/README.md
@@ -40,9 +40,7 @@ After that you should see logs of every block produced by your localnet
 
 To run the NEAR Indexer connected to Betanet we need to have configs and keys prepopulated, you can get them with the [nearup](https://github.com/near/nearup). Clone it and follow the instruction to run non-validating node (leaving account ID empty).
 
-Configs for beta net are in the `~/.near/betanet` folder. We need to ensure `"tracked_shards"` parameter in `~/.near/betaneta/config.json` set up properly.
-
-It has to be
+Configs for betanet are in the `~/.near/betanet` folder. We need to ensure that NEAR Indexer follows all the necessary shards, so `"tracked_shards"` parameter in `~/.near/betaneta/config.json` needs to be configured properly. For example, with a single shared network, you just add the shard #0 to the list:
 
 ```
 ...

--- a/chain/indexer/README.md
+++ b/chain/indexer/README.md
@@ -36,7 +36,7 @@ $ cargo run
 After that you should see logs of every block produced by your localnet
 
 
-### Betanet
+### betanet
 
 To run the NEAR Indexer connected to Betanet we need to have configs and keys prepopulated, you can get them with the [nearup](https://github.com/near/nearup). Clone it and follow the instruction to run non-validating node (leaving account ID empty).
 

--- a/chain/indexer/README.md
+++ b/chain/indexer/README.md
@@ -34,7 +34,13 @@ $ cd tools/indexer/example
 $ cargo run --release
 ```
 
-After that you should see logs of every block produced by your localnet
+After the node is started, you should see logs of every block produced in your localnet. Get back to the code to implement any custom handling of the data flowing into the indexer.
+
+Use [near-shell](https://github.com/near/near-shell) to submit transactions. For example, to create a new user you run the following command:
+
+```
+$ env NEAR_ENV=local near --keyPath ~/.near/localnet/validator_key.json create_account new-account.test.near --masterAccount test.near
+```
 
 
 ### betanet

--- a/chain/indexer/README.md
+++ b/chain/indexer/README.md
@@ -31,7 +31,7 @@ The above commands should initialize necessary configs and keys to run localnet
 
 ```bash
 $ cd tools/indexer/example
-$ cargo run --release
+$ cargo run --release /path/to/.near/config_dir/
 ```
 
 After the node is started, you should see logs of every block produced in your localnet. Get back to the code to implement any custom handling of the data flowing into the indexer.

--- a/chain/indexer/README.md
+++ b/chain/indexer/README.md
@@ -24,14 +24,14 @@ Clone [nearcore](https://github.com/nearprotocol/nearcore)
 ```bash
 $ git clone git@github.com:nearprotocol/nearcore.git
 $ cd nearcore
-$ cargo run --package neard --bin neard init
+$ env "NEAR_HOME=$HOME/.near/localnet" cargo run --release --package neard --bin neard init
 ```
 
-The above commands should initialize necessary configs and keys to run localnet
+The above commands should initialize necessary configs and keys to run localnet in `~/.near/localnet`.
 
 ```bash
 $ cd tools/indexer/example
-$ cargo run --release /path/to/.near/config_dir/
+$ cargo run --release ~/.near/localnet/
 ```
 
 After the node is started, you should see logs of every block produced in your localnet. Get back to the code to implement any custom handling of the data flowing into the indexer.
@@ -47,9 +47,14 @@ $ env NEAR_ENV=local near --keyPath ~/.near/localnet/validator_key.json create_a
 
 To run the NEAR Indexer connected to betanet we need to have configs and keys prepopulated, you can get them with the [nearup](https://github.com/near/nearup). Clone it and follow the instruction to run non-validating node (leaving account ID empty).
 
-Configs for betanet are in the `~/.near/betanet` folder. We need to ensure that NEAR Indexer follows all the necessary shards, so `"tracked_shards"` parameter in `~/.near/betaneta/config.json` needs to be configured properly. For example, with a single shared network, you just add the shard #0 to the list:
-
+Configs for betanet are in the `~/.near/betanet` folder. We need to ensure that NEAR Indexer follows all the necessary shards and syncs all the blocks, so `"tracked_shards"` and `"block_fetch_horizon"` parameters in `~/.near/betanet/config.json` need to be configured properly. For example, with a single shared network, you just add the shard #0 to the list:
 ```
+...
+"consensus": {
+  ...
+  "block_fetch_horizon": 18446744073709551615,
+  ...
+},
 ...
 "tracked_shards": [0],
 ...
@@ -61,7 +66,7 @@ Follow to `nearcore` folder.
 
 ```bash
 $ cd nearcore/tools/indexer/example
-$ cargo run --release
+$ cargo run --release ~/.near/betanet
 ```
 
 After the network is synced, you should see logs of every block produced in Betanet. Get back to the code to implement any custom handling of the data flowing into the indexer.

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -1,0 +1,49 @@
+//! Indexer creates a queue, starts the near-streamer, passing this queue in there.
+//! Listens to that queue and returns near_streamer::BlockResponse for further handling
+use std::path::PathBuf;
+
+use actix::System;
+use tokio::sync::mpsc;
+
+use neard;
+mod streamer;
+
+pub use self::streamer::{BlockResponse, Outcome};
+pub use near_primitives;
+
+/// Creates runtime and runs `neard` and `streamer`.
+pub struct Indexer {
+    near_config: neard::config::NearConfig,
+    system_runner: actix::SystemRunner,
+    view_client: actix::Addr<near_client::ViewClientActor>,
+    client: actix::Addr<near_client::ClientActor>,
+}
+
+impl Indexer {
+    /// Build the Indexer struct
+    pub fn new(custom_home_dir: Option<&str>) -> Self {
+        let home_dir = if !custom_home_dir.is_some() {
+            PathBuf::from(neard::get_default_home())
+        } else {
+            PathBuf::from(custom_home_dir.unwrap())
+        };
+
+        let near_config = neard::load_config(&home_dir);
+        let system = System::new("NEAR Indexer");
+        let (client, view_client) = neard::start_with_config(&home_dir, near_config.clone());
+        Self { near_config, system_runner: system, view_client, client }
+    }
+
+    /// Setups `near_indexer::streamer` and returns Receiver
+    pub fn receiver(&self) -> mpsc::Receiver<streamer::BlockResponse> {
+        let (sender, receiver) = mpsc::channel(16);
+        actix::spawn(streamer::start(self.view_client.clone(), self.client.clone(), sender));
+        receiver
+    }
+
+    /// Starts runtime after validating genesis.
+    pub fn start(self) {
+        neard::genesis_validate::validate_genesis(&self.near_config.genesis);
+        self.system_runner.run().unwrap();
+    }
+}

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -36,7 +36,7 @@ impl Indexer {
 
         let near_config = neard::load_config(&home_dir);
         let system = System::new("NEAR Indexer");
-        let (client, view_client) = neard::start_with_config(&home_dir, near_config.clone());
+        let (client, view_client, _) = neard::start_with_config(&home_dir, near_config.clone());
         neard::genesis_validate::validate_genesis(&near_config.genesis);
         Self { actix_runtime: system, view_client, client }
     }

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -1,3 +1,3 @@
 mod streamer;
-pub use self::streamer::start;
+pub(crate) use self::streamer::start;
 pub use self::streamer::{BlockResponse, Outcome};

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -1,0 +1,3 @@
+mod streamer;
+pub use self::streamer::start;
+pub use self::streamer::{BlockResponse, Outcome};

--- a/chain/indexer/src/streamer/streamer.rs
+++ b/chain/indexer/src/streamer/streamer.rs
@@ -58,7 +58,10 @@ async fn fetch_status(
 async fn fetch_latest_block(
     client: &Addr<near_client::ViewClientActor>,
 ) -> Result<views::BlockView, FailedToFetchData> {
-    client.send(near_client::GetBlock::latest()).await?.map_err(|_| FailedToFetchData)
+    client
+        .send(near_client::GetBlock(types::BlockIdOrFinality::Finality(types::Finality::Final)))
+        .await?
+        .map_err(|_| FailedToFetchData)
 }
 
 /// Fetches specific block by it's height

--- a/chain/indexer/src/streamer/streamer.rs
+++ b/chain/indexer/src/streamer/streamer.rs
@@ -2,11 +2,11 @@
 //! into one struct and pushes in in to the given queue
 use std::time::Duration;
 
-use actix::Addr;
+use actix::{Addr, MailboxError};
 use futures::stream::StreamExt;
 use tokio::sync::mpsc;
 use tokio::time;
-use tracing::{debug, info};
+use tracing::{debug, error, info};
 
 use near_client;
 pub use near_primitives::hash::CryptoHash;
@@ -18,6 +18,17 @@ const INDEXER: &str = "indexer";
 /// Error occurs in case of failed data fetch
 #[derive(Debug)]
 pub struct FailedToFetchData;
+
+impl From<MailboxError> for FailedToFetchData {
+    fn from(_actix_error: MailboxError) -> Self {
+        FailedToFetchData
+    }
+}
+
+struct FetchBlockResponse {
+    block_response: BlockResponse,
+    new_outcomes_to_get: Vec<types::TransactionOrReceiptId>,
+}
 
 /// Resulting struct represents block with chunks
 #[derive(Debug)]
@@ -38,8 +49,7 @@ async fn fetch_status(
 ) -> Result<near_primitives::views::StatusResponse, FailedToFetchData> {
     client
         .send(near_client::Status { is_health_check: false })
-        .await
-        .map_err(|_| FailedToFetchData)?
+        .await?
         .map_err(|_| FailedToFetchData)
 }
 
@@ -48,11 +58,7 @@ async fn fetch_status(
 async fn fetch_latest_block(
     client: &Addr<near_client::ViewClientActor>,
 ) -> Result<views::BlockView, FailedToFetchData> {
-    client
-        .send(near_client::GetBlock::latest())
-        .await
-        .map_err(|_| FailedToFetchData)?
-        .map_err(|_| FailedToFetchData)
+    client.send(near_client::GetBlock::latest()).await?.map_err(|_| FailedToFetchData)
 }
 
 /// Fetches specific block by it's height
@@ -64,8 +70,7 @@ async fn fetch_block_by_height(
         .send(near_client::GetBlock(near_primitives::types::BlockIdOrFinality::BlockId(
             near_primitives::types::BlockId::Height(height),
         )))
-        .await
-        .map_err(|_| FailedToFetchData)?
+        .await?
         .map_err(|_| FailedToFetchData)
 }
 
@@ -75,39 +80,31 @@ async fn fetch_block_by_height(
 async fn fetch_block_with_chunks(
     client: &Addr<near_client::ViewClientActor>,
     block: views::BlockView,
-    outcomes_to_get: std::vec::Drain<'_, types::TransactionOrReceiptId>,
-) -> Result<(BlockResponse, Vec<types::TransactionOrReceiptId>), FailedToFetchData> {
+    outcomes_to_get: impl Iterator<Item = types::TransactionOrReceiptId>,
+) -> Result<FetchBlockResponse, FailedToFetchData> {
     let chunks = fetch_chunks(&client, &block.chunks).await?;
-    let (outcomes, outcomes_to_retry) = fetch_outcomes(&client, outcomes_to_get).await;
+    let (outcomes, mut outcomes_to_retry) = fetch_outcomes(&client, outcomes_to_get).await;
 
-    let mut transaction_or_receipt_ids: Vec<types::TransactionOrReceiptId> = chunks
-        .iter()
-        .map(|chunk| {
-            let mut transaction_ids: Vec<types::TransactionOrReceiptId> = chunk
-                .transactions
-                .iter()
-                .map(|transaction| types::TransactionOrReceiptId::Transaction {
-                    transaction_hash: transaction.hash.clone(),
-                    sender_id: transaction.signer_id.to_string(),
-                })
-                .collect::<Vec<types::TransactionOrReceiptId>>();
-            let receipt_ids: Vec<types::TransactionOrReceiptId> = chunk
-                .receipts
-                .iter()
-                .map(|receipt| types::TransactionOrReceiptId::Receipt {
-                    receipt_id: receipt.receipt_id,
-                    receiver_id: receipt.receiver_id.to_string().clone(),
-                })
-                .collect::<Vec<types::TransactionOrReceiptId>>();
-            transaction_ids.extend(receipt_ids);
-            transaction_ids
-        })
-        .flatten()
-        .collect();
+    for chunk in &chunks {
+        outcomes_to_retry.extend(chunk.transactions.iter().map(|transaction| {
+            types::TransactionOrReceiptId::Transaction {
+                transaction_hash: transaction.hash.clone(),
+                sender_id: transaction.signer_id.to_string(),
+            }
+        }));
 
-    transaction_or_receipt_ids.extend(outcomes_to_retry);
+        outcomes_to_retry.extend(chunk.receipts.iter().map(|receipt| {
+            types::TransactionOrReceiptId::Receipt {
+                receipt_id: receipt.receipt_id,
+                receiver_id: receipt.receiver_id.to_string().clone(),
+            }
+        }));
+    }
 
-    Ok((BlockResponse { block, chunks, outcomes }, transaction_or_receipt_ids))
+    Ok(FetchBlockResponse {
+        block_response: BlockResponse { block, chunks, outcomes },
+        new_outcomes_to_get: outcomes_to_retry,
+    })
 }
 
 /// Fetches single chunk (as `near_primitives::views::ChunkView`) by provided `near_client::GetChunk` enum
@@ -115,7 +112,7 @@ async fn fetch_single_chunk(
     client: &Addr<near_client::ViewClientActor>,
     get_chunk: near_client::GetChunk,
 ) -> Result<views::ChunkView, FailedToFetchData> {
-    client.send(get_chunk).await.map_err(|_| FailedToFetchData)?.map_err(|_| FailedToFetchData)
+    client.send(get_chunk).await?.map_err(|_| FailedToFetchData)
 }
 
 /// Fetch ExecutionOutcomeWithId for receipts and transactions from previous block
@@ -123,28 +120,24 @@ async fn fetch_single_chunk(
 /// in the next block
 async fn fetch_outcomes(
     client: &Addr<near_client::ViewClientActor>,
-    mut outcomes_drain: std::vec::Drain<'_, types::TransactionOrReceiptId>,
+    mut outcomes_drain: impl Iterator<Item = types::TransactionOrReceiptId>,
 ) -> (Vec<Outcome>, Vec<types::TransactionOrReceiptId>) {
     let mut outcomes: Vec<Outcome> = vec![];
     let mut outcomes_to_retry: Vec<types::TransactionOrReceiptId> = vec![];
     while let Some(transaction_or_receipt_id) = outcomes_drain.next() {
-        let outcome_type = match &transaction_or_receipt_id {
-            types::TransactionOrReceiptId::Transaction { .. } => "transaction",
-            _ => "receipt",
-        };
         match client
             .send(near_client::GetExecutionOutcome { id: transaction_or_receipt_id.clone() })
             .await
             .map_err(|_| FailedToFetchData)
-            .map_err(|_| FailedToFetchData)
         {
-            Ok(Ok(outcome)) => {
-                if outcome_type == "transaction" {
+            Ok(Ok(outcome)) => match &transaction_or_receipt_id {
+                types::TransactionOrReceiptId::Transaction { .. } => {
                     outcomes.push(Outcome::Transaction(outcome.outcome_proof));
-                } else {
+                }
+                _ => {
                     outcomes.push(Outcome::Receipt(outcome.outcome_proof));
                 }
-            }
+            },
             _ => {
                 outcomes_to_retry.push(transaction_or_receipt_id);
             }
@@ -164,7 +157,7 @@ async fn fetch_chunks(
         chunks.iter().map(|chunk| near_client::GetChunk::ChunkHash(chunk.chunk_hash.into()));
     let mut chunks: futures::stream::FuturesUnordered<_> =
         chunks_hashes.map(|get_chunk| fetch_single_chunk(&client, get_chunk)).collect();
-    let mut response: Vec<views::ChunkView> = vec![];
+    let mut response = Vec::<views::ChunkView>::with_capacity(chunks.len());
 
     while let Some(chunk) = chunks.next().await {
         response.push(chunk?);
@@ -185,7 +178,7 @@ pub async fn start(
     info!(target: INDEXER, "Starting Streamer...");
     let mut outcomes_to_get: Vec<types::TransactionOrReceiptId> = vec![];
     let mut last_synced_block_height: types::BlockHeight = 0;
-    loop {
+    'main: loop {
         time::delay_for(INTERVAL).await;
         let status = fetch_status(&client).await;
         if let Ok(status) = status {
@@ -212,11 +205,18 @@ pub async fn start(
                         fetch_block_with_chunks(&view_client, block, outcomes_to_get.drain(..))
                             .await;
 
-                    if let Ok((block_response, new_outcome_to_get)) = response {
-                        outcomes_to_get = new_outcome_to_get;
-                        debug!(target: INDEXER, "{:#?}", &block_response);
-                        match queue.send(block_response).await {
-                            _ => {} // TODO: handle error somehow
+                    if let Ok(fetch_block_response) = response {
+                        outcomes_to_get = fetch_block_response.new_outcomes_to_get;
+                        debug!(target: INDEXER, "{:#?}", &fetch_block_response.block_response);
+                        match queue.send(fetch_block_response.block_response).await {
+                            Ok(_) => {}
+                            _ => {
+                                error!(
+                                        target: INDEXER,
+                                        "Unable to send BlockResponse to listener, listener doesn't listen. terminating..."
+                                    );
+                                break 'main;
+                            }
                         };
                     } else {
                         debug!(target: INDEXER, "Missing data, skipping...");

--- a/chain/indexer/src/streamer/streamer.rs
+++ b/chain/indexer/src/streamer/streamer.rs
@@ -1,0 +1,230 @@
+//! Streamer watches the network and collects all the blocks and related chunks
+//! into one struct and pushes in in to the given queue
+use std::time::Duration;
+
+use actix::Addr;
+use futures::stream::StreamExt;
+use tokio::sync::mpsc;
+use tokio::time;
+use tracing::{debug, info};
+
+use near_client;
+pub use near_primitives::hash::CryptoHash;
+pub use near_primitives::{types, views};
+
+const INTERVAL: Duration = Duration::from_millis(500);
+const INDEXER: &str = "indexer";
+
+/// Error occurs in case of failed data fetch
+#[derive(Debug)]
+pub struct FailedToFetchData;
+
+/// Resulting struct represents block with chunks
+#[derive(Debug)]
+pub struct BlockResponse {
+    pub block: views::BlockView,
+    pub chunks: Vec<views::ChunkView>,
+    pub outcomes: Vec<Outcome>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Outcome {
+    Receipt(views::ExecutionOutcomeWithIdView),
+    Transaction(views::ExecutionOutcomeWithIdView),
+}
+
+async fn fetch_status(
+    client: &Addr<near_client::ClientActor>,
+) -> Result<near_primitives::views::StatusResponse, FailedToFetchData> {
+    client
+        .send(near_client::Status { is_health_check: false })
+        .await
+        .map_err(|_| FailedToFetchData)?
+        .map_err(|_| FailedToFetchData)
+}
+
+/// Fetches the status to retrieve `latest_block_height` to determine if we need to fetch
+/// entire block or we already fetched this block.
+async fn fetch_latest_block(
+    client: &Addr<near_client::ViewClientActor>,
+) -> Result<views::BlockView, FailedToFetchData> {
+    client
+        .send(near_client::GetBlock::latest())
+        .await
+        .map_err(|_| FailedToFetchData)?
+        .map_err(|_| FailedToFetchData)
+}
+
+/// Fetches specific block by it's height
+async fn fetch_block_by_height(
+    client: &Addr<near_client::ViewClientActor>,
+    height: u64,
+) -> Result<views::BlockView, FailedToFetchData> {
+    client
+        .send(near_client::GetBlock(near_primitives::types::BlockIdOrFinality::BlockId(
+            near_primitives::types::BlockId::Height(height),
+        )))
+        .await
+        .map_err(|_| FailedToFetchData)?
+        .map_err(|_| FailedToFetchData)
+}
+
+/// This function supposed to return the entire `BlockResponse`.
+/// It calls fetches the block and fetches all the chunks for the block
+/// and returns everything together in one struct
+async fn fetch_block_with_chunks(
+    client: &Addr<near_client::ViewClientActor>,
+    block: views::BlockView,
+    outcomes_to_get: std::vec::Drain<'_, types::TransactionOrReceiptId>,
+) -> Result<(BlockResponse, Vec<types::TransactionOrReceiptId>), FailedToFetchData> {
+    let chunks = fetch_chunks(&client, &block.chunks).await?;
+    let (outcomes, outcomes_to_retry) = fetch_outcomes(&client, outcomes_to_get).await;
+
+    let mut transaction_or_receipt_ids: Vec<types::TransactionOrReceiptId> = chunks
+        .iter()
+        .map(|chunk| {
+            let mut transaction_ids: Vec<types::TransactionOrReceiptId> = chunk
+                .transactions
+                .iter()
+                .map(|transaction| types::TransactionOrReceiptId::Transaction {
+                    transaction_hash: transaction.hash.clone(),
+                    sender_id: transaction.signer_id.to_string(),
+                })
+                .collect::<Vec<types::TransactionOrReceiptId>>();
+            let receipt_ids: Vec<types::TransactionOrReceiptId> = chunk
+                .receipts
+                .iter()
+                .map(|receipt| types::TransactionOrReceiptId::Receipt {
+                    receipt_id: receipt.receipt_id,
+                    receiver_id: receipt.receiver_id.to_string().clone(),
+                })
+                .collect::<Vec<types::TransactionOrReceiptId>>();
+            transaction_ids.extend(receipt_ids);
+            transaction_ids
+        })
+        .flatten()
+        .collect();
+
+    transaction_or_receipt_ids.extend(outcomes_to_retry);
+
+    Ok((BlockResponse { block, chunks, outcomes }, transaction_or_receipt_ids))
+}
+
+/// Fetches single chunk (as `near_primitives::views::ChunkView`) by provided `near_client::GetChunk` enum
+async fn fetch_single_chunk(
+    client: &Addr<near_client::ViewClientActor>,
+    get_chunk: near_client::GetChunk,
+) -> Result<views::ChunkView, FailedToFetchData> {
+    client.send(get_chunk).await.map_err(|_| FailedToFetchData)?.map_err(|_| FailedToFetchData)
+}
+
+/// Fetch ExecutionOutcomeWithId for receipts and transactions from previous block
+/// Returns fetched Outcomes and Vec of failed to fetch outcome which should be retried to fetch
+/// in the next block
+async fn fetch_outcomes(
+    client: &Addr<near_client::ViewClientActor>,
+    mut outcomes_drain: std::vec::Drain<'_, types::TransactionOrReceiptId>,
+) -> (Vec<Outcome>, Vec<types::TransactionOrReceiptId>) {
+    let mut outcomes: Vec<Outcome> = vec![];
+    let mut outcomes_to_retry: Vec<types::TransactionOrReceiptId> = vec![];
+    while let Some(transaction_or_receipt_id) = outcomes_drain.next() {
+        let outcome_type = match &transaction_or_receipt_id {
+            types::TransactionOrReceiptId::Transaction { .. } => "transaction",
+            _ => "receipt",
+        };
+        match client
+            .send(near_client::GetExecutionOutcome { id: transaction_or_receipt_id.clone() })
+            .await
+            .map_err(|_| FailedToFetchData)
+            .map_err(|_| FailedToFetchData)
+        {
+            Ok(Ok(outcome)) => {
+                if outcome_type == "transaction" {
+                    outcomes.push(Outcome::Transaction(outcome.outcome_proof));
+                } else {
+                    outcomes.push(Outcome::Receipt(outcome.outcome_proof));
+                }
+            }
+            _ => {
+                outcomes_to_retry.push(transaction_or_receipt_id);
+            }
+        }
+    }
+    (outcomes, outcomes_to_retry)
+}
+
+/// Fetches all the chunks by their hashes.
+/// Includes transactions and receipts in custom struct (to provide more info).
+/// Returns Chunks as a `Vec`
+async fn fetch_chunks(
+    client: &Addr<near_client::ViewClientActor>,
+    chunks: &[views::ChunkHeaderView],
+) -> Result<Vec<views::ChunkView>, FailedToFetchData> {
+    let chunks_hashes =
+        chunks.iter().map(|chunk| near_client::GetChunk::ChunkHash(chunk.chunk_hash.into()));
+    let mut chunks: futures::stream::FuturesUnordered<_> =
+        chunks_hashes.map(|get_chunk| fetch_single_chunk(&client, get_chunk)).collect();
+    let mut response: Vec<views::ChunkView> = vec![];
+
+    while let Some(chunk) = chunks.next().await {
+        response.push(chunk?);
+    }
+
+    Ok(response)
+}
+
+/// Function that starts Streamer's busy loop. Every half a seconds it fetches the status
+/// compares to already fetched block height and in case it differs fetches new block of given height.
+///
+/// We have to pass `client: Addr<near_client::ClientActor>` and `view_client: Addr<near_client::ViewClientActor>`.
+pub async fn start(
+    view_client: Addr<near_client::ViewClientActor>,
+    client: Addr<near_client::ClientActor>,
+    mut queue: mpsc::Sender<BlockResponse>,
+) {
+    info!(target: INDEXER, "Starting Streamer...");
+    let mut outcomes_to_get: Vec<types::TransactionOrReceiptId> = vec![];
+    let mut last_synced_block_height: types::BlockHeight = 0;
+    loop {
+        time::delay_for(INTERVAL).await;
+        let status = fetch_status(&client).await;
+        if let Ok(status) = status {
+            if status.sync_info.syncing {
+                continue;
+            }
+        }
+
+        let block = if let Ok(block) = fetch_latest_block(&view_client).await {
+            block
+        } else {
+            continue;
+        };
+
+        let latest_block_height = block.header.height;
+        if last_synced_block_height == 0 {
+            last_synced_block_height = latest_block_height;
+        }
+        debug!(target: INDEXER, "{:?}", latest_block_height);
+        for block_height in (last_synced_block_height + 1)..=latest_block_height {
+            match fetch_block_by_height(&view_client, block_height).await {
+                Ok(block) => {
+                    let response =
+                        fetch_block_with_chunks(&view_client, block, outcomes_to_get.drain(..))
+                            .await;
+
+                    if let Ok((block_response, new_outcome_to_get)) = response {
+                        outcomes_to_get = new_outcome_to_get;
+                        debug!(target: INDEXER, "{:#?}", &block_response);
+                        match queue.send(block_response).await {
+                            _ => {} // TODO: handle error somehow
+                        };
+                    } else {
+                        debug!(target: INDEXER, "Missing data, skipping...");
+                    }
+                }
+                _ => {}
+            }
+            last_synced_block_height = block_height;
+        }
+    }
+}

--- a/chain/indexer/src/streamer/streamer.rs
+++ b/chain/indexer/src/streamer/streamer.rs
@@ -78,7 +78,7 @@ async fn fetch_block_by_height(
 }
 
 /// This function supposed to return the entire `BlockResponse`.
-/// It calls fetches the block and fetches all the chunks for the block
+/// It fetches the block and fetches all the chunks for the block
 /// and returns everything together in one struct
 async fn fetch_block_with_chunks(
     client: &Addr<near_client::ViewClientActor>,
@@ -156,10 +156,12 @@ async fn fetch_chunks(
     client: &Addr<near_client::ViewClientActor>,
     chunks: &[views::ChunkHeaderView],
 ) -> Result<Vec<views::ChunkView>, FailedToFetchData> {
-    let chunks_hashes =
-        chunks.iter().map(|chunk| near_client::GetChunk::ChunkHash(chunk.chunk_hash.into()));
-    let mut chunks: futures::stream::FuturesUnordered<_> =
-        chunks_hashes.map(|get_chunk| fetch_single_chunk(&client, get_chunk)).collect();
+    let mut chunks: futures::stream::FuturesUnordered<_> = chunks
+        .iter()
+        .map(|chunk| {
+            fetch_single_chunk(&client, near_client::GetChunk::ChunkHash(chunk.chunk_hash.into()))
+        })
+        .collect();
     let mut response = Vec::<views::ChunkView>::with_capacity(chunks.len());
 
     while let Some(chunk) = chunks.next().await {

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -531,7 +531,10 @@ pub enum ValidatorKickoutReason {
     DidNotGetASeat,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize, Serialize)]
+pub struct StateHeaderKey(pub ShardId, pub CryptoHash);
+
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TransactionOrReceiptId {
     Transaction { transaction_hash: CryptoHash, sender_id: AccountId },

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -531,9 +531,6 @@ pub enum ValidatorKickoutReason {
     DidNotGetASeat,
 }
 
-#[derive(PartialEq, Eq, Clone, Debug, BorshSerialize, BorshDeserialize, Serialize)]
-pub struct StateHeaderKey(pub ShardId, pub CryptoHash);
-
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TransactionOrReceiptId {

--- a/tools/indexer/example/Cargo.toml
+++ b/tools/indexer/example/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 actix = "0.9"
 serde_json = "1.0.55"
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "0.2", features = ["sync"] }
 tracing-subscriber = "0.2.4"
 
 near-indexer = { path = "../../../chain/indexer" }

--- a/tools/indexer/example/Cargo.toml
+++ b/tools/indexer/example/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "indexer-example"
+version = "0.1.0"
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2018"
+
+[dependencies]
+actix = "0.9"
+serde_json = "1.0.55"
+tokio = { version = "0.2", features = ["full"] }
+tracing-subscriber = "0.2.4"
+
+near-indexer = { path = "../../../chain/indexer" }

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -1,0 +1,58 @@
+use std::env;
+use std::io;
+
+use actix;
+
+use tokio::sync::mpsc;
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::EnvFilter;
+
+use near_indexer;
+
+fn init_logging(verbose: bool) {
+    let mut env_filter = EnvFilter::new("tokio_reactor=info,near=info,stats=info,telemetry=info");
+
+    if verbose {
+        env_filter = env_filter
+            .add_directive("cranelift_codegen=warn".parse().unwrap())
+            .add_directive("cranelift_codegen=warn".parse().unwrap())
+            .add_directive("h2=warn".parse().unwrap())
+            .add_directive("trust_dns_resolver=warn".parse().unwrap())
+            .add_directive("trust_dns_proto=warn".parse().unwrap());
+
+        env_filter = env_filter.add_directive(LevelFilter::DEBUG.into());
+    } else {
+        env_filter = env_filter.add_directive(LevelFilter::WARN.into());
+    }
+
+    if let Ok(rust_log) = env::var("RUST_LOG") {
+        for directive in rust_log.split(',').filter_map(|s| match s.parse() {
+            Ok(directive) => Some(directive),
+            Err(err) => {
+                eprintln!("Ignoring directive `{}`: {}", s, err);
+                None
+            }
+        }) {
+            env_filter = env_filter.add_directive(directive);
+        }
+    }
+    tracing_subscriber::fmt::Subscriber::builder()
+        .with_env_filter(env_filter)
+        .with_writer(io::stderr)
+        .init();
+}
+
+async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) {
+    while let Some(block) = stream.recv().await {
+        // TODO: handle data as you need
+        eprintln!("{:#?}", block);
+    }
+}
+
+fn main() {
+    init_logging(true);
+    let indexer = near_indexer::Indexer::new(None);
+    let stream = indexer.receiver();
+    actix::spawn(listen_blocks(stream));
+    indexer.start();
+}

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -52,7 +52,7 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) 
 fn main() {
     init_logging(true);
     let indexer = near_indexer::Indexer::new(None);
-    let stream = indexer.receiver();
+    let stream = indexer.streamer();
     actix::spawn(listen_blocks(stream));
     indexer.start();
 }

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -45,6 +45,167 @@ fn init_logging(verbose: bool) {
 async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) {
     while let Some(block) = stream.recv().await {
         // TODO: handle data as you need
+        // Example of `block` with all the data
+        // Note that `outcomes` for specific transaction won't be in the same block
+        // (it should be in the next one)
+        // BlockResponse {
+        //     block: BlockView {
+        //         author: "test.near",
+        //         header: BlockHeaderView {
+        //             height: 426,
+        //             epoch_id: `11111111111111111111111111111111`,
+        //             next_epoch_id: `9dH4uF6d3bQtXa7v8CyLPhPXGBUikCCdWB26JWVFRsBY`,
+        //             hash: `99fpSqxeiMe8iTfh72reaLvx4R16kPYAr1TYuxS3zqkB`,
+        //             prev_hash: `8try83LRTx76jfbmPv8SxJchgW8XeQH3gt2piKT6Ykpj`,
+        //             prev_state_root: `DjCJizTpo86umJHv6urA37RJqXkztV1VXpRQysTaKpZA`,
+        //             chunk_receipts_root: `GcXz5GG5oTYvdYK7jzqUt2gGQtw36gE2Hu2MxXxuBh7`,
+        //             chunk_headers_root: `GibE7k6ychYbjJHaURHV369WSGR2jjfgCCF3xL4Qgi9Y`,
+        //             chunk_tx_root: `7tkzFg8RHBmMw1ncRJZCCZAizgq4rwCftTKYLce8RU8t`,
+        //             outcome_root: `JfGt9hY94ftG2sswDQduL5U3GVb7drdX14oJZvGpuoV`,
+        //             chunks_included: 1,
+        //             challenges_root: `11111111111111111111111111111111`,
+        //             timestamp: 1594306903797198000,
+        //             timestamp_nanosec: 1594306903797198000,
+        //             random_value: `EhqGHhUP8W4ULtHF6N7pjB6hSJRE7noUKgmQvy6kfZTZ`,
+        //             validator_proposals: [],
+        //             chunk_mask: [
+        //                 true,
+        //             ],
+        //             gas_price: 5000,
+        //             rent_paid: 0,
+        //             validator_reward: 0,
+        //             total_supply: 2049999999999999997877224687500000,
+        //             challenges_result: [],
+        //             last_final_block: `2eiUwiZxqo5fRSKPqJ5Nq4oSYRQZE5gRuA9p7TcjFRSJ`,
+        //             last_ds_final_block: `8try83LRTx76jfbmPv8SxJchgW8XeQH3gt2piKT6Ykpj`,
+        //             next_bp_hash: `BsoSx2Ea1Vcomv3Ygw95E8ZeNq5QYrZLdcsYdbs3SWpC`,
+        //             block_merkle_root: `EUmovh7K8yRgboG6vXxCP2dN3ChMLByX846MZG1y6xwG`,
+        //             approvals: [
+        //                 Some(
+        //                     ed25519:42QiF81ZvRx5PfFzZxKgYC3yBfFJ4nSJCSwyiiZoztf34NXx8ottoz9jj3urtuwCHV8u6gJ9GHxUhNqbB1KpTeCH,
+        //                 ),
+        //             ],
+        //             signature: ed25519:27iPMfiR3fh5nC4wmWA3XXjXvA6yffNcnF7PMeMKRnLDpeHytV6GPtzrNNyDsuLVEWjFJvQLfp1kPw8S16zexy2d,
+        //             latest_protocol_version: 29,
+        //         },
+        //         chunks: [
+        //             ChunkHeaderView {
+        //                 chunk_hash: `7Qz2B7MumKt68iNFjSwahG35cynVLrkCfXjopFZQFLg4`,
+        //                 prev_block_hash: `8try83LRTx76jfbmPv8SxJchgW8XeQH3gt2piKT6Ykpj`,
+        //                 outcome_root: `86VPrDDpopYnn5pXSZWh6LqHjBUui2reaQT3kPYpthUs`,
+        //                 prev_state_root: `F53dYSv5z9ejgDEt1keCY2JxEeDSTUPeGsEkVg21QbBH`,
+        //                 encoded_merkle_root: `6s1QWaxhbL7EwzE7ccmhqAAebYBaziXBbumNCEqkKL76`,
+        //                 encoded_length: 208,
+        //                 height_created: 426,
+        //                 height_included: 426,
+        //                 shard_id: 0,
+        //                 gas_used: 424555062500,
+        //                 gas_limit: 1000000000000000,
+        //                 rent_paid: 0,
+        //                 validator_reward: 0,
+        //                 balance_burnt: 2122775312500000,
+        //                 outgoing_receipts_root: `7LstzSPfxFErjyxZg8nhvcXUxMUpDBysEF53w3uFF5dc`,
+        //                 tx_root: `11111111111111111111111111111111`,
+        //                 validator_proposals: [],
+        //                 signature: ed25519:4P2mYEGHU5L2JW2smLuy92DBRJ1iZmmjFmbHNV6PddCD46UW9Nmb5E285AKcK2XCjishc9NLyByMudursGxCatkf,
+        //             },
+        //         ],
+        //     },
+        //     chunks: [
+        //         ChunkView {
+        //             author: "test.near",
+        //             header: ChunkHeaderView {
+        //                 chunk_hash: `7Qz2B7MumKt68iNFjSwahG35cynVLrkCfXjopFZQFLg4`,
+        //                 prev_block_hash: `8try83LRTx76jfbmPv8SxJchgW8XeQH3gt2piKT6Ykpj`,
+        //                 outcome_root: `86VPrDDpopYnn5pXSZWh6LqHjBUui2reaQT3kPYpthUs`,
+        //                 prev_state_root: `F53dYSv5z9ejgDEt1keCY2JxEeDSTUPeGsEkVg21QbBH`,
+        //                 encoded_merkle_root: `6s1QWaxhbL7EwzE7ccmhqAAebYBaziXBbumNCEqkKL76`,
+        //                 encoded_length: 208,
+        //                 height_created: 426,
+        //                 height_included: 0,
+        //                 shard_id: 0,
+        //                 gas_used: 424555062500,
+        //                 gas_limit: 1000000000000000,
+        //                 rent_paid: 0,
+        //                 validator_reward: 0,
+        //                 balance_burnt: 2122775312500000,
+        //                 outgoing_receipts_root: `7LstzSPfxFErjyxZg8nhvcXUxMUpDBysEF53w3uFF5dc`,
+        //                 tx_root: `11111111111111111111111111111111`,
+        //                 validator_proposals: [],
+        //                 signature: ed25519:4P2mYEGHU5L2JW2smLuy92DBRJ1iZmmjFmbHNV6PddCD46UW9Nmb5E285AKcK2XCjishc9NLyByMudursGxCatkf,
+        //             },
+        //             transactions: [
+        //                 SignedTransactionView {
+        //                     signer_id: "test.near",
+        //                     public_key: ed25519:8dM8rHT6bzGY2y5aZt6rMDFPeW3ZMsDtGxzEzAb6okPs,
+        //                     nonce: 2,
+        //                     receiver_id: "inx04.test.near",
+        //                     actions: [
+        //                         CreateAccount,
+        //                         Transfer {
+        //                             deposit: 10000000000000000000000000000,
+        //                         },
+        //                         AddKey {
+        //                             public_key: ed25519:Df3CyHVsEdSfRtYDa286BFJN6nYePmoNvdgoxJ9F7PDM,
+        //                             access_key: AccessKeyView {
+        //                                 nonce: 0,
+        //                                 permission: FullAccess,
+        //                             },
+        //                         },
+        //                     ],
+        //                     signature: ed25519:2kZ6eckZAAJCmx69zJNkShWGju41nRZJYoktRdSQahZmyH4xvtg8mMbrhjoPxyUCJQJTaGh3NpLisgpRiXCrySuL,
+        //                     hash: `GaZk7PVHQ7FPdn69tGKdLoYgH5sFYqidBxKFDvyvCncw`,
+        //                 },
+        //             ],
+        //             receipts: [
+        //                 ReceiptView {
+        //                     predecessor_id: "test.near",
+        //                     receiver_id: "inx03.test.near",
+        //                     receipt_id: `6yAABgeyTYcf9pauF7yvRnnxxsSGVF9RcDt5TK3cLVGg`,
+        //                     receipt: Action {
+        //                         signer_id: "test.near",
+        //                         signer_public_key: ed25519:8dM8rHT6bzGY2y5aZt6rMDFPeW3ZMsDtGxzEzAb6okPs,
+        //                         gas_price: 5150,
+        //                         output_data_receivers: [],
+        //                         input_data_ids: [],
+        //                         actions: [
+        //                             CreateAccount,
+        //                             Transfer {
+        //                                 deposit: 10000000000000000000000000000,
+        //                             },
+        //                             AddKey {
+        //                                 public_key: ed25519:DRR2T8XKzVBLyeADvcVpLki9aonwJN2CdMBxbJijwvbW,
+        //                                 access_key: AccessKeyView {
+        //                                     nonce: 0,
+        //                                     permission: FullAccess,
+        //                                 },
+        //                             },
+        //                         ],
+        //                     },
+        //                 },
+        //             ],
+        //         },
+        //     ],
+        //     outcomes: [
+        //         Transaction(
+        //             ExecutionOutcomeWithIdView {
+        //                 proof: [],
+        //                 block_hash: `99fpSqxeiMe8iTfh72reaLvx4R16kPYAr1TYuxS3zqkB`,
+        //                 id: `FTeMWryKrKaKSgCXhgMe7rtMyxbpsxscGAiCjbRZndit`,
+        //                 outcome: ExecutionOutcomeView {
+        //                     logs: [],
+        //                     receipt_ids: [
+        //                         `6yAABgeyTYcf9pauF7yvRnnxxsSGVF9RcDt5TK3cLVGg`,
+        //                     ],
+        //                     gas_burnt: 424555062500,
+        //                     tokens_burnt: 2122775312500000,
+        //                     executor_id: "test.near",
+        //                     status: SuccessReceiptId(6yAABgeyTYcf9pauF7yvRnnxxsSGVF9RcDt5TK3cLVGg),
+        //                 },
+        //             },
+        //         ),
+        //     ],
+        // }
         eprintln!("{:#?}", block);
     }
 }

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -46,8 +46,12 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) 
     while let Some(block) = stream.recv().await {
         // TODO: handle data as you need
         // Example of `block` with all the data
-        // Note that `outcomes` for specific transaction won't be in the same block
-        // (it should be in the next one)
+        //
+        // Note that `outcomes` for a given transaction won't be included into the same block.
+        // Execution outcomes are included into the blocks after the transaction or receipt
+        // are recorded on a chain; in most cases, it is the next block after the one that has
+        // the transaction or receipt.
+        //
         // BlockResponse {
         //     block: BlockView {
         //         author: "test.near",

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -215,8 +215,10 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) 
 }
 
 fn main() {
+    let home_dir: Option<String> = env::args().nth(1);
+
     init_logging(true);
-    let indexer = near_indexer::Indexer::new(None);
+    let indexer = near_indexer::Indexer::new(home_dir.as_ref().map(AsRef::as_ref));
     let stream = indexer.streamer();
     actix::spawn(listen_blocks(stream));
     indexer.start();


### PR DESCRIPTION
Work in progress on network-indexer and explorer backend.

Corresponding issue  in [near-explorer #236](https://github.com/near/near-explorer/issues/236)

Currently we have:

* `indexer` at `chain/indexer`
* `indexer-explorer`

We have indexer that can run `neard` (though we need to set predefined parameters and learn what args we need to be ready to receive) and streamer that watches for each newly created block, collects chunks related to the block and sends it to channel.

`indexer-explorer` is the usage of the `indexer`.

