### PR TITLE
fix(near-chunks): remove unnecessary Result

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -414,7 +414,7 @@ impl ShardsManager {
                 )
                 && self.me.as_ref() != Some(&validator_stake.account_id)
             {
-                block_producers.push(validator_stake.account_id.clone());
+                block_producers.push(validator_stake.account_id);
             }
         }
 

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1274,7 +1274,7 @@ impl ShardsManager {
 
 #[cfg(test)]
 mod test {
-    use crate::{ChunkRequestInfo, ShardsManager};
+    use crate::{ChunkRequestInfo, ShardsManager, CHUNK_REQUEST_RETRY_MS};
     use near_chain::test_utils::KeyValueRuntime;
     use near_network::test_utils::MockNetworkAdapter;
     use near_primitives::hash::hash;
@@ -1300,7 +1300,7 @@ mod test {
                 last_requested: Instant::now(),
             },
         );
-        std::thread::sleep(Duration::from_millis(200));
+        std::thread::sleep(Duration::from_millis(2 * CHUNK_REQUEST_RETRY_MS));
         shards_manager.resend_chunk_requests();
         assert!(network_adapter.requests.read().unwrap().is_empty());
     }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -480,7 +480,7 @@ impl ShardsManager {
     }
 
     /// Resends chunk requests if haven't received it within expected time.
-    pub fn resend_chunk_requests(&mut self) -> Result<(), Error> {
+    pub fn resend_chunk_requests(&mut self) {
         // Process chunk one part requests.
         let requests = self.requested_partial_encoded_chunks.fetch();
         for (chunk_hash, chunk_request) in requests {
@@ -500,7 +500,6 @@ impl ShardsManager {
                 }
             }
         }
-        Ok(())
     }
 
     pub fn store_partial_encoded_chunk(
@@ -1302,7 +1301,7 @@ mod test {
             },
         );
         std::thread::sleep(Duration::from_millis(200));
-        shards_manager.resend_chunk_requests().unwrap();
+        shards_manager.resend_chunk_requests();
         assert!(network_adapter.requests.read().unwrap().is_empty());
     }
 }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -963,12 +963,7 @@ impl ClientActor {
 
     /// Job to retry chunks that were requested but not received within expected time.
     fn chunk_request_retry(&mut self, ctx: &mut Context<ClientActor>) {
-        match self.client.shards_mgr.resend_chunk_requests() {
-            Ok(_) => {}
-            Err(err) => {
-                error!(target: "client", "Failed to resend chunk requests: {}", err);
-            }
-        };
+        self.client.shards_mgr.resend_chunk_requests();
         ctx.run_later(self.client.config.chunk_request_retry_period, move |act, ctx| {
             act.chunk_request_retry(ctx);
         });


### PR DESCRIPTION
`ShardsManager::resend_chunk_requests` returned a `Result` type, but never actually returned any error. We change the return type to `()` to make it clear this call will not fail.

Other miscellaneous changes:
* remove an unnecessary `clone` call in `ShardsManager::get_random_shard_block_producer`
* change `near_chunks::test::test_request_partial_encoded_chunk_from_self` to use a constant instead of a "magic number"