### PR TITLE
fix(nightly): bump borsh version to match near-sdk-rs

### DIFF
--- a/pytest/empty-contract-rs/Cargo.toml
+++ b/pytest/empty-contract-rs/Cargo.toml
@@ -12,7 +12,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 wee_alloc = "0.4.5"
 
-borsh = "0.6.2"
+borsh = "0.7.0"
 
 near-sdk = { git = "https://github.com/near/near-sdk-rs", branch = "master"}
 


### PR DESCRIPTION
* Fixes recent nightly failures due to the change of the `borsh` version in `near-sdk-rs`.