### PR TITLE
testing: add mocknet tests to nightly

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -150,3 +150,8 @@ expensive nearcore test_simple test::test_7_10_multiple_nodes
 expensive nearcore test_rejoin test::test_4_20_kill1
 expensive nearcore test_rejoin test::test_4_20_kill1_two_shards
 expensive nearcore test_rejoin test::test_4_20_kill2
+
+# mocknet tests
+mocknet --timeout=300 mocknet/sanity.py
+mocknet --timeout=2700 mocknet/outage.py
+mocknet --timeout=300 mocknet/bounce.py


### PR DESCRIPTION
The mocknet tests are given as their own testing group to ensure they are only run in the sequential nightly runner. This is important because multiple tests against the mocknet cannot run at the same time since they cause drastic effects on the network (e.g. shutting down one or more nodes).

Corresponding PR in the nightly runner: https://github.com/nearprotocol/nightly/pull/9