### PR TITLE
fix(nightly): bump dep version to be not conflict with nightly

### DIFF
--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -6,7 +6,7 @@ retry
 ed25519
 base58
 prometheus-client
-python-rc==0.1.9
+python-rc==0.3.9
 tqdm
 deepdiff
 pynacl


### PR DESCRIPTION
Currently we install this dep first (0.1.9), then nightly's dep (0.3.9), then run all nightly tests. As a result, if we install dep here automatically everytime we run nightly, it will override nightly dep version to 0.1.9 and make mocknet tests fails. 

Test Plan
---------
This is already the case we run in nightly (0.3.9), so no extra test needed.