### PR TITLE
Revert "feat(config): run metrics in different port (#2881)"

### DIFF
--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -925,7 +925,6 @@ pub fn load_test_config(seed: &str, port: u16, genesis: Arc<Genesis>) -> NearCon
     let mut config = Config::default();
     config.network.addr = format!("0.0.0.0:{}", port);
     config.rpc.addr = format!("0.0.0.0:{}", open_port());
-    config.rpc.metrics_addr = config.rpc.addr.clone();
     config.consensus.min_block_production_delay =
         Duration::from_millis(FAST_MIN_BLOCK_PRODUCTION_DELAY);
     config.consensus.max_block_production_delay =


### PR DESCRIPTION
This reverts commit 10e6dfe1f313260f8ed9765bbc8e0a551ee356e7.

This change inadvertently breaks all the python tests, and half of the expensive
tests.
Both infrastructures need to be running nodes with different metrics
ports.