### PR TITLE
Removed the curl dependency and fixed the wrong path to load genesis …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,36 +1057,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curl"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0447a642435be046540f042950d874a4907f9fee28c0513a0beb3ba89f91eb7"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.32+curl-7.70.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834425a2f22fdd621434196965bf99fbfd9eaed96348488e27b7ac40736c560b"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "curve25519-dalek"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2045,18 +2015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libz-sys"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "lightbeam"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2777,11 +2735,11 @@ name = "neard"
 version = "1.2.0"
 dependencies = [
  "actix",
+ "actix-web",
  "borsh",
  "byteorder",
  "chrono",
  "clap",
- "curl",
  "dirs",
  "easy-ext",
  "futures",

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 actix = "0.9"
+actix-web = { version = "2", features = [ "openssl" ] }
 byteorder = "1.2"
 easy-ext = "0.2"
 rocksdb = "0.14"
@@ -23,7 +24,6 @@ borsh = "0.7.0"
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 num-rational = { version = "0.2.4", features = ["serde"] }
-curl = "0.4.30"
 
 near-actix-utils = { path = "../utils/actix" }
 near-crypto = { path = "../core/crypto" }


### PR DESCRIPTION
…on download

Summary:

Test Plan:

```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download) [101]> rm -rf ~/.near
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download)> RUST_BACKTRACE=1 cargo run --bin neard init --account-id sandi.betanet --chain-id betanet --download-genesis
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `/home/sandi/workspace/near/core/target/debug/neard init --account-id sandi.betanet --chain-id betanet --download-genesis`
Jul 09 17:44:51.157  INFO near: Version: 1.2.0, Build: 8407c0b4-modified, Latest Protocol: 29
Jul 09 17:44:51.158  INFO near: Use key ed25519:7n9enzWFFfGavzQTz5R7UdieJoGbpzqihxHc142tzmMG for sandi.betanet to stake.
Jul 09 17:44:51.158  INFO near: Downloading config file from: https://s3-us-west-1.amazonaws.com/build.nearprotocol.com/nearcore-deploy/betanet/genesis.json ...
Jul 09 17:45:28.961  INFO neard::config: Downloaded: 149578759 bytes
Jul 09 17:45:29.052  INFO near: Saved the config file to: /home/sandi/.near/genesis.json ...
Jul 09 17:45:43.792  INFO near: Generated for betanet network node key and genesis file in /home/sandi/.near
```

```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download)> cp ~/.near/genesis.json /tmp
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download)> rm -rf ~/.near
```

```
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/neard (neard-genesis-config-download)> RUST_BACKTRACE=1 cargo run --bin neard init --account-id sandi.betanet --chain-id betanet --genesis /tmp/genesis.json
    Finished dev [unoptimized + debuginfo] target(s) in 0.15s
     Running `/home/sandi/workspace/near/core/target/debug/neard init --account-id sandi.betanet --chain-id betanet --genesis /tmp/genesis.json`
Jul 09 17:46:23.084  INFO near: Version: 1.2.0, Build: 8407c0b4-modified, Latest Protocol: 29
Jul 09 17:46:23.085  INFO near: Use key ed25519:5nnrGdjZhna7rUGnaqgUUXPmATbaanDxhpuQgecNSCxX for sandi.betanet to stake.
Jul 09 17:46:37.752  INFO near: Generated for betanet network node key and genesis file in /home/sandi/.near
```