### PR TITLE
fix(bridge): add receiver_id to ExecutionOutcome

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -630,7 +630,7 @@ impl RuntimeAdapter for KeyValueRuntime {
                         receipt_ids: new_receipt_hashes,
                         gas_burnt: 0,
                         tokens_burnt: 0,
-                        receiver_id: to.clone(),
+                        executor_id: to.clone(),
                     },
                 });
             }

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -630,6 +630,7 @@ impl RuntimeAdapter for KeyValueRuntime {
                         receipt_ids: new_receipt_hashes,
                         gas_burnt: 0,
                         tokens_burnt: 0,
+                        receiver_id: to.clone(),
                     },
                 });
             }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -581,7 +581,7 @@ mod tests {
                 receipt_ids: vec![hash(&[1])],
                 gas_burnt: 100,
                 tokens_burnt: 10000,
-                receiver_id: "alice".to_string(),
+                executor_id: "alice".to_string(),
             },
         };
         let outcome2 = ExecutionOutcomeWithId {
@@ -592,7 +592,7 @@ mod tests {
                 receipt_ids: vec![],
                 gas_burnt: 0,
                 tokens_burnt: 0,
-                receiver_id: "bob".to_string(),
+                executor_id: "bob".to_string(),
             },
         };
         let outcomes = vec![outcome1, outcome2];

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -581,6 +581,7 @@ mod tests {
                 receipt_ids: vec![hash(&[1])],
                 gas_burnt: 100,
                 tokens_burnt: 10000,
+                receiver_id: "alice".to_string(),
             },
         };
         let outcome2 = ExecutionOutcomeWithId {
@@ -591,6 +592,7 @@ mod tests {
                 receipt_ids: vec![],
                 gas_burnt: 0,
                 tokens_burnt: 0,
+                receiver_id: "bob".to_string(),
             },
         };
         let outcomes = vec![outcome1, outcome2];

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -235,7 +235,7 @@ struct PartialExecutionOutcome {
     pub gas_burnt: Gas,
     #[serde(with = "u128_dec_format")]
     pub tokens_burnt: Balance,
-    pub receiver_id: AccountId,
+    pub executor_id: AccountId,
     pub status: PartialExecutionStatus,
 }
 
@@ -245,7 +245,7 @@ impl From<&ExecutionOutcome> for PartialExecutionOutcome {
             receipt_ids: outcome.receipt_ids.clone(),
             gas_burnt: outcome.gas_burnt,
             tokens_burnt: outcome.tokens_burnt,
-            receiver_id: outcome.receiver_id.clone(),
+            executor_id: outcome.executor_id.clone(),
             status: outcome.status.clone().into(),
         }
     }
@@ -284,8 +284,9 @@ pub struct ExecutionOutcome {
     /// This value doesn't always equal to the `gas_burnt` multiplied by the gas price, because
     /// the prepaid gas price might be lower than the actual gas price and it creates a deficit.
     pub tokens_burnt: Balance,
-    /// Receiver of the transaction or receipt.
-    pub receiver_id: AccountId,
+    /// The id of the account on which the execution happens. For transaction this is signer_id,
+    /// for receipt this is receiver_id.
+    pub executor_id: AccountId,
     /// Execution status. Contains the result in case of successful execution.
     /// NOTE: Should be the latest field since it contains unparsable by light client
     /// ExecutionStatus::Failure
@@ -452,7 +453,7 @@ mod tests {
             receipt_ids: vec![],
             gas_burnt: 123,
             tokens_burnt: 1234000,
-            receiver_id: "alice".to_string(),
+            executor_id: "alice".to_string(),
         };
         let hashes = outcome.to_hashes();
         assert_eq!(hashes.len(), 3);

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -235,7 +235,20 @@ struct PartialExecutionOutcome {
     pub gas_burnt: Gas,
     #[serde(with = "u128_dec_format")]
     pub tokens_burnt: Balance,
+    pub receiver_id: AccountId,
     pub status: PartialExecutionStatus,
+}
+
+impl From<&ExecutionOutcome> for PartialExecutionOutcome {
+    fn from(outcome: &ExecutionOutcome) -> Self {
+        Self {
+            receipt_ids: outcome.receipt_ids.clone(),
+            gas_burnt: outcome.gas_burnt,
+            tokens_burnt: outcome.tokens_burnt,
+            receiver_id: outcome.receiver_id.clone(),
+            status: outcome.status.clone().into(),
+        }
+    }
 }
 
 /// ExecutionStatus for proof. Excludes failure debug info.
@@ -271,6 +284,8 @@ pub struct ExecutionOutcome {
     /// This value doesn't always equal to the `gas_burnt` multiplied by the gas price, because
     /// the prepaid gas price might be lower than the actual gas price and it creates a deficit.
     pub tokens_burnt: Balance,
+    /// Receiver of the transaction or receipt.
+    pub receiver_id: AccountId,
     /// Execution status. Contains the result in case of successful execution.
     /// NOTE: Should be the latest field since it contains unparsable by light client
     /// ExecutionStatus::Failure
@@ -280,14 +295,7 @@ pub struct ExecutionOutcome {
 impl ExecutionOutcome {
     pub fn to_hashes(&self) -> Vec<CryptoHash> {
         let mut result = vec![hash(
-            &PartialExecutionOutcome {
-                receipt_ids: self.receipt_ids.clone(),
-                gas_burnt: self.gas_burnt,
-                tokens_burnt: self.tokens_burnt,
-                status: self.status.clone().into(),
-            }
-            .try_to_vec()
-            .expect("Failed to serialize"),
+            &PartialExecutionOutcome::from(self).try_to_vec().expect("Failed to serialize"),
         )];
         for log in self.logs.iter() {
             result.push(hash(log.as_bytes()));
@@ -444,6 +452,7 @@ mod tests {
             receipt_ids: vec![],
             gas_burnt: 123,
             tokens_burnt: 1234000,
+            receiver_id: "alice".to_string(),
         };
         let hashes = outcome.to_hashes();
         assert_eq!(hashes.len(), 3);

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -17,6 +17,6 @@ pub const DB_VERSION: DbVersion = 2;
 pub type ProtocolVersion = u32;
 
 /// Current latest version of the protocol.
-pub const PROTOCOL_VERSION: ProtocolVersion = 27;
+pub const PROTOCOL_VERSION: ProtocolVersion = 28;
 
 pub const FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = PROTOCOL_VERSION;

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -805,8 +805,9 @@ pub struct ExecutionOutcomeView {
     /// the prepaid gas price might be lower than the actual gas price and it creates a deficit.
     #[serde(with = "u128_dec_format")]
     pub tokens_burnt: Balance,
-    /// Receiver id of the transaction or receipt.
-    pub receiver_id: String,
+    /// The id of the account on which the execution happens. For transaction this is signer_id,
+    /// for receipt this is receiver_id.
+    pub executor_id: AccountId,
     /// Execution status. Contains the result in case of successful execution.
     pub status: ExecutionStatusView,
 }
@@ -818,7 +819,7 @@ impl From<ExecutionOutcome> for ExecutionOutcomeView {
             receipt_ids: outcome.receipt_ids,
             gas_burnt: outcome.gas_burnt,
             tokens_burnt: outcome.tokens_burnt,
-            receiver_id: outcome.receiver_id,
+            executor_id: outcome.executor_id,
             status: outcome.status.into(),
         }
     }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -805,6 +805,8 @@ pub struct ExecutionOutcomeView {
     /// the prepaid gas price might be lower than the actual gas price and it creates a deficit.
     #[serde(with = "u128_dec_format")]
     pub tokens_burnt: Balance,
+    /// Receiver id of the transaction or receipt.
+    pub receiver_id: String,
     /// Execution status. Contains the result in case of successful execution.
     pub status: ExecutionStatusView,
 }
@@ -816,6 +818,7 @@ impl From<ExecutionOutcome> for ExecutionOutcomeView {
             receipt_ids: outcome.receipt_ids,
             gas_burnt: outcome.gas_burnt,
             tokens_burnt: outcome.tokens_burnt,
+            receiver_id: outcome.receiver_id,
             status: outcome.status.into(),
         }
     }

--- a/neard/res/genesis_config.json
+++ b/neard/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 27,
+  "protocol_version": 28,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -465,7 +465,13 @@ fn outcome_view_to_hashes(outcome: &ExecutionOutcomeView) -> Vec<CryptoHash> {
         ExecutionStatusView::SuccessReceiptId(id) => PartialExecutionStatus::SuccessReceiptId(*id),
     };
     let mut result = vec![hash(
-        &(outcome.receipt_ids.clone(), outcome.gas_burnt, outcome.tokens_burnt, status)
+        &(
+            outcome.receipt_ids.clone(),
+            outcome.gas_burnt,
+            outcome.tokens_burnt,
+            outcome.receiver_id.clone(),
+            status,
+        )
             .try_to_vec()
             .expect("Failed to serialize"),
     )];

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -469,7 +469,7 @@ fn outcome_view_to_hashes(outcome: &ExecutionOutcomeView) -> Vec<CryptoHash> {
             outcome.receipt_ids.clone(),
             outcome.gas_burnt,
             outcome.tokens_burnt,
-            outcome.receiver_id.clone(),
+            outcome.executor_id.clone(),
             status,
         )
             .try_to_vec()

--- a/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
+++ b/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
@@ -42,7 +42,7 @@ partial_execution_outcome_schema = dict([
             ['receipt_ids', [[32]]],
             ['gas_burnt', 'u64'],
             ['tokens_burnt', 'u128'],
-            ['receiver_id', 'string'],
+            ['executor_id', 'string'],
             ['status', PartialExecutionStatus],
         ]
     },
@@ -79,7 +79,7 @@ def serialize_execution_outcome_with_id(outcome, id):
     partial_outcome.receipt_ids = [base58.b58decode(x) for x in outcome['receipt_ids']]
     partial_outcome.gas_burnt = outcome['gas_burnt']
     partial_outcome.tokens_burnt = int(outcome['tokens_burnt'])
-    partial_outcome.receiver_id = outcome['receiver_id']
+    partial_outcome.executor_id = outcome['executor_id']
     execution_status = PartialExecutionStatus()
     if 'SuccessValue' in outcome['status']:
         execution_status.enum = 'successValue'

--- a/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
+++ b/pytest/tests/sanity/rpc_light_client_execution_outcome_proof.py
@@ -42,6 +42,7 @@ partial_execution_outcome_schema = dict([
             ['receipt_ids', [[32]]],
             ['gas_burnt', 'u64'],
             ['tokens_burnt', 'u128'],
+            ['receiver_id', 'string'],
             ['status', PartialExecutionStatus],
         ]
     },
@@ -78,6 +79,7 @@ def serialize_execution_outcome_with_id(outcome, id):
     partial_outcome.receipt_ids = [base58.b58decode(x) for x in outcome['receipt_ids']]
     partial_outcome.gas_burnt = outcome['gas_burnt']
     partial_outcome.tokens_burnt = int(outcome['tokens_burnt'])
+    partial_outcome.receiver_id = outcome['receiver_id']
     execution_status = PartialExecutionStatus()
     if 'SuccessValue' in outcome['status']:
         execution_status.enum = 'successValue'

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -260,7 +260,7 @@ impl Runtime {
                         receipt_ids: vec![receipt.receipt_id],
                         gas_burnt: verification_result.gas_burnt,
                         tokens_burnt: verification_result.burnt_amount,
-                        receiver_id: transaction.receiver_id.clone(),
+                        executor_id: transaction.signer_id.clone(),
                     },
                 };
                 Ok((receipt, outcome))
@@ -661,7 +661,7 @@ impl Runtime {
                 receipt_ids,
                 gas_burnt: result.gas_burnt,
                 tokens_burnt,
-                receiver_id: account_id.clone(),
+                executor_id: account_id.clone(),
             },
         })
     }

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -260,6 +260,7 @@ impl Runtime {
                         receipt_ids: vec![receipt.receipt_id],
                         gas_burnt: verification_result.gas_burnt,
                         tokens_burnt: verification_result.burnt_amount,
+                        receiver_id: transaction.receiver_id.clone(),
                     },
                 };
                 Ok((receipt, outcome))
@@ -660,6 +661,7 @@ impl Runtime {
                 receipt_ids,
                 gas_burnt: result.gas_burnt,
                 tokens_burnt,
+                receiver_id: account_id.clone(),
             },
         })
     }

--- a/scripts/migrations/28-add-executor-id-to-execution-outcome.py
+++ b/scripts/migrations/28-add-executor-id-to-execution-outcome.py
@@ -1,5 +1,5 @@
 """
-Adding `receiver_id` to `ExecutionOutcome`, `PartialExecutionOutcome`, `FinalExecutionOutcome` and views.
+Adding `executor_id` to `ExecutionOutcome`, `PartialExecutionOutcome`, `FinalExecutionOutcome` and views.
 """
 
 import sys

--- a/scripts/migrations/28-add-receiver-id-to-execution-outcome.py
+++ b/scripts/migrations/28-add-receiver-id-to-execution-outcome.py
@@ -1,0 +1,19 @@
+"""
+Adding `receiver_id` to `ExecutionOutcome`, `PartialExecutionOutcome`, `FinalExecutionOutcome` and views.
+"""
+
+import sys
+import os
+import json
+from collections import OrderedDict
+
+home = sys.argv[1]
+output_home = sys.argv[2]
+
+config = json.load(open(os.path.join(home, 'output.json')), object_pairs_hook=OrderedDict)
+
+assert config['protocol_version'] == 27
+
+config['protocol_version'] = 28
+
+json.dump(config, open(os.path.join(output_home, 'output.json'), 'w'), indent=2)


### PR DESCRIPTION
Add `receiver_id` to `ExecutionOutcome` so that the bridge can verify cross contract calls easily. Fixes #2902.