### PR TITLE
fix(pytest): Import borsh from near-sdk-rs directly

### DIFF
--- a/pytest/empty-contract-rs/Cargo.toml
+++ b/pytest/empty-contract-rs/Cargo.toml
@@ -12,8 +12,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 wee_alloc = "0.4.5"
 
-borsh = "0.7.0"
-
 near-sdk = { git = "https://github.com/near/near-sdk-rs", branch = "master"}
 
 [profile.release]

--- a/pytest/empty-contract-rs/Cargo.toml
+++ b/pytest/empty-contract-rs/Cargo.toml
@@ -8,10 +8,6 @@ edition = "2018"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-wee_alloc = "0.4.5"
-
 near-sdk = { git = "https://github.com/near/near-sdk-rs", branch = "master"}
 
 [profile.release]

--- a/pytest/empty-contract-rs/src/lib.rs
+++ b/pytest/empty-contract-rs/src/lib.rs
@@ -2,4 +2,4 @@ use near_sdk::{env, metadata, near_bindgen};
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 
 #[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+static ALLOC: near_sdk::wee_alloc::WeeAlloc = near_sdk::wee_alloc::WeeAlloc::INIT;

--- a/pytest/empty-contract-rs/src/lib.rs
+++ b/pytest/empty-contract-rs/src/lib.rs
@@ -1,5 +1,5 @@
-use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::{env, metadata, near_bindgen};
+use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;


### PR DESCRIPTION
* `near-sdk-rs` now re-exports its `borsh`, so we do not need a separate dependency for it