### PR TITLE
fix(chain): do not verify approvals produced by self

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -734,7 +734,7 @@ impl Client {
         let next_block_producer =
             self.runtime_adapter.get_block_producer(&next_epoch_id, approval.target_height)?;
         if Some(&next_block_producer) == self.validator_signer.as_ref().map(|x| x.validator_id()) {
-            self.collect_block_approval(&approval, false);
+            self.collect_block_approval(&approval, true);
         } else {
             let approval_message = ApprovalMessage::new(approval, next_block_producer);
             self.network_adapter.do_send(NetworkRequests::Approval { approval_message });


### PR DESCRIPTION
When an approval is produced by the node itself, there is no need to verify it.

Test plan
---------
Existing tests pass.