### PR TITLE
fix(script): binary release rename

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ release:
 	cargo build -p genesis-csv-to-json --release
 	cargo build -p near-vm-runner-standalone --release
 	cargo build -p state-viewer --release
-	cargo build -p store-validator --release
+	cargo build -p store-validator-bin --release
 
 debug:
 	cargo build -p neard
@@ -15,4 +15,4 @@ debug:
 	cargo build -p genesis-csv-to-json
 	cargo build -p near-vm-runner-standalone
 	cargo build -p state-viewer
-	cargo build -p store-validator
+	cargo build -p store-validator-bin

--- a/scripts/binary-release.sh
+++ b/scripts/binary-release.sh
@@ -20,4 +20,4 @@ upload_binary keypair-generator
 upload_binary genesis-csv-to-json
 upload_binary near-vm-runner-standalone
 upload_binary state-viewer
-upload_binary store-validator
+upload_binary store-validator-bin


### PR DESCRIPTION
Fix the binary release fail due to a rename on store-validator to store-validator-bin

Test Plan
---------
cargo build -p store-validator-bin