### PR TITLE
Promote EXPERIMENTAL_light_client_proof to non-experimental

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -227,9 +227,7 @@ impl JsonRpcHandler {
             "EXPERIMENTAL_changes" => self.changes_in_block_by_type(request.params).await,
             "EXPERIMENTAL_changes_in_block" => self.changes_in_block(request.params).await,
             "next_light_client_block" => self.next_light_client_block(request.params).await,
-            "EXPERIMENTAL_light_client_proof" => {
-                self.light_client_execution_outcome_proof(request.params).await
-            }
+            "light_client_proof" => self.light_client_execution_outcome_proof(request.params).await,
             "network_info" => self.network_info().await,
             "gas_price" => self.gas_price(request.params).await,
             _ => Err(RpcError::method_not_found(request.method)),

--- a/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
+++ b/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
@@ -174,7 +174,7 @@ def check_transaction_outcome_proof(should_succeed, nonce):
                         "light_client_head": light_client_block_hash})
 
     for query, (outcome, id) in zip(queries, outcomes):
-        res = nodes[0].json_rpc('EXPERIMENTAL_light_client_proof', query, timeout=10)
+        res = nodes[0].json_rpc('light_client_proof', query, timeout=10)
         assert 'error' not in res, res
         light_client_proof = res['result']
         # check that execution outcome root proof is valid


### PR DESCRIPTION
For consistency with `next_light_client_block`