### PR TITLE
fix: Return experimental endpoint for `light_client_proof` RPC

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -227,6 +227,9 @@ impl JsonRpcHandler {
             "EXPERIMENTAL_changes" => self.changes_in_block_by_type(request.params).await,
             "EXPERIMENTAL_changes_in_block" => self.changes_in_block(request.params).await,
             "next_light_client_block" => self.next_light_client_block(request.params).await,
+            "EXPERIMENTAL_light_client_proof" => {
+                self.light_client_execution_outcome_proof(request.params).await
+            }
             "light_client_proof" => self.light_client_execution_outcome_proof(request.params).await,
             "network_info" => self.network_info().await,
             "gas_price" => self.gas_price(request.params).await,


### PR DESCRIPTION
Otherwise the current nearlib tests are failing, because they still depend on the `EXPERIMENTAL_light_client_proof`.
The proper migration should be first introducing `light_client_proof` then moving nearlib API to the new RPC endpoint. And once all chains are upgraded to the new endpoint, only then the EXPERIMENTAL endpoint can be deprecated.

# Test plan:
- CI 
