### PR TITLE
fix(test): ensure wait-on-server indeed happen and buildkite instance not reuse

### DIFF
--- a/scripts/test_nearlib.sh
+++ b/scripts/test_nearlib.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-curl localhost:3030/status
+curl localhost:3030/status || true
 
 export RUST_BACKTRACE=full
 ./scripts/start_unittest.py --local &

--- a/scripts/test_nearlib.sh
+++ b/scripts/test_nearlib.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -ex
 
+curl localhost:3030/status
+
 export RUST_BACKTRACE=full
 ./scripts/start_unittest.py --local &
 export NEAR_PID=$!

--- a/scripts/waitonserver.sh
+++ b/scripts/waitonserver.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 echo 'waiting on healthcheck' >&2
 
@@ -6,6 +7,7 @@ for _ in {1..500}; do
     echo -n '.' >&2
     kill -0 $NEAR_PID > /dev/null 2>&1 || exit 1
     if [[ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3030/status)" == "200" ]]; then
+        echo 'near node is running'
         exit 0
     fi
     sleep 5


### PR DESCRIPTION
Recently i renable nearlib tests, but it occasionaly failed on CI, seems that wait-on-server.sh doesn't have effect. Debug locally shows it has effect, unless previously there's a near running on localhost:3030. It's possible because buildkite reuse an instance that still have local neard running. Make this experimental PR to see

Test Plan
---------
Ideally buildkite reuse is fixed, and also wait-on-server.sh works.