### PR TITLE
feat: Making light client conformant with the new spec

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -414,12 +414,26 @@ impl Chain {
     ///  * `header` - the last finalized block seen from `header` (not pushed back) will be used to
     ///               compute the light client block
     pub fn create_light_client_block(
-        header: &BlockHeader,
+        header: BlockHeader,
         runtime_adapter: &dyn RuntimeAdapter,
         chain_store: &mut dyn ChainStoreAccess,
     ) -> Result<LightClientBlockView, Error> {
-        let final_block_header =
-            chain_store.get_block_header(&header.inner_rest.last_final_block)?.clone();
+        let final_block_header = {
+            let ret = chain_store.get_block_header(&header.inner_rest.last_final_block)?.clone();
+            let two_ahead = chain_store.get_header_by_height(ret.inner_lite.height + 2)?;
+            if two_ahead.inner_lite.epoch_id != ret.inner_lite.epoch_id {
+                let one_ahead = chain_store.get_header_by_height(ret.inner_lite.height + 1)?;
+                if one_ahead.inner_lite.epoch_id != ret.inner_lite.epoch_id {
+                    let new_final_hash = ret.inner_rest.last_final_block.clone();
+                    chain_store.get_block_header(&new_final_hash)?.clone()
+                } else {
+                    let new_final_hash = one_ahead.inner_rest.last_final_block.clone();
+                    chain_store.get_block_header(&new_final_hash)?.clone()
+                }
+            } else {
+                ret
+            }
+        };
 
         let next_block_producers = get_epoch_block_producers_view(
             &final_block_header.inner_lite.next_epoch_id,
@@ -2794,7 +2808,7 @@ impl<'a> ChainUpdate<'a> {
         self.chain_store_update.save_next_block_hash(&header.prev_hash, header.hash());
 
         Chain::create_light_client_block(
-            header,
+            header.clone(),
             &*self.runtime_adapter,
             &mut self.chain_store_update,
         )

--- a/chain/chain/src/lightclient.rs
+++ b/chain/chain/src/lightclient.rs
@@ -45,6 +45,7 @@ pub fn create_light_client_block_view(
         outcome_root: inner_lite.outcome_root,
         timestamp: inner_lite.timestamp,
         next_bp_hash: inner_lite.next_bp_hash,
+        block_merkle_root: inner_lite.block_merkle_root,
     };
     let inner_rest_hash = block_header.inner_rest.hash();
 
@@ -54,7 +55,6 @@ pub fn create_light_client_block_view(
         &next_block_header.inner_lite,
         &next_block_header.inner_rest,
     );
-    let approvals_next = next_block_header.inner_rest.approvals.clone();
 
     let after_next_block_hash = chain_store.get_next_block_hash(&next_block_hash)?.clone();
     let after_next_block_header = chain_store.get_block_header(&after_next_block_hash)?;
@@ -66,7 +66,6 @@ pub fn create_light_client_block_view(
         inner_lite: inner_lite_view,
         inner_rest_hash,
         next_bps: next_block_producers,
-        approvals_next,
         approvals_after_next,
     })
 }

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -529,7 +529,7 @@ impl Handler<GetNextLightClientBlock> for ViewClientActor {
                 .get_block_header(&head.last_block_hash)
                 .map_err(|err| err.to_string())?;
             let ret = Chain::create_light_client_block(
-                &head_header.clone(),
+                head_header.clone(),
                 &*self.runtime_adapter,
                 self.chain.mut_store(),
             )

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -433,6 +433,7 @@ pub struct BlockHeaderInnerLiteView {
     pub outcome_root: CryptoHash,
     pub timestamp: u64,
     pub next_bp_hash: CryptoHash,
+    pub block_merkle_root: CryptoHash,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -1014,7 +1015,6 @@ pub struct LightClientBlockView {
     pub inner_lite: BlockHeaderInnerLiteView,
     pub inner_rest_hash: CryptoHash,
     pub next_bps: Option<Vec<ValidatorStakeView>>,
-    pub approvals_next: Vec<Option<Signature>>,
     pub approvals_after_next: Vec<Option<Signature>>,
 }
 

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -21,7 +21,7 @@ pytest --timeout=300 sanity/state_sync_late.py notx
 pytest sanity/rpc_tx_forwarding.py
 pytest --timeout=240 sanity/skip_epoch.py
 pytest --timeout=240 sanity/one_val.py
-# pytest --timeout=240 sanity/lightclnt.py
+pytest --timeout=240 sanity/lightclnt.py
 pytest --timeout=240 sanity/rpc_query.py
 pytest --timeout=240 sanity/block_sync.py
 pytest --timeout=240 sanity/validator_switch.py

--- a/pytest/lib/lightclient.py
+++ b/pytest/lib/lightclient.py
@@ -10,7 +10,7 @@ inner_lite_schema = dict([
     [
         BlockHeaderInnerLite, {
             'kind':
-                'struct',
+            'struct',
             'fields': [
                 ['height', 'u64'],
                 ['epoch_id', [32]],
@@ -19,6 +19,7 @@ inner_lite_schema = dict([
                 ['outcome_root', [32]],
                 ['timestamp', 'u64'],
                 ['next_bp_hash', [32]],
+                ['block_merkle_root', [32]],
             ]
         }
     ],
@@ -43,6 +44,7 @@ def compute_block_hash(inner_lite_view, inner_rest_hash, prev_hash):
     inner_lite.outcome_root = base58.b58decode(inner_lite_view['outcome_root'])
     inner_lite.timestamp = inner_lite_view['timestamp']
     inner_lite.next_bp_hash = base58.b58decode(inner_lite_view['next_bp_hash'])
+    inner_lite.block_merkle_root = base58.b58decode(inner_lite_view['block_merkle_root'])
 
     msg = BinarySerializer(inner_lite_schema).serialize(inner_lite)
     inner_lite_hash = hashlib.sha256(msg).digest()
@@ -59,105 +61,39 @@ def validate_light_client_block(last_known_block,
                                 panic=False):
     new_block_hash = compute_block_hash(new_block['inner_lite'],
                                         new_block['inner_rest_hash'],
-                                        new_block['prev_hash'])
+                                        new_block['prev_block_hash'])
 
     if new_block['inner_lite']['epoch_id'] not in [
             last_known_block['inner_lite']['epoch_id'],
             last_known_block['inner_lite']['next_epoch_id']
     ]:
-        if panic:
-            assert False
+        if panic: assert False
         return False
 
     block_producers = block_producers_map[new_block['inner_lite']['epoch_id']]
-    if len(new_block['qv_approvals']) != len(block_producers) or len(
-            new_block['qc_approvals']) != len(block_producers):
-        if panic:
-            assert False
+    if len(new_block['approvals_after_next']) != len(block_producers):
+        if panic: assert False
         return False
-
-    if len(new_block['future_inner_hashes']) > 50:
-        if panic:
-            assert False
-        return False
-
-    qv_blocks = set()
-    qc_blocks = set()
-
-    prev_hash = base58.b58decode(new_block_hash)
-    passed_qv = False
-    qv_hash = base58.b58decode(new_block['qv_hash'])
-    for future_inner_hash in new_block['future_inner_hashes']:
-        cur_hash = combine_hash(base58.b58decode(future_inner_hash), prev_hash)
-        if cur_hash == qv_hash:
-            passed_qv = True
-        if passed_qv:
-            qc_blocks.add(cur_hash)
-        else:
-            qv_blocks.add(cur_hash)
-        prev_hash = cur_hash
-
-    if not passed_qv:
-        if panic:
-            assert False
-        return False
-
-    qv_blocks = [base58.b58encode(x).decode('ascii') for x in qv_blocks]
-    qc_blocks = [base58.b58encode(x).decode('ascii') for x in qc_blocks]
 
     total_stake = 0
-    qv_stake = 0
-    qc_stake = 0
+    approved_stake = 0
 
-    for qv_approval, qc_approval, stake in zip(new_block['qv_approvals'],
-                                               new_block['qc_approvals'],
-                                               block_producers):
-        if qv_approval is not None:
-            qv_stake += int(stake['stake'])
-            if qv_approval['parent_hash'] not in qv_blocks and qv_approval[
-                    'parent_hash'] != new_block_hash.decode('ascii'):
-                if panic:
-                    assert False
-                return False
-            if qv_approval['reference_hash'] in qv_blocks:
-                if panic:
-                    assert False
-                return False
-            #if not validate_signature(qv_approval.signature, hash(qv_approval), stake.public_key):
-            #    if panic: assert False
-            #    return False
-
-        if qc_approval is not None:
-            qc_stake += int(stake['stake'])
-            if qc_approval['parent_hash'] not in qc_blocks:
-                if panic:
-                    assert False
-                return False
-            if qc_approval['reference_hash'] in qc_blocks or qc_approval[
-                    'reference_hash'] in qv_blocks:
-                if panic:
-                    assert False
-                return False
-            #if not validate_signature(qc_approval.signature, hash(qc_approval), stake.public_key):
-            #    return false
+    for approval, stake in zip(new_block['approvals_after_next'],
+                               block_producers):
+        if approval is not None:
+            approved_stake += int(stake['stake'])
 
         total_stake += int(stake['stake'])
 
     threshold = total_stake * 2 // 3
-    if qv_stake <= threshold:
-        if panic:
-            assert False
-        return False
-    if qc_stake <= threshold:
-        if panic:
-            assert False
+    if approved_stake <= threshold:
+        if panic: assert False
         return False
 
     if new_block['inner_lite']['epoch_id'] == last_known_block['inner_lite'][
             'next_epoch_id']:
         if new_block['next_bps'] is None:
-            if panic:
-                assert False
+            if panic: assert False
             return False
 
         # TODO: MOO check hash

--- a/pytest/tests/sanity/lightclnt.py
+++ b/pytest/tests/sanity/lightclnt.py
@@ -46,6 +46,9 @@ hash_to_next_epoch = {}
 height_to_hash = {}
 epochs = []
 
+first_epoch_switch_height = None
+last_epoch = None
+
 block_producers_map = {}
 
 
@@ -62,7 +65,7 @@ def get_light_client_block(hash_, last_known_block):
 
 
 def get_up_to(from_, to):
-    global hash_to_height, hash_to_epoch, hash_to_next_epoch, height_to_hash, epochs
+    global hash_to_height, hash_to_epoch, hash_to_next_epoch, height_to_hash, epochs, first_epoch_switch_height, last_epoch
 
     while True:
         assert time.time() - started < TIMEOUT
@@ -76,28 +79,38 @@ def get_up_to(from_, to):
         hash_to_height[hash_] = height
         height_to_hash[height] = hash_
 
-        hash_to_epoch[hash_] = block['result']['header']['epoch_id']
+        cur_epoch = block['result']['header']['epoch_id']
+
+        hash_to_epoch[hash_] = cur_epoch
         hash_to_next_epoch[hash_] = block['result']['header']['next_epoch_id']
+
+        if first_epoch_switch_height is None and last_epoch is not None and last_epoch != cur_epoch:
+            first_epoch_switch_height = height
+        last_epoch = cur_epoch
 
         if height >= to:
             break
 
     for i in range(from_, to + 1):
         hash_ = height_to_hash[i]
-        print(i, hash_to_epoch[hash_], hash_to_next_epoch[hash_])
+        print(i, hash_, hash_to_epoch[hash_], hash_to_next_epoch[hash_])
 
         if len(epochs) == 0 or epochs[-1] != hash_to_epoch[hash_]:
             epochs.append(hash_to_epoch[hash_])
 
 
-# don't start from 1, sicne couple heights get produced while the nodes spin up
-get_up_to(4, 29)
+# don't start from 1, since couple heights get produced while the nodes spin up
+get_up_to(4, 15)
+get_up_to(16, 22 + first_epoch_switch_height)
 
 # since we already "know" the first block, the first light client block that will be returned
 # will be for the second epoch. The second epoch spans blocks 7-12, and the last final block in
 # it has height 10. Then blocks go in increments of 6.
 # the last block returned will be the last final block, with height 27
-heights = [None, 10, 16, 22, 27]
+heights = [
+    None, 3 + first_epoch_switch_height, 9 + first_epoch_switch_height,
+    15 + first_epoch_switch_height, 20 + first_epoch_switch_height
+]
 
 last_known_block_hash = height_to_hash[4]
 last_known_block = None
@@ -108,18 +121,18 @@ while True:
 
     res = get_light_client_block(last_known_block_hash, last_known_block)
 
-    if last_known_block_hash == height_to_hash[27]:
+    if last_known_block_hash == height_to_hash[20 + first_epoch_switch_height]:
         assert res['result'] is None
         break
 
     assert res['result']['inner_lite']['epoch_id'] == epochs[iter_]
     print(iter_, heights[iter_])
-    assert res['result']['inner_lite']['height'] == heights[iter_], res[
-        'result']['inner_lite']
+    assert res['result']['inner_lite']['height'] == heights[iter_], (
+        res['result']['inner_lite'], first_epoch_switch_height)
 
     last_known_block_hash = compute_block_hash(
         res['result']['inner_lite'], res['result']['inner_rest_hash'],
-        res['result']['prev_hash']).decode('ascii')
+        res['result']['prev_block_hash']).decode('ascii')
     assert last_known_block_hash == height_to_hash[
         res['result']['inner_lite']['height']], "%s != %s" % (
             last_known_block_hash,
@@ -132,22 +145,40 @@ while True:
 
     iter_ += 1
 
-res = get_light_client_block(height_to_hash[26], last_known_block)
+res = get_light_client_block(height_to_hash[19 + first_epoch_switch_height],
+                             last_known_block)
 print(res)
-assert res['result']['inner_lite']['height'] == 27
+assert res['result']['inner_lite']['height'] == 20 + first_epoch_switch_height
 
-get_up_to(30, 31)
+get_up_to(23 + first_epoch_switch_height, 24 + first_epoch_switch_height)
 
-res = get_light_client_block(height_to_hash[26], last_known_block)
-assert res['result']['inner_lite']['height'] == 28
+# Test that the light client block is always in the same epoch as the block 2 heights onward (needed to make
+# sure that the proofs can be verified using the keys of the block producers of the epoch of the block).
+# Before the loop below the last block is 24 + C, which is in the new epoch, thus we expect the light client
+# block during the first iteration to be 21 + C. After the first iteration we move one block onward, now
+# having the head at 25 + C. At this point the last final block is 23 + C, still in the previous epoch, so
+# we still expect 21 + C to be returned. We then move again to 26 + C, and (in the section after the loop)
+# check that the light client block now corresponds to 24 + C, which is in the same epoch as 26 + C.
+for i in range(2):
+    res = get_light_client_block(
+        height_to_hash[19 + first_epoch_switch_height], last_known_block)
+    assert res['result']['inner_lite'][
+        'height'] == 21 + first_epoch_switch_height, (
+            res['result']['inner_lite']['height'],
+            21 + first_epoch_switch_height)
 
-res = get_light_client_block(height_to_hash[27], last_known_block)
-assert res['result']['inner_lite']['height'] == 28
+    res = get_light_client_block(
+        height_to_hash[20 + first_epoch_switch_height], last_known_block)
+    assert res['result']['inner_lite'][
+        'height'] == 21 + first_epoch_switch_height
 
-res = get_light_client_block(height_to_hash[28], last_known_block)
-assert res['result'] is None
+    res = get_light_client_block(
+        height_to_hash[21 + first_epoch_switch_height], last_known_block)
+    assert res['result'] is None
 
-get_up_to(32, 33)
+    get_up_to(i + 25 + first_epoch_switch_height,
+              i + 25 + first_epoch_switch_height)
 
-res = get_light_client_block(height_to_hash[28], last_known_block)
-assert res['result']['inner_lite']['height'] == 31
+res = get_light_client_block(height_to_hash[21 + first_epoch_switch_height],
+                             last_known_block)
+assert res['result']['inner_lite']['height'] == 24 + first_epoch_switch_height


### PR DESCRIPTION
* Remove `approvals_next`
* Make the block for which the light client view is crated be pushed
back if the block two heights onward is in a different epoch

Test plan
---------
Restoring the old python test