### PR TITLE
fix: Use prometheus naming conventions for metrics

### DIFF
--- a/chain/chain/src/metrics.rs
+++ b/chain/chain/src/metrics.rs
@@ -5,22 +5,24 @@ use near_metrics::{
 
 lazy_static! {
     pub static ref BLOCK_PROCESSED_TOTAL: near_metrics::Result<IntCounter> =
-        try_create_int_counter("block_processed_total", "Total number of blocks processed");
+        try_create_int_counter("near_block_processed_total", "Total number of blocks processed");
     pub static ref BLOCK_PROCESSED_SUCCESSFULLY_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "block_processed_successfully_total",
+            "near_block_processed_successfully_total",
             "Total number of blocks processed successfully"
         );
     pub static ref BLOCK_PROCESSING_TIME: near_metrics::Result<Histogram> =
-        try_create_histogram("block_processing_time", "Time taken to process blocks");
-    pub static ref BLOCK_HEIGHT_HEAD: near_metrics::Result<IntGauge> =
-        try_create_int_gauge("block_height_head", "Height of the current head of the blockchain");
+        try_create_histogram("near_block_processing_time", "Time taken to process blocks");
+    pub static ref BLOCK_HEIGHT_HEAD: near_metrics::Result<IntGauge> = try_create_int_gauge(
+        "near_block_height_head",
+        "Height of the current head of the blockchain"
+    );
     pub static ref VALIDATOR_AMOUNT_STAKED: near_metrics::Result<IntGauge> = try_create_int_gauge(
-        "validators_amount_staked",
+        "near_validators_stake_total",
         "The total stake of all active validators during the last block"
     );
     pub static ref VALIDATOR_ACTIVE_TOTAL: near_metrics::Result<IntGauge> = try_create_int_gauge(
-        "validator_active_total",
+        "near_validator_active_total",
         "The total number of validators active after last block"
     );
 }

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -118,7 +118,7 @@ impl InfoHelper {
         set_gauge(&metrics::SENT_BYTES_PER_SECOND, network_info.sent_bytes_per_sec as i64);
         set_gauge(&metrics::BLOCKS_PER_MINUTE, (avg_bls * (60 as f64)) as i64);
         set_gauge(&metrics::CPU_USAGE, cpu_usage as i64);
-        set_gauge(&metrics::MEMORY_USAGE, memory_usage as i64);
+        set_gauge(&metrics::MEMORY_USAGE, (memory_usage * 1024) as i64);
 
         self.started = Instant::now();
         self.num_blocks_processed = 0;

--- a/chain/client/src/metrics.rs
+++ b/chain/client/src/metrics.rs
@@ -2,23 +2,23 @@ use near_metrics::{try_create_int_counter, try_create_int_gauge, IntCounter, Int
 
 lazy_static! {
     pub static ref BLOCK_PRODUCED_TOTAL: near_metrics::Result<IntCounter> = try_create_int_counter(
-        "block_produced_total",
+        "near_block_produced_total",
         "Total number of blocks produced since starting this node"
     );
     pub static ref IS_VALIDATOR: near_metrics::Result<IntGauge> =
-        try_create_int_gauge("is_validator", "Bool to denote if it is currently validating");
+        try_create_int_gauge("near_is_validator", "Bool to denote if it is currently validating");
     pub static ref RECEIVED_BYTES_PER_SECOND: near_metrics::Result<IntGauge> = try_create_int_gauge(
-        "received_bytes_per_second",
+        "near_received_bytes_per_second",
         "Number of bytes per second received over the network overall"
     );
     pub static ref SENT_BYTES_PER_SECOND: near_metrics::Result<IntGauge> = try_create_int_gauge(
-        "sent_bytes_per_second",
+        "near_sent_bytes_per_second",
         "Number of bytes per second sent over the network overall"
     );
     pub static ref BLOCKS_PER_MINUTE: near_metrics::Result<IntGauge> =
-        try_create_int_gauge("blocks_per_minute", "Blocks produced per minute");
+        try_create_int_gauge("near_blocks_per_minute", "Blocks produced per minute");
     pub static ref CPU_USAGE: near_metrics::Result<IntGauge> =
-        try_create_int_gauge("cpu_usage", "Percent of CPU usage");
+        try_create_int_gauge("near_cpu_usage_ratio", "Percent of CPU usage");
     pub static ref MEMORY_USAGE: near_metrics::Result<IntGauge> =
-        try_create_int_gauge("memory_usage", "Amount of RAM memory usage");
+        try_create_int_gauge("near_memory_usage_bytes", "Amount of RAM memory usage");
 }

--- a/chain/network/src/metrics.rs
+++ b/chain/network/src/metrics.rs
@@ -8,78 +8,63 @@ use strum::VariantNames;
 
 lazy_static! {
     pub static ref PEER_CONNECTIONS_TOTAL: near_metrics::Result<IntGauge> =
-        try_create_int_gauge("peer_connections_total", "Current number of connected peers");
+        try_create_int_gauge("near_peer_connections_total", "Number of connected peers");
     pub static ref PEER_DATA_RECEIVED_BYTES: near_metrics::Result<IntCounter> =
-        try_create_int_counter("peer_data_received_bytes", "Total data received by peers");
+        try_create_int_counter("near_peer_data_received_bytes", "Total data received from peers");
     pub static ref PEER_MESSAGE_RECEIVED_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "peer_message_received_total",
-            "Total number of messages received from peers"
+            "near_peer_message_received_total",
+            "Number of messages received from peers"
         );
     pub static ref PEER_CLIENT_MESSAGE_RECEIVED_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "peer_client_message_received_total",
-            "Total number of messages for client received from peers"
+            "near_peer_client_message_received_total",
+            "Number of messages for client received from peers"
         );
     pub static ref PEER_BLOCK_RECEIVED_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "peer_block_received_total",
-            "Total number of blocks received by peers"
+            "near_peer_block_received_total",
+            "Number of blocks received by peers"
         );
     pub static ref PEER_TRANSACTION_RECEIVED_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "peer_transaction_received_total",
-            "Total number of transactions received by peers"
+            "near_peer_transaction_received_total",
+            "Number of transactions received by peers"
         );
 
     // Routing table metrics
     pub static ref ROUTING_TABLE_RECALCULATIONS: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "routing_table_recalculations",
+            "near_routing_table_recalculations_total",
             "Number of times routing table have been recalculated from scratch"
         );
 
 
     pub static ref ROUTING_TABLE_RECALCULATION_HISTOGRAM: near_metrics::Result<Histogram> =
         try_create_histogram(
-            "routing_table_recalculation_histogram",
+            "near_routing_table_recalculation_seconds",
             "Time spent recalculating routing table"
         );
 
     pub static ref EDGE_UPDATES: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "edge_updates",
-            "Total edge updates received not previously known"
+            "near_edge_updates",
+            "Unique edge updates"
         );
     pub static ref EDGE_ACTIVE: near_metrics::Result<IntGauge> =
         try_create_int_gauge(
-            "edge_active",
+            "near_edge_active",
             "Total edges active between peers"
-        );
-    pub static ref EDGE_INACTIVE: near_metrics::Result<IntGauge> =
-        try_create_int_gauge(
-            "edge_inactive",
-            "Total edges that where active and are currently inactive"
         );
     pub static ref PEER_REACHABLE: near_metrics::Result<IntGauge> =
         try_create_int_gauge(
-            "peer_reachable",
+            "near_peer_reachable",
             "Total peers such that there is a path potentially through other peers"
-        );
-    pub static ref ACCOUNT_KNOWN: near_metrics::Result<IntCounter> =
-        try_create_int_counter(
-            "account_known",
-            "Total accounts known"
         );
     pub static ref DROP_MESSAGE_UNKNOWN_ACCOUNT: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "drop_message_unknown_account",
+            "near_drop_message_unknown_account",
             "Total messages dropped because target account is not known"
-        );
-    pub static ref DROP_MESSAGE_UNREACHABLE_PEER: near_metrics::Result<IntCounter> =
-        try_create_int_counter(
-            "drop_message_unreachable_peer",
-            "Total messages dropped because target peer is not reachable"
         );
     pub static ref RECEIVED_INFO_ABOUT_ITSELF: near_metrics::Result<IntCounter> = try_create_int_counter("received_info_about_itself", "Number of times a peer tried to connect to itself");
 }
@@ -122,15 +107,15 @@ impl NetworkMetrics {
     }
 
     pub fn peer_message_total_rx(message_name: &str) -> String {
-        format!("{}_total", message_name)
+        format!("near_{}_total", message_name.to_lowercase())
     }
 
     pub fn peer_message_bytes_rx(message_name: &str) -> String {
-        format!("{}_bytes", message_name)
+        format!("near_{}_bytes", message_name.to_lowercase())
     }
 
     pub fn peer_message_dropped(message_name: &str) -> String {
-        format!("{}_dropped", message_name)
+        format!("near_{}_dropped", message_name.to_lowercase())
     }
 
     pub fn inc(&self, message_name: &str) {

--- a/runtime/runtime/src/metrics.rs
+++ b/runtime/runtime/src/metrics.rs
@@ -3,54 +3,54 @@ use near_metrics::{try_create_int_counter, IntCounter};
 lazy_static::lazy_static! {
     pub static ref ACTION_CREATE_ACCOUNT_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "action_create_account_total",
+            "near_action_create_account_total",
             "The number of CreateAccount actions called since starting this node"
         );
     pub static ref ACTION_DEPLOY_CONTRACT_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "action_deploy_contract_total",
+            "near_action_deploy_contract_total",
             "The number of DeployContract actions called since starting this node"
         );
     pub static ref ACTION_FUNCTION_CALL_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "action_function_call_total",
+            "near_action_function_call_total",
             "The number of FunctionCall actions called since starting this node"
         );
     pub static ref ACTION_TRANSFER_TOTAL: near_metrics::Result<IntCounter> = try_create_int_counter(
-        "action_transfer_total",
+        "near_action_transfer_total",
         "The number of Transfer actions called since starting this node"
     );
     pub static ref ACTION_STAKE_TOTAL: near_metrics::Result<IntCounter> = try_create_int_counter(
-        "action_stake_total",
+        "near_action_stake_total",
         "The number of stake actions called since starting this node"
     );
     pub static ref ACTION_ADD_KEY_TOTAL: near_metrics::Result<IntCounter> = try_create_int_counter(
-        "action_add_key_total",
+        "near_action_add_key_total",
         "The number of AddKey actions called since starting this node"
     );
     pub static ref ACTION_DELETE_KEY_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "action_delete_key_total",
+            "near_action_delete_key_total",
             "The number of DeleteKey actions called since starting this node"
         );
     pub static ref ACTION_DELETE_ACCOUNT_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "action_delete_account_total",
+            "near_action_delete_account_total",
             "The number of DeleteAccount actions called since starting this node"
         );
     pub static ref TRANSACTION_PROCESSED_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "transaction_processed_total",
+            "near_transaction_processed_total",
             "The number of transactions processed since starting this node"
         );
     pub static ref TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "transaction_processed_successefully_total",
+            "near_transaction_processed_successfully_total",
             "The number of transactions processed successfully since starting this node"
         );
     pub static ref TRANSACTION_PROCESSED_FAILED_TOTAL: near_metrics::Result<IntCounter> =
         try_create_int_counter(
-            "transaction_processed_failed_total",
+            "near_transaction_processed_failed_total",
             "The number of transactions processed and failed since starting this node"
         );
 }


### PR DESCRIPTION
* Add prefix `near`
* Use lowercase for names
* Add meaninful suffix

fixes: #2873

Test Plan
=========
Run localnet. Check metrics names are correct
on http://*:3030/metrics