### PR TITLE
fix(rpc): do not serve rpc while the node is syncing

### DIFF
--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -183,8 +183,6 @@ jsonrpc_client!(pub struct JsonRpcClient {
     pub fn broadcast_tx_commit(&self, tx: String) -> RpcRequest<FinalExecutionOutcomeView>;
     pub fn status(&self) -> RpcRequest<StatusResponse>;
     #[allow(non_snake_case)]
-    pub fn EXPERIMENTAL_check_tx(&self, tx: String) -> RpcRequest<serde_json::Value>;
-    #[allow(non_snake_case)]
     pub fn EXPERIMENTAL_genesis_config(&self) -> RpcRequest<serde_json::Value>;
     pub fn health(&self) -> RpcRequest<()>;
     pub fn tx(&self, hash: String, account_id: String) -> RpcRequest<FinalExecutionOutcomeView>;

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -51,6 +51,25 @@ mod metrics;
 const JSON_PAYLOAD_MAX_SIZE: usize = 2 * 1024 * 1024;
 const QUERY_DATA_MAX_SIZE: usize = 10 * 1024;
 
+/// RPCs that should only be called when the node is synced
+const RPC_REQUIRES_SYNC: [&'static str; 15] = [
+    "broadcast_tx_async",
+    "EXPERIMENTAL_broadcast_tx_sync",
+    "broadcast_tx_commit",
+    "validators",
+    "query",
+    "health",
+    "tx",
+    "block",
+    "chunk",
+    "EXPERIMENTAL_changes",
+    "EXPERIMENTAL_changes_in_block",
+    "next_light_client_block",
+    "EXPERIMENTAL_light_client_proof",
+    "light_client_proof",
+    "gas_price",
+];
+
 #[derive(Serialize, Deserialize, Clone, Copy, Debug)]
 pub struct RpcPollingConfig {
     pub polling_interval: Duration,
@@ -131,6 +150,7 @@ pub enum ServerError {
     Timeout,
     Closed,
     InternalError,
+    IsSyncing,
 }
 
 impl Display for ServerError {
@@ -140,6 +160,7 @@ impl Display for ServerError {
             ServerError::Timeout => write!(f, "ServerError: Timeout"),
             ServerError::Closed => write!(f, "ServerError: Closed"),
             ServerError::InternalError => write!(f, "ServerError: Internal Error"),
+            ServerError::IsSyncing => write!(f, "ServerError: Node is syncing"),
         }
     }
 }
@@ -209,11 +230,22 @@ impl JsonRpcHandler {
             }
         }
 
+        if RPC_REQUIRES_SYNC.iter().find(|&&s| s == &request.method).is_some() {
+            match self.client_addr.send(Status { is_health_check: false }).await {
+                Ok(Ok(result)) => {
+                    if result.sync_info.syncing {
+                        return Err(ServerError::IsSyncing.into());
+                    }
+                }
+                Ok(Err(err)) => return Err(RpcError::new(-32_001, err, None)),
+                Err(_) => return Err(RpcError::server_error::<()>(None)),
+            }
+        }
+
         match request.method.as_ref() {
             "broadcast_tx_async" => self.send_tx_async(request.params).await,
             "EXPERIMENTAL_broadcast_tx_sync" => self.send_tx_sync(request.params).await,
             "broadcast_tx_commit" => self.send_tx_commit(request.params).await,
-            "EXPERIMENTAL_check_tx" => self.check_tx(request.params).await,
             "validators" => self.validators(request.params).await,
             "query" => self.query(request.params).await,
             "health" => self.health().await,
@@ -321,10 +353,6 @@ impl JsonRpcHandler {
 
     async fn send_tx_sync(&self, params: Option<Value>) -> Result<Value, RpcError> {
         self.send_or_check_tx(params, false).await
-    }
-
-    async fn check_tx(&self, params: Option<Value>) -> Result<Value, RpcError> {
-        self.send_or_check_tx(params, true).await
     }
 
     async fn send_or_check_tx(

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -201,28 +201,3 @@ fn test_tx_status_missing_tx() {
         }
     });
 }
-
-#[test]
-fn test_check_invalid_tx() {
-    test_with_client!(test_utils::NodeType::Validator, client, async move {
-        let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
-        // invalid base hash
-        let tx = SignedTransaction::send_money(
-            1,
-            "test1".to_string(),
-            "test2".to_string(),
-            &signer,
-            100,
-            hash(&[1]),
-        );
-        let bytes = tx.try_to_vec().unwrap();
-        match client.EXPERIMENTAL_check_tx(to_base64(&bytes)).await {
-            Err(e) => {
-                let s = serde_json::to_string(&e.data.unwrap()).unwrap();
-                println!("{}", s);
-                assert_eq!(s, "{\"TxExecutionError\":{\"InvalidTxError\":\"Expired\"}}");
-            }
-            Ok(_) => panic!("transaction should not succeed"),
-        }
-    });
-}

--- a/pytest/tests/sanity/rpc_sync.py
+++ b/pytest/tests/sanity/rpc_sync.py
@@ -1,0 +1,37 @@
+# test that rpc is properly disabled when a node is syncing
+
+import sys, time
+
+sys.path.append('lib')
+
+from cluster import start_cluster
+
+TIME_OUT = 100
+TARGET_HEIGHT = 100
+
+nodes = start_cluster(
+    1, 1, 1, None,
+    [["epoch_length", 50],
+     ["block_producer_kickout_threshold", 70]], {1: {"tracked_shards": [0]}})
+
+time.sleep(2)
+nodes[1].kill()
+
+status = nodes[0].get_status()
+height = status['sync_info']['latest_block_height']
+
+started = time.time()
+while height < TARGET_HEIGHT:
+    assert time.time() - started < TIME_OUT
+    time.sleep(2)
+    status = nodes[0].get_status()
+    height = status['sync_info']['latest_block_height']
+
+nodes[1].start(nodes[0].node_key.pk, nodes[0].addr())
+time.sleep(2)
+
+status = nodes[1].get_status()
+assert status['sync_info']['syncing']
+
+res = nodes[1].json_rpc('block', [20])
+assert 'IsSyncing' in res['error']['data'], res


### PR DESCRIPTION
A node should not serve rpc while it is syncing since it would both slow down the node and also gives inconsistent result from other nodes. Fixes https://github.com/nearprotocol/nearcore/issues/2795

Test plan
---------
* python test `rpc_sync.py`.