### PR TITLE
feat(RPC): Add burnt amount to ExecutionOutcome

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -629,7 +629,7 @@ impl RuntimeAdapter for KeyValueRuntime {
                         logs: vec![],
                         receipt_ids: new_receipt_hashes,
                         gas_burnt: 0,
-                        amount_burnt: 0,
+                        tokens_burnt: 0,
                     },
                 });
             }

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -629,6 +629,7 @@ impl RuntimeAdapter for KeyValueRuntime {
                         logs: vec![],
                         receipt_ids: new_receipt_hashes,
                         gas_burnt: 0,
+                        amount_burnt: 0,
                     },
                 });
             }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -580,6 +580,7 @@ mod tests {
                 logs: vec!["outcome1".to_string()],
                 receipt_ids: vec![hash(&[1])],
                 gas_burnt: 100,
+                amount_burnt: 10000,
             },
         };
         let outcome2 = ExecutionOutcomeWithId {
@@ -589,6 +590,7 @@ mod tests {
                 logs: vec!["outcome2".to_string()],
                 receipt_ids: vec![],
                 gas_burnt: 0,
+                amount_burnt: 0,
             },
         };
         let outcomes = vec![outcome1, outcome2];

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -580,7 +580,7 @@ mod tests {
                 logs: vec!["outcome1".to_string()],
                 receipt_ids: vec![hash(&[1])],
                 gas_burnt: 100,
-                amount_burnt: 10000,
+                tokens_burnt: 10000,
             },
         };
         let outcome2 = ExecutionOutcomeWithId {
@@ -590,7 +590,7 @@ mod tests {
                 logs: vec!["outcome2".to_string()],
                 receipt_ids: vec![],
                 gas_burnt: 0,
-                amount_burnt: 0,
+                tokens_burnt: 0,
             },
         };
         let outcomes = vec![outcome1, outcome2];

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -234,7 +234,7 @@ struct PartialExecutionOutcome {
     pub receipt_ids: Vec<CryptoHash>,
     pub gas_burnt: Gas,
     #[serde(with = "u128_dec_format")]
-    pub amount_burnt: Balance,
+    pub tokens_burnt: Balance,
     pub status: PartialExecutionStatus,
 }
 
@@ -270,7 +270,7 @@ pub struct ExecutionOutcome {
     /// The amount of tokens burnt corresponding to the burnt gas amount.
     /// This value doesn't always equal to the `gas_burnt` multiplied by the gas price, because
     /// the prepaid gas price might be lower than the actual gas price and it creates a deficit.
-    pub amount_burnt: Balance,
+    pub tokens_burnt: Balance,
     /// Execution status. Contains the result in case of successful execution.
     /// NOTE: Should be the latest field since it contains unparsable by light client
     /// ExecutionStatus::Failure
@@ -283,7 +283,7 @@ impl ExecutionOutcome {
             &PartialExecutionOutcome {
                 receipt_ids: self.receipt_ids.clone(),
                 gas_burnt: self.gas_burnt,
-                amount_burnt: self.amount_burnt,
+                tokens_burnt: self.tokens_burnt,
                 status: self.status.clone().into(),
             }
             .try_to_vec()
@@ -302,7 +302,7 @@ impl fmt::Debug for ExecutionOutcome {
             .field("logs", &format_args!("{}", logging::pretty_vec(&self.logs)))
             .field("receipt_ids", &format_args!("{}", logging::pretty_vec(&self.receipt_ids)))
             .field("burnt_gas", &self.gas_burnt)
-            .field("amount_burnt", &self.amount_burnt)
+            .field("tokens_burnt", &self.tokens_burnt)
             .field("status", &self.status)
             .finish()
     }
@@ -443,7 +443,7 @@ mod tests {
             logs: vec!["123".to_string(), "321".to_string()],
             receipt_ids: vec![],
             gas_burnt: 123,
-            amount_burnt: 1234000,
+            tokens_burnt: 1234000,
         };
         let hashes = outcome.to_hashes();
         assert_eq!(hashes.len(), 3);

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -12,7 +12,7 @@ use crate::errors::TxExecutionError;
 use crate::hash::{hash, CryptoHash};
 use crate::logging;
 use crate::merkle::MerklePath;
-use crate::serialize::{base64_format, u128_dec_format_compatible};
+use crate::serialize::{base64_format, u128_dec_format, u128_dec_format_compatible};
 use crate::types::{AccountId, Balance, Gas, Nonce};
 
 pub type LogEntry = String;
@@ -233,6 +233,8 @@ impl Default for ExecutionStatus {
 struct PartialExecutionOutcome {
     pub receipt_ids: Vec<CryptoHash>,
     pub gas_burnt: Gas,
+    #[serde(with = "u128_dec_format")]
+    pub amount_burnt: Balance,
     pub status: PartialExecutionStatus,
 }
 
@@ -265,8 +267,13 @@ pub struct ExecutionOutcome {
     pub receipt_ids: Vec<CryptoHash>,
     /// The amount of the gas burnt by the given transaction or receipt.
     pub gas_burnt: Gas,
+    /// The amount of tokens burnt corresponding to the burnt gas amount.
+    /// This value doesn't always equal to the `gas_burnt` multiplied by the gas price, because
+    /// the prepaid gas price might be lower than the actual gas price and it creates a deficit.
+    pub amount_burnt: Balance,
     /// Execution status. Contains the result in case of successful execution.
-    /// Should be the latest field since contains unparsable by light client ExecutionStatus::Failure
+    /// NOTE: Should be the latest field since it contains unparsable by light client
+    /// ExecutionStatus::Failure
     pub status: ExecutionStatus,
 }
 
@@ -276,6 +283,7 @@ impl ExecutionOutcome {
             &PartialExecutionOutcome {
                 receipt_ids: self.receipt_ids.clone(),
                 gas_burnt: self.gas_burnt,
+                amount_burnt: self.amount_burnt,
                 status: self.status.clone().into(),
             }
             .try_to_vec()
@@ -294,6 +302,7 @@ impl fmt::Debug for ExecutionOutcome {
             .field("logs", &format_args!("{}", logging::pretty_vec(&self.logs)))
             .field("receipt_ids", &format_args!("{}", logging::pretty_vec(&self.receipt_ids)))
             .field("burnt_gas", &self.gas_burnt)
+            .field("amount_burnt", &self.amount_burnt)
             .field("status", &self.status)
             .finish()
     }
@@ -434,6 +443,7 @@ mod tests {
             logs: vec!["123".to_string(), "321".to_string()],
             receipt_ids: vec![],
             gas_burnt: 123,
+            amount_burnt: 1234000,
         };
         let hashes = outcome.to_hashes();
         assert_eq!(hashes.len(), 3);

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -17,6 +17,6 @@ pub const DB_VERSION: DbVersion = 2;
 pub type ProtocolVersion = u32;
 
 /// Current latest version of the protocol.
-pub const PROTOCOL_VERSION: ProtocolVersion = 26;
+pub const PROTOCOL_VERSION: ProtocolVersion = 27;
 
 pub const FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = PROTOCOL_VERSION;

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -804,7 +804,7 @@ pub struct ExecutionOutcomeView {
     /// This value doesn't always equal to the `gas_burnt` multiplied by the gas price, because
     /// the prepaid gas price might be lower than the actual gas price and it creates a deficit.
     #[serde(with = "u128_dec_format")]
-    pub amount_burnt: Balance,
+    pub tokens_burnt: Balance,
     /// Execution status. Contains the result in case of successful execution.
     pub status: ExecutionStatusView,
 }
@@ -815,7 +815,7 @@ impl From<ExecutionOutcome> for ExecutionOutcomeView {
             logs: outcome.logs,
             receipt_ids: outcome.receipt_ids,
             gas_burnt: outcome.gas_burnt,
-            amount_burnt: outcome.amount_burnt,
+            tokens_burnt: outcome.tokens_burnt,
             status: outcome.status.into(),
         }
     }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -800,6 +800,11 @@ pub struct ExecutionOutcomeView {
     pub receipt_ids: Vec<CryptoHash>,
     /// The amount of the gas burnt by the given transaction or receipt.
     pub gas_burnt: Gas,
+    /// The amount of tokens burnt corresponding to the burnt gas amount.
+    /// This value doesn't always equal to the `gas_burnt` multiplied by the gas price, because
+    /// the prepaid gas price might be lower than the actual gas price and it creates a deficit.
+    #[serde(with = "u128_dec_format")]
+    pub amount_burnt: Balance,
     /// Execution status. Contains the result in case of successful execution.
     pub status: ExecutionStatusView,
 }
@@ -810,6 +815,7 @@ impl From<ExecutionOutcome> for ExecutionOutcomeView {
             logs: outcome.logs,
             receipt_ids: outcome.receipt_ids,
             gas_burnt: outcome.gas_burnt,
+            amount_burnt: outcome.amount_burnt,
             status: outcome.status.into(),
         }
     }

--- a/neard/res/genesis_config.json
+++ b/neard/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 26,
+  "protocol_version": 27,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -465,7 +465,7 @@ fn outcome_view_to_hashes(outcome: &ExecutionOutcomeView) -> Vec<CryptoHash> {
         ExecutionStatusView::SuccessReceiptId(id) => PartialExecutionStatus::SuccessReceiptId(*id),
     };
     let mut result = vec![hash(
-        &(outcome.receipt_ids.clone(), outcome.gas_burnt, status)
+        &(outcome.receipt_ids.clone(), outcome.gas_burnt, outcome.amount_burnt, status)
             .try_to_vec()
             .expect("Failed to serialize"),
     )];

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -465,7 +465,7 @@ fn outcome_view_to_hashes(outcome: &ExecutionOutcomeView) -> Vec<CryptoHash> {
         ExecutionStatusView::SuccessReceiptId(id) => PartialExecutionStatus::SuccessReceiptId(*id),
     };
     let mut result = vec![hash(
-        &(outcome.receipt_ids.clone(), outcome.gas_burnt, outcome.amount_burnt, status)
+        &(outcome.receipt_ids.clone(), outcome.gas_burnt, outcome.tokens_burnt, status)
             .try_to_vec()
             .expect("Failed to serialize"),
     )];

--- a/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
+++ b/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
@@ -41,6 +41,7 @@ partial_execution_outcome_schema = dict([
         'fields': [
             ['receipt_ids', [[32]]],
             ['gas_burnt', 'u64'],
+            ['amount_burnt', 'u128'],
             ['status', PartialExecutionStatus],
         ]
     },
@@ -76,6 +77,7 @@ def serialize_execution_outcome_with_id(outcome, id):
     partial_outcome = PartialExecutionOutcome()
     partial_outcome.receipt_ids = [base58.b58decode(x) for x in outcome['receipt_ids']]
     partial_outcome.gas_burnt = outcome['gas_burnt']
+    partial_outcome.amount_burnt = int(outcome['amount_burnt'])
     execution_status = PartialExecutionStatus()
     if 'SuccessValue' in outcome['status']:
         execution_status.enum = 'successValue'
@@ -131,7 +133,7 @@ def check_transaction_outcome_proof(should_succeed, nonce):
     status = nodes[1].get_status()
     latest_block_hash = status['sync_info']['latest_block_hash']
     function_caller_key = nodes[0].signer_key
-    gas = 10000000000000000 if should_succeed else 1000
+    gas = 300000000000000 if should_succeed else 1000
 
     function_call_1_tx = transaction.sign_function_call_tx(
         function_caller_key, contract_key.account_id, 'setKeyValue',

--- a/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
+++ b/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
@@ -41,7 +41,7 @@ partial_execution_outcome_schema = dict([
         'fields': [
             ['receipt_ids', [[32]]],
             ['gas_burnt', 'u64'],
-            ['amount_burnt', 'u128'],
+            ['tokens_burnt', 'u128'],
             ['status', PartialExecutionStatus],
         ]
     },
@@ -77,7 +77,7 @@ def serialize_execution_outcome_with_id(outcome, id):
     partial_outcome = PartialExecutionOutcome()
     partial_outcome.receipt_ids = [base58.b58decode(x) for x in outcome['receipt_ids']]
     partial_outcome.gas_burnt = outcome['gas_burnt']
-    partial_outcome.amount_burnt = int(outcome['amount_burnt'])
+    partial_outcome.tokens_burnt = int(outcome['tokens_burnt'])
     execution_status = PartialExecutionStatus()
     if 'SuccessValue' in outcome['status']:
         execution_status.enum = 'successValue'

--- a/pytest/tests/sanity/rpc_state_changes.py
+++ b/pytest/tests/sanity/rpc_state_changes.py
@@ -430,7 +430,7 @@ def test_key_value_changes():
             json.dumps({
                 "key": "my_key",
                 "value": "my_value_1"
-            }).encode('utf-8'), 10000000000000000, 100000000000, 20,
+            }).encode('utf-8'), 300000000000000, 100000000000, 20,
             base58.b58decode(latest_block_hash.encode('utf8')))
         nodes[1].send_tx_and_wait(function_call_1_tx, 10)
 
@@ -442,7 +442,7 @@ def test_key_value_changes():
         json.dumps({
             "key": "my_key",
             "value": "my_value_2"
-        }).encode('utf-8'), 10000000000000000, 100000000000, 30,
+        }).encode('utf-8'), 300000000000000, 100000000000, 30,
         base58.b58decode(latest_block_hash.encode('utf8')))
     function_call_2_response = nodes[1].send_tx_and_wait(function_call_2_tx, 10)
     assert function_call_2_response['result']['receipts_outcome'][0]['outcome']['status'] == {'SuccessValue': ''}, \

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -550,6 +550,9 @@ impl Runtime {
         // `gas_deficit_amount` is strictly less than `gas_price * gas_burnt`.
         let mut tx_burnt_amount =
             safe_gas_to_balance(apply_state.gas_price, result.gas_burnt)? - gas_deficit_amount;
+        // The amount of tokens burnt for the execution of this receipt. It's used in the execution
+        // outcome.
+        let amount_burnt = tx_burnt_amount;
 
         // Adding burnt gas reward for function calls if the account exists.
         let receiver_gas_reward = result.gas_burnt_for_function_call
@@ -656,7 +659,7 @@ impl Runtime {
                 logs: result.logs,
                 receipt_ids,
                 gas_burnt: result.gas_burnt,
-                amount_burnt: tx_burnt_amount + receiver_reward,
+                amount_burnt,
             },
         })
     }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -259,6 +259,7 @@ impl Runtime {
                         logs: vec![],
                         receipt_ids: vec![receipt.receipt_id],
                         gas_burnt: verification_result.gas_burnt,
+                        amount_burnt: verification_result.burnt_amount,
                     },
                 };
                 Ok((receipt, outcome))
@@ -655,6 +656,7 @@ impl Runtime {
                 logs: result.logs,
                 receipt_ids,
                 gas_burnt: result.gas_burnt,
+                amount_burnt: tx_burnt_amount + receiver_reward,
             },
         })
     }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -259,7 +259,7 @@ impl Runtime {
                         logs: vec![],
                         receipt_ids: vec![receipt.receipt_id],
                         gas_burnt: verification_result.gas_burnt,
-                        amount_burnt: verification_result.burnt_amount,
+                        tokens_burnt: verification_result.burnt_amount,
                     },
                 };
                 Ok((receipt, outcome))
@@ -552,7 +552,7 @@ impl Runtime {
             safe_gas_to_balance(apply_state.gas_price, result.gas_burnt)? - gas_deficit_amount;
         // The amount of tokens burnt for the execution of this receipt. It's used in the execution
         // outcome.
-        let amount_burnt = tx_burnt_amount;
+        let tokens_burnt = tx_burnt_amount;
 
         // Adding burnt gas reward for function calls if the account exists.
         let receiver_gas_reward = result.gas_burnt_for_function_call
@@ -659,7 +659,7 @@ impl Runtime {
                 logs: result.logs,
                 receipt_ids,
                 gas_burnt: result.gas_burnt,
-                amount_burnt,
+                tokens_burnt,
             },
         })
     }

--- a/scripts/migrations/27-add-amount-burnt-to-execution-outcome.py
+++ b/scripts/migrations/27-add-amount-burnt-to-execution-outcome.py
@@ -1,0 +1,19 @@
+"""
+Adding `burnt_amount` to `ExecutionOutcome`, `PartialExecutionOutcome`, `FinalExecutionOutcome` and views.
+"""
+
+import sys
+import os
+import json
+from collections import OrderedDict
+
+home = sys.argv[1]
+output_home = sys.argv[2]
+
+config = json.load(open(os.path.join(home, 'output.json')), object_pairs_hook=OrderedDict)
+
+assert config['protocol_version'] == 26
+
+config['protocol_version'] = 27
+
+json.dump(config, open(os.path.join(output_home, 'output.json'), 'w'), indent=2)


### PR DESCRIPTION
Because of the variable gas pricing during the execution the `gas_burnt` is not enough anymore to determine the amount of fees that was used for the given transaction execution. We need to expose the `tokens_burnt` which returns the actual amount that was used for the TX/receipt execution fees.

Bumping protocol version, because it changes the spec.

# Test plan:
- CI  