### PR TITLE
Spread Client, PeerManager and ViewClient on different threads

### DIFF
--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -2,13 +2,13 @@
 extern crate lazy_static;
 
 pub use crate::client::Client;
-pub use crate::client_actor::ClientActor;
+pub use crate::client_actor::{start_client, ClientActor};
 pub use crate::types::{
     Error, GetBlock, GetBlockWithMerkleTree, GetChunk, GetGasPrice, GetNetworkInfo,
     GetNextLightClientBlock, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo, Query,
     Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
 };
-pub use crate::view_client::ViewClientActor;
+pub use crate::view_client::{start_view_client, ViewClientActor};
 
 mod client;
 mod client_actor;

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -36,7 +36,7 @@ use near_store::test_utils::create_test_store;
 use near_store::Store;
 use near_telemetry::TelemetryActor;
 
-use crate::{Client, ClientActor, SyncStatus, ViewClientActor};
+use crate::{start_view_client, Client, ClientActor, SyncStatus, ViewClientActor};
 use near_network::test_utils::MockNetworkAdapter;
 use num_rational::Rational;
 
@@ -57,7 +57,7 @@ pub fn setup(
     network_adapter: Arc<dyn NetworkAdapter>,
     transaction_validity_period: NumBlocks,
     genesis_time: DateTime<Utc>,
-) -> (Block, ClientActor, ViewClientActor) {
+) -> (Block, ClientActor, Addr<ViewClientActor>) {
     let store = create_test_store();
     let num_validator_seats = validators.iter().map(|x| x.len()).sum::<usize>() as NumSeats;
     let runtime = Arc::new(KeyValueRuntime::new_with_validators(
@@ -96,14 +96,13 @@ pub fn setup(
         num_validator_seats,
         archive,
     );
-    let view_client = ViewClientActor::new(
+    let view_client_addr = start_view_client(
         Some(signer.validator_id().clone()),
-        &chain_genesis,
+        chain_genesis.clone(),
         runtime.clone(),
         network_adapter.clone(),
         config.clone(),
-    )
-    .unwrap();
+    );
 
     let client = ClientActor::new(
         config,
@@ -116,7 +115,7 @@ pub fn setup(
         enable_doomslug,
     )
     .unwrap();
-    (genesis_block, client, view_client)
+    (genesis_block, client, view_client_addr)
 }
 
 /// Sets up ClientActor and ViewClientActor with mock PeerManager.
@@ -158,7 +157,7 @@ pub fn setup_mock_with_validity_period(
     transaction_validity_period: NumBlocks,
 ) -> (Addr<ClientActor>, Addr<ViewClientActor>) {
     let network_adapter = Arc::new(NetworkRecipient::new());
-    let (_, client, view_client) = setup(
+    let (_, client, view_client_addr) = setup(
         vec![validators],
         1,
         1,
@@ -174,7 +173,6 @@ pub fn setup_mock_with_validity_period(
         Utc::now(),
     );
     let client_addr = client.start();
-    let view_client_addr = view_client.start();
     let client_addr1 = client_addr.clone();
 
     let network_actor = NetworkMock::mock(Box::new(move |msg, ctx| {
@@ -660,7 +658,7 @@ pub fn setup_mock_all_validators(
             .start();
             let network_adapter = NetworkRecipient::new();
             network_adapter.set_recipient(pm.recipient());
-            let (block, client, view_client) = setup(
+            let (block, client, view_client_addr) = setup(
                 validators_clone1.clone(),
                 validator_groups,
                 num_shards,
@@ -675,7 +673,7 @@ pub fn setup_mock_all_validators(
                 10000,
                 genesis_time,
             );
-            *view_client_addr1.write().unwrap() = Some(view_client.start());
+            *view_client_addr1.write().unwrap() = Some(view_client_addr);
             *genesis_block1.write().unwrap() = Some(block);
             client
         });

--- a/chain/network/src/lib.rs
+++ b/chain/network/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate lazy_static;
 
-pub use peer_manager::PeerManagerActor;
+pub use peer_manager::{start_network, PeerManagerActor};
 pub use types::{
     FullPeerInfo, NetworkAdapter, NetworkClientMessages, NetworkClientResponses, NetworkConfig,
     NetworkRecipient, NetworkRequests, NetworkResponses, PeerInfo,

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -1,7 +1,7 @@
 use std::cmp::max;
-use std::io;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
+use std::{io, thread};
 
 use actix::io::{FramedWrite, WriteHandler};
 use actix::{
@@ -535,6 +535,7 @@ impl Actor for Peer {
     type Context = Context<Peer>;
 
     fn started(&mut self, ctx: &mut Self::Context) {
+        println!("STARTED Peer in arbiter thread {:?}", thread::current().id());
         near_metrics::inc_gauge(&metrics::PEER_CONNECTIONS_TOTAL);
         // Fetch genesis hash from the client.
         self.fetch_client_chain_info(ctx);

--- a/chain/network/tests/runner/mod.rs
+++ b/chain/network/tests/runner/mod.rs
@@ -11,7 +11,7 @@ use futures::{future, FutureExt, TryFutureExt};
 use near_chain::test_utils::KeyValueRuntime;
 use near_chain::ChainGenesis;
 use near_chain_configs::ClientConfig;
-use near_client::{ClientActor, ViewClientActor};
+use near_client::{start_view_client, ClientActor};
 use near_crypto::KeyType;
 use near_logger_utils::init_test_logger;
 use near_network::test_utils::{
@@ -88,15 +88,13 @@ pub fn setup_network_node(
         )
         .unwrap()
         .start();
-        let view_client_actor = ViewClientActor::new(
+        let view_client_actor = start_view_client(
             config.account_id.clone(),
-            &chain_genesis,
+            chain_genesis.clone(),
             runtime.clone(),
             network_adapter.clone(),
             client_config,
-        )
-        .unwrap()
-        .start();
+        );
 
         PeerManagerActor::new(
             store.clone(),

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -72,6 +72,8 @@ pub struct ClientConfig {
     pub tracked_shards: Vec<ShardId>,
     /// Not clear old data, set `true` for archive nodes.
     pub archive: bool,
+    /// Number of threads for ViewClientActor pool.
+    pub view_client_threads: usize,
 }
 
 impl ClientConfig {
@@ -121,6 +123,7 @@ impl ClientConfig {
             tracked_accounts: vec![],
             tracked_shards: vec![],
             archive,
+            view_client_threads: 1,
         }
     }
 }

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -3,6 +3,7 @@ name = "neard"
 version = "1.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
+default-run = "neard"
 
 [dependencies]
 actix = "0.9"

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -258,6 +258,10 @@ fn default_sync_step_period() -> Duration {
     Duration::from_millis(10)
 }
 
+fn default_view_client_threads() -> usize {
+    4
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Consensus {
     /// Minimum number of peers to start syncing.
@@ -345,6 +349,8 @@ pub struct Config {
     pub tracked_accounts: Vec<AccountId>,
     pub tracked_shards: Vec<ShardId>,
     pub archive: bool,
+    #[serde(default = "default_view_client_threads")]
+    pub view_client_threads: usize,
 }
 
 impl Default for Config {
@@ -361,6 +367,7 @@ impl Default for Config {
             tracked_accounts: vec![],
             tracked_shards: vec![],
             archive: false,
+            view_client_threads: 4,
         }
     }
 }
@@ -523,6 +530,7 @@ impl NearConfig {
                 tracked_accounts: config.tracked_accounts,
                 tracked_shards: config.tracked_shards,
                 archive: config.archive,
+                view_client_threads: config.view_client_threads,
             },
             network_config: NetworkConfig {
                 public_key: network_key_pair.public_key,


### PR DESCRIPTION
After some research, it appeared that Actix doesn't automatically spread actors among threads.
To do that, multiple Arbiters are needed. Additionally, Actix has a way to maintain a pool of same type actors and route between them via SyncArbiter.

This fixes #2751 in next way:
 - Client has it's own Arbiter (thread)
 - PeerManager and all Peers under it have separate Arbiter (thread).
 - ViewClient has SyncArbiter with 4 thread (by default, can configure in config.json)

 Ideally each Peer should be in separate thread as well to not block network, but that would require bigger refactoring, as SyncArbiter needs to create all actors at the construction time. Meaning Peer would become long lived actors that would be reused across connections.

Testing plan
-------
 - CI passes
 - @SkidanovAlex benchmark is improved.