### PR TITLE
Help wanted: cannot get complete log (end with panic) in node0

### DIFF
--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -148,6 +148,10 @@ impl InfoHelper {
         } else {
             serde_json::to_value(&info).expect("Telemetry must serialize to json")
         };
+
+        if head.height > 10 {
+            panic!("INTENTIONAL");
+        }
         telemetry(&self.telemetry_actor, content);
     }
 }


### PR DESCRIPTION
Following up #2761 , 
To reproduce:
1. compile neard in this branch
2. run pytest `python block_production.py`
3. with this PR (sleep 5s in every cleanup, `grep -nH INTENTIONAL ~/.near/*/stderr` you'll see it's in four nodes' log file
4. comment out sleep(5), run block_production.py again, grep again you'll only see panic in only node1-node3 but not node0

Expected:
should have a reliable way to kill all the nodes (this is done, nodes' pid is guaranteed not exist after node.kill()), and have stderr log fully written to node<i>/stderr (This is not the case for node0 with sleep)

I have problem with figuring out what is wrong here for a day but couldn't solve it, Will be appreciate if any one knows what happened! @frol @chefsale @bowenwang1996 @SkidanovAlex 
Thanks!

Some interesting finding:
1.
```python
# in python repl, leave repl open
import subprocess
p = subprocess.popen(['ls'])
p.kill() # or os.kill(pid) or kill in anyway in bash would not kill "ls", even though it's already finished
# must do a p.poll() to terminate it
```

2. sleep(20) for only node0, it should be equivalent to sleep(5) for four nodes at exit since atexit is execute sequentially in the reverse sequence of atexit.register, doesn't give you complete log of node0

3. try to do something like in node.kill:
```
for i in range(N):
    time.sleep(0.1)
    try:
        print(subprocess.check_output('grep INTENTIONAL ' + self.stderr_name, shell=True))
    except:
        print('not found')
```
Doesn't tell me when that line is write in log, if N is small, grep gives nothing. if N is big, grep gives the line at the first iteration
