### PR TITLE
Change ClientActor to prioritize block production during high load

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -714,7 +714,9 @@ impl ClientActor {
     fn try_handle_block_production(&mut self) {
         let now = Utc::now();
         if let Some(prev) = self.last_block_production_attempt {
-            if (now - prev).to_std().unwrap_or_default() < self.client.config.block_production_tracking_delay {
+            if (now - prev).to_std().unwrap_or_default()
+                < self.client.config.block_production_tracking_delay
+            {
                 return;
             }
         }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -495,6 +495,8 @@ impl Handler<Status> for ClientActor {
     type Result = Result<StatusResponse, String>;
 
     fn handle(&mut self, msg: Status, _: &mut Context<Self>) -> Self::Result {
+        self.try_handle_block_production();
+
         let head = self.client.chain.head().map_err(|err| err.to_string())?;
         let header = self
             .client
@@ -561,6 +563,8 @@ impl Handler<GetNetworkInfo> for ClientActor {
     type Result = Result<NetworkInfoResponse, String>;
 
     fn handle(&mut self, _: GetNetworkInfo, _: &mut Context<Self>) -> Self::Result {
+        self.try_handle_block_production();
+
         Ok(NetworkInfoResponse {
             active_peers: self
                 .network_info

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -718,8 +718,8 @@ impl ClientActor {
         // There is a bug in Actix library. While there are messages in mailbox, Actix
         // will prioritize processing messages until mailbox is empty. Execution of any other task
         // scheduled with run_later will be delayed.
-        self.try_handle_block_production();
         self.try_doomslug_timer(ctx);
+        self.try_handle_block_production();
         self.try_chunk_request_retry(ctx);
     }
 


### PR DESCRIPTION
``ClientActor`` will try to check if it's time to do block production every time it receives messages from inbox in ``handle`` method. This will ensure that block production still happens during high load.

Context:
There is a bug in Actix library. While there are messages in mailbox, Actix
will prioritize processing messages until mailbox is empty. Execution of any other task
scheduled with run_later will be delayed.