### PR TITLE
Added CI for database migration #2927

### DIFF
--- a/pytest/tests/sanity/db_migration.py
+++ b/pytest/tests/sanity/db_migration.py
@@ -1,0 +1,79 @@
+#!/usr/bin/python3
+"""
+Spins up a node with old version and wait until it produces some blocks.
+Shutdowns the node and restarts with the same data folder with the new binary.
+Makes sure that the node can still produce blocks.
+"""
+
+import logging
+import os
+import sys
+import time
+import subprocess
+
+sys.path.append('lib')
+
+import branches
+import cluster
+from utils import wait_for_blocks_or_timeout
+
+logging.basicConfig(level=logging.INFO)
+
+
+def main():
+    near_root, (stable_branch,
+                current_branch) = branches.prepare_ab_test("beta")
+    node_root = os.path.join(os.path.expanduser("~"), "./near")
+
+    logging.info(f"The near root is {near_root}...")
+    logging.info(f"The node root is {node_root}...")
+
+    init_command = [
+        "%snear-%s" % (near_root, stable_branch),
+        "--home=%s" % node_root,
+        "init",
+        "--fast",
+    ]
+
+    # Init local node
+    subprocess.call(init_command)
+
+    # Run stable node for few blocks.
+    config = {
+        "local": True,
+        'near_root': near_root,
+        'binary_name': "near-%s" % stable_branch
+    }
+
+    logging.info("Starting the stable node...")
+    stable_node = cluster.spin_up_node(config, near_root, node_root, 0, None,
+                                       None)
+
+    logging.info("Running the stable node...")
+    wait_for_blocks_or_timeout(stable_node, 20, 100)
+
+    subprocess.call(["cp", "-r", node_root, "/tmp/near"])
+    stable_node.cleanup()
+
+    logging.info(
+        "Stable node has produced blocks... Stopping the stable node... ")
+
+    # Run new node and verify it runs for a few more blocks.
+    config["binary_name"] = "near-%s" % current_branch
+    subprocess.call(["cp", "-r", "/tmp/near", node_root])
+
+    logging.info("Starting the current node...")
+    current_node = cluster.spin_up_node(config, near_root, node_root, 0, None,
+                                        None)
+
+    logging.info("Running the current node...")
+    wait_for_blocks_or_timeout(current_node, 20, 100)
+
+    logging.info(
+        "Currnet node has produced blocks... Stopping the current node... ")
+
+    current_node.cleanup()
+
+
+if __name__ == "__main__":
+    main()

--- a/pytest/tests/sanity/state_migration.py
+++ b/pytest/tests/sanity/state_migration.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python3
 """
 Spins up stable node, runs it for a few blocks and stops it.
 Dump state via the stable state-viewer.
@@ -19,15 +19,7 @@ sys.path.append('lib')
 
 import branches
 import cluster
-
-
-def wait_for_blocks_or_timeout(node, num_blocks, timeout):
-    max_height = 0
-    started = time.time()
-    while max_height < num_blocks:
-        assert time.time() - started < timeout
-        status = node.get_status()
-        max_height = status['sync_info']['latest_block_height']
+from utils import wait_for_blocks_or_timeout
 
 
 def main():


### PR DESCRIPTION
Test Plan:
```
 5 sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/c/pytest (db_migration_sanity)> python3 tests/sanity/db_migration.py
  6    Compiling neard v1.2.0 (/home/sandi/workspace/near/core/neard)               
  7     Finished dev [unoptimized + debuginfo] target(s) in 28.83s                  
  8     Finished dev [unoptimized + debuginfo] target(s) in 0.18s                   
  9 Updated 0 paths from the index                                                  
 10 Downloading near & state-viewer for beta@Linux                                  
 11 INFO:root:The near root is ../target/debug/...                                  
 12 INFO:root:The node root is /home/sandi/./near...                                
 13 Jul 14 19:14:18.625  INFO near: Version: 1.2.0, Build: 86e4397c, Latest Protocol: 30
 14 Jul 14 19:14:18.626  INFO near: Generated node key, validator key, genesis file in /home/sandi/./near
 15 INFO:root:Starting the stable node...                                           
 16 Starting node 0 as BOOT NODE                                                    
 17 node 0 started                                                                  
 18 INFO:root:Running the stable node...                                            
 19 INFO:root:Stable node has produced blocks... Stopping the stable node...        
 20 INFO:root:Starting the current node...                                          
 21 Starting node 0 as BOOT NODE                                                    
 22 node 0 started                                                                  
 23 INFO:root:Running the current node...                                           
 24 INFO:root:Currnet node has produced blocks... Stopping the current node...      
 25 Cleaning up node 127.0.0.1:24577 on script exit                                 
 26 Executed store validity tests: 0                                                
 27 Cleaning up node 127.0.0.1:24577 on script exit                                 
 28 Executed store validity tests: 0      
```