### PR TITLE
fix(catchup tests): increasing block_prod_time

### DIFF
--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -437,7 +437,7 @@ mod tests {
                 key_pairs.clone(),
                 validator_groups,
                 true,
-                1800,
+                3500,
                 false,
                 false,
                 5,
@@ -600,7 +600,7 @@ mod tests {
             );
             *connectors.write().unwrap() = conn;
 
-            near_network::test_utils::wait_or_panic(240000);
+            near_network::test_utils::wait_or_panic(480000);
         })
         .unwrap();
     }


### PR DESCRIPTION
Fixes #2866.

According to https://github.com/nearprotocol/nearcore/issues/2866#issuecomment-646727726, it should be enough to increase `block_prod_time`.

The issue of incorrect [PASSED] test marks in Nightly should be resolved separately.