### PR TITLE
fix(test_nearlib): use nonzero gas price in unittest script

### DIFF
--- a/scripts/start_unittest.py
+++ b/scripts/start_unittest.py
@@ -41,5 +41,4 @@ if __name__ == "__main__":
                   ],
                   boot_nodes='',
                   telemetry_url='',
-                  verbose=args.verbose,
-                  no_gas_price=True)
+                  verbose=args.verbose)


### PR DESCRIPTION
Use nonzero gas price in nearlib tests to make behavior the same with nearlib CI.