### PR TITLE
fix(store validator): don't run while syncing + minor fixes

### DIFF
--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -22,6 +22,7 @@ const STORAGE_COMMON_FAILURE: &str = "STORAGE_COMMON_FAILURE";
 #[derive(Debug)]
 pub struct StoreValidatorCache {
     head: BlockHeight,
+    header_head: BlockHeight,
     tail: BlockHeight,
     chunk_tail: BlockHeight,
     block_heights_less_tail: Vec<CryptoHash>,
@@ -34,6 +35,7 @@ impl StoreValidatorCache {
     fn new() -> Self {
         Self {
             head: 0,
+            header_head: 0,
             tail: 0,
             chunk_tail: 0,
             block_heights_less_tail: vec![],

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -123,8 +123,10 @@ class BaseNode(object):
     def get_status(self):
         r = requests.get("http://%s:%s/status" % self.rpc_addr(), timeout=2)
         r.raise_for_status()
-        self.check_refmap()
-        self.check_store()
+        if json.loads(r.content)['sync_info']['syncing'] == False:
+            # Storage is not guaranteed to be in consistent state while syncing
+            self.check_refmap()
+            self.check_store()
         return json.loads(r.content)
 
     def get_all_heights(self):

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -123,11 +123,12 @@ class BaseNode(object):
     def get_status(self):
         r = requests.get("http://%s:%s/status" % self.rpc_addr(), timeout=2)
         r.raise_for_status()
-        if json.loads(r.content)['sync_info']['syncing'] == False:
+        status = json.loads(r.content)
+        if status['sync_info']['syncing'] == False:
             # Storage is not guaranteed to be in consistent state while syncing
             self.check_refmap()
             self.check_store()
-        return json.loads(r.content)
+        return status
 
     def get_all_heights(self):
         status = self.get_status()


### PR DESCRIPTION
Fixes https://github.com/nearprotocol/nearcore/issues/2817.

- do not run validators in python tests while the node is syncing
- use Header Head properly
- setting `is_block_height_cmp_tail_prepared` properly