### PR TITLE
Fix(script): normal target to avoid flag mess up in nightly

### DIFF
--- a/test-utils/testlib/src/node/process_node.rs
+++ b/test-utils/testlib/src/node/process_node.rs
@@ -130,7 +130,7 @@ impl ProcessNode {
             ]);
             command
         } else {
-            let mut command = Command::new("target/debug/neard");
+            let mut command = Command::new("normal_target/debug/neard");
             command.args(&["--home", &self.work_dir, "run"]);
             command
         }


### PR DESCRIPTION
Nightly expensive tests use --all-features to build, but some expensive test need a neard build without `--all-features`, if, use same target dir, will cause those expensive tests recompiling after compile the neard

Test Plan
------------
Precompile neard in nightly.py to normal_target dir