### PR TITLE
fix(test): allow comment out very expensive test

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -70,7 +70,6 @@ expensive --timeout=1800 near-client catching_up tests::test_all_chunks_accepted
 expensive near-client catching_up tests::test_catchup_sanity_blocks_produced_doomslug
 expensive near-client catching_up tests::test_catchup_receipts_sync_hold
 expensive near-client catching_up tests::test_chunk_grieving
-expensive near-client catching_up tests::test_all_chunks_accepted_1000_slow
 
 expensive nearcore test_catchup test_catchup
 
@@ -120,8 +119,6 @@ expensive nearcore test_cases_testnet_rpc test::test_add_key_testnet
 expensive nearcore test_cases_testnet_rpc test::test_delete_access_key_testnet
 expensive nearcore test_cases_testnet_rpc test::test_add_access_key_with_allowance_testnet
 expensive nearcore test_cases_testnet_rpc test::test_delete_access_key_with_allowance_testnet
-# The next test is disabled due to #2208
-# expensive nearcore test_cases_testnet_rpc test::test_access_key_smart_contract_testnet
 expensive nearcore test_cases_testnet_rpc test::test_access_key_smart_contract_testnet
 
 # GC tests

--- a/scripts/check_nightly.py
+++ b/scripts/check_nightly.py
@@ -19,13 +19,13 @@ def find_first(str1, candidates, start):
         return -1, None
     
 
-
 def find_fn(str1, start):
     fn_start = str1.find('fn ', start)
     match = re.search(r'[a-zA-Z0-9_]+', str1[fn_start+3:])
     if match:
         return match.group(0)
     return None
+
 
 def expensive_tests_in_file(file):
     with(open(file)) as f:
@@ -62,7 +62,8 @@ def nightly_tests():
     ret = set()
     for test in tests:
         t = test.strip().split(' ')
-        if t[0] == 'expensive':
+        if t[0] == 'expensive' or (t[0] == '#' and t[1] == 'expensive'):
+            # It's okay to comment out a very expensive test intentionally
             ret.add(t[-1].split('::')[-1])
     return ret
 


### PR DESCRIPTION
tests::test_all_chunks_accepted_1000_slow takes more than an hour to finish. Original plan is mark it as very_expensive in rust, but it become non trivial to accomodate check_nightly.py to parse it. So instead, a commented expensive test is allowed in nightly.txt, but a missing one is not allowed. 

Test Plan
---------
Sanity check should pass