### PR TITLE
fix(test): enforce backward compatible test when protocol version not changed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "actix",
  "borsh",

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -38,10 +38,9 @@ def main():
 
     with open(
             os.path.join(os.path.dirname(__file__),
-                         '../../../core/primitives/src/version.rs')) as f:
-        for line in f:
-            if line.startswith('pub const PROTOCOL_VERSION'):
-                current_protocol_version = int(line.split('=')[1].split(';')[0])
+                         '../../../neard/res/genesis_config.json')) as f:
+        current_genesis = json.load(f)
+        current_protocol_version = current_genesis['protocol_version']
     if current_protocol_version > stable_protocol_version:
         print('Protcol upgrade, does not need backward compatible')
         exit(0)

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import time
 import shutil
+import json
 
 sys.path.append('lib')
 
@@ -30,6 +31,20 @@ def main():
         "%snear-%s" % (near_root, stable_branch),
         "--home=%s" % node_root, "testnet", "--v", "2", "--prefix", "test"
     ])
+
+    with open('/tmp/near/backward/test0/genesis.json') as f:
+        stable_genesis = json.load(f)
+        stable_protocol_version = stable_genesis['protocol_version']
+
+    with open(
+            os.path.join(os.path.dirname(__file__),
+                         '../../../core/primitives/src/version.rs')) as f:
+        for line in f:
+            if line.startswith('pub const PROTOCOL_VERSION'):
+                current_protocol_version = int(line.split('=')[1].split(';')[0])
+    if current_protocol_version > stable_protocol_version:
+        print('Protcol upgrade, does not need backward compatible')
+        exit(0)
 
     # Run both binaries at the same time.
     config = {


### PR DESCRIPTION
Fix #2443 

Test Plan
---------
When protocol version not changed (now it's the case), it run as usual. When it changes (tested by bump protocol version to 30), it will exit early. Once this merged, I'll turn on backward compatible test as "must pass" on buildkite