### PR TITLE
feat(config): run metrics in different port

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -66,9 +66,15 @@ impl Default for RpcPollingConfig {
     }
 }
 
+fn default_metrics_addr() -> String {
+    "0.0.0.0:3030".to_owned()
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct RpcConfig {
     pub addr: String,
+    #[serde(default = "default_metrics_addr")]
+    pub metrics_addr: String,
     pub cors_allowed_origins: Vec<String>,
     pub polling_config: RpcPollingConfig,
 }
@@ -77,6 +83,7 @@ impl Default for RpcConfig {
     fn default() -> Self {
         RpcConfig {
             addr: "0.0.0.0:3030".to_owned(),
+            metrics_addr: "0.0.0.0:3030".to_owned(),
             cors_allowed_origins: vec!["*".to_owned()],
             polling_config: Default::default(),
         }
@@ -842,9 +849,34 @@ pub fn start_http(
     client_addr: Addr<ClientActor>,
     view_client_addr: Addr<ViewClientActor>,
 ) {
-    let RpcConfig { addr, polling_config, cors_allowed_origins } = config;
+    let RpcConfig { addr, metrics_addr, polling_config, cors_allowed_origins } = config;
+    let same_addr = addr == metrics_addr;
+    if !same_addr {
+        let client_addr = client_addr.clone();
+        let view_client_addr = view_client_addr.clone();
+        let polling_config = polling_config.clone();
+        let genesis = Arc::clone(&genesis);
+
+        HttpServer::new(move || {
+            App::new()
+                .wrap(middleware::Logger::default())
+                .data(JsonRpcHandler {
+                    client_addr: client_addr.clone(),
+                    view_client_addr: view_client_addr.clone(),
+                    polling_config,
+                    genesis: Arc::clone(&genesis),
+                })
+                .app_data(web::JsonConfig::default().limit(JSON_PAYLOAD_MAX_SIZE))
+                .service(web::resource("/metrics").route(web::get().to(prometheus_handler)))
+        })
+        .bind(metrics_addr)
+        .unwrap()
+        .workers(1)
+        .shutdown_timeout(5)
+        .run();
+    }
     HttpServer::new(move || {
-        App::new()
+        let app = App::new()
             .wrap(get_cors(&cors_allowed_origins))
             .data(JsonRpcHandler {
                 client_addr: client_addr.clone(),
@@ -865,8 +897,12 @@ pub fn start_http(
                     .route(web::get().to(health_handler))
                     .route(web::head().to(health_handler)),
             )
-            .service(web::resource("/network_info").route(web::get().to(network_info_handler)))
-            .service(web::resource("/metrics").route(web::get().to(prometheus_handler)))
+            .service(web::resource("/network_info").route(web::get().to(network_info_handler)));
+        if same_addr {
+            app.service(web::resource("/metrics").route(web::get().to(prometheus_handler)))
+        } else {
+            app
+        }
     })
     .bind(addr)
     .unwrap()

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -92,7 +92,7 @@ impl Default for RpcConfig {
 
 impl RpcConfig {
     pub fn new(addr: &str) -> Self {
-        RpcConfig { addr: addr.to_owned(), ..Default::default() }
+        RpcConfig { addr: addr.to_owned(), metrics_addr: addr.to_owned(), ..Default::default() }
     }
 }
 

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -925,6 +925,7 @@ pub fn load_test_config(seed: &str, port: u16, genesis: Arc<Genesis>) -> NearCon
     let mut config = Config::default();
     config.network.addr = format!("0.0.0.0:{}", port);
     config.rpc.addr = format!("0.0.0.0:{}", open_port());
+    config.rpc.metrics_addr = config.rpc.addr.clone();
     config.consensus.min_block_production_delay =
         Duration::from_millis(FAST_MIN_BLOCK_PRODUCTION_DELAY);
     config.consensus.max_block_production_delay =


### PR DESCRIPTION
Fix #2825 

Test Plan
---------
- current config shouldn't panic with this change
- set metrics_addr to another port should host /metrics in another port, /status etc. should still available in current port