### PR TITLE
fix: persist chunk tail

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2249,6 +2249,11 @@ impl<'a> ChainStoreUpdate<'a> {
                 .set_ser(ColBlockMisc, LARGEST_TARGET_HEIGHT_KEY, &t)
                 .map_err::<Error, _>(|e| e.into())?;
         }
+        if let Some(chunk_tail) = self.chunk_tail {
+            store_update
+                .set_ser(ColBlockMisc, CHUNK_TAIL_KEY, &chunk_tail)
+                .map_err::<Error, _>(|e| e.into())?;
+        }
         for (hash, block) in self.chain_store_cache_update.blocks.iter() {
             let mut map =
                 match self.chain_store.get_all_block_hashes_by_height(block.header().height()) {

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2244,12 +2244,12 @@ impl<'a> ChainStoreUpdate<'a> {
                 .set_ser(ColBlockMisc, SYNC_HEAD_KEY, &t)
                 .map_err::<Error, _>(|e| e.into())?;
         }
-        if let Some(t) = self.largest_target_height {
+        if let Some(t) = self.largest_target_height.take() {
             store_update
                 .set_ser(ColBlockMisc, LARGEST_TARGET_HEIGHT_KEY, &t)
                 .map_err::<Error, _>(|e| e.into())?;
         }
-        if let Some(chunk_tail) = self.chunk_tail {
+        if let Some(chunk_tail) = self.chunk_tail.take() {
             store_update
                 .set_ser(ColBlockMisc, CHUNK_TAIL_KEY, &chunk_tail)
                 .map_err::<Error, _>(|e| e.into())?;

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -264,7 +264,7 @@ pub(crate) fn chunk_tail_validity(
     check_cached!(sv.inner.is_misc_set, "misc");
     let chunk_tail = sv.inner.chunk_tail;
     let height = shard_chunk.header.inner.height_created;
-    if height < chunk_tail {
+    if height != sv.config.genesis_height && height < chunk_tail {
         err!(
             "Invalid ShardChunk stored, chunk_tail = {:?}, ShardChunk = {:?}",
             chunk_tail,

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -111,16 +111,24 @@ macro_rules! unwrap_or_err_db {
 // All validations start here
 
 pub(crate) fn head_tail_validity(sv: &mut StoreValidator) -> Result<(), StoreValidatorError> {
-    let tail = unwrap_or_err!(
+    let mut tail = sv.config.genesis_height;
+    let mut chunk_tail = sv.config.genesis_height;
+    let tail_db = unwrap_or_err!(
         sv.store.get_ser::<BlockHeight>(ColBlockMisc, TAIL_KEY),
         "Can't get Tail from storage"
-    )
-    .unwrap_or(sv.config.genesis_height);
-    let chunk_tail = unwrap_or_err!(
+    );
+    let chunk_tail_db = unwrap_or_err!(
         sv.store.get_ser::<BlockHeight>(ColBlockMisc, CHUNK_TAIL_KEY),
         "Can't get Chunk Tail from storage"
-    )
-    .unwrap_or(sv.config.genesis_height);
+    );
+    if tail_db.is_none() && chunk_tail_db.is_some() || tail_db.is_some() && chunk_tail_db.is_none()
+    {
+        err!("Tail is {:?} and Chunk Tail is {:?}", tail_db, chunk_tail_db);
+    }
+    if tail_db.is_some() && chunk_tail_db.is_some() {
+        tail = tail_db.unwrap();
+        chunk_tail = chunk_tail_db.unwrap();
+    }
     let head = unwrap_or_err_db!(
         sv.store.get_ser::<Tip>(ColBlockMisc, HEAD_KEY),
         "Can't get Head from storage"

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -788,6 +788,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
                 .is_ok());
         }
     }
+    assert_eq!(env.clients[0].chain.store().chunk_tail().unwrap(), epoch_length - 1);
     assert!(check_refcount_map(&mut env.clients[0].chain).is_ok());
 }
 


### PR DESCRIPTION
Garbage collection is slow because we do not persist chunk tail and therefore `clear_chunk_data` iterates from 0 to min_chunk_height every time it is called. Fixes #2806.