### PR TITLE
Disable thread rocksdb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,9 +477,9 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.53.2"
+version = "0.54.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb26d6a69a335b8cb0e7c7e9775cd5666611dc50a37177c3f2cedcfc040e8c8"
+checksum = "f4d49b80beb70d76cdac92f5681e666f9a697c737c4f4117a67229a0386dc736"
 dependencies = [
  "bitflags",
  "cexpr",
@@ -2004,9 +2004,8 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "6.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883213ae3d09bfc3d104aefe94b25ebb183b6f4d3a515b23b14817e1f4854005"
+version = "6.10.2"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=d6c779c179aa3e5f68e4d6a3dfef27a6f776d92c#d6c779c179aa3e5f68e4d6a3dfef27a6f776d92c"
 dependencies = [
  "bindgen",
  "cc",
@@ -3508,8 +3507,7 @@ dependencies = [
 [[package]]
 name = "rocksdb"
 version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61aa17a99a2413cd71c1106691bf59dad7de0cd5099127f90e9d99c429c40d4a"
+source = "git+https://github.com/rust-rocksdb/rust-rocksdb?rev=d6c779c179aa3e5f68e4d6a3dfef27a6f776d92c#d6c779c179aa3e5f68e4d6a3dfef27a6f776d92c"
 dependencies = [
  "libc",
  "librocksdb-sys",

--- a/chain/chain/Cargo.toml
+++ b/chain/chain/Cargo.toml
@@ -10,7 +10,7 @@ log = "0.4"
 failure = "0.1"
 failure_derive = "0.1"
 lazy_static = "1.4"
-rocksdb = "0.14"
+rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "d6c779c179aa3e5f68e4d6a3dfef27a6f776d92c" }
 rand = "0.7"
 serde = { version = "1", features = [ "derive" ] }
 cached = "0.12"

--- a/chain/client/Cargo.toml
+++ b/chain/client/Cargo.toml
@@ -9,7 +9,7 @@ ansi_term = "0.11"
 actix = "0.9"
 futures = "0.3"
 chrono = { version = "0.4.4", features = ["serde"] }
-rocksdb = "0.14"
+rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "d6c779c179aa3e5f68e4d6a3dfef27a6f776d92c" }
 log = "0.4"
 rand = "0.7"
 serde = { version = "1", features = ["derive"] }

--- a/chain/network/src/peer_store.rs
+++ b/chain/network/src/peer_store.rs
@@ -406,14 +406,14 @@ mod test {
         let peer_info_to_ban = gen_peer_info(1);
         let boot_nodes = vec![peer_info_a.clone(), peer_info_to_ban.clone()];
         {
-            let store = create_store(tmp_dir.path().to_str().unwrap());
+            let store = create_store(tmp_dir.path().to_str().unwrap(), true);
             let mut peer_store = PeerStore::new(store, &boot_nodes).unwrap();
             assert_eq!(peer_store.healthy_peers(3).iter().count(), 2);
             peer_store.peer_ban(&peer_info_to_ban.id, ReasonForBan::Abusive).unwrap();
             assert_eq!(peer_store.healthy_peers(3).iter().count(), 1);
         }
         {
-            let store_new = create_store(tmp_dir.path().to_str().unwrap());
+            let store_new = create_store(tmp_dir.path().to_str().unwrap(), true);
             let peer_store_new = PeerStore::new(store_new, &boot_nodes).unwrap();
             assert_eq!(peer_store_new.healthy_peers(3).iter().count(), 1);
         }

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -9,7 +9,7 @@ byteorder = "1.2"
 derive_more = "0.99.3"
 elastic-array = "0.11"
 lazy_static = "1.4"
-rocksdb = "0.14"
+rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "d6c779c179aa3e5f68e4d6a3dfef27a6f776d92c" }
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 cached = "0.12"

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -347,7 +347,7 @@ fn rocksdb_read_options() -> ReadOptions {
 }
 
 /// DB level options
-fn rocksdb_options() -> Options {
+fn rocksdb_options(mutlithread: bool) -> Options {
     let mut opts = Options::default();
 
     opts.create_missing_column_families(true);
@@ -358,7 +358,13 @@ fn rocksdb_options() -> Options {
     opts.set_bytes_per_sync(1048576);
     opts.set_write_buffer_size(1024 * 1024 * 512 / 2);
     opts.set_max_bytes_for_level_base(1024 * 1024 * 512 / 2);
-    opts.increase_parallelism(cmp::max(1, num_cpus::get() as i32 / 2));
+    if mutlithread {
+        opts.increase_parallelism(cmp::max(1, num_cpus::get() as i32 / 2));
+    } else {
+        opts.set_disable_auto_compactions(true);
+        opts.set_max_background_compactions(0);
+        opts.set_max_background_flushes(0);
+    }
     opts.set_max_total_wal_size(1 * 1024 * 1024 * 1024);
 
     return opts;
@@ -407,8 +413,8 @@ impl RocksDB {
         Ok(Self { db, cfs })
     }
 
-    pub fn new<P: AsRef<std::path::Path>>(path: P) -> Result<Self, DBError> {
-        let options = rocksdb_options();
+    pub fn new<P: AsRef<std::path::Path>>(path: P, mutlithread: bool) -> Result<Self, DBError> {
+        let options = rocksdb_options(mutlithread);
         let cf_names: Vec<_> = (0..NUM_COLS).map(|col| format!("col{}", col)).collect();
         let cf_descriptors = cf_names
             .iter()

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -254,8 +254,8 @@ pub fn read_with_cache<'a, T: BorshDeserialize + 'a>(
     Ok(None)
 }
 
-pub fn create_store(path: &str) -> Arc<Store> {
-    let db = Arc::new(RocksDB::new(path).expect("Failed to open the database"));
+pub fn create_store(path: &str, multithread: bool) -> Arc<Store> {
+    let db = Arc::new(RocksDB::new(path, multithread).expect("Failed to open the database"));
     Arc::new(Store::new(db))
 }
 

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -85,7 +85,7 @@ impl GenesisBuilder {
     }
 
     pub fn from_config(home_dir: &Path, genesis: Arc<Genesis>) -> Self {
-        let store = create_store(&get_store_path(home_dir));
+        let store = create_store(&get_store_path(home_dir), true);
         Self::from_config_and_store(home_dir, genesis, store)
     }
 

--- a/genesis-tools/genesis-populate/src/main.rs
+++ b/genesis-tools/genesis-populate/src/main.rs
@@ -28,7 +28,7 @@ fn main() {
         .unwrap();
     let near_config = load_config(home_dir);
 
-    let store = create_store(&get_store_path(home_dir));
+    let store = create_store(&get_store_path(home_dir), true);
     GenesisBuilder::from_config_and_store(home_dir, Arc::clone(&near_config.genesis), store)
         .add_additional_accounts(additional_accounts_num)
         .add_additional_accounts_contract(

--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -9,7 +9,7 @@ actix = "0.9"
 actix-web = { version = "2", features = [ "openssl" ] }
 byteorder = "1.2"
 easy-ext = "0.2"
-rocksdb = "0.14"
+rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "d6c779c179aa3e5f68e4d6a3dfef27a6f776d92c" }
 log = "0.4"
 chrono = { version = "0.4.4", features = ["serde"] }
 git-version = "0.3.1"

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -71,21 +71,21 @@ pub fn apply_store_migrations(path: &String) {
         // Does not need to do anything since open db with option `create_missing_column_families`
         // Nevertheless need to bump db version, because db_version 1 binary can't open db_version 2 db
         info!(target: "near", "Migrate DB from version 1 to 2");
-        let store = create_store(&path);
+        let store = create_store(&path, true);
         set_store_version(&store, 2);
     }
     if db_version <= 2 {
         // version 2 => 3: add ColOutcomesByBlockHash + rename LastComponentNonce -> ColLastComponentNonce
         // The column number is the same, so we don't need additional updates
         info!(target: "near", "Migrate DB from version 2 to 3");
-        let store = create_store(&path);
+        let store = create_store(&path, true);
         fill_col_outcomes_by_hash(&store);
         set_store_version(&store, 3);
     }
     if db_version <= 3 {
         // version 3 => 4: add ColTransactionRefCount
         info!(target: "near", "Migrate DB from version 3 to 4");
-        let store = create_store(&path);
+        let store = create_store(&path, true);
         fill_col_transaction_refcount(&store);
         set_store_version(&store, 4);
     }
@@ -100,7 +100,7 @@ pub fn init_and_migrate_store(home_dir: &Path) -> Arc<Store> {
     if store_exists {
         apply_store_migrations(&path);
     }
-    let store = create_store(&path);
+    let store = create_store(&path, true);
     if !store_exists {
         set_store_version(&store, near_primitives::version::DB_VERSION);
     }

--- a/neard/src/runtime.rs
+++ b/neard/src/runtime.rs
@@ -1438,7 +1438,7 @@ mod test {
             has_reward: bool,
         ) -> Self {
             let dir = tempfile::Builder::new().prefix(prefix).tempdir().unwrap();
-            let store = create_store(&get_store_path(dir.path()));
+            let store = create_store(&get_store_path(dir.path()), true);
             let all_validators = validators.iter().fold(BTreeSet::new(), |acc, x| {
                 acc.union(&x.iter().map(|x| x.as_str()).collect()).cloned().collect()
             });

--- a/runtime/runtime-params-estimator/src/testbed.rs
+++ b/runtime/runtime-params-estimator/src/testbed.rs
@@ -34,7 +34,7 @@ impl RuntimeTestbed {
     pub fn from_state_dump(dump_dir: &Path) -> Self {
         let workdir = tempfile::Builder::new().prefix("runtime_testbed").tempdir().unwrap();
         println!("workdir {}", workdir.path().to_str().unwrap());
-        let store = create_store(&get_store_path(workdir.path()));
+        let store = create_store(&get_store_path(workdir.path()), false);
         let tries = ShardTries::new(store.clone(), 1);
 
         let mut state_file = dump_dir.to_path_buf();

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -9,7 +9,7 @@ byteorder = "1.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
-rocksdb = "0.14"
+rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "d6c779c179aa3e5f68e4d6a3dfef27a6f776d92c" }
 rand = "0.7"
 sha2 = "0.8"
 sha3 = "0.8"

--- a/runtime/runtime/tests/test_regression.rs
+++ b/runtime/runtime/tests/test_regression.rs
@@ -63,7 +63,7 @@ fn template_test(transaction_type: TransactionType, db_type: DataBaseType, expec
     let tmpdir = tempfile::Builder::new().prefix("storage").tempdir().unwrap();
     let tries = match db_type {
         DataBaseType::Disk => {
-            let store = create_store(tmpdir.path().to_str().unwrap());
+            let store = create_store(tmpdir.path().to_str().unwrap(), true);
             ShardTries::new(store, 1)
         }
         DataBaseType::InMemory => create_tries(),

--- a/test-utils/loadtester/src/main.rs
+++ b/test-utils/loadtester/src/main.rs
@@ -197,7 +197,7 @@ fn load_state_dump(matches: &clap::ArgMatches<'_>) {
     let state_dump_path = value_t_or_exit!(matches, "state_dump", PathBuf);
     let dir = dir_buf.as_path();
     let state_dump = state_dump_path.as_path();
-    let store = create_store(&get_store_path(dir));
+    let store = create_store(&get_store_path(dir), true);
     store.load_from_file(ColState, state_dump).expect("Failed to read state dump");
 }
 

--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -241,7 +241,7 @@ fn main() {
     let home_dir = matches.value_of("home").map(|dir| Path::new(dir)).unwrap();
     let near_config = load_config(home_dir);
 
-    let store = create_store(&get_store_path(&home_dir));
+    let store = create_store(&get_store_path(&home_dir), true);
 
     match matches.subcommand() {
         ("peers", Some(_args)) => {

--- a/test-utils/store-validator/src/main.rs
+++ b/test-utils/store-validator/src/main.rs
@@ -29,7 +29,7 @@ fn main() {
     let home_dir = matches.value_of("home").map(|dir| Path::new(dir)).unwrap();
     let near_config = load_config(home_dir);
 
-    let store = create_store(&get_store_path(&home_dir));
+    let store = create_store(&get_store_path(&home_dir), true);
 
     let runtime_adapter: Arc<dyn RuntimeAdapter> = Arc::new(neard::NightshadeRuntime::new(
         &home_dir,


### PR DESCRIPTION
@olonho 
This unfortunately seems to have no use: although according to rocksdb wiki and manually lookup option.h, these are only options control background threads:
https://github.com/facebook/rocksdb/wiki/Thread-Pool
https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h

```
(lldb) thread list
Process 19245 stopped
* thread #1: tid = 0x1c3af28, 0x000000010df4844a runtime-params-estimator`rocksdb::MemTable::Add(this=0x00007fb56e0e4600, s=481200, type=kTypeValue, key=0x00007ffee2757298, value=0x00007ffee2757288, allow_concurrent=false, post_process_info=0x0000000000000000, hint=0x0000000000000000) at memtable.cc:590:3, queue = 'com.apple.main-thread', stop reason = signal SIGSTOP
  thread #2: tid = 0x1c3af29, 0x00007fff672cf86a libsystem_kernel.dylib`__psynch_cvwait + 10
  thread #3: tid = 0x1c3af2a, 0x00007fff672cf86a libsystem_kernel.dylib`__psynch_cvwait + 10
  thread #4: tid = 0x1c3afe2, 0x00007fff672cf86a libsystem_kernel.dylib`__psynch_cvwait + 10
  thread #5: tid = 0x1c3afe3, 0x00007fff672cf86a libsystem_kernel.dylib`__psynch_cvwait + 10
(lldb) t 2
* thread #2
    frame #0: 0x00007fff672cf86a libsystem_kernel.dylib`__psynch_cvwait + 10
libsystem_kernel.dylib`__psynch_cvwait:
->  0x7fff672cf86a <+10>: jae    0x7fff672cf874            ; <+20>
    0x7fff672cf86c <+12>: movq   %rax, %rdi
    0x7fff672cf86f <+15>: jmp    0x7fff672cc457            ; cerror_nocancel
    0x7fff672cf874 <+20>: retq   
(lldb) bt
* thread #2
  * frame #0: 0x00007fff672cf86a libsystem_kernel.dylib`__psynch_cvwait + 10
    frame #1: 0x00007fff6738e56e libsystem_pthread.dylib`_pthread_cond_wait + 722
    frame #2: 0x00007fff643c9a0a libc++.1.dylib`std::__1::condition_variable::wait(std::__1::unique_lock<std::__1::mutex>&) + 18
    frame #3: 0x000000010e28b4a6 runtime-params-estimator`rocksdb::ThreadPoolImpl::Impl::BGThread(this=0x00007fb5adc1acb0, thread_id=0) at threadpool_imp.cc:197:17
    frame #4: 0x000000010e28bbc6 runtime-params-estimator`rocksdb::ThreadPoolImpl::Impl::BGThreadWrapper(arg=0x00007fb5adc801d0) at threadpool_imp.cc:307:7
    frame #5: 0x000000010e28fb35 runtime-params-estimator`decltype(__f=(0x00007fb5adc80688), __args=0x00007fb5adc80690)(void*)>(fp)(std::__1::forward<rocksdb::BGThreadMetadata*>(fp0))) std::__1::__invoke<void (*)(void*), rocksdb::BGThreadMetadata*>(void (*&&)(void*), rocksdb::BGThreadMetadata*&&) at type_traits:4339:1
    frame #6: 0x000000010e28faae runtime-params-estimator`void std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (*)(void*), rocksdb::BGThreadMetadata*, 2ul>(__t=size=3, (null)=__tuple_indices<2> @ 0x0000700008fb0eb8)(void*), rocksdb::BGThreadMetadata*>&, std::__1::__tuple_indices<2ul>) at thread:342:5
    frame #7: 0x000000010e28f2d6 runtime-params-estimator`void* std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, void (*)(void*), rocksdb::BGThreadMetadata*> >(__vp=0x00007fb5adc80680) at thread:352:5
    frame #8: 0x00007fff6738b2eb libsystem_pthread.dylib`_pthread_body + 126
    frame #9: 0x00007fff6738e249 libsystem_pthread.dylib`_pthread_start + 66
    frame #10: 0x00007fff6738a40d libsystem_pthread.dylib`thread_start + 13
(lldb) ^D
```

Note the `rocksdb::ThreadPoolImpl::Impl::BGThread` above. I'll give c++ rocksdb a last try next Monday to see it's not fault of rust-rocksdb doesn't pass correct option in ffi (unlikely). Otherwise, we may need to use some mock storage in param estimator.
