### PR TITLE
Fix(test): fix path error in backward compatible

### DIFF
--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -24,7 +24,7 @@ def main():
 
     # near_root, (stable_branch,
     #             current_branch) = branches.prepare_ab_test("beta")
-    (near_root, (stable_branch, current_branch)) = ('../target/debug', ('beta', 'upgradability'))
+    (near_root, (stable_branch, current_branch)) = ('../target/debug/', ('beta', 'upgradability'))
 
     # Setup local network.
     subprocess.call([

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -22,9 +22,8 @@ def main():
         shutil.rmtree(node_root)
     subprocess.check_output('mkdir -p /tmp/near', shell=True)
 
-    # near_root, (stable_branch,
-    #             current_branch) = branches.prepare_ab_test("beta")
-    (near_root, (stable_branch, current_branch)) = ('../target/debug/', ('beta', 'upgradability'))
+    near_root, (stable_branch,
+                current_branch) = branches.prepare_ab_test("beta")
 
     # Setup local network.
     subprocess.call([


### PR DESCRIPTION
backward compatible was failing because binary not build

Test Plan
---------
backward compatible test should pass. Note, backward_compatible with beta currently still fails, because it's not backward compatible, backward_compatible with master is passing as expected