### PR TITLE
feat(Store Validator): use thiserror + minor updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2035,6 +2035,7 @@ dependencies = [
  "rand 0.7.3",
  "rocksdb",
  "serde",
+ "thiserror",
  "tracing",
 ]
 
@@ -2285,6 +2286,7 @@ dependencies = [
  "near-rpc-error-macro",
  "near-vm-errors",
  "num-rational",
+ "primitive-types",
  "rand 0.7.3",
  "reed-solomon-erasure",
  "regex",
@@ -2462,7 +2464,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "actix",
  "borsh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,6 +1085,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "enum-iterator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,6 +2040,7 @@ dependencies = [
  "borsh",
  "cached",
  "chrono",
+ "enum-iterator",
  "failure",
  "failure_derive",
  "lazy_static",
@@ -2361,6 +2382,7 @@ dependencies = [
  "cached",
  "derive_more",
  "elastic-array",
+ "enum-iterator",
  "near-crypto",
  "near-primitives",
  "num_cpus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,26 +1085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "enum-iterator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79a6321a1197d7730510c7e3f6cb80432dfefecb32426de8cea0aa19b4bb8d7"
-dependencies = [
- "enum-iterator-derive",
-]
-
-[[package]]
-name = "enum-iterator-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e94aa31f7c0dc764f57896dc615ddd76fc13b0d5dca7eb6cc5e018a5a09ec06"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,7 +2020,6 @@ dependencies = [
  "borsh",
  "cached",
  "chrono",
- "enum-iterator",
  "failure",
  "failure_derive",
  "lazy_static",
@@ -2056,6 +2035,7 @@ dependencies = [
  "rand 0.7.3",
  "rocksdb",
  "serde",
+ "strum",
  "thiserror",
  "tracing",
 ]
@@ -2382,7 +2362,6 @@ dependencies = [
  "cached",
  "derive_more",
  "elastic-array",
- "enum-iterator",
  "near-crypto",
  "near-primitives",
  "num_cpus",
@@ -2390,6 +2369,8 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "tempfile",
 ]
 

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -17,6 +17,7 @@ lazy_static = "1.4"
 num-rational = "0.2.4"
 tracing = "0.1.13"
 thiserror = "1.0"
+enum-iterator = "0.6.0"
 
 borsh = "0.6.2"
 

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1.4"
 num-rational = "0.2.4"
 tracing = "0.1.13"
 thiserror = "1.0"
-enum-iterator = "0.6.0"
+strum = "0.18"
 
 borsh = "0.6.2"
 

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -16,6 +16,7 @@ cached = "0.12"
 lazy_static = "1.4"
 num-rational = "0.2.4"
 tracing = "0.1.13"
+thiserror = "1.0"
 
 borsh = "0.6.2"
 

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -316,7 +316,7 @@ impl Chain {
             Err(err) => match err.kind() {
                 ErrorKind::DBNotFoundErr(_) => {
                     for chunk in genesis_chunks {
-                        store_update.save_chunk(&chunk.chunk_hash, chunk.clone());
+                        store_update.save_chunk(chunk.clone());
                     }
                     runtime_adapter.add_validator_proposals(BlockHeaderInfo::new(
                         &genesis.header(),
@@ -3387,7 +3387,7 @@ impl<'a> ChainUpdate<'a> {
         let (outcome_root, outcome_proofs) =
             ApplyTransactionResult::compute_outcomes_proof(&apply_result.outcomes);
 
-        self.chain_store_update.save_chunk(&chunk.chunk_hash, chunk.clone());
+        self.chain_store_update.save_chunk(chunk.clone());
 
         self.chain_store_update.save_trie_changes(apply_result.trie_changes);
         let chunk_extra = ChunkExtra::new(

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1652,16 +1652,14 @@ impl<'a> ChainStoreUpdate<'a> {
         self.chain_store_cache_update.chunk_extras.insert((*block_hash, shard_id), chunk_extra);
     }
 
-    pub fn save_chunk(&mut self, chunk_hash: &ChunkHash, chunk: ShardChunk) {
-        self.chain_store_cache_update.chunks.insert(chunk_hash.clone(), chunk);
+    pub fn save_chunk(&mut self, chunk: ShardChunk) {
+        self.chain_store_cache_update.chunks.insert(chunk.chunk_hash.clone(), chunk);
     }
 
-    pub fn save_partial_chunk(
-        &mut self,
-        chunk_hash: &ChunkHash,
-        partial_chunk: PartialEncodedChunk,
-    ) {
-        self.chain_store_cache_update.partial_chunks.insert(chunk_hash.clone(), partial_chunk);
+    pub fn save_partial_chunk(&mut self, partial_chunk: PartialEncodedChunk) {
+        self.chain_store_cache_update
+            .partial_chunks
+            .insert(partial_chunk.header.hash.clone(), partial_chunk);
     }
 
     pub fn save_block_merkle_tree(

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use borsh::BorshDeserialize;
-use enum_iterator::IntoEnumIterator;
+use strum::IntoEnumIterator;
 
 use near_chain_configs::GenesisConfig;
 use near_primitives::block::{Block, BlockHeader};
@@ -187,7 +187,7 @@ impl StoreValidator {
         if let Err(e) = validate::head_tail_validity(self) {
             self.process_error(e, "HEAD / HEADER_HEAD / TAIL / CHUNK_TAIL", DBCol::ColBlockMisc)
         }
-        for col in DBCol::into_enum_iter() {
+        for col in DBCol::iter() {
             if let Err(e) = self.validate_col(col) {
                 self.process_error(e, col.to_string(), col)
             }

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -214,3 +214,123 @@ impl StoreValidator {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use near_store::test_utils::create_test_store;
+
+    use super::*;
+    use crate::test_utils::KeyValueRuntime;
+    use crate::{Chain, ChainGenesis, DoomslugThresholdMode};
+
+    fn init() -> (Chain, StoreValidator) {
+        let store = create_test_store();
+        let chain_genesis = ChainGenesis::test();
+        let runtime_adapter = Arc::new(KeyValueRuntime::new(store.clone()));
+        let mut genesis = GenesisConfig::default();
+        genesis.genesis_height = 0;
+        let chain =
+            Chain::new(runtime_adapter.clone(), &chain_genesis, DoomslugThresholdMode::NoApprovals)
+                .unwrap();
+        (chain, StoreValidator::new(None, genesis.clone(), runtime_adapter, store))
+    }
+
+    #[test]
+    fn test_io_error() {
+        let (mut chain, mut sv) = init();
+        let mut store_update = chain.store().owned_store().store_update();
+        assert!(sv.validate_col(DBCol::ColBlock).is_ok());
+        store_update
+            .set_ser::<Vec<u8>>(
+                DBCol::ColBlock,
+                chain.get_block_by_height(0).unwrap().hash().as_ref(),
+                &vec![123],
+            )
+            .unwrap();
+        store_update.commit().unwrap();
+        match sv.validate_col(DBCol::ColBlock) {
+            Err(StoreValidatorError::IOError(_)) => {}
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_db_corruption() {
+        let (chain, mut sv) = init();
+        let mut store_update = chain.store().owned_store().store_update();
+        assert!(sv.validate_col(DBCol::ColTrieChanges).is_ok());
+        store_update.set_ser::<Vec<u8>>(DBCol::ColTrieChanges, "567".as_ref(), &vec![123]).unwrap();
+        store_update.commit().unwrap();
+        match sv.validate_col(DBCol::ColTrieChanges) {
+            Err(StoreValidatorError::DBCorruption(_)) => {}
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_db_not_found() {
+        let (mut chain, mut sv) = init();
+        let block = chain.get_block_by_height(0).unwrap();
+        assert!(validate::block_header_exists(&mut sv, &block.hash(), block).is_ok());
+        match validate::block_header_exists(&mut sv, &CryptoHash::default(), block) {
+            Err(StoreValidatorError::DBNotFound { .. }) => {}
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_discrepancy() {
+        let (mut chain, mut sv) = init();
+        let block_header = chain.get_header_by_height(0).unwrap();
+        assert!(validate::block_header_hash_validity(&mut sv, block_header.hash(), block_header)
+            .is_ok());
+        match validate::block_header_hash_validity(&mut sv, &CryptoHash::default(), block_header) {
+            Err(StoreValidatorError::Discrepancy { .. }) => {}
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    fn test_cache_not_found() {
+        let (mut chain, mut sv) = init();
+        let genesis_hash = chain.genesis().hash().clone();
+        match validate::block_height_validity(
+            &mut sv,
+            &CryptoHash::default(),
+            chain.get_block(&genesis_hash).unwrap(),
+        ) {
+            Err(StoreValidatorError::CacheNotFound { .. }) => {}
+            _ => assert!(false),
+        }
+        match validate::block_height_cmp_tail(&mut sv) {
+            Err(StoreValidatorError::CacheNotFound { .. }) => {}
+            _ => assert!(false),
+        }
+        assert!(validate::head_tail_validity(&mut sv).is_ok());
+        match validate::block_height_cmp_tail(&mut sv) {
+            Err(StoreValidatorError::CacheNotFound { .. }) => {}
+            _ => assert!(false),
+        }
+        assert!(validate::block_height_validity(
+            &mut sv,
+            &CryptoHash::default(),
+            chain.get_block(&genesis_hash).unwrap(),
+        )
+        .is_ok());
+        assert!(validate::block_height_cmp_tail(&mut sv).is_ok());
+    }
+
+    #[test]
+    fn test_validation_failed() {
+        let (_chain, mut sv) = init();
+        sv.inner.is_block_height_cmp_tail_prepared = true;
+        assert!(validate::block_height_cmp_tail(&mut sv).is_ok());
+        sv.inner.block_heights_less_tail.push(CryptoHash::default());
+        assert!(validate::block_height_cmp_tail(&mut sv).is_ok());
+        sv.inner.block_heights_less_tail.push(CryptoHash::default());
+        match validate::block_height_cmp_tail(&mut sv) {
+            Err(StoreValidatorError::ValidationFailed { .. }) => {}
+            _ => assert!(false),
+        }
+    }
+}

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
+use thiserror::Error;
+
 use near_primitives::block::{Block, BlockHeader, Tip};
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunk};
@@ -11,7 +13,25 @@ use near_store::{
     HEAD_KEY, TAIL_KEY,
 };
 
-use crate::{ErrorMessage, StoreValidator};
+use crate::StoreValidator;
+
+#[derive(Error, Debug)]
+pub enum StoreValidatorError {
+    #[error("DB is corrupted: can't read Key, {0}")]
+    CorruptedKey(String),
+    #[error("DB is corrupted: can't read Value, {0}")]
+    CorruptedValue(String),
+    #[error("Function {func_name:?}: data is invalid, {reason:?}")]
+    InvalidData { func_name: String, reason: String },
+    #[error("Function {func_name:?}: data that expected to exist in DB is not found, {reason:?}")]
+    NotFound { func_name: String, reason: String },
+    #[error("Function {func_name:?}: {reason:?}, expected {expected:?}, found {found:?}")]
+    Discrepancy { func_name: String, reason: String, expected: String, found: String },
+    #[error("Function {func_name:?}: inner Store Validator error, cache not set")]
+    CacheNotFound { func_name: String },
+    #[error("Function {func_name:?}: error {error:?}")]
+    Other { func_name: String, error: String },
+}
 
 macro_rules! get_parent_function_name {
     () => {{
@@ -20,14 +40,37 @@ macro_rules! get_parent_function_name {
             std::any::type_name::<T>()
         }
         let name = type_name_of(f);
-        &name[..name.len() - 3].split("::").last().unwrap()
+        (&name[..name.len() - 3].split("::").last().unwrap()).to_string()
     }};
 }
 
 macro_rules! err {
     ($($x: tt),*) => (
-        Err(ErrorMessage::new(get_parent_function_name!(), format!($($x),*)))
+        return Err(StoreValidatorError::Other { func_name: get_parent_function_name!(), error: format!($($x),*) } );
     )
+}
+
+macro_rules! check_discrepancy {
+    ($arg1: expr, $arg2: expr, $($x: tt),*) => {
+        if $arg1 != $arg2 {
+            return Err(StoreValidatorError::Discrepancy {
+                func_name: get_parent_function_name!(),
+                reason: format!($($x),*),
+                expected: format!("{:?}", $arg1),
+                found: format!("{:?}", $arg2),
+            });
+        }
+    };
+}
+
+macro_rules! check_cached {
+    ($obj: expr, $($x: tt),*) => {
+        if !$obj {
+            return Err(StoreValidatorError::CacheNotFound {
+                func_name: get_parent_function_name!(),
+            });
+        }
+    };
 }
 
 macro_rules! unwrap_or_err {
@@ -35,7 +78,10 @@ macro_rules! unwrap_or_err {
         match $obj {
             Ok(value) => value,
             Err(e) => {
-                return Err(ErrorMessage::new(get_parent_function_name!(), format!("{}, error: {}", format!($($x),*), e)))
+                return Err(StoreValidatorError::InvalidData {
+                    func_name: get_parent_function_name!(),
+                    reason: format!("{}, error: {}", format!($($x),*), e)
+                })
             }
         };
     };
@@ -46,10 +92,16 @@ macro_rules! unwrap_or_err_db {
         match $obj {
             Ok(Some(value)) => value,
             Err(e) => {
-                return Err(ErrorMessage::new(get_parent_function_name!(), format!("{}, error: {}", format!($($x),*), e)))
+                return Err(StoreValidatorError::NotFound {
+                    func_name: get_parent_function_name!(),
+                    reason: format!("{}, error: {}", format!($($x),*), e)
+                })
             }
             _ => {
-                return Err(ErrorMessage::new(get_parent_function_name!(), format!($($x),*)))
+                return Err(StoreValidatorError::NotFound {
+                    func_name: get_parent_function_name!(),
+                    reason: format!($($x),*)
+                })
             }
         };
     };
@@ -61,7 +113,7 @@ pub(crate) fn head_tail_validity<T, U>(
     sv: &mut StoreValidator,
     _key: &T,
     _value: &U,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     let tail = unwrap_or_err!(
         sv.store.get_ser::<BlockHeight>(ColBlockMisc, TAIL_KEY),
         "Can't get Tail from storage"
@@ -86,13 +138,13 @@ pub(crate) fn head_tail_validity<T, U>(
     sv.inner.chunk_tail = chunk_tail;
     sv.inner.is_misc_set = true;
     if chunk_tail > tail {
-        return err!("chunk_tail > tail, {:?} > {:?}", chunk_tail, tail);
+        err!("chunk_tail > tail, {:?} > {:?}", chunk_tail, tail);
     }
     if tail > head.height {
-        return err!("tail > head.height, {:?} > {:?}", tail, head);
+        err!("tail > head.height, {:?} > {:?}", tail, head);
     }
     if head.height > header_head.height {
-        return err!("head.height > header_head.height, {:?} > {:?}", tail, head);
+        err!("head.height > header_head.height, {:?} > {:?}", tail, head);
     }
     Ok(())
 }
@@ -101,10 +153,8 @@ pub(crate) fn block_header_hash_validity(
     _sv: &mut StoreValidator,
     block_hash: &CryptoHash,
     header: &BlockHeader,
-) -> Result<(), ErrorMessage> {
-    if header.hash() != block_hash {
-        return err!("Invalid Block Header stored, hash = {:?}, header = {:?}", block_hash, header);
-    }
+) -> Result<(), StoreValidatorError> {
+    check_discrepancy!(header.hash(), block_hash, "Invalid Block Header stored");
     Ok(())
 }
 
@@ -112,14 +162,12 @@ pub(crate) fn block_header_height_validity(
     sv: &mut StoreValidator,
     _block_hash: &CryptoHash,
     header: &BlockHeader,
-) -> Result<(), ErrorMessage> {
-    if !sv.inner.is_misc_set {
-        return err!("Can't validate, is_misc_set == false");
-    }
+) -> Result<(), StoreValidatorError> {
+    check_cached!(sv.inner.is_misc_set, "misc is not set");
     let height = header.height();
     let head = sv.inner.header_head;
     if height > head {
-        return err!("Invalid Block Header stored, Head = {:?}, header = {:?}", head, header);
+        err!("Invalid Block Header stored, Head = {:?}, header = {:?}", head, header);
     }
     Ok(())
 }
@@ -128,10 +176,8 @@ pub(crate) fn block_hash_validity(
     _sv: &mut StoreValidator,
     block_hash: &CryptoHash,
     block: &Block,
-) -> Result<(), ErrorMessage> {
-    if block.hash() != block_hash {
-        return err!("Invalid Block stored, hash = {:?}, block = {:?}", block_hash, block);
-    }
+) -> Result<(), StoreValidatorError> {
+    check_discrepancy!(block.hash(), block_hash, "Invalid Block stored");
     Ok(())
 }
 
@@ -139,10 +185,8 @@ pub(crate) fn block_height_validity(
     sv: &mut StoreValidator,
     _block_hash: &CryptoHash,
     block: &Block,
-) -> Result<(), ErrorMessage> {
-    if !sv.inner.is_misc_set {
-        return err!("Can't validate, is_misc_set == false");
-    }
+) -> Result<(), StoreValidatorError> {
+    check_cached!(sv.inner.is_misc_set, "misc is not set");
     let height = block.header().height();
     let tail = sv.inner.tail;
     if height < tail && height != sv.config.genesis_height {
@@ -152,7 +196,7 @@ pub(crate) fn block_height_validity(
 
     let head = sv.inner.head;
     if height > head {
-        return err!("Invalid Block stored, Head = {:?}, block = {:?}", head, block);
+        err!("Invalid Block stored, Head = {:?}, block = {:?}", head, block);
     }
     Ok(())
 }
@@ -161,7 +205,7 @@ pub(crate) fn block_indexed_by_height(
     sv: &mut StoreValidator,
     block_hash: &CryptoHash,
     block: &Block,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     let height = block.header().height();
     let block_hashes: HashSet<CryptoHash> = unwrap_or_err_db!(
         sv.store.get_ser::<HashMap<EpochId, HashSet<CryptoHash>>>(
@@ -176,7 +220,7 @@ pub(crate) fn block_indexed_by_height(
     .cloned()
     .collect();
     if !block_hashes.contains(&block_hash) {
-        return err!("Block {:?} is not found in ColBlockPerHeight", block);
+        err!("Block {:?} is not found in ColBlockPerHeight", block);
     }
     Ok(())
 }
@@ -185,7 +229,7 @@ pub(crate) fn block_header_exists(
     sv: &mut StoreValidator,
     block_hash: &CryptoHash,
     _block: &Block,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     unwrap_or_err_db!(
         sv.store.get_ser::<BlockHeader>(ColBlockHeader, block_hash.as_ref()),
         "Can't get Block Header from storage"
@@ -197,10 +241,13 @@ pub(crate) fn chunk_hash_validity(
     _sv: &mut StoreValidator,
     chunk_hash: &ChunkHash,
     shard_chunk: &ShardChunk,
-) -> Result<(), ErrorMessage> {
-    if shard_chunk.chunk_hash != *chunk_hash {
-        return err!("Invalid ShardChunk {:?} stored", shard_chunk);
-    }
+) -> Result<(), StoreValidatorError> {
+    check_discrepancy!(
+        shard_chunk.chunk_hash,
+        *chunk_hash,
+        "Invalid ShardChunk {:?} stored",
+        shard_chunk
+    );
     Ok(())
 }
 
@@ -208,14 +255,12 @@ pub(crate) fn chunk_tail_validity(
     sv: &mut StoreValidator,
     _chunk_hash: &ChunkHash,
     shard_chunk: &ShardChunk,
-) -> Result<(), ErrorMessage> {
-    if !sv.inner.is_misc_set {
-        return err!("Can't validate, is_misc_set == false");
-    }
+) -> Result<(), StoreValidatorError> {
+    check_cached!(sv.inner.is_misc_set, "misc is not set");
     let chunk_tail = sv.inner.chunk_tail;
     let height = shard_chunk.header.inner.height_created;
     if height < chunk_tail {
-        return err!(
+        err!(
             "Invalid ShardChunk stored, chunk_tail = {:?}, ShardChunk = {:?}",
             chunk_tail,
             shard_chunk
@@ -228,7 +273,7 @@ pub(crate) fn chunk_indexed_by_height_created(
     sv: &mut StoreValidator,
     _chunk_hash: &ChunkHash,
     shard_chunk: &ShardChunk,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     let height = shard_chunk.header.inner.height_created;
     let chunk_hashes = unwrap_or_err_db!(
         sv.store.get_ser::<HashSet<ChunkHash>>(ColChunkHashesByHeight, &index_to_bytes(height)),
@@ -237,7 +282,7 @@ pub(crate) fn chunk_indexed_by_height_created(
         shard_chunk
     );
     if !chunk_hashes.contains(&shard_chunk.chunk_hash) {
-        return err!("Can't find ShardChunk {:?} on Height {:?}", shard_chunk, height);
+        err!("Can't find ShardChunk {:?} on Height {:?}", shard_chunk, height);
     }
     Ok(())
 }
@@ -246,7 +291,7 @@ pub(crate) fn block_chunks_exist(
     sv: &mut StoreValidator,
     _block_hash: &CryptoHash,
     block: &Block,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     for chunk_header in block.chunks().iter() {
         match &sv.me {
             Some(me) => {
@@ -279,10 +324,10 @@ pub(crate) fn block_chunks_height_validity(
     _sv: &mut StoreValidator,
     _block_hash: &CryptoHash,
     block: &Block,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     for chunk_header in block.chunks().iter() {
         if chunk_header.inner.height_created > block.header().height() {
-            return err!(
+            err!(
                 "Invalid ShardChunk included, chunk_header = {:?}, block = {:?}",
                 chunk_header,
                 block
@@ -296,31 +341,31 @@ pub(crate) fn block_height_cmp_tail<T, U>(
     sv: &mut StoreValidator,
     _key: &T,
     _value: &U,
-) -> Result<(), ErrorMessage> {
-    if !sv.inner.is_misc_set {
-        return err!("Can't validate, is_block_height_cmp_tail_prepared == false");
-    }
-    if sv.inner.block_heights_less_tail.len() < 2 {
-        Ok(())
-    } else {
+) -> Result<(), StoreValidatorError> {
+    check_cached!(
+        sv.inner.is_block_height_cmp_tail_prepared,
+        "call block_height_validity before running block_height_cmp_tail"
+    );
+    if sv.inner.block_heights_less_tail.len() >= 2 {
         let len = sv.inner.block_heights_less_tail.len();
         let blocks = &sv.inner.block_heights_less_tail;
         err!("Found {:?} Blocks with height lower than Tail, {:?}", len, blocks)
     }
+    Ok(())
 }
 
 pub(crate) fn canonical_header_validity(
     sv: &mut StoreValidator,
     height: &BlockHeight,
     hash: &CryptoHash,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     let header = unwrap_or_err_db!(
         sv.store.get_ser::<BlockHeader>(ColBlockHeader, hash.as_ref()),
         "Can't get Block Header {:?} from ColBlockHeader",
         hash
     );
     if header.height() != *height {
-        return err!("Block on Height {:?} doesn't have required Height, {:?}", height, header);
+        err!("Block on Height {:?} doesn't have required Height, {:?}", height, header);
     }
     Ok(())
 }
@@ -329,7 +374,7 @@ pub(crate) fn canonical_prev_block_validity(
     sv: &mut StoreValidator,
     height: &BlockHeight,
     hash: &CryptoHash,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     if *height != sv.config.genesis_height {
         let header = unwrap_or_err_db!(
             sv.store.get_ser::<BlockHeader>(ColBlockHeader, hash.as_ref()),
@@ -349,14 +394,12 @@ pub(crate) fn canonical_prev_block_validity(
             prev_height,
             prev_header
         );
-        if prev_hash != same_prev_hash {
-            return err!(
-                "Prev Block Hashes in ColBlockHeight and ColBlockHeader at height {:?} are different, {:?}, {:?}",
-                prev_height,
-                prev_hash,
-                same_prev_hash
-            );
-        }
+        check_discrepancy!(
+            prev_hash,
+            same_prev_hash,
+            "Prev Block Hashes in ColBlockHeight and ColBlockHeader at height {:?} are different",
+            prev_height
+        );
 
         for cur_height in prev_height + 1..*height {
             let cur_hash = unwrap_or_err!(
@@ -365,7 +408,7 @@ pub(crate) fn canonical_prev_block_validity(
                 cur_height
             );
             if cur_hash.is_some() {
-                return err!("Unexpected Block on the Canonical Chain is found between Heights {:?} and {:?}, {:?}", prev_height, height, cur_hash);
+                err!("Unexpected Block on the Canonical Chain is found between Heights {:?} and {:?}, {:?}", prev_height, height, cur_hash);
             }
         }
     }
@@ -376,7 +419,7 @@ pub(crate) fn trie_changes_chunk_extra_exists(
     sv: &mut StoreValidator,
     (block_hash, shard_id): &(CryptoHash, ShardId),
     trie_changes: &TrieChanges,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     let new_root = trie_changes.new_root;
     // 1. Block with `block_hash` should be available
     let block = unwrap_or_err_db!(
@@ -418,30 +461,21 @@ pub(crate) fn trie_changes_chunk_extra_exists(
             /*
             #[cfg(feature = "adversarial")]
             {
-                let prev_state_root = chunk_header.inner.prev_state_root;
-                let old_root = trie_changes.adv_get_old_root();
-                if prev_state_root != old_root {
-                    return err!(
-                        "Prev State Root discrepancy, {:?} != {:?}, ShardChunk {:?}",
-                        old_root,
-                        prev_state_root,
-                        chunk_header
-                    );
-                }
+                check_discrepancy!(
+                    chunk_header.inner.prev_state_root,
+                    trie_changes.adv_get_old_root(),
+                    "Prev State Root discrepancy, ShardChunk {:?}",
+                    chunk_header
+                );
             }
             */
             // 7. State Roots should be equal
-            let state_root = chunk_extra.state_root;
-            return if state_root == new_root {
-                Ok(())
-            } else {
-                err!(
-                    "State Root discrepancy, {:?} != {:?}, ShardChunk {:?}",
-                    new_root,
-                    state_root,
-                    chunk_header
-                )
-            };
+            check_discrepancy!(
+                chunk_extra.state_root,
+                new_root,
+                "State Root discrepancy, ShardChunk {:?}",
+                chunk_header
+            );
         }
     }
     err!("ShardChunk is not included into Block {:?}", block)
@@ -451,16 +485,19 @@ pub(crate) fn chunk_of_height_exists(
     sv: &mut StoreValidator,
     height: &BlockHeight,
     chunk_hashes: &HashSet<ChunkHash>,
-) -> Result<(), ErrorMessage> {
+) -> Result<(), StoreValidatorError> {
     for chunk_hash in chunk_hashes {
         let shard_chunk = unwrap_or_err_db!(
             sv.store.get_ser::<ShardChunk>(ColChunks, chunk_hash.as_ref()),
             "Can't get Chunk from storage with ChunkHash {:?}",
             chunk_hash
         );
-        if shard_chunk.header.inner.height_created != *height {
-            return err!("Invalid ShardChunk {:?} stored at Height {:?}", shard_chunk, height);
-        }
+        check_discrepancy!(
+            shard_chunk.header.inner.height_created,
+            *height,
+            "Invalid ShardChunk {:?} stored",
+            shard_chunk
+        );
     }
     Ok(())
 }

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -447,7 +447,7 @@ pub(crate) fn trie_changes_chunk_extra_exists(
                 unwrap_or_err!(item, "Can't find ShardChunk {:?} in Trie", chunk_header);
             }
             // 6. Prev State Roots should be equal
-            // TODO #2623: enable
+            // TODO #2843: enable
             /*
             #[cfg(feature = "adversarial")]
             {
@@ -466,6 +466,7 @@ pub(crate) fn trie_changes_chunk_extra_exists(
                 "State Root discrepancy, ShardChunk {:?}",
                 chunk_header
             );
+            return Ok(());
         }
     }
     err!("ShardChunk is not included into Block {:?}", block)

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -24,7 +24,7 @@ pub enum StoreValidatorError {
     #[error("Function {func_name:?}: data is invalid, {reason:?}")]
     InvalidData { func_name: String, reason: String },
     #[error("Function {func_name:?}: data that expected to exist in DB is not found, {reason:?}")]
-    NotFound { func_name: String, reason: String },
+    DBNotFound { func_name: String, reason: String },
     #[error("Function {func_name:?}: {reason:?}, expected {expected:?}, found {found:?}")]
     Discrepancy { func_name: String, reason: String, expected: String, found: String },
     #[error("Function {func_name:?}: inner Store Validator error, cache {cache:?} not set")]
@@ -93,13 +93,13 @@ macro_rules! unwrap_or_err_db {
         match $obj {
             Ok(Some(value)) => value,
             Err(e) => {
-                return Err(StoreValidatorError::NotFound {
+                return Err(StoreValidatorError::DBNotFound {
                     func_name: get_parent_function_name!(),
                     reason: format!("{}, error: {}", format!($($x),*), e)
                 })
             }
             _ => {
-                return Err(StoreValidatorError::NotFound {
+                return Err(StoreValidatorError::DBNotFound {
                     func_name: get_parent_function_name!(),
                     reason: format!($($x),*)
                 })

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1242,7 +1242,7 @@ impl ShardsManager {
                 .collect(),
         };
 
-        store_update.save_partial_chunk(&chunk_entry.header.chunk_hash(), partial_chunk);
+        store_update.save_partial_chunk(partial_chunk);
     }
 
     pub fn decode_and_persist_encoded_chunk(
@@ -1274,7 +1274,7 @@ impl ShardsManager {
             );
 
             // Decoded a valid chunk, store it in the permanent store
-            store_update.save_chunk(&chunk_hash, shard_chunk);
+            store_update.save_chunk(shard_chunk);
             store_update.commit()?;
 
             self.requested_partial_encoded_chunks.remove(&chunk_hash);

--- a/core/primitives/src/utils.rs
+++ b/core/primitives/src/utils.rs
@@ -30,6 +30,11 @@ pub fn get_block_shard_id(block_hash: &CryptoHash, shard_id: ShardId) -> Vec<u8>
 pub fn get_block_shard_id_rev(
     key: &[u8],
 ) -> Result<(CryptoHash, ShardId), Box<dyn std::error::Error>> {
+    if key.len() != 40 {
+        return Err(
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid key length").into()
+        );
+    }
     let block_hash_vec: Vec<u8> = key[0..32].iter().cloned().collect();
     let block_hash = CryptoHash::try_from(block_hash_vec)?;
     let mut shard_id_arr: [u8; 8] = Default::default();

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -14,7 +14,8 @@ serde_json = "1"
 cached = "0.12"
 num_cpus = "1.11"
 rand = "0.7.2"
-enum-iterator = "0.6.0"
+strum = "0.18"
+strum_macros = "0.18"
 
 borsh = "0.6.2"
 

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1"
 cached = "0.12"
 num_cpus = "1.11"
 rand = "0.7.2"
+enum-iterator = "0.6.0"
 
 borsh = "0.6.2"
 

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use std::io;
 use std::sync::RwLock;
 
+use enum_iterator::IntoEnumIterator;
 use rocksdb::{
     BlockBasedOptions, ColumnFamily, ColumnFamilyDescriptor, Direction, IteratorMode, Options,
     ReadOptions, WriteBatch, DB,
@@ -33,7 +34,7 @@ impl Into<io::Error> for DBError {
     }
 }
 
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone, IntoEnumIterator)]
 pub enum DBCol {
     /// Column to indicate which version of database this is.
     ColDbVersion = 0,

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -3,11 +3,11 @@ use std::collections::HashMap;
 use std::io;
 use std::sync::RwLock;
 
-use enum_iterator::IntoEnumIterator;
 use rocksdb::{
     BlockBasedOptions, ColumnFamily, ColumnFamilyDescriptor, Direction, IteratorMode, Options,
     ReadOptions, WriteBatch, DB,
 };
+use strum_macros::EnumIter;
 
 use near_primitives::version::DbVersion;
 
@@ -34,7 +34,7 @@ impl Into<io::Error> for DBError {
     }
 }
 
-#[derive(PartialEq, Debug, Copy, Clone, IntoEnumIterator)]
+#[derive(PartialEq, Debug, Copy, Clone, EnumIter)]
 pub enum DBCol {
     /// Column to indicate which version of database this is.
     ColDbVersion = 0,

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::process;
 use std::sync::Arc;
 
-use ansi_term::Color::{Green, Red, White, Yellow};
+use ansi_term::Color::{Green, Red, Yellow};
 use clap::{App, Arg, SubCommand};
 
 use near_chain::store_validator::StoreValidator;
@@ -57,11 +57,10 @@ fn main() {
     );
     for error in store_validator.errors.iter() {
         println!(
-            "{}  {}  {}  {}",
-            Red.bold().paint(&error.func.to_string()),
-            Yellow.bold().paint(&error.col.unwrap().to_string()),
-            White.bold().paint(error.key.as_ref().unwrap()),
-            error.reason
+            "{}  {}  {}",
+            Red.bold().paint(&error.col.to_string()),
+            Yellow.bold().paint(&error.key),
+            error.err
         );
     }
     if store_validator.is_failed() {


### PR DESCRIPTION
- DBCol is iterable by `strum`
- `save_chunk` and `save_partial_chunk` are safe from incorrect writing
- StoreValidator error usage refactoring, using `thiserror` crate
- sanity tests for StoreValidator errors are added
- `check_discrepancy` and `check_cached` macro for quick validations
- `get_block_shard_id_rev` not panics for invalid keys
- minor updates