### PR TITLE
Fix(ci): update badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ master | beta | stable
 ---|---|---|
 [![Build Status][ci-badge-master]][ci-url] | [![Build Status][ci-badge-beta]][ci-url] | [![Build Status][ci-badge-stable]][ci-url] 
 
-[ci-badge-master]: https://badge.buildkite.com/a81147cb62c585cc434459eedd1d25e521453120ead9ee6c64.svg
+[ci-badge-master]: https://badge.buildkite.com/a81147cb62c585cc434459eedd1d25e521453120ead9ee6c64.svg?branch=master
 [ci-badge-beta]: https://badge.buildkite.com/a81147cb62c585cc434459eedd1d25e521453120ead9ee6c64.svg?branch=beta
 [ci-badge-stable]: https://badge.buildkite.com/a81147cb62c585cc434459eedd1d25e521453120ead9ee6c64.svg?branch=stable
 [ci-url]: https://buildkite.com/nearprotocol/nearcore


### PR DESCRIPTION
buildkite badge has a bad default that without adding branch it shows latest build of all branches (probably comes from a failed PR branch), instead of master branch, which shows fail at this moment while our master is actually pass

Test Plan
---------
badge should show pass