### PR TITLE
fix: Ban peers that try to send very large message

### DIFF
--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -4,7 +4,9 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use bytes::{Buf, BufMut, BytesMut};
 use tokio_util::codec::{Decoder, Encoder};
 
-use crate::types::PeerMessage;
+use crate::types::{PeerMessage, ReasonForBan};
+
+const NETWORK_MESSAGE_MAX_SIZE: u32 = 16 << 20; // 16MB
 
 pub struct Codec {
     max_length: u32,
@@ -13,7 +15,7 @@ pub struct Codec {
 #[allow(clippy::new_without_default)]
 impl Codec {
     pub fn new() -> Self {
-        Codec { max_length: std::u32::MAX }
+        Codec { max_length: NETWORK_MESSAGE_MAX_SIZE }
     }
 }
 
@@ -35,22 +37,29 @@ impl Encoder for Codec {
 }
 
 impl Decoder for Codec {
-    type Item = Vec<u8>;
+    type Item = Result<Vec<u8>, ReasonForBan>;
     type Error = Error;
 
-    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Vec<u8>>, Error> {
+    fn decode(&mut self, buf: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
         if buf.len() < 4 {
             // not enough bytes to start decoding
             return Ok(None);
         }
+
         let mut len_bytes: [u8; 4] = [0; 4];
         len_bytes.copy_from_slice(&buf[0..4]);
         let len = u32::from_le_bytes(len_bytes);
+
+        if len > self.max_length {
+            // If this point is reached, abusive peer is banned.
+            return Ok(Some(Err(ReasonForBan::Abusive)));
+        }
+
         if buf.len() < 4 + len as usize {
             // not enough bytes, keep waiting
             Ok(None)
         } else {
-            let res = Some(buf[4..4 + len as usize].to_vec());
+            let res = Some(Ok(buf[4..4 + len as usize].to_vec()));
             buf.advance(4 + len as usize);
             Ok(res)
         }
@@ -85,7 +94,7 @@ mod test {
         let mut codec = Codec::new();
         let mut buffer = BytesMut::new();
         codec.encode(peer_message_to_bytes(msg.clone()).unwrap(), &mut buffer).unwrap();
-        let decoded = codec.decode(&mut buffer).unwrap().unwrap();
+        let decoded = codec.decode(&mut buffer).unwrap().unwrap().unwrap();
         assert_eq!(bytes_to_peer_message(&decoded).unwrap(), msg);
     }
 
@@ -148,7 +157,7 @@ mod test {
                 account_id: "test2".to_string(),
                 inner: ApprovalInner::Endorsement(CryptoHash::default()),
                 target_height: 1,
-                signature: signature,
+                signature,
             }),
         });
         test_codec(msg);
@@ -160,5 +169,23 @@ mod test {
         let enc = account_id.as_bytes();
         let dec_account_id = String::from_utf8_lossy(enc).to_string();
         assert_eq!(account_id, dec_account_id);
+    }
+
+    #[test]
+    fn test_abusive() {
+        let mut codec = Codec::new();
+        let mut buffer = BytesMut::new();
+        buffer.reserve(4);
+        buffer.put_u32_le(NETWORK_MESSAGE_MAX_SIZE + 1);
+        assert_eq!(codec.decode(&mut buffer).unwrap(), Some(Err(ReasonForBan::Abusive)));
+    }
+
+    #[test]
+    fn test_not_abusive() {
+        let mut codec = Codec::new();
+        let mut buffer = BytesMut::new();
+        buffer.reserve(4);
+        buffer.put_u32_le(NETWORK_MESSAGE_MAX_SIZE);
+        assert_ne!(codec.decode(&mut buffer).unwrap(), Some(Err(ReasonForBan::Abusive)));
     }
 }

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -6,7 +6,7 @@ use tokio_util::codec::{Decoder, Encoder};
 
 use crate::types::{PeerMessage, ReasonForBan};
 
-const NETWORK_MESSAGE_MAX_SIZE: u32 = 16 << 20; // 16MB
+const NETWORK_MESSAGE_MAX_SIZE: u32 = 512 << 20; // 512MB
 
 pub struct Codec {
     max_length: u32,

--- a/pytest/tests/sanity/large_messages.py
+++ b/pytest/tests/sanity/large_messages.py
@@ -5,10 +5,10 @@ sys.path.append('lib')
 
 from cluster import start_cluster
 
-BUFFER_LEN = 16 * 1024 * 1024
-N_PROCESSES = 10
+PACKAGE_LEN = 16 * 1024 * 1024
+N_PROCESSES = 16
 
-buf = bytes([0] * BUFFER_LEN)
+buf = bytes([0] * PACKAGE_LEN)
 
 nodes = start_cluster(2, 0, 4, None, [], {})
 
@@ -18,10 +18,10 @@ def one_process(ord_, seconds):
     sent = 0
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.connect(nodes[0].addr())
-        s.send(struct.pack('I', 2**31 - 1))
         while time.time() - started < seconds:
+            s.send(struct.pack('I', PACKAGE_LEN))
             s.send(buf)
-            sent += BUFFER_LEN
+            sent += PACKAGE_LEN
             print("PROCESS %s SENT %s BYTES" % (ord_, sent))
 
 

--- a/pytest/tests/sanity/network_drop_package.py
+++ b/pytest/tests/sanity/network_drop_package.py
@@ -1,0 +1,37 @@
+import sys, time, random
+import multiprocessing
+
+sys.path.append('lib')
+
+from cluster import start_cluster
+from proxy import proxify_node
+from peer import *
+
+from multiprocessing import Value
+
+TIMEOUT = 90
+success = Value('i', 0)
+
+# Ratio of message that are dropped to simulate bad network performance
+DROP_RATIO = 0.05
+
+
+def handler(msg, fr, to):
+    if msg.enum == 'Block':
+        print('Block height:', msg.Block.BlockV1.header.BlockHeaderV1.inner_lite.height)
+        if msg.Block.BlockV1.header.BlockHeaderV1.inner_lite.height >= 10:
+            print('SUCCESS')
+            success.value = 1
+    return random.random() > DROP_RATIO
+
+
+start_cluster(4, 0, 1, None, [], {}, handler)
+
+started = time.time()
+
+while True:
+    assert time.time() - started < TIMEOUT
+    time.sleep(1)
+
+    if success.value == 1:
+        break


### PR DESCRIPTION
When a peer sends a message with a header indicating that
it is sending a message larger than the limit it is banned.
And the connection is dropped. Otherwise honest node was
keeping a huge cache with all information that is probably
garbage.

Test plan
=========

* Unit tests in codec
* large_message.py sends trash message on this threshold.
  If message were one byte larger connection would be dropped
  immediatelly. This case is already covered by previous unit tests.

test: Dropping messages

* Tests were message were 5% of messages was randomly being dropped
  and check that nodes are able to make progress (produce blocks)