### PR TITLE
fix(nightly): fix state_sync2.py

### DIFF
--- a/pytest/tests/sanity/state_sync2.py
+++ b/pytest/tests/sanity/state_sync2.py
@@ -13,8 +13,6 @@ from utils import LogTracker
 
 fcntl.fcntl(1, fcntl.F_SETFL, 0)  # no cache when execute from nightly runner
 
-print('start state sync2')
-print('start state sync2', file=sys.stderr)
 TIMEOUT = 600
 BLOCKS = 105  # should be enough to trigger state sync for node 1 later, see comments there
 
@@ -22,7 +20,7 @@ nodes = start_cluster(
     2, 0, 2, None,
     [["num_block_producer_seats", 199],
      ["num_block_producer_seats_per_shard", [99, 100]], ["epoch_length", 10],
-     ["block_producer_kickout_threshold", 80]], {})
+     ["block_producer_kickout_threshold", 10], ["chunk_producer_kickout_threshold", 10]], {})
 print('cluster started')
 
 started = time.time()


### PR DESCRIPTION
state_sync2.py was failing because the block producer that the node is supposed to sync from gets kicked out a while ago and therefore doesn't track the shard, so naturally it doesn't have the state.