### PR TITLE
Fix(test): test upgradable test as the last pytest

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -35,7 +35,6 @@ pytest --timeout=300 sanity/gc_after_sync.py
 pytest --timeout=300 sanity/gc_sync_after_sync.py
 pytest --timeout=300 sanity/gc_sync_after_sync.py swap_nodes
 pytest --timeout=300 sanity/large_messages.py
-pytest --timeout=300 sanity/upgradable.py
 pytest --timeout=240 sanity/validator_switch_key.py
 pytest sanity/nodes_proxy.py
 
@@ -62,6 +61,9 @@ pytest adversarial/start_from_genesis.py
 pytest adversarial/start_from_genesis.py overtake
 pytest adversarial/start_from_genesis.py doomslug_off
 pytest adversarial/start_from_genesis.py overtake doomslug_off
+
+# python upgradable test
+pytest --timeout=300 sanity/upgradable.py
 
 # catchup tests
 expensive --timeout=1800 near-client catching_up tests::test_catchup_receipts_sync_third_epoch

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -63,6 +63,7 @@ pytest adversarial/start_from_genesis.py doomslug_off
 pytest adversarial/start_from_genesis.py overtake doomslug_off
 
 # python upgradable test
+# upgradable.py moves `near` binary, and must be the last python test in the set
 pytest --timeout=300 sanity/upgradable.py
 
 # catchup tests


### PR DESCRIPTION
Currently pytest after nightly all fail: http://nightly.neartest.com/run/master_8b939a057186449638ac6dada096f286d95faba8_20200629_094402 Because it recompile binary and rename in a way that break the per-compilation used by the other nightly pytests. It's possible to put upgradable test in medium and do cleanup / recompile tests for other nightly tests, but recompile takes additional time.

Test Plan
---------
Test after upgradable should pass. However, this can't be tested on buildkite nightly, because it's parallel