### PR TITLE
fix(GC): replace gc_step_size with gc_blocks_limit

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -557,7 +557,7 @@ impl Chain {
             if gc_blocks_remaining == 0 {
                 return Ok(());
             }
-            self.clear_forks_data(tries.clone(), height, gc_blocks_remaining)?;
+            self.clear_forks_data(tries.clone(), height, &mut gc_blocks_remaining)?;
         }
 
         // Canonical Chain Clearing
@@ -600,7 +600,7 @@ impl Chain {
         &mut self,
         tries: ShardTries,
         height: BlockHeight,
-        mut gc_blocks_remaining: NumBlocks,
+        gc_blocks_remaining: &mut NumBlocks,
     ) -> Result<(), Error> {
         if let Ok(blocks_current_height) = self.store.get_all_block_hashes_by_height(height) {
             let blocks_current_height =
@@ -608,7 +608,7 @@ impl Chain {
             for block_hash in blocks_current_height.iter() {
                 let mut current_hash = *block_hash;
                 loop {
-                    if gc_blocks_remaining == 0 {
+                    if *gc_blocks_remaining == 0 {
                         return Ok(());
                     }
                     // Block `block_hash` is not on the Canonical Chain
@@ -624,7 +624,7 @@ impl Chain {
                         chain_store_update
                             .clear_block_data(current_hash, GCMode::Fork(tries.clone()))?;
                         chain_store_update.commit()?;
-                        gc_blocks_remaining -= 1;
+                        *gc_blocks_remaining -= 1;
 
                         current_hash = prev_hash;
                     } else {

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1,4 +1,3 @@
-use std::cmp::min;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::{Duration as TimeDuration, Instant};
@@ -540,27 +539,32 @@ impl Chain {
     pub fn clear_data(
         &mut self,
         tries: ShardTries,
-        gc_step_size: BlockHeightDelta,
+        gc_blocks_limit: NumBlocks,
     ) -> Result<(), Error> {
         let head = self.store.head()?;
         let tail = self.store.tail()?;
-        let mut gc_stop_height = self.runtime_adapter.get_gc_stop_height(&head.last_block_hash)?;
+        let gc_stop_height = self.runtime_adapter.get_gc_stop_height(&head.last_block_hash)?;
         if gc_stop_height > head.height {
             return Err(ErrorKind::GCError(
                 "gc_stop_height cannot be larger than head.height".into(),
             )
             .into());
         }
-        // To avoid network slowdown, we limit the number of heights to clear per GC execution
-        gc_stop_height = min(gc_stop_height, tail + gc_step_size);
+        let mut gc_blocks_remaining = gc_blocks_limit;
 
         // Forks Cleaning
         for height in tail..gc_stop_height {
-            self.clear_forks_data(tries.clone(), height)?;
+            if gc_blocks_remaining == 0 {
+                return Ok(());
+            }
+            self.clear_forks_data(tries.clone(), height, gc_blocks_remaining)?;
         }
 
         // Canonical Chain Clearing
         for height in tail + 1..gc_stop_height {
+            if gc_blocks_remaining == 0 {
+                return Ok(());
+            }
             let mut chain_store_update = self.store.store_update();
             if let Ok(blocks_current_height) =
                 chain_store_update.get_all_block_hashes_by_height(height)
@@ -577,6 +581,7 @@ impl Chain {
                         debug_assert_eq!(blocks_current_height.len(), 1);
                         chain_store_update
                             .clear_block_data(*block_hash, GCMode::Canonical(tries.clone()))?;
+                        gc_blocks_remaining -= 1;
                     } else {
                         return Err(ErrorKind::GCError(
                             "block on canonical chain shouldn't have refcount 0".into(),
@@ -595,6 +600,7 @@ impl Chain {
         &mut self,
         tries: ShardTries,
         height: BlockHeight,
+        mut gc_blocks_remaining: NumBlocks,
     ) -> Result<(), Error> {
         if let Ok(blocks_current_height) = self.store.get_all_block_hashes_by_height(height) {
             let blocks_current_height =
@@ -602,6 +608,9 @@ impl Chain {
             for block_hash in blocks_current_height.iter() {
                 let mut current_hash = *block_hash;
                 loop {
+                    if gc_blocks_remaining == 0 {
+                        return Ok(());
+                    }
                     // Block `block_hash` is not on the Canonical Chain
                     // because shorter chain cannot be Canonical one
                     // and it may be safely deleted
@@ -615,6 +624,7 @@ impl Chain {
                         chain_store_update
                             .clear_block_data(current_hash, GCMode::Fork(tries.clone()))?;
                         chain_store_update.commit()?;
+                        gc_blocks_remaining -= 1;
 
                         current_hash = prev_hash;
                     } else {

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2727,7 +2727,7 @@ mod tests {
         assert!(check_refcount_map(&mut chain).is_ok());
         chain.epoch_length = 1;
         let trie = chain.runtime_adapter.get_tries();
-        assert!(chain.clear_data(trie, MAX_HEIGHTS_TO_CLEAR).is_ok());
+        assert!(chain.clear_data(trie, 100).is_ok());
 
         assert!(chain.get_block(&blocks[0].hash()).is_ok());
 
@@ -2846,7 +2846,7 @@ mod tests {
 
         for iter in 0..10 {
             println!("ITERATION #{:?}", iter);
-            assert!(chain.clear_data(trie.clone(), MAX_HEIGHTS_TO_CLEAR).is_ok());
+            assert!(chain.clear_data(trie.clone(), 100).is_ok());
 
             assert!(chain.get_block(&blocks[0].hash()).is_ok());
 

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -789,7 +789,7 @@ impl Client {
             if !self.config.archive {
                 if let Err(err) = self
                     .chain
-                    .clear_data(self.runtime_adapter.get_tries(), self.config.gc_step_size)
+                    .clear_data(self.runtime_adapter.get_tries(), self.config.gc_blocks_limit)
                 {
                     error!(target: "client", "Can't clear old data, {:?}", err);
                     debug_assert!(false);

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -67,8 +67,8 @@ pub struct ClientConfig {
     pub chunk_request_retry_period: Duration,
     /// Behind this horizon header fetch kicks in.
     pub block_header_fetch_horizon: BlockHeightDelta,
-    /// Number of heights to garbage collect at every gc call.
-    pub gc_step_size: BlockHeightDelta,
+    /// Number of blocks to garbage collect at every gc call.
+    pub gc_blocks_limit: NumBlocks,
     /// Accounts that this client tracks
     pub tracked_accounts: Vec<AccountId>,
     /// Shards that this client tracks
@@ -121,7 +121,7 @@ impl ClientConfig {
                 Duration::from_millis(min_block_prod_time / 5),
             ),
             block_header_fetch_horizon: 50,
-            gc_step_size: 100,
+            gc_blocks_limit: 100,
             tracked_accounts: vec![],
             tracked_shards: vec![],
             archive,

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -264,7 +264,7 @@ fn default_sync_step_period() -> Duration {
     Duration::from_millis(10)
 }
 
-fn default_gc_step_size() -> BlockHeightDelta {
+fn default_gc_blocks_limit() -> NumBlocks {
     2
 }
 
@@ -355,8 +355,8 @@ pub struct Config {
     pub tracked_accounts: Vec<AccountId>,
     pub tracked_shards: Vec<ShardId>,
     pub archive: bool,
-    #[serde(default = "default_gc_step_size")]
-    pub gc_step_size: BlockHeightDelta,
+    #[serde(default = "default_gc_blocks_limit")]
+    pub gc_blocks_limit: NumBlocks,
 }
 
 impl Default for Config {
@@ -373,7 +373,7 @@ impl Default for Config {
             tracked_accounts: vec![],
             tracked_shards: vec![],
             archive: false,
-            gc_step_size: default_gc_step_size(),
+            gc_blocks_limit: default_gc_blocks_limit(),
         }
     }
 }
@@ -537,7 +537,7 @@ impl NearConfig {
                 tracked_accounts: config.tracked_accounts,
                 tracked_shards: config.tracked_shards,
                 archive: config.archive,
-                gc_step_size: config.gc_step_size,
+                gc_blocks_limit: config.gc_blocks_limit,
             },
             network_config: NetworkConfig {
                 public_key: network_key_pair.public_key,


### PR DESCRIPTION
https://github.com/nearprotocol/nearcore/pull/2807 is insufficient because of two major reasons:
1. It doesn't help in case of having lots of Forks on the Heights within `gc_step_size` because all those Forks expected to be cleared in one GC call.
2. It breaks GC completely if there is any Fork of Height longer than `gc_step_size`. Such Fork will be never cleared and Tail will be never increased.

This PR replaces `gc_step_size` with `gc_blocks_limit` - maximum number of Blocks that may be deleted per one GC call. It handles Fork Block deletions and doesn't stuck in case of long Forks.