### PR TITLE
feat(pytest): basic tests using mocknet (#2862)

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -473,7 +473,9 @@ chmod +x near
         return super().json_rpc(method, params, timeout=timeout)
 
     def get_status(self):
-        r = requests.get("http://%s:%s/status" % self.rpc_addr(), timeout=10)
+        r = retrying.retry(lambda: requests.get(
+            "http://%s:%s/status" % self.rpc_addr(), timeout=10),
+                           timeout=20)
         r.raise_for_status()
         return json.loads(r.content)
 

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -525,21 +525,6 @@ def spin_up_node(config,
     return node
 
 
-def connect_to_mocknet(config):
-    if not config:
-        config = load_config()
-
-    if 'local' in config:
-        print("Attempt to launch a mocknet test with a regular config",
-              file=sys.stderr)
-        sys.exit(1)
-
-    return [RpcNode(node['ip'], node['port']) for node in config['nodes']], [
-        Key(account['account_id'], account['pk'], account['sk'])
-        for account in config['accounts']
-    ]
-
-
 def init_cluster(num_nodes, num_observers, num_shards, config,
                  genesis_config_changes, client_config_changes):
     """

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -1,8 +1,9 @@
 import base58
 from cluster import GCloudNode, Key
-from transaction import sign_payment_tx
+from transaction import sign_payment_tx_and_get_hash, sign_staking_tx_and_get_hash
 import json
 import os
+import time
 from rc import run, pmap
 
 NUM_SECONDS_PER_YEAR = 3600 * 24 * 365
@@ -48,23 +49,60 @@ def get_validator_account(node):
     return Key.from_json_file(f'{target_dir}/validator_key.json')
 
 
-def get_epoch_length_in_seconds(node):
+def get_epoch_length_in_blocks(node):
     m = node.machine
     target_dir = create_target_dir(m)
     m.download(f'/home/ubuntu/.near/genesis.json', target_dir)
     with open(f'{target_dir}/genesis.json') as f:
         config = json.load(f)
         epoch_length_in_blocks = config['epoch_length']
-        blocks_per_second = max(
-            config['num_blocks_per_year'] / NUM_SECONDS_PER_YEAR, 1)
-        return epoch_length_in_blocks / blocks_per_second
+        return epoch_length_in_blocks
+
+
+# Sends the transaction to the network via `node` and checks for success.
+# Some retrying is done when the node returns a Timeout error.
+def send_transaction(node, tx, tx_hash, account_id, timeout=30):
+    response = node.send_tx_and_wait(tx, timeout)
+    loop_start = time.time()
+    missing_count = 0
+    while 'error' in response.keys():
+        error_data = response['error']['data']
+        if error_data == 'Timeout':
+            print(
+                f'WARN: transaction {tx_hash} returned Timout, checking status again.'
+            )
+            time.sleep(2)
+            response = node.get_tx(tx_hash, account_id)
+        elif "doesn't exist" in error_data:
+            missing_count += 1
+            print(
+                f'WARN: transaction {tx_hash} falied to be recieved by the node, checking again.'
+            )
+            if missing_count < 10:
+                time.sleep(2)
+                response = node.get_tx(tx_hash, account_id)
+            else:
+                print(f'WARN: re-sending transaction {tx_hash}.')
+                response = node.send_tx_and_wait(tx, timeout)
+                missing_count = 0
+        else:
+            raise RuntimeError(
+                f'Error in processing transaction {tx_hash}: {response}')
+        if time.time() - loop_start > timeout:
+            raise TimeoutError(
+                f'Transaction {tx_hash} did not complete successfully within the timeout'
+            )
+
+    if 'SuccessValue' not in response['result']['status'].keys():
+        raise RuntimeError(
+            f'ERROR: Failed transaction {tx_hash}. Response: {response}')
 
 
 def transfer_between_nodes(nodes):
     print('INFO: Testing transfer between mocknet validators')
     node = nodes[0]
-    alice = get_validator_account(nodes[0])
-    bob = get_validator_account(nodes[1])
+    alice = get_validator_account(nodes[1])
+    bob = get_validator_account(nodes[0])
     transfer_amount = 100
     get_balance = lambda account: int(
         node.get_account(account.account_id)['result']['amount'])
@@ -75,12 +113,13 @@ def transfer_between_nodes(nodes):
     print(f'INFO: Alice initial balance: {alice_initial_balance}')
     print(f'INFO: Bob initial balance: {bob_initial_balance}')
 
-    last_block_hash = nodes[0].get_status()['sync_info']['latest_block_hash']
+    last_block_hash = node.get_status()['sync_info']['latest_block_hash']
     last_block_hash_decoded = base58.b58decode(last_block_hash.encode('utf8'))
 
-    tx = sign_payment_tx(alice, bob.account_id, transfer_amount,
-                         alice_nonce + 1, last_block_hash_decoded)
-    node.send_tx_and_wait(tx, timeout=10)
+    tx, tx_hash = sign_payment_tx_and_get_hash(alice, bob.account_id,
+                                               transfer_amount, alice_nonce + 1,
+                                               last_block_hash_decoded)
+    send_transaction(node, tx, tx_hash, alice.account_id)
 
     alice_final_balance = get_balance(alice)
     bob_final_balance = get_balance(bob)
@@ -91,6 +130,25 @@ def transfer_between_nodes(nodes):
     assert (alice_initial_balance -
             alice_final_balance) % 1000 == transfer_amount
     assert bob_final_balance - bob_initial_balance == transfer_amount
+
+
+def stake_node(node):
+    account = get_validator_account(node)
+    print(f'INFO: Staking {account.account_id}.')
+    nonce = node.get_nonce_for_pk(account.account_id, account.pk)
+
+    validators = node.get_validators()['result']
+    if account.account_id in validators['current_validators']:
+        return
+    stake_amount = max(
+        map(lambda v: int(v['stake']), validators['current_validators']))
+
+    latest_block_hash = node.get_status()['sync_info']['latest_block_hash']
+    last_block_hash_decoded = base58.b58decode(latest_block_hash.encode('utf8'))
+
+    staking_tx, staking_tx_hash = sign_staking_tx_and_get_hash(
+        account, account, stake_amount, nonce + 1, last_block_hash_decoded)
+    send_transaction(node, staking_tx, staking_tx_hash, account.account_id)
 
 
 def accounts_from_nodes(nodes):

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -1,0 +1,130 @@
+import base58
+from cluster import GCloudNode, Key
+from transaction import sign_payment_tx
+import json
+import os
+from rc import run, pmap
+
+NUM_SECONDS_PER_YEAR = 3600 * 24 * 365
+NUM_NODES = 8
+NODE_BASE_NAME = 'mocknet-node'
+NODE_USERNAME = 'ubuntu'
+NODE_SSH_KEY_PATH = '~/.ssh/near_ops'
+KEY_TARGET_ENV_VAR = 'NEAR_PYTEST_KEY_TARGET'
+DEFAULT_KEY_TARGET = '/tmp/mocknet'
+
+TMUX_STOP_SCRIPT = '''
+while tmux has-session -t near; do
+tmux kill-session -t near || true
+done
+'''
+
+TMUX_START_SCRIPT = '''
+sudo rm -rf /tmp/near.log
+tmux new -s near -d bash
+tmux send-keys -t near 'RUST_BACKTRACE=full /home/ubuntu/near run 2>&1 | tee /home/ubuntu/near.log' C-m
+'''
+
+
+def get_nodes():
+    nodes = [GCloudNode(f'{NODE_BASE_NAME}{i}') for i in range(0, NUM_NODES)]
+    for n in nodes:
+        n.machine.username = NODE_USERNAME
+        n.machine.ssh_key_path = NODE_SSH_KEY_PATH
+    return nodes
+
+
+def create_target_dir(machine):
+    base_target_dir = os.environ.get(KEY_TARGET_ENV_VAR, DEFAULT_KEY_TARGET)
+    target_dir = f'{base_target_dir}/{machine.name}'
+    run(f'mkdir -p {target_dir}')
+    return target_dir
+
+
+def get_validator_account(node):
+    m = node.machine
+    target_dir = create_target_dir(m)
+    m.download(f'/home/ubuntu/.near/validator_key.json', target_dir)
+    return Key.from_json_file(f'{target_dir}/validator_key.json')
+
+
+def get_epoch_length_in_seconds(node):
+    m = node.machine
+    target_dir = create_target_dir(m)
+    m.download(f'/home/ubuntu/.near/genesis.json', target_dir)
+    with open(f'{target_dir}/genesis.json') as f:
+        config = json.load(f)
+        epoch_length_in_blocks = config['epoch_length']
+        blocks_per_second = max(
+            config['num_blocks_per_year'] / NUM_SECONDS_PER_YEAR, 1)
+        return epoch_length_in_blocks / blocks_per_second
+
+
+def transfer_between_nodes(nodes):
+    print('INFO: Testing transfer between mocknet validators')
+    node = nodes[0]
+    alice = get_validator_account(nodes[0])
+    bob = get_validator_account(nodes[1])
+    transfer_amount = 100
+    get_balance = lambda account: int(
+        node.get_account(account.account_id)['result']['amount'])
+
+    alice_initial_balance = get_balance(alice)
+    alice_nonce = node.get_nonce_for_pk(alice.account_id, alice.pk)
+    bob_initial_balance = get_balance(bob)
+    print(f'INFO: Alice initial balance: {alice_initial_balance}')
+    print(f'INFO: Bob initial balance: {bob_initial_balance}')
+
+    last_block_hash = nodes[0].get_status()['sync_info']['latest_block_hash']
+    last_block_hash_decoded = base58.b58decode(last_block_hash.encode('utf8'))
+
+    tx = sign_payment_tx(alice, bob.account_id, transfer_amount,
+                         alice_nonce + 1, last_block_hash_decoded)
+    node.send_tx_and_wait(tx, timeout=10)
+
+    alice_final_balance = get_balance(alice)
+    bob_final_balance = get_balance(bob)
+    print(f'INFO: Alice final balance: {alice_final_balance}')
+    print(f'INFO: Bob final balance: {bob_final_balance}')
+
+    # Check mod 1000 to ignore the cost of the transaction itself
+    assert (alice_initial_balance -
+            alice_final_balance) % 1000 == transfer_amount
+    assert bob_final_balance - bob_initial_balance == transfer_amount
+
+
+def accounts_from_nodes(nodes):
+    return pmap(get_validator_account, nodes)
+
+
+def kill_proccess_script(pid):
+    return f'''
+        sudo kill {pid}
+        while kill -0 {pid}; do
+            sleep 1
+        done
+    '''
+
+
+def get_near_pid(machine):
+    p = machine.run(
+        "ps aux | grep 'near.* run' | grep -v grep | awk '{print $2}'")
+    return p.stdout.strip()
+
+
+def stop_node(node):
+    m = node.machine
+    print(f'INFO: Stopping node {m.name}')
+    pid = get_near_pid(m)
+    if pid != '':
+        m.run('bash', input=kill_proccess_script(pid))
+        m.run('sudo -u ubuntu -i', input=TMUX_STOP_SCRIPT)
+
+
+def start_node(node):
+    m = node.machine
+    print(f'INFO: Starting node {m.name}')
+    pid = get_near_pid(m)
+    if pid == '':
+        start_process = m.run('sudo -u ubuntu -i', input=TMUX_START_SCRIPT)
+        assert start_process.returncode == 0, m.name + '\n' + start_process.stderr

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -93,7 +93,7 @@ def send_transaction(node, tx, tx_hash, account_id, timeout=30):
                 f'Transaction {tx_hash} did not complete successfully within the timeout'
             )
 
-    if 'SuccessValue' not in response['result']['status'].keys():
+    if 'SuccessValue' not in response['result']['status']:
         raise RuntimeError(
             f'ERROR: Failed transaction {tx_hash}. Response: {response}')
 

--- a/pytest/tests/mocknet/bounce.py
+++ b/pytest/tests/mocknet/bounce.py
@@ -1,0 +1,25 @@
+# Stop all mocknet nodes, wait 1s, then start all nodes again.
+# Nodes should be responsive again after this operation.
+
+import sys, time
+from rc import pmap
+
+sys.path.append('lib')
+import mocknet
+
+nodes = mocknet.get_nodes()
+
+# stop nodes
+pmap(mocknet.stop_node, nodes)
+
+# wait 1s
+time.sleep(1)
+
+# start nodes
+pmap(mocknet.start_node, nodes)
+
+# give some time to come back up
+time.sleep(5)
+
+# test network still functions
+mocknet.transfer_between_nodes(nodes)

--- a/pytest/tests/mocknet/outage.py
+++ b/pytest/tests/mocknet/outage.py
@@ -10,14 +10,40 @@ sys.path.append('lib')
 import mocknet
 
 nodes = mocknet.get_nodes()
-epoch_length = mocknet.get_epoch_length_in_seconds(nodes[0])
 
-# Nodes 0, 1, 2, and 3 are validators and all have equal stake.
-# We stop node 0, thus stopping 25% of the stake.
-mocknet.stop_node(nodes[0])
+validators = nodes[0].get_validators()['result']
+validator_accounts = set(
+    map(lambda v: v['account_id'], validators['current_validators']))
+# Nodes 0, 1, 2, 3 are initially validators
+assert validator_accounts == {'node0', 'node1', 'node2', 'node3'}
+
+epoch_length = mocknet.get_epoch_length_in_blocks(nodes[0])
 
 # Function to do a transfer, but not using the first node
 check_transfer = lambda: mocknet.transfer_between_nodes(nodes[1:])
+
+
+# Function to wait until a particular block height (used to wait for next epoch to start)
+def wait_until_height(target_height, query_node):
+    while query_node.get_status(
+    )['sync_info']['latest_block_height'] < target_height:
+        time.sleep(5)
+
+
+print('INFO: Starting Outage test.')
+
+# Ensure we start the test closer to the beginning of an epoch than the end.
+current_height = nodes[0].get_status()['sync_info']['latest_block_height']
+if current_height > validators['epoch_start_height'] + (epoch_length / 2):
+    print(
+        'INFO: Presently over half way through epoch, waiting for the next epoch to start'
+    )
+    wait_until_height(validators['epoch_start_height'] + epoch_length + 1,
+                      nodes[0])
+
+# Nodes 0, 1, 2, and 3 all have roughly equal stake.
+# We stop node 0, thus stopping 25% of the stake.
+mocknet.stop_node(nodes[0])
 
 # Wait a moment
 time.sleep(1)
@@ -26,13 +52,22 @@ time.sleep(1)
 check_transfer()
 
 # Wait an epoch
-time.sleep(epoch_length)
+print('INFO: Waiting until next epoch.')
+validators = nodes[1].get_validators()['result']
+wait_until_height(validators['epoch_start_height'] + epoch_length + 1, nodes[1])
 
 # Check the network still functions
 check_transfer()
 
+# Confirm node0 was kicked out for being offline
+validators = nodes[1].get_validators()['result']
+kick_out = validators['prev_epoch_kickout'][0]
+assert kick_out['account_id'] == 'node0'
+assert 'NotEnoughBlocks' in kick_out['reason'].keys()
+
 # Wait another epoch
-time.sleep(epoch_length)
+print('INFO: Waiting until next epoch.')
+wait_until_height(validators['epoch_start_height'] + epoch_length + 1, nodes[1])
 
 # Check the network still functions
 check_transfer()
@@ -45,7 +80,8 @@ time.sleep(5)
 
 # Let the node catch up
 sync_start = time.time()
-sync_timeout = epoch_length
+sync_timeout = 300  # allow up to 5 minutes for syncing
+print('INFO: Waiting for node0 to sync.')
 while nodes[0].get_status()['sync_info']['syncing']:
     if time.time() - sync_start >= sync_timeout:
         raise TimeoutError('nodes[0] seems to be stalled while syncing')
@@ -53,3 +89,19 @@ while nodes[0].get_status()['sync_info']['syncing']:
 
 # Check the node functions by using it as the basis for transfer
 mocknet.transfer_between_nodes(nodes)
+
+# re-stake node0 since it was kicked out
+mocknet.stake_node(nodes[0])
+validators = nodes[0].get_validators()['result']
+print('INFO: Waiting until next epoch.')
+wait_until_height(validators['epoch_start_height'] + epoch_length + 1, nodes[0])
+
+# Confirm node0 will be a validator in the next epoch
+validators = nodes[0].get_validators()['result']
+assert 'node0' in map(lambda v: v['account_id'], validators['next_validators'])
+wait_until_height(validators['epoch_start_height'] + epoch_length + 1, nodes[0])
+
+# Confirm node0 is a validator again
+validators = nodes[0].get_validators()['result']
+assert 'node0' in map(lambda v: v['account_id'],
+                      validators['current_validators'])

--- a/pytest/tests/mocknet/outage.py
+++ b/pytest/tests/mocknet/outage.py
@@ -23,10 +23,10 @@ epoch_length = mocknet.get_epoch_length_in_blocks(nodes[0])
 check_transfer = lambda: mocknet.transfer_between_nodes(nodes[1:])
 
 
-# Function to wait until a particular block height (used to wait for next epoch to start)
-def wait_until_height(target_height, query_node):
-    while query_node.get_status(
-    )['sync_info']['latest_block_height'] < target_height:
+# Function to wait until the next epoch
+def wait_until_next_epoch(current_start_height, query_node):
+    while query_node.get_validators(
+    )['result']['epoch_start_height'] <= current_start_height:
         time.sleep(5)
 
 
@@ -38,8 +38,7 @@ if current_height > validators['epoch_start_height'] + (epoch_length / 2):
     print(
         'INFO: Presently over half way through epoch, waiting for the next epoch to start'
     )
-    wait_until_height(validators['epoch_start_height'] + epoch_length + 1,
-                      nodes[0])
+    wait_until_next_epoch(validators['epoch_start_height'], nodes[0])
 
 # Nodes 0, 1, 2, and 3 all have roughly equal stake.
 # We stop node 0, thus stopping 25% of the stake.
@@ -54,7 +53,7 @@ check_transfer()
 # Wait an epoch
 print('INFO: Waiting until next epoch.')
 validators = nodes[1].get_validators()['result']
-wait_until_height(validators['epoch_start_height'] + epoch_length + 1, nodes[1])
+wait_until_next_epoch(validators['epoch_start_height'], nodes[1])
 
 # Check the network still functions
 check_transfer()
@@ -67,7 +66,7 @@ assert 'NotEnoughBlocks' in kick_out['reason'].keys()
 
 # Wait another epoch
 print('INFO: Waiting until next epoch.')
-wait_until_height(validators['epoch_start_height'] + epoch_length + 1, nodes[1])
+wait_until_next_epoch(validators['epoch_start_height'], nodes[1])
 
 # Check the network still functions
 check_transfer()
@@ -94,14 +93,18 @@ mocknet.transfer_between_nodes(nodes)
 mocknet.stake_node(nodes[0])
 validators = nodes[0].get_validators()['result']
 print('INFO: Waiting until next epoch.')
-wait_until_height(validators['epoch_start_height'] + epoch_length + 1, nodes[0])
+wait_until_next_epoch(validators['epoch_start_height'], nodes[0])
 
 # Confirm node0 will be a validator in the next epoch
 validators = nodes[0].get_validators()['result']
 assert 'node0' in map(lambda v: v['account_id'], validators['next_validators'])
-wait_until_height(validators['epoch_start_height'] + epoch_length + 1, nodes[0])
+print('INFO: node0 in next epoch validator set.')
+print('INFO: Waiting until next epoch.')
+wait_until_next_epoch(validators['epoch_start_height'], nodes[0])
 
 # Confirm node0 is a validator again
 validators = nodes[0].get_validators()['result']
 assert 'node0' in map(lambda v: v['account_id'],
                       validators['current_validators'])
+print('INFO: node0 in current epoch validator set.')
+print('INFO: Outage test complete.')

--- a/pytest/tests/mocknet/outage.py
+++ b/pytest/tests/mocknet/outage.py
@@ -1,0 +1,55 @@
+# Stop fewer than one third of mocknet nodes for two full epochs.
+# During this time the network should continue to function.
+# The stopped nodes are then restarted, should come back up,
+# sync successfully and become operational again.
+
+import sys, time
+from rc import pmap
+
+sys.path.append('lib')
+import mocknet
+
+nodes = mocknet.get_nodes()
+epoch_length = mocknet.get_epoch_length_in_seconds(nodes[0])
+
+# Nodes 0, 1, 2, and 3 are validators and all have equal stake.
+# We stop node 0, thus stopping 25% of the stake.
+mocknet.stop_node(nodes[0])
+
+# Function to do a transfer, but not using the first node
+check_transfer = lambda: mocknet.transfer_between_nodes(nodes[1:])
+
+# Wait a moment
+time.sleep(1)
+
+# Check the network still functions
+check_transfer()
+
+# Wait an epoch
+time.sleep(epoch_length)
+
+# Check the network still functions
+check_transfer()
+
+# Wait another epoch
+time.sleep(epoch_length)
+
+# Check the network still functions
+check_transfer()
+
+# Bring the node back up
+mocknet.start_node(nodes[0])
+
+# Wait a moment
+time.sleep(5)
+
+# Let the node catch up
+sync_start = time.time()
+sync_timeout = epoch_length
+while nodes[0].get_status()['sync_info']['syncing']:
+    if time.time() - sync_start >= sync_timeout:
+        raise TimeoutError('nodes[0] seems to be stalled while syncing')
+    time.sleep(5)
+
+# Check the node functions by using it as the basis for transfer
+mocknet.transfer_between_nodes(nodes)

--- a/pytest/tests/mocknet/sanity.py
+++ b/pytest/tests/mocknet/sanity.py
@@ -6,11 +6,12 @@ import sys, time, random, base58
 
 sys.path.append('lib')
 
-from cluster import connect_to_mocknet
+import mocknet
 from transaction import sign_payment_tx, sign_function_call_tx, sign_deploy_contract_tx
 from utils import load_binary_file
 
-nodes, accounts = connect_to_mocknet(None)
+nodes = mocknet.get_nodes()
+accounts = mocknet.accounts_from_nodes(nodes)
 
 print()
 


### PR DESCRIPTION
Introduces tests which can be setup to run automatically on mocknet. This PR only introduces the tests, the automation will need to be done later as part of our own infrastructure.

The test scenarios include:

* Bounce (take all nodes down, then bring them back up)
* Outage (take < 1/3 nodes down, make sure network continues, then bring nodes back and make sure they sync and the network recovers)