### PR TITLE
feat(Store Validator): Execution limiting in Nightly validation

### DIFF
--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -18,18 +17,13 @@ mod validate;
 
 #[derive(Debug)]
 pub struct StoreValidatorCache {
-    functions_executed: HashSet<String>,
     block_heights_less_tail: Vec<CryptoHash>,
     is_block_height_cmp_tail_prepared: bool,
 }
 
 impl StoreValidatorCache {
     fn new() -> Self {
-        Self {
-            functions_executed: HashSet::new(),
-            block_heights_less_tail: vec![],
-            is_block_height_cmp_tail_prepared: false,
-        }
+        Self { block_heights_less_tail: vec![], is_block_height_cmp_tail_prepared: false }
     }
 }
 
@@ -150,11 +144,6 @@ impl StoreValidator {
         self.check_simple(&validate::block_height_cmp_tail, "TAIL", DBCol::ColBlockMisc);
         self.validate_col(DBCol::ColChunks);
         self.validate_col(DBCol::ColChunkHashesByHeight);
-
-        if let None = self.timeout {
-            // All functions must be executed if no timeout was set
-            assert_eq!(self.inner.functions_executed.len() as u64, validate::TOTAL_FUNCTIONS);
-        }
     }
 
     fn check(

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -105,15 +105,13 @@ impl StoreValidator {
             match col {
                 DBCol::ColBlockHeader => {
                     // Block Header Hash is valid
-                    self.check(&validate::block_header_validity, &key, &value, col);
+                    self.check(&validate::block_header_basic_validity, &key, &value, col);
                 }
                 DBCol::ColBlock => {
                     // Block Hash is valid
-                    self.check(&validate::block_hash_validity, &key, &value, col);
+                    self.check(&validate::block_basic_validity, &key, &value, col);
                     // Block Header for current Block exists
                     self.check(&validate::block_header_exists, &key, &value, col);
-                    // Block Height is greater or equal to tail, or to Genesis Height
-                    self.check(&validate::block_height_cmp_tail_prepare, &key, &value, col);
                     // Chunks for current Block exist
                     self.check(&validate::block_chunks_exist, &key, &value, col);
                 }
@@ -148,6 +146,7 @@ impl StoreValidator {
         );
         self.validate_col(DBCol::ColBlockHeader);
         self.validate_col(DBCol::ColBlock);
+        // There is no more than one Block which Height is lower than Tail and not equal to Genesis
         self.check_simple(&validate::block_height_cmp_tail, "TAIL", DBCol::ColBlockMisc);
         self.validate_col(DBCol::ColChunks);
         self.validate_col(DBCol::ColChunkHashesByHeight);

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -16,8 +16,6 @@ use near_store::{
 
 use crate::{ErrorMessage, StoreValidator};
 
-pub const TOTAL_FUNCTIONS: u64 = 10;
-
 macro_rules! get_parent_function_name {
     () => {{
         fn f() {}
@@ -67,7 +65,6 @@ pub(crate) fn head_tail_validity(
     _key: &[u8],
     _value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     let tail = unwrap_or_err!(
         sv.store.get_ser::<BlockHeight>(ColBlockMisc, TAIL_KEY),
         "Can't get Tail from storage"
@@ -92,11 +89,10 @@ pub(crate) fn head_tail_validity(
 }
 
 pub(crate) fn block_header_basic_validity(
-    sv: &mut StoreValidator,
+    _sv: &mut StoreValidator,
     key: &[u8],
     value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     let block_hash =
         unwrap_or_err!(CryptoHash::try_from(key.as_ref()), "Can't deserialize Block Hash");
     let header =
@@ -112,7 +108,6 @@ pub(crate) fn block_basic_validity(
     key: &[u8],
     value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     let block_hash =
         unwrap_or_err!(CryptoHash::try_from(key.as_ref()), "Can't deserialize Block Hash");
     let block = unwrap_or_err!(Block::try_from_slice(value), "Can't deserialize Block");
@@ -138,7 +133,6 @@ pub(crate) fn block_header_exists(
     key: &[u8],
     _value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     let block_hash =
         unwrap_or_err!(CryptoHash::try_from(key.as_ref()), "Can't deserialize Block Hash");
     unwrap_or_err_db!(
@@ -149,11 +143,10 @@ pub(crate) fn block_header_exists(
 }
 
 pub(crate) fn chunk_basic_validity(
-    sv: &mut StoreValidator,
+    _sv: &mut StoreValidator,
     key: &[u8],
     value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     let chunk_hash =
         unwrap_or_err!(ChunkHash::try_from_slice(key.as_ref()), "Can't deserialize Chunk Hash");
     let shard_chunk =
@@ -169,7 +162,6 @@ pub(crate) fn block_chunks_exist(
     _key: &[u8],
     value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     let block = unwrap_or_err!(Block::try_from_slice(value), "Can't deserialize Block");
     for chunk_header in block.chunks {
         match &sv.me {
@@ -204,7 +196,6 @@ pub(crate) fn block_height_cmp_tail(
     _key: &[u8],
     _value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     assert!(sv.inner.is_block_height_cmp_tail_prepared);
     if sv.inner.block_heights_less_tail.len() < 2 {
         Ok(())
@@ -216,11 +207,10 @@ pub(crate) fn block_height_cmp_tail(
 }
 
 pub(crate) fn chunks_state_roots_in_trie(
-    sv: &mut StoreValidator,
+    _sv: &mut StoreValidator,
     _key: &[u8],
     _value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     // TODO enable after fixing #2623
     /*
     let shard_chunk: ShardChunk =
@@ -245,7 +235,6 @@ pub(crate) fn chunks_indexed_by_height_created(
     _key: &[u8],
     value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     let shard_chunk: ShardChunk =
         unwrap_or_err!(ShardChunk::try_from_slice(value), "Can't deserialize ShardChunk");
     let height = shard_chunk.header.inner.height_created;
@@ -267,7 +256,6 @@ pub(crate) fn chunk_of_height_exists(
     key: &[u8],
     value: &[u8],
 ) -> Result<(), ErrorMessage> {
-    sv.inner.functions_executed.insert(get_parent_function_name!());
     let height: BlockHeight =
         unwrap_or_err!(BlockHeight::try_from_slice(key), "Can't deserialize Height");
     let chunk_hashes: HashSet<ChunkHash> =

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -257,7 +257,9 @@ impl Handler<NetworkClientMessages> for ClientActor {
                         }
                     }
                     NetworkAdversarialMessage::AdvCheckStorageConsistency => {
-                        info!(target: "adversary", "Check Storage Consistency");
+                        // timeout is set to 1.5 seconds to give some room as we wait in Nightly for 2 seconds
+                        let timeout = 1500;
+                        info!(target: "adversary", "Check Storage Consistency, timeout set to {:?} milliseconds", timeout);
                         let mut genesis = GenesisConfig::default();
                         genesis.genesis_height = self.client.chain.store().get_genesis_height();
                         let mut store_validator = StoreValidator::new(
@@ -266,6 +268,7 @@ impl Handler<NetworkClientMessages> for ClientActor {
                             self.client.runtime_adapter.clone(),
                             self.client.chain.store().owned_store(),
                         );
+                        store_validator.set_timeout(timeout);
                         store_validator.validate();
                         if store_validator.is_failed() {
                             error!(target: "client", "Storage Validation failed, {:?}", store_validator.errors);


### PR DESCRIPTION
Running Store Validator in Nightly after each `get_status()` takes time and may lead to timeout. The solution is to limit Store Validator in Nightly as it still:
- tries to check as many conditions as possible (not turning Store Validator off at all)
- works well on small tests
- not dependent on size of the Storage to validate

We also need to do https://github.com/nearprotocol/nightly/issues/5 to run full Store Validator at the end anyway.

TEST PLAN
-----------

`state_sync3.py` not failing on adv_check_store() execution