### PR TITLE
fix(test): abort in actix should treat as fail in tests

### DIFF
--- a/utils/actix/src/lib.rs
+++ b/utils/actix/src/lib.rs
@@ -11,6 +11,7 @@ pub fn init_stop_on_panic() {
             if actix::System::is_set() {
                 actix::System::with_current(|sys| sys.stop_with_code(1));
             }
+            debug_assert!(false);
         }));
     })
 }


### PR DESCRIPTION
In #2871 @Kouprin found tests are failed but marks at pass in nightly

Test Plan
---------
Add panic! at same place of 
```
thread 'tests::test_catchup_random_single_part_sync_send_15' panicked at 'assertion failed: block.header().height() <= 32', chain/client/tests/catching_up.rs:508:37
```
as in
http://nightly.neartest.com/run/master_9bdc06527451f54d2fbdbd9ea6e8904556513928_20200622_144553/expensive/expensive_near-client_catching_up_tests__test_catchup_random_single_part_sync_send_15/stderr
and observe test fails with exit code 101 (And backtrace is still readable)