### PR TITLE
Added download option for the genesis in neard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,12 +1057,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "ct-logs"
-version = "0.6.0"
+name = "curl"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3686f5fa27dbc1d76c751300376e167c5a43387f44bb451fd1c24776e49113"
+checksum = "b0447a642435be046540f042950d874a4907f9fee28c0513a0beb3ba89f91eb7"
 dependencies = [
- "sct",
+ "curl-sys",
+ "libc",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "socket2",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "curl-sys"
+version = "0.4.32+curl-7.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "834425a2f22fdd621434196965bf99fbfd9eaed96348488e27b7ac40736c560b"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+ "winapi 0.3.8",
 ]
 
 [[package]]
@@ -1783,12 +1804,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac965ea399ec3a25ac7d13b8affd4b8f39325cca00858ddf5eb29b79e6b14b08"
 dependencies = [
  "bytes",
- "ct-logs",
  "futures-util",
  "hyper",
  "log",
  "rustls",
- "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "webpki",
@@ -1877,7 +1896,7 @@ dependencies = [
  "socket2",
  "widestring",
  "winapi 0.3.8",
- "winreg",
+ "winreg 0.6.2",
 ]
 
 [[package]]
@@ -2023,6 +2042,18 @@ dependencies = [
  "cc",
  "glob 0.3.0",
  "libc",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2750,6 +2781,7 @@ dependencies = [
  "byteorder",
  "chrono",
  "clap",
+ "curl",
  "dirs",
  "easy-ext",
  "futures",
@@ -3439,11 +3471,11 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.10.4"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b81e49ddec5109a9dcfc5f2a317ff53377c915e9ae9d4f2fb50914b85614e2"
+checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.12.3",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3465,7 +3497,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "time",
  "tokio",
  "tokio-rustls",
  "tokio-tls",
@@ -3474,7 +3505,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "winreg",
+ "winreg 0.7.0",
 ]
 
 [[package]]
@@ -3600,18 +3631,6 @@ dependencies = [
  "ring",
  "sct",
  "webpki",
-]
-
-[[package]]
-name = "rustls-native-certs"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75ffeb84a6bd9d014713119542ce415db3a3e4748f0bfce1e1416cd224a23a5"
-dependencies = [
- "openssl-probe",
- "rustls",
- "schannel",
- "security-framework",
 ]
 
 [[package]]
@@ -4868,9 +4887,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cd5736df7f12a964a5067a12c62fa38e1bd8080aff1f80bc29be7c80d19ab4"
+checksum = "f8eff4b7516a57307f9349c64bf34caa34b940b66fed4b2fb3136cb7386e5739"
 dependencies = [
  "webpki",
 ]
@@ -4938,6 +4957,15 @@ name = "winreg"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
+dependencies = [
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
  "winapi 0.3.8",
 ]

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -23,6 +23,7 @@ borsh = "0.7.0"
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 num-rational = { version = "0.2.4", features = ["serde"] }
+curl = "0.4.30"
 
 near-actix-utils = { path = "../utils/actix" }
 near-crypto = { path = "../core/crypto" }

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -78,7 +78,9 @@ fn main() {
             .arg(Arg::with_name("test-seed").long("test-seed").takes_value(true).help("Specify private key generated from seed (TESTING ONLY)"))
             .arg(Arg::with_name("num-shards").long("num-shards").takes_value(true).help("Number of shards to initialize the chain with"))
             .arg(Arg::with_name("fast").long("fast").takes_value(false).help("Makes block production fast (TESTING ONLY)"))
-            .arg(Arg::with_name("genesis").long("genesis").takes_value(true).help("Genesis file to use when initialize testnet"))
+            .arg(Arg::with_name("genesis").long("genesis").takes_value(true).help("Genesis file to use when initialize testnet (including downloading)"))
+            .arg(Arg::with_name("download-genesis").long("download-genesis").takes_value(false).help("Download the verified NEAR genesis file automatically."))
+            .arg(Arg::with_name("download-genesis-url").long("download-genesis-url").takes_value(true).help("Specify a custom download URL for the genesis-file."))
         )
         .subcommand(SubCommand::with_name("testnet").about("Setups testnet configuration with all necessary files (validator key, node key, genesis and config)")
             .arg(Arg::with_name("v").long("v").takes_value(true).help("Number of validators to initialize the testnet with (default 4)"))
@@ -122,12 +124,33 @@ fn main() {
             let account_id = args.value_of("account-id");
             let test_seed = args.value_of("test-seed");
             let genesis = args.value_of("genesis");
+            let download = args.is_present("download-genesis");
+            let download_url = args.value_of("download-genesis-url");
             let num_shards = args
                 .value_of("num-shards")
                 .map(|s| s.parse().expect("Number of shards must be a number"))
                 .unwrap_or(1);
             let fast = args.is_present("fast");
-            init_configs(home_dir, chain_id, account_id, test_seed, num_shards, fast, genesis);
+
+            if (args.is_present("download-genesis") || args.is_present("download-genesis-url"))
+                && args.is_present("genesis")
+            {
+                panic!(
+                    "Please specify a local genesis file or download the NEAR genesis or specify your own."
+                );
+            }
+
+            init_configs(
+                home_dir,
+                chain_id,
+                account_id,
+                test_seed,
+                num_shards,
+                fast,
+                genesis,
+                download,
+                download_url,
+            );
         }
         ("testnet", Some(args)) => {
             let num_validators = args


### PR DESCRIPTION
Test Plan:
```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download) [101]> cargo run --bin neard init --account-id sandi.betanet --chain-id betanet --download-genesis
   Compiling neard v1.2.0 (/home/sandi/workspace/near/core/neard)
    Finished dev [unoptimized + debuginfo] target(s) in 18.63s
     Running `/home/sandi/workspace/near/core/target/debug/neard init --account-id sandi.betanet --chain-id betanet --download-genesis`
Jul 08 16:14:49.366  INFO near: Version: 1.2.0, Build: dc59fe28-modified, Latest Protocol: 29
thread 'main' panicked at 'To download the genesis you have to specify the download path --genesis', neard/src/main.rs:144:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download) [101]> cargo run --bin neard init --account-id sandi.betanet --chain-id betanet --download-genesis --genesis /tmp/
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `/home/sandi/workspace/near/core/target/debug/neard init --account-id sandi.betanet --chain-id betanet --download-genesis --genesis /tmp/`
Jul 08 16:14:57.995  INFO near: Version: 1.2.0, Build: dc59fe28-modified, Latest Protocol: 29
thread 'main' panicked at 'The following file already exists!!!
                            Please specify a non existing path for download or remove the download flag', neard/src/main.rs:138:25
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download) [101]> cargo run --bin neard init --account-id sandi.betanet --chain-id betanet --download-genesis --genesis /tmp/genesis.json
    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `/home/sandi/workspace/near/core/target/debug/neard init --account-id sandi.betanet --chain-id betanet --download-genesis --genesis /tmp/genesis.json`
Jul 08 16:15:02.978  INFO near: Version: 1.2.0, Build: dc59fe28-modified, Latest Protocol: 29
Jul 08 16:15:02.979  INFO near: Use key ed25519:Afic82VnVA4L6E8y5CkUPAQK4sdoprBRGupKFv1KVhLT for sandi.betanet to stake.
Jul 08 16:15:02.980  INFO near: Downloading config file from: https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/betanet/genesis.json ...
Jul 08 16:16:01.509  INFO near: Downloaded config file to: /tmp/genesis.json ...
Jul 08 16:16:15.962  INFO near: Generated for betanet network node key and genesis file in /home/sandi/.near
```

```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download)> ls ~/.near
config.json  genesis.json  node_key.json  validator_key.json
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download)> rm -rf ~/.near
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download)> cargo run --bin neard init --account-id sandi.betanet --chain-id betanet --genesis /tmp/genesis.json

    Finished dev [unoptimized + debuginfo] target(s) in 0.16s
     Running `/home/sandi/workspace/near/core/target/debug/neard init --account-id sandi.betanet --chain-id betanet --genesis /tmp/genesis.json`
Jul 08 16:16:30.863  INFO near: Version: 1.2.0, Build: dc59fe28-modified, Latest Protocol: 29
Jul 08 16:16:30.864  INFO near: Use key ed25519:Cu3kokZ4Cw13Sbs4DTsgZqn8ZfzmKeFzES7erAqtgdsh for sandi.betanet to stake.
Jul 08 16:16:45.325  INFO near: Generated for betanet network node key and genesis file in /home/sandi/.near
```
```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download)> ls ~/.near
config.json  genesis.json  node_key.json  validator_key.json
```