### PR TITLE
fix(test): enforce all expensive test is in nightly

### DIFF
--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -74,6 +74,7 @@ fn test_keyvalue_runtime_balances() {
     .unwrap();
 }
 
+#[cfg(feature = "expensive_tests")]
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
@@ -370,9 +371,6 @@ mod tests {
         test_doomslug: bool,
         block_production_time: u64,
     ) {
-        if !cfg!(feature = "expensive_tests") {
-            return;
-        }
         let validator_groups = 4;
         init_test_logger();
         System::run(move || {

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -68,6 +68,9 @@ expensive --timeout=3600 near-client catching_up tests::test_all_chunks_accepted
 # expensive --timeout=7200 near-client catching_up tests::test_all_chunks_accepted_1000_slow
 expensive --timeout=1800 near-client catching_up tests::test_all_chunks_accepted_1000_rare_epoch_changing
 expensive near-client catching_up tests::test_catchup_sanity_blocks_produced_doomslug
+expensive near-client catching_up tests::test_catchup_receipts_sync_hold
+expensive near-client catching_up tests::test_chunk_grieving
+expensive near-client catching_up tests::test_all_chunks_accepted_1000_slow
 
 expensive nearcore test_catchup test_catchup
 
@@ -77,6 +80,8 @@ expensive --timeout=1500 near-client cross_shard_tx tests::test_cross_shard_tx_d
 expensive --timeout=1500 near-client cross_shard_tx tests::test_cross_shard_tx_drop_chunks
 expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_1
 expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_2
+expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_8_iterations
+expensive --timeout=4800 near-client cross_shard_tx tests::test_cross_shard_tx_8_iterations_drop_chunks
 
 # consensus tests
 expensive --timeout=3000 near-chain doomslug tests::test_fuzzy_doomslug_liveness_and_safety
@@ -117,6 +122,7 @@ expensive nearcore test_cases_testnet_rpc test::test_add_access_key_with_allowan
 expensive nearcore test_cases_testnet_rpc test::test_delete_access_key_with_allowance_testnet
 # The next test is disabled due to #2208
 # expensive nearcore test_cases_testnet_rpc test::test_access_key_smart_contract_testnet
+expensive nearcore test_cases_testnet_rpc test::test_access_key_smart_contract_testnet
 
 # GC tests
 expensive --timeout=600 near-chain gc tests::test_gc_remove_fork_large

--- a/scripts/check_nightly.py
+++ b/scripts/check_nightly.py
@@ -52,8 +52,6 @@ def expensive_tests_in_file(file):
             elif tok == test_pattern:
                 fn = find_fn(content, start)
                 if fn:
-                    if fn == 'test_gc_remove_fork_fail_often':
-                        print('==', fn, level)
                     ret.append(fn)
     return ret
 

--- a/scripts/check_nightly.py
+++ b/scripts/check_nightly.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+
+import glob
+import re
+import sys
+import os
+
+expensive_pattern = '#[cfg(feature = "expensive_tests")]'
+test_pattern = '#[test]'
+
+
+def find_first(str1, candidates, start):
+    found = list(filter(lambda x: x[0]>=0, 
+                          map(lambda str2: (str1.find(str2, start), str2),
+                          candidates)))
+    if found:
+        return min(found)
+    else:
+        return -1, None
+    
+
+
+def find_fn(str1, start):
+    fn_start = str1.find('fn ', start)
+    match = re.search(r'[a-zA-Z0-9_]+', str1[fn_start+3:])
+    if match:
+        return match.group(0)
+    return None
+
+def expensive_tests_in_file(file):
+    with(open(file)) as f:
+        content = f.read()
+    start = 0
+    ret = []
+    while True:
+        start = content.find(expensive_pattern, start)
+        if start == -1:
+            return ret
+        start += len(expensive_pattern)
+        level = 0
+        while True:
+            start, tok = find_first(content, ['{', '}', test_pattern], start)
+            if start == -1:
+                break
+            start += len(tok)
+            if tok == '{':
+                level += 1
+            elif tok == '}':
+                level -= 1
+                if level == 0:
+                    break
+            elif tok == test_pattern:
+                fn = find_fn(content, start)
+                if fn:
+                    if fn == 'test_gc_remove_fork_fail_often':
+                        print('==', fn, level)
+                    ret.append(fn)
+    return ret
+
+
+def nightly_tests():
+    with open(os.path.join(os.path.dirname(__file__), '../nightly/nightly.txt')) as f:
+        tests = f.readlines()
+    ret = set()
+    for test in tests:
+        t = test.strip().split(' ')
+        if t[0] == 'expensive':
+            ret.add(t[-1].split('::')[-1])
+    return ret
+
+if __name__ == '__main__':
+    nightly_txt_tests = nightly_tests()
+    rust_src = glob.glob(os.path.join(os.path.dirname(__file__), '../') + '**/*.rs', recursive=True)
+    rust_src = list(filter(lambda f: f.find('/target/') == -1, rust_src))
+    for rs in rust_src:
+        rs = os.path.abspath(rs)
+        print(f'checking file {rs}')
+        expensive_tests = expensive_tests_in_file(rs)
+        for t in expensive_tests:
+            print(f'  expensive test {t}')
+            if t not in nightly_txt_tests:
+                print(f'error: file {rs} test {t} not in nightly.txt')
+                exit(1)
+    print('all tests in nightly')


### PR DESCRIPTION
Currently we have a few expensive tests not in nightly.txt, it's also deserve a check to enforce future expensive tests are in nightly.txt. I didn't find a cargo feature to list all tests or a rust parser binding in python and write this check in rust with std::ast is too heavy so it's a simple hacking parser

Test Plan
---------
Run locally, find a few missing nightly tests. Also I've add this test to buildkite, sanity check step, so it will be checked there