### PR TITLE
fix(script): disable codecov status check to polute commit status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project:
+      default: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,4 @@
 coverage:
   status:
-    project:
-      default: false
+    project: off
+    patch: off


### PR DESCRIPTION
codecov status check is annoying and pollute commit status, we still want a `codecov 88%` badge in readme, but don't want a drop in coverage makes our commit in master branch shows `X`.

Test Plan
---------
enable codecov for this pr, it should always pass even coverage drops.