### PR TITLE
feat: Infrastructure to intercept network messages in python

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -37,6 +37,7 @@ pytest --timeout=300 sanity/gc_sync_after_sync.py swap_nodes
 pytest --timeout=300 sanity/large_messages.py
 pytest --timeout=300 sanity/upgradable.py
 pytest --timeout=240 sanity/validator_switch_key.py
+pytest sanity/nodes_proxy.py
 
 # python tests for smart contract deployment and invocation
 pytest contracts/deploy_call_smart_contract.py

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -73,7 +73,11 @@ class Key(object):
             return Key.from_json(json.loads(f.read()))
 
     def to_json(self):
-        return {'account_id': self.account_id, 'public_key': self.pk, 'secret_key': self.sk}
+        return {
+            'account_id': self.account_id,
+            'public_key': self.pk,
+            'secret_key': self.sk
+        }
 
 
 class BaseNode(object):
@@ -202,11 +206,14 @@ class BaseNode(object):
                 self.get_status()['validators']))
 
     def stop_checking_refmap(self):
-        print("WARN: Stopping checking Reference Map for inconsistency for %s:%s" % self.addr())
+        print(
+            "WARN: Stopping checking Reference Map for inconsistency for %s:%s"
+            % self.addr())
         self.is_check_refmap = False
 
     def stop_checking_store(self):
-        print("WARN: Stopping checking Storage for inconsistency for %s:%s" % self.addr())
+        print("WARN: Stopping checking Storage for inconsistency for %s:%s" %
+              self.addr())
         self.is_check_store = False
 
     def check_refmap(self):
@@ -231,9 +238,12 @@ class BaseNode(object):
                 pass
             else:
                 if res['result'] == 0:
-                    print("ERROR: Storage for %s:%s in inconsistent state, stopping" % self.addr())
+                    print(
+                        "ERROR: Storage for %s:%s in inconsistent state, stopping"
+                        % self.addr())
                     self.kill()
                 self.store_tests += res['result']
+
 
 class RpcNode(BaseNode):
     """ A running node only interact by rpc queries """
@@ -627,8 +637,12 @@ def apply_config_changes(node_dir, client_config_change):
         f.write(json.dumps(config_json, indent=2))
 
 
-def start_cluster(num_nodes, num_observers, num_shards, config,
-                  genesis_config_changes, client_config_changes,
+def start_cluster(num_nodes,
+                  num_observers,
+                  num_shards,
+                  config,
+                  genesis_config_changes,
+                  client_config_changes,
                   message_handler=None):
     if not config:
         config = load_config()

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -17,6 +17,7 @@ import rc
 from rc import gcloud
 import uuid
 import network
+from proxy import NodesProxy
 
 os.environ["ADVERSARY_CONSENT"] = "1"
 
@@ -489,7 +490,8 @@ def spin_up_node(config,
                  ordinal,
                  boot_key,
                  boot_addr,
-                 blacklist=[]):
+                 blacklist=[],
+                 proxy=None):
     is_local = config['local']
 
     print("Starting node %s %s" % (ordinal,
@@ -518,6 +520,9 @@ def spin_up_node(config,
         with remote_nodes_lock:
             remote_nodes.append(node)
         print(f"node {ordinal} machine created")
+
+    if proxy is not None:
+        proxy.proxify_node(node)
 
     node.start(boot_key, boot_addr)
     time.sleep(3)
@@ -623,7 +628,8 @@ def apply_config_changes(node_dir, client_config_change):
 
 
 def start_cluster(num_nodes, num_observers, num_shards, config,
-                  genesis_config_changes, client_config_changes):
+                  genesis_config_changes, client_config_changes,
+                  message_handler=None):
     if not config:
         config = load_config()
 
@@ -641,9 +647,11 @@ def start_cluster(num_nodes, num_observers, num_shards, config,
             filter(lambda n: not n.endswith('_finished'), node_dirs))
     ret = []
 
+    proxy = NodesProxy(message_handler) if message_handler is not None else None
+
     def spin_up_node_and_push(i, boot_key, boot_addr):
         node = spin_up_node(config, near_root, node_dirs[i], i, boot_key,
-                            boot_addr)
+                            boot_addr, [], proxy)
         while len(ret) < i:
             time.sleep(0.01)
         ret.append(node)

--- a/pytest/lib/messages/block.py
+++ b/pytest/lib/messages/block.py
@@ -1,0 +1,259 @@
+from messages.crypto import PublicKey, Signature, MerklePath, ShardProof
+from messages.tx import Receipt
+
+class Block:
+    pass
+
+
+class BlockV1:
+    pass
+
+
+class BlockHeader:
+    pass
+
+
+class BlockHeaderV1:
+    pass
+
+
+class BlockHeaderInnerLite:
+    pass
+
+
+class BlockHeaderInnerRest:
+    pass
+
+
+class ShardChunkHeader:
+    pass
+
+
+class ShardChunkHeaderInner:
+    pass
+
+
+class PartialEncodedChunkPart:
+    pass
+
+
+class ReceiptProof:
+    pass
+
+
+class PartialEncodedChunk:
+    pass
+
+
+class PartialEncodedChunkRequestMsg:
+    pass
+
+
+class PartialEncodedChunkResponseMsg:
+    pass
+
+
+class ValidatorStake:
+    pass
+
+
+class Approval:
+    pass
+
+
+class ApprovalInner:
+    pass
+
+
+block_schema = [
+    [
+        Block, {
+            'kind': 'enum',
+            'field': 'enum',
+            'values': [
+                ['BlockV1', BlockV1]
+            ]
+        }
+    ],
+    [
+        BlockV1, {
+            'kind': 'struct',
+            'fields': [
+                ['header', BlockHeader],
+                ['chunks', [ShardChunkHeader]],
+                ['challenges', [()]], # TODO
+
+                ['vrf_value', [32]],
+                ['vrf_proof', [64]],
+            ]
+        }
+    ],
+    [
+        BlockHeader, {
+            'kind': 'enum',
+            'field': 'enum',
+            'values': [
+                ['BlockHeaderV1', BlockHeaderV1]
+            ]
+        }
+    ],
+    [
+        BlockHeaderV1, {
+            'kind': 'struct',
+            'fields': [
+                ['prev_hash', [32]],
+                ['inner_lite', BlockHeaderInnerLite],
+                ['inner_rest', BlockHeaderInnerRest],
+                ['signature', Signature],
+            ]
+        }
+    ],
+    [
+        BlockHeaderInnerLite, {
+            'kind': 'struct',
+            'fields': [
+                ['height', 'u64'],
+                ['epoch_id', [32]],
+                ['next_epoch_id', [32]],
+                ['prev_state_root', [32]],
+                ['outcome_root', [32]],
+                ['timestamp', 'u64'],
+                ['next_bp_hash', [32]],
+                ['block_merkle_root', [32]],
+            ]
+        }
+    ],
+    [
+        BlockHeaderInnerRest, {
+            'kind': 'struct',
+            'fields': [
+                ['chunk_receipts_root', [32]],
+                ['chunk_headers_root', [32]],
+                ['chunk_tx_root', [32]],
+                ['chunks_included', 'u64'],
+                ['challenges_root', [32]],
+                ['random_value', [32]],
+                ['validator_proposals', [ValidatorStake]],
+                ['chunk_mask', ['u8']],
+                ['gas_price', 'u128'],
+                ['total_supply', 'u128'],
+                ['challenges_result', [()]], # TODO
+                ['last_final_block', [32]],
+                ['last_ds_final_block', [32]],
+                ['approvals', [{'kind': 'option', 'type': Signature}]],
+                ['latest_protocol_verstion', 'u32'],
+            ]
+        }
+    ],
+    [
+        ShardChunkHeader, {
+            'kind': 'struct',
+            'fields': [
+                ['inner', ShardChunkHeaderInner],
+                ['height_included', 'u64'],
+                ['signature', Signature],
+            ]
+        }
+    ],
+    [
+        ShardChunkHeaderInner, {
+            'kind': 'struct',
+            'fields': [
+                ['prev_block_hash', [32]],
+                ['prev_state_root', [32]],
+                ['outcome_root', [32]],
+                ['encoded_merkle_root', [32]],
+                ['encoded_length', 'u64'],
+                ['height_created', 'u64'],
+                ['shard_id', 'u64'],
+                ['gas_used', 'u64'],
+                ['gas_limit', 'u64'],
+                ['balance_burnt', 'u128'],
+                ['outgoing_receipt_root', [32]],
+                ['tx_root', [32]],
+                ['validator_proposals', [ValidatorStake]],
+            ]
+        }
+    ],
+    [
+        PartialEncodedChunkPart, {
+            'kind': 'struct',
+            'fields': [
+                ['part_ord', 'u64'],
+                ['part', ['u8']],
+                ['merkle_proof', MerklePath],
+            ]
+        }
+    ],
+    [
+        ReceiptProof, {
+            'kind': 'struct',
+            'fields': [
+                ['f1', [Receipt]],
+                ['f2', ShardProof],
+            ]
+        }
+    ],
+    [
+        PartialEncodedChunk, {
+            'kind': 'struct',
+            'fields': [
+                ['header', ShardChunkHeader],
+                ['parts', [PartialEncodedChunkPart]],
+                ['receipts', [ReceiptProof]]
+            ]
+        }
+    ],
+    [
+        PartialEncodedChunkRequestMsg, {
+            'kind': 'struct',
+            'fields': [
+                ['chunk_hash', [32]],
+                ['part_ords', ['u64']],
+                ['tracking_shards', ['u64']]
+            ]
+        }
+    ],
+    [
+        PartialEncodedChunkResponseMsg, {
+            'kind': 'struct',
+            'fields': [
+                ['chunk_hash', [32]],
+                ['parts', [PartialEncodedChunkPart]],
+                ['receipts', [ReceiptProof]]
+            ]
+        }
+    ],
+    [
+        ValidatorStake, {
+            'kind': 'struct',
+            'fields': [
+                ['account_id', 'string'],
+                ['public_key', PublicKey],
+                ['stake', 'u128'],
+            ]
+        }
+    ],
+    [
+        Approval, {
+            'kind': 'struct',
+            'fields': [
+                ['inner', ApprovalInner],
+                ['target_height', 'u64'],
+                ['signature', Signature],
+                ['account_id', 'string'],
+            ]
+        }
+    ],
+    [
+        ApprovalInner, {
+            'kind': 'enum',
+            'field': 'enum',
+            'values': [
+                ['Endorsement', [32]],
+                ['Skip', 'u64'],
+            ]
+        }
+    ],
+]
+

--- a/pytest/lib/messages/crypto.py
+++ b/pytest/lib/messages/crypto.py
@@ -21,6 +21,15 @@ class FunctionCallPermission:
 class FullAccessPermission:
     pass
 
+class Direction:
+    pass
+
+class MerklePath:
+    pass
+
+class ShardProof:
+    pass
+
 
 crypto_schema = [
     [
@@ -63,7 +72,7 @@ crypto_schema = [
             'fields': [
                 ['allowance', {
                     'kind': 'option',
-                    type: 'u128'
+                    'type': 'u128'
                 }],
                 ['receiverId', 'string'],
                 ['methodNames', ['string']],
@@ -73,5 +82,18 @@ crypto_schema = [
     [FullAccessPermission, {
         'kind': 'struct',
         'fields': []
+    }],
+    [Direction, {
+        'kind': 'enum',
+        'field': 'enum',
+        'values': [['Left', ()], ['Right', ()]],
+    }],
+    [MerklePath, {
+        'kind': 'struct',
+        'fields': [['f1', [([32], Direction)]]],
+    }],
+    [ShardProof, {
+        'kind': 'struct',
+        'fields': [['from_shard_id', 'u64'], ['to_shard_id', 'u64'], ['proof', MerklePath]],
     }],
 ]

--- a/pytest/lib/messages/network.py
+++ b/pytest/lib/messages/network.py
@@ -1,4 +1,6 @@
 from messages.crypto import Signature, PublicKey
+from messages.tx import SignedTransaction
+from messages.block import Block, Approval, PartialEncodedChunk, PartialEncodedChunkRequestMsg, PartialEncodedChunkResponseMsg, BlockHeader
 
 
 class SocketAddr:
@@ -33,6 +35,34 @@ class GenesisId:
     pass
 
 
+class Edge:
+    pass
+
+
+class SyncData:
+    pass
+
+
+class AnnounceAccount:
+    pass
+
+
+class RoutedMessage:
+    pass
+
+
+class PeerIdOrHash:
+    pass
+
+
+class RoutedMessageBody:
+    pass
+
+
+class PingPong:
+    pass
+
+
 network_schema = [
     [
         SocketAddr, {
@@ -48,7 +78,21 @@ network_schema = [
             'field':
                 'enum',
             'values': [['Handshake', Handshake],
-                       ['HandshakeFailure', (PeerInfo, HandshakeFailureReason)]]
+                       ['HandshakeFailure', (PeerInfo, HandshakeFailureReason)],
+                       ['LastEdge', Edge],
+                       ['Sync', SyncData],
+                       ['RequestUpdateNonce', EdgeInfo],
+                       ['ResponseUpdateNonce', Edge],
+                       ['PeersRequest', ()],
+                       ['PeersResponse', [PeerInfo]],
+                       ['BlockHeadersRequest', [[32]]],
+                       ['BlockHeaders', [BlockHeader]],
+                       ['BlockRequest', [32]],
+                       ['Block', Block],
+                       ['Transaction', SignedTransaction],
+                       ['Routed', RoutedMessage],
+                       ['Disconnect', ()],
+                       ['Challenge', None]] # TODO
         }
     ],
     [
@@ -104,6 +148,28 @@ network_schema = [
         }
     ],
     [
+        Edge, {
+            'kind': 'struct',
+            'fields': [
+                ['peer0', PublicKey],
+                ['peer1', PublicKey],
+                ['nonce', 'u64'],
+                ['signature0', Signature],
+                ['signature1', Signature],
+                ['removal_info', {'kind': 'option', 'type': ('u8', Signature)}],
+            ]
+        }
+    ],
+    [
+        SyncData, {
+            'kind': 'struct',
+            'fields': [
+                ['edges', [Edge]],
+                ['accounts', [AnnounceAccount]],
+            ]
+        }
+    ],
+    [
         EdgeInfo, {
             'kind': 'struct',
             'fields': [
@@ -120,5 +186,68 @@ network_schema = [
                 ['hash', [32]],
             ]
         }
-    ]
+    ],
+    [
+        AnnounceAccount, {
+            'kind': 'struct',
+            'fields': [
+                ['account_id', 'string'],
+                ['peer_id', PublicKey],
+                ['epoch_id', [32]],
+                ['signature', Signature],
+            ]
+        }
+    ],
+    [
+        RoutedMessage, {
+            'kind': 'struct',
+            'fields': [
+                ['target', PeerIdOrHash],
+                ['author', PublicKey],
+                ['signature', Signature],
+                ['ttl', 'u8'],
+                ['body', RoutedMessageBody],
+            ]
+        }
+    ],
+    [
+        PeerIdOrHash, {
+            'kind': 'enum',
+            'field': 'enum',
+            'values': [
+                ['PeerId', PublicKey],
+                ['Hash', [32]],
+            ]
+        }
+    ],
+    [
+        RoutedMessageBody, {
+            'kind': 'enum',
+            'field': 'enum',
+            'values': [
+                ['BlockApproval', Approval],
+                ['ForwardTx', SignedTransaction],
+                ['TxStatusRequest', ('string', [32])],
+                ['TxStatusResponse', None], # TODO
+                ['QueryRequest', None], # TODO
+                ['QueryResponse', None], # TODO
+                ['ReceiptOutcomeRequest', [32]],
+                ['ReceiptOutcomeResponse', None], # TODO
+                ['StateRequestHeader', ('u64', [32])],
+                ['StateRequestPart', ('u64', [32], 'u64')],
+                ['StateResponseInfo', None], # TODO
+                ['PartialEncodedChunkRequest', PartialEncodedChunkRequestMsg],
+                ['PartialEncodedChunkResponse', PartialEncodedChunkResponseMsg],
+                ['PartialEncodedChunk', PartialEncodedChunk],
+                ['Ping', PingPong],
+                ['Pong', PingPong],
+            ]
+        }
+    ],
+    [
+        PingPong, {
+            'kind': 'struct',
+            'fields': [['nonce', 'u64'], ['source', PublicKey]]
+        }
+    ],
 ]

--- a/pytest/lib/messages/tx.py
+++ b/pytest/lib/messages/tx.py
@@ -45,6 +45,26 @@ class DeleteAccount:
     pass
 
 
+class Receipt:
+    pass
+
+
+class ReceiptEnum:
+    pass
+
+
+class ActionReceipt:
+    pass
+
+
+class DataReceipt:
+    pass
+
+
+class DataReceiver:
+    pass
+
+
 tx_schema = [
     [
         SignedTransaction, {
@@ -119,6 +139,58 @@ tx_schema = [
         DeleteAccount, {
             'kind': 'struct',
             'fields': [['beneficiaryId', 'string']]
+        }
+    ],
+    [
+        Receipt, {
+            'kind': 'struct',
+            'fields': [
+                ['predecessor_id', 'string'],
+                ['receiver_id', 'string'],
+                ['receipt_id', [32]],
+                ['receipt', ReceiptEnum],
+            ]
+        }
+    ],
+    [
+        ReceiptEnum, {
+            'kind': 'enum',
+            'field': 'enum',
+            'values': [
+                ['Action', ActionReceipt],
+                ['Data', DataReceipt],
+            ]
+        }
+    ],
+    [
+        ActionReceipt, {
+            'kind': 'struct',
+            'fields': [
+                ['signer_id', 'string'],
+                ['signer_public_key', PublicKey],
+                ['gas_price', 'u128'],
+                ['output_data_receivers', [DataReceiver]],
+                ['input_data_ids', [[32]]],
+                ['actions', [Action]],
+            ],
+        }
+    ],
+    [
+        DataReceipt, {
+            'kind': 'struct',
+            'fields': [
+                ['data_id', [32]],
+                ['data', {'kind': 'option', 'type': ['u8']}],
+            ]
+        }
+    ],
+    [
+        DataReceiver, {
+            'kind': 'struct',
+            'fields': [
+                ['data_id', [32]],
+                ['receiver_id', 'string'],
+            ]
         }
     ],
 ]

--- a/pytest/lib/peer.py
+++ b/pytest/lib/peer.py
@@ -5,6 +5,7 @@ from messages.network import *
 
 ED_PREFIX = "ed25519:"
 
+
 def create_handshake(my_key_pair_nacl, their_pk_serialized, listen_port):
     handshake = Handshake()
     handshake.version = 26
@@ -18,7 +19,8 @@ def create_handshake(my_key_pair_nacl, their_pk_serialized, listen_port):
     handshake.peer_id.data = bytes(my_key_pair_nacl.verify_key)
 
     handshake.target_peer_id.keyType = 0
-    handshake.target_peer_id.data = base58.b58decode(their_pk_serialized[len(ED_PREFIX):])
+    handshake.target_peer_id.data = base58.b58decode(
+        their_pk_serialized[len(ED_PREFIX):])
 
     handshake.chain_info.genesis_id = GenesisId()
     handshake.chain_info.height = 0
@@ -46,8 +48,11 @@ def sign_handshake(my_key_pair_nacl, handshake):
     if peer1.data < peer0.data:
         peer0, peer1 = peer1, peer0
 
-    arr = bytes(bytearray([0]) + peer0.data + bytearray([0]) + peer1.data + struct.pack('Q', handshake.edge_info.nonce))
-    handshake.edge_info.signature.data = my_key_pair_nacl.sign(hashlib.sha256(arr).digest()).signature
+    arr = bytes(
+        bytearray([0]) + peer0.data + bytearray([0]) + peer1.data +
+        struct.pack('Q', handshake.edge_info.nonce))
+    handshake.edge_info.signature.data = my_key_pair_nacl.sign(
+        hashlib.sha256(arr).digest()).signature
 
 
 def send_msg(sock, msg):
@@ -66,5 +71,3 @@ def recv_msg(sock):
 
 def recv_obj(sock, schema, type_):
     return BinarySerializer(schema).deserialize(recv_msg(sock), type_)
-
-

--- a/pytest/lib/peer.py
+++ b/pytest/lib/peer.py
@@ -7,7 +7,7 @@ ED_PREFIX = "ed25519:"
 
 def create_handshake(my_key_pair_nacl, their_pk_serialized, listen_port):
     handshake = Handshake()
-    handshake.version = 17
+    handshake.version = 26
     handshake.peer_id = PublicKey()
     handshake.target_peer_id = PublicKey()
     handshake.listen_port = listen_port

--- a/pytest/lib/proxy.py
+++ b/pytest/lib/proxy.py
@@ -1,0 +1,205 @@
+# A library providing a node wrapper that intercepts all the incoming messages and
+# outgoing responces (but not the initiated outgoing messages and incoming responces)
+# from a node, and calls a handler on them. The handler can then decide to drop the
+# message, deliver the message, or change the message.
+#
+# Usage:
+# 1. Create a proxy = NodesProxy(handler).
+#    handler takes two arguments, the message (deserialized), the ordinal of the sending
+#    peer and the ordinal of the receiving peer. The ordinal is derived from the port,
+#    and assumes no tampering with ports was done
+# 2. Call proxy.proxify_node(node) before the node is started.
+#    proxify_node will start a process that receives the connections on the port 100
+#    larger than the original node port. It will change the port of the `Node` object
+#    passed to it.
+# 
+# Note that since the handler is called on incoming messages and outgoing responces, if
+# all the nodes in the cluster are proxified, each message exchanged in the cluster will
+# have the handler called exactly once.
+#
+# The proxy will register an atexit function that will gracefully shut down all the
+# processes, and fail the test if any of the processes failed.
+#
+# `start_cluster` accepts a handler as its last argument, and automatically proxifies
+# all the nodes if the parameter is not None
+#
+# See `tests/sanity/nodes_proxy.py` for an example usage
+
+import multiprocessing, struct, socket, select, atexit
+
+from serializer import BinarySerializer
+
+from messages.crypto import *
+from messages.network import *
+from messages.block import *
+from messages.tx import *
+
+MSG_TIMEOUT = 10
+
+schema = dict(crypto_schema + network_schema + block_schema + tx_schema)
+
+def proxy_cleanup(proxy):
+    proxy.stopped.value = 1
+    for p in proxy.ps:
+        p.join()
+    if proxy.error.value != 0:
+        assert False, "One of the proxy processes failed, search for the stacktraces above"
+
+
+class NodesProxy:
+    def __init__(self, handler):
+        assert handler is not None
+        self.handler = handler
+        self.stopped = multiprocessing.Value('i', 0)
+        self.error = multiprocessing.Value('i', 0)
+        self.ps = []
+        atexit.register(proxy_cleanup, self)
+
+    def proxify_node(self, node):
+        p = proxify_node(node, self.handler, self.stopped, self.error)
+        self.ps.append(p)
+        
+
+def proxify_node(node, handler, stopped, error):
+    old_port = node.port
+    new_port = old_port + 100
+
+    def handle_connection(conn, addr, stopped, error):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s_node:
+                s_node.connect(("127.0.0.1", old_port))
+
+                conn.setblocking(0)
+                s_node.setblocking(0)
+
+                peer_port_holder = [None]
+
+                while 0 == stopped.value and 0 == error.value:
+                    ready = select.select([conn, s_node], [], [], MSG_TIMEOUT)
+                    if not ready[0]:
+                        print("TIMEOUT")
+                        time.sleep(1)
+                        continue
+
+                    if conn in ready[0]:
+                        data = conn.recv(4)
+
+                        if not data:
+                            continue
+
+                        data = conn.recv(struct.unpack('I', data)[0])
+                        decision = call_handler(data, handler, peer_port_holder, [node.port])
+                        if type(decision) == bytes:
+                            data = decision
+                            decision = True
+                        assert type(decision) == bool, type(decision)
+
+                        if decision:
+                            s_node.sendall(struct.pack('I', len(data)))
+                            s_node.sendall(data)
+
+                    elif s_node in ready[0]:
+                        data = s_node.recv(4)
+
+                        if not data:
+                            continue
+
+                        data = s_node.recv(struct.unpack('I', data)[0])
+                        decision = call_handler(data, handler, [node.port], peer_port_holder)
+
+                        if type(decision) == bytes:
+                            data = decision
+                            decision = True
+                        assert type(decision) == bool, type(decision)
+
+                        if decision:
+                            conn.sendall(struct.pack('I', len(data)))
+                            conn.sendall(data)
+
+                    else:
+                        assert False, (conn, s_node, ready[0])
+        except ConnectionResetError:
+            print("Connection closed, ignoring the error")
+            pass
+        except:
+            error.value = 1
+            raise
+
+    def listener():
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s_inc:
+                s_inc.settimeout(1)
+                s_inc.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                s_inc.bind(("127.0.0.1", new_port))
+                s_inc.listen()
+                while 0 == stopped.value and 0 == error.value:
+                    try:
+                        conn, addr = s_inc.accept()
+                    except socket.timeout:
+                        continue
+                    print('Connected by', addr)
+                    p = multiprocessing.Process(target=handle_connection, args=(conn, addr, stopped, error))
+                    p.start()
+                    
+        except:
+            error.value = 1
+            raise
+
+    p = multiprocessing.Process(target=listener, args=())
+    p.start()
+
+    node.port = new_port
+    return p
+
+
+def port_holder_to_node_ord(holder):
+    return None if holder[0] is None else (holder[0] - 24477) % 100
+
+
+def call_handler(raw_msg, handler, sender_port_holder, receiver_port_holder):
+    try:
+        obj = BinarySerializer(schema).deserialize(raw_msg, PeerMessage)
+        assert BinarySerializer(schema).serialize(obj) == raw_msg
+
+        if obj.enum == 'Handshake':
+            obj.Handshake.listen_port += 100
+            if sender_port_holder[0] is None:
+                sender_port_holder[0] = obj.Handshake.listen_port
+
+        decision = handler(obj,
+                           port_holder_to_node_ord(sender_port_holder), 
+                           port_holder_to_node_ord(receiver_port_holder))
+
+        if decision == True and obj.enum == 'Handshake':
+            decision = obj
+
+        if type(decision) != bool:
+            decision = BinarySerializer(schema).serialize(decision)
+
+        return decision
+
+    except:
+        if raw_msg[0] == 13:
+            # raw_msg[0] == 13 is RoutedMessage. Skip leading fields to get to the RoutedMessageBody
+            ser = BinarySerializer(schema)
+            ser.array = bytearray(raw_msg)
+            ser.offset = 1
+            ser.deserialize_field(PeerIdOrHash)
+            ser.deserialize_field(PublicKey)
+            ser.deserialize_field(Signature)
+            ser.deserialize_field('u8')
+
+            # The next byte is the variant ordinal of the `RoutedMessageBody`.
+            # Skip if it's the ordinal of a variant for which the schema is not ported yet
+            if raw_msg[ser.offset] in [3, 4, 5, 7, 10]:
+                return True
+            print("ERROR 13", int(raw_msg[ser.offset]))
+
+        else:
+            print("ERROR", int(raw_msg[0]))
+
+        raise
+
+    return True
+
+

--- a/pytest/lib/proxy.py
+++ b/pytest/lib/proxy.py
@@ -12,7 +12,7 @@
 #    proxify_node will start a process that receives the connections on the port 100
 #    larger than the original node port. It will change the port of the `Node` object
 #    passed to it.
-# 
+#
 # Note that since the handler is called on incoming messages and outgoing responces, if
 # all the nodes in the cluster are proxified, each message exchanged in the cluster will
 # have the handler called exactly once.
@@ -38,6 +38,7 @@ MSG_TIMEOUT = 10
 
 schema = dict(crypto_schema + network_schema + block_schema + tx_schema)
 
+
 def proxy_cleanup(proxy):
     proxy.stopped.value = 1
     for p in proxy.ps:
@@ -47,6 +48,7 @@ def proxy_cleanup(proxy):
 
 
 class NodesProxy:
+
     def __init__(self, handler):
         assert handler is not None
         self.handler = handler
@@ -58,7 +60,7 @@ class NodesProxy:
     def proxify_node(self, node):
         p = proxify_node(node, self.handler, self.stopped, self.error)
         self.ps.append(p)
-        
+
 
 def proxify_node(node, handler, stopped, error):
     old_port = node.port
@@ -88,7 +90,8 @@ def proxify_node(node, handler, stopped, error):
                             continue
 
                         data = conn.recv(struct.unpack('I', data)[0])
-                        decision = call_handler(data, handler, peer_port_holder, [node.port])
+                        decision = call_handler(data, handler, peer_port_holder,
+                                                [node.port])
                         if type(decision) == bytes:
                             data = decision
                             decision = True
@@ -105,7 +108,8 @@ def proxify_node(node, handler, stopped, error):
                             continue
 
                         data = s_node.recv(struct.unpack('I', data)[0])
-                        decision = call_handler(data, handler, [node.port], peer_port_holder)
+                        decision = call_handler(data, handler, [node.port],
+                                                peer_port_holder)
 
                         if type(decision) == bytes:
                             data = decision
@@ -138,9 +142,11 @@ def proxify_node(node, handler, stopped, error):
                     except socket.timeout:
                         continue
                     print('Connected by', addr)
-                    p = multiprocessing.Process(target=handle_connection, args=(conn, addr, stopped, error))
+                    p = multiprocessing.Process(target=handle_connection,
+                                                args=(conn, addr, stopped,
+                                                      error))
                     p.start()
-                    
+
         except:
             error.value = 1
             raise
@@ -166,8 +172,7 @@ def call_handler(raw_msg, handler, sender_port_holder, receiver_port_holder):
             if sender_port_holder[0] is None:
                 sender_port_holder[0] = obj.Handshake.listen_port
 
-        decision = handler(obj,
-                           port_holder_to_node_ord(sender_port_holder), 
+        decision = handler(obj, port_holder_to_node_ord(sender_port_holder),
                            port_holder_to_node_ord(receiver_port_holder))
 
         if decision == True and obj.enum == 'Handshake':
@@ -201,5 +206,3 @@ def call_handler(raw_msg, handler, sender_port_holder, receiver_port_holder):
         raise
 
     return True
-
-

--- a/pytest/tests/sanity/block_production.py
+++ b/pytest/tests/sanity/block_production.py
@@ -20,7 +20,7 @@ BLOCKS = 50
 
 nodes = start_cluster(
     4, 0, 4, None,
-    [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {})
+    [["epoch_length", 10], ["block_producer_kickout_threshold", 60], ["chunk_producer_kickout_threshold", 60]], {})
 
 started = time.time()
 

--- a/pytest/tests/sanity/nodes_proxy.py
+++ b/pytest/tests/sanity/nodes_proxy.py
@@ -1,0 +1,35 @@
+import sys, time
+import multiprocessing
+
+sys.path.append('lib')
+
+from cluster import start_cluster
+from proxy import proxify_node
+from peer import *
+
+from multiprocessing import Value
+
+TIMEOUT = 30
+success = Value('i', 0)
+
+def handler(msg, fr, to):
+    if msg.enum == 'Block':
+        if msg.Block.BlockV1.header.BlockHeaderV1.inner_lite.height >= 10:
+            print('SUCCESS')
+            success.value = 1
+    return True
+
+start_cluster(
+    4, 0, 1, None,
+    [], {}, handler)
+
+started = time.time()
+
+while True:
+    assert time.time() - started < TIMEOUT
+    time.sleep(1)
+
+    if success.value == 1:
+        break
+
+

--- a/pytest/tests/sanity/nodes_proxy.py
+++ b/pytest/tests/sanity/nodes_proxy.py
@@ -12,6 +12,7 @@ from multiprocessing import Value
 TIMEOUT = 30
 success = Value('i', 0)
 
+
 def handler(msg, fr, to):
     if msg.enum == 'Block':
         if msg.Block.BlockV1.header.BlockHeaderV1.inner_lite.height >= 10:
@@ -19,9 +20,8 @@ def handler(msg, fr, to):
             success.value = 1
     return True
 
-start_cluster(
-    4, 0, 1, None,
-    [], {}, handler)
+
+start_cluster(4, 0, 1, None, [], {}, handler)
 
 started = time.time()
 
@@ -31,5 +31,3 @@ while True:
 
     if success.value == 1:
         break
-
-

--- a/pytest/tests/sanity/transactions.py
+++ b/pytest/tests/sanity/transactions.py
@@ -38,7 +38,6 @@ while True:
     hash_ = status['sync_info']['latest_block_hash']
 
     if step == 0:
-        print(f'step {step}')
         if height >= 1:
             tx = sign_payment_tx(nodes[0].signer_key, 'test1', 100, 1,
                                  base58.b58decode(hash_.encode('utf8')))

--- a/pytest/tests/spec/network/handshake.py
+++ b/pytest/tests/spec/network/handshake.py
@@ -36,7 +36,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     send_obj(s, schema, handshake)
     response = recv_obj(s, schema, PeerMessage)
 
-    assert response.enum == 'Handshake'
+    assert response.enum == 'Handshake', response.enum
     assert response.Handshake.chain_info.genesis_id.chain_id == handshake.Handshake.chain_info.genesis_id.chain_id
     assert response.Handshake.chain_info.genesis_id.hash == handshake.Handshake.chain_info.genesis_id.hash
     assert response.Handshake.edge_info.nonce == 1


### PR DESCRIPTION
This change introduces a large percentage of the `PeerMessage` schema ported to python, and a
library that allows wrapping nodes of the cluster in such a way that the messages between
them are intercepted by the test, de-borshified, and passed to a handler that can decide to
drop them, deliver them, or change them on the fly.