### PR TITLE
fix: fixing rpc_light_client_execution_outcome_proof.py

### DIFF
--- a/pytest/lib/serializer.py
+++ b/pytest/lib/serializer.py
@@ -11,6 +11,8 @@ class BinarySerializer:
         return ret
 
     def serialize_num(self, value, n_bytes):
+        if type(value) == str:
+            value = int(value)
         assert value >= 0
         for i in range(n_bytes):
             self.array.append(value & 255)


### PR DESCRIPTION
After we started returning timestamps as a string in the JSON RPC, the
test broke trying to borshify the timestamp received from the RPC.
I made the fix in the serializer itself, I don't think there's a reason
not to allow to pass integers as strings into borshifier.