### PR TITLE
refactor: Remove warnings

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2631,7 +2631,6 @@ mod tests {
     use cached::Cached;
     use strum::IntoEnumIterator;
 
-    use near_chain_configs::GenesisConfig;
     use near_crypto::KeyType;
     use near_primitives::block::{Block, Tip};
     use near_primitives::errors::InvalidTxError;
@@ -2643,11 +2642,12 @@ mod tests {
 
     use crate::chain::check_refcount_map;
     use crate::store::{ChainStoreAccess, GCMode};
-    use crate::store_validator::StoreValidator;
     use crate::test_utils::KeyValueRuntime;
     use crate::{Chain, ChainGenesis, DoomslugThresholdMode};
 
     use near_store::DBCol;
+    #[cfg(feature = "expensive_tests")]
+    use {crate::store_validator::StoreValidator, near_chain_configs::GenesisConfig};
 
     fn get_chain() -> Chain {
         get_chain_with_epoch_length(10)
@@ -3016,6 +3016,7 @@ mod tests {
         test_clear_old_data_too_many_heights_common(87);
     }
 
+    #[cfg(feature = "expensive_tests")]
     fn test_clear_old_data_too_many_heights_common(gc_blocks_limit: NumBlocks) {
         let mut chain = get_chain_with_epoch_length(1);
         let genesis = chain.get_block_by_height(0).unwrap().clone();

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1412,21 +1412,25 @@ impl ShardsManager {
 mod test {
     use crate::test_utils::SealsManagerTestFixture;
     use crate::{
-        ChunkRequestInfo, Seal, SealsManager, ShardsManager, ACCEPTING_SEAL_PERIOD_MS,
-        CHUNK_REQUEST_RETRY_MS, NUM_PARTS_REQUESTED_IN_SEAL, PAST_SEAL_HEIGHT_HORIZON,
+        ChunkRequestInfo, Seal, SealsManager, ShardsManager, CHUNK_REQUEST_RETRY_MS,
+        NUM_PARTS_REQUESTED_IN_SEAL, PAST_SEAL_HEIGHT_HORIZON,
     };
     use near_chain::test_utils::KeyValueRuntime;
-    use near_chain::{ChainStore, RuntimeAdapter};
-    use near_crypto::KeyType;
-    use near_logger_utils::init_test_logger;
     use near_network::test_utils::MockNetworkAdapter;
-    use near_primitives::hash::{hash, CryptoHash};
-    use near_primitives::merkle::merklize;
-    use near_primitives::sharding::{ChunkHash, ReedSolomonWrapper};
-    use near_primitives::validator_signer::InMemoryValidatorSigner;
+    use near_primitives::hash::hash;
+    use near_primitives::sharding::ChunkHash;
     use near_store::test_utils::create_test_store;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
+
+    #[cfg(feature = "expensive_tests")]
+    use {
+        crate::ACCEPTING_SEAL_PERIOD_MS, near_chain::ChainStore, near_chain::RuntimeAdapter,
+        near_crypto::KeyType, near_logger_utils::init_test_logger,
+        near_primitives::hash::CryptoHash, near_primitives::merkle::merklize,
+        near_primitives::sharding::ReedSolomonWrapper,
+        near_primitives::validator_signer::InMemoryValidatorSigner,
+    };
 
     /// should not request partial encoded chunk from self
     #[test]


### PR DESCRIPTION
Remove warning about unused code because some `uses` were only used behind feature flag `expensive_test`. 

Test plan
=======
- `cargo check --all --tests --benches` pass with no warnings.
- `cargo check --all --tests --benches --features expensive_tests` pass with no warnings.