### PR TITLE
Revert "Fix(test): log is not shown completely when node crashed in p…

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -324,12 +324,6 @@ class LocalNode(BaseNode):
     def kill(self):
         if self.pid.value != 0:
             os.kill(self.pid.value, signal.SIGKILL)
-            while True:
-                try:
-                    os.kill(self.pid.value, 0)
-                    break
-                except OSError:
-                    break
             self.pid.value = 0
 
     def reset_data(self):


### PR DESCRIPTION
…ytest (#2763)"

This reverts commit 088fc324c65eccc88089a8c27e476a50e249d0bf.

As I comment in #2761, the commit solves a non-existent problem (unless the behavior on my machine differs from that on others): before this commit `node2` (the block producer at 11, and thus the first node that observes the block) does have the stack trace in its logs.

If we still believe that are some other situations in which the logs get truncated, we need to have a repro for them, and solve them separately.
Alternatively, if there are other environments in which `node2` has logs truncated, we should continue investigating the correct fix for the problem.

The commit I'm reverting most certainly is not a correct fix: the `while True` loop breaks in all branches, and thus doesn't actually wait for the process to finish. So this commit must be reverted even if we believe that the solution it attempts to use is needed.