### PR TITLE
fix(nightly): running lib tests

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2818,6 +2818,7 @@ mod tests {
     }
 
     /// Test that MAX_HEIGHTS_TO_CLEAR works properly
+    #[cfg(feature = "expensive_tests")]
     #[test]
     fn test_clear_old_data_too_many_heights() {
         let mut chain = get_chain_with_epoch_length(1);

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -135,6 +135,10 @@ expensive --timeout=900 near-chain gc tests::test_gc_random_large
 expensive --timeout=600 near-chain gc tests::test_gc_pine
 expensive --timeout=600 near-chain gc tests::test_gc_star_large
 
+# lib tests
+lib near-chunks test::test_seal_removal
+lib near-chain store::tests::test_clear_old_data_too_many_heights
+
 # other tests
 expensive nearcore test_simple test::test_2_10_multiple_nodes
 expensive nearcore test_simple test::test_4_10_multiple_nodes
@@ -143,4 +147,3 @@ expensive nearcore test_simple test::test_7_10_multiple_nodes
 expensive nearcore test_rejoin test::test_4_20_kill1
 expensive nearcore test_rejoin test::test_4_20_kill1_two_shards
 expensive nearcore test_rejoin test::test_4_20_kill2
-expensive nearcore near-chunks test_seal_removal

--- a/scripts/check_nightly.py
+++ b/scripts/check_nightly.py
@@ -62,8 +62,8 @@ def nightly_tests():
     ret = set()
     for test in tests:
         t = test.strip().split(' ')
-        if t[0] == 'expensive' or (t[0] == '#' and t[1] == 'expensive'):
-            # It's okay to comment out a very expensive test intentionally
+        if t[0] == 'expensive' or (t[0] == '#' and t[1] == 'expensive') or t[0] == 'lib' or (t[0] == '#' and t[1] == 'lib'):
+            # It's okay to comment out a test intentionally
             ret.add(t[-1].split('::')[-1])
     return ret
 


### PR DESCRIPTION
Fixes `test_seal_removal` test + moves test_clear_old_data_too_many_heights to Nightly.
Blocked by https://github.com/nearprotocol/nightly/pull/4.