### PR TITLE
feat(Store Validator): Running Store Validator in Nightly + fixes

### DIFF
--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -1043,7 +1043,11 @@ fn test_gc_tail_update() {
     let prev_sync_block = blocks[blocks.len() - 3].clone();
     let sync_block = blocks[blocks.len() - 2].clone();
     env.clients[1].chain.reset_data_pre_state_sync(sync_block.hash()).unwrap();
-    env.clients[1].chain.save_block(&sync_block).unwrap();
+    let mut store_update = env.clients[1].chain.mut_store().store_update();
+    store_update.save_block(prev_sync_block.clone());
+    store_update.inc_block_refcount(&prev_sync_block.hash()).unwrap();
+    store_update.save_block(sync_block.clone());
+    store_update.commit().unwrap();
     env.clients[1]
         .chain
         .reset_heads_post_state_sync(&None, sync_block.hash(), |_| {}, |_| {}, |_| {})

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -217,8 +217,6 @@ class BaseNode(object):
                     self.kill()
 
     def check_store(self):
-        # TODO #2597 enable
-        return
         if self.is_check_store:
             res = self.json_rpc('adv_check_store', [])
             if not 'result' in res:


### PR DESCRIPTION
- Updating Tail and Chunk Tail inside `reset_heads_post_state_sync`
- Explicit clearing of Chunks in `reset_data_pre_state_sync`
- Not allowing to clear Chunks of Genesis Height
- `block_height_cmp_tail_count` function in validator to check Tail properly (update description of https://github.com/nearprotocol/nearcore/issues/2597)
- Disabling `chunks_state_roots_in_trie` until https://github.com/nearprotocol/nearcore/issues/2623 happens
- Fixing https://github.com/nearprotocol/nearcore/issues/2774
- Minor refactoring