### PR TITLE
fix(test): fix cross_shard_tx tests

### DIFF
--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -727,7 +727,7 @@ impl ClientActor {
 
         if self.sync_started {
             self.doomslug_timer_next_attempt = self.run_timer(
-                Duration::from_millis(50),
+                self.client.config.doosmslug_step_period,
                 self.doomslug_timer_next_attempt,
                 ctx,
                 |act, ctx| act.try_doomslug_timer(ctx),

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -65,6 +65,8 @@ pub struct ClientConfig {
     pub catchup_step_period: Duration,
     /// Time between checking to re-request chunks.
     pub chunk_request_retry_period: Duration,
+    /// Time between running doomslug timer.
+    pub doosmslug_step_period: Duration,
     /// Behind this horizon header fetch kicks in.
     pub block_header_fetch_horizon: BlockHeightDelta,
     /// Number of blocks to garbage collect at every gc call.
@@ -122,6 +124,7 @@ impl ClientConfig {
                 Duration::from_millis(100),
                 Duration::from_millis(min_block_prod_time / 5),
             ),
+            doosmslug_step_period: Duration::from_millis(100),
             block_header_fetch_horizon: 50,
             gc_blocks_limit: 100,
             tracked_accounts: vec![],

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -77,7 +77,7 @@ const BLOCK_HEADER_FETCH_HORIZON: BlockHeightDelta = 50;
 const CATCHUP_STEP_PERIOD: u64 = 100;
 
 /// Time between checking to re-request chunks.
-const CHUNK_REQUEST_RETRY_PERIOD: u64 = 200;
+const CHUNK_REQUEST_RETRY_PERIOD: u64 = 400;
 
 /// Expected epoch length.
 pub const EXPECTED_EPOCH_LENGTH: BlockHeightDelta = (5 * 60 * 1000) / MIN_BLOCK_PRODUCTION_DELAY;
@@ -293,6 +293,10 @@ fn default_view_client_threads() -> usize {
     4
 }
 
+fn default_doomslug_step_period() -> Duration {
+    Duration::from_millis(100)
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Consensus {
     /// Minimum number of peers to start syncing.
@@ -338,6 +342,9 @@ pub struct Consensus {
     /// During sync the time we wait before reentering the sync loop
     #[serde(default = "default_sync_step_period")]
     pub sync_step_period: Duration,
+    /// Time between running doomslug timer.
+    #[serde(default = "default_doomslug_step_period")]
+    pub doomslug_step_period: Duration,
 }
 
 impl Default for Consensus {
@@ -362,6 +369,7 @@ impl Default for Consensus {
             ),
             sync_check_period: default_sync_check_period(),
             sync_step_period: default_sync_step_period(),
+            doomslug_step_period: default_doomslug_step_period(),
         }
     }
 }
@@ -562,6 +570,7 @@ impl NearConfig {
                 block_header_fetch_horizon: config.consensus.block_header_fetch_horizon,
                 catchup_step_period: config.consensus.catchup_step_period,
                 chunk_request_retry_period: config.consensus.chunk_request_retry_period,
+                doosmslug_step_period: config.consensus.doomslug_step_period,
                 tracked_accounts: config.tracked_accounts,
                 tracked_shards: config.tracked_shards,
                 archive: config.archive,


### PR DESCRIPTION
Cross shard tx tests are broken after https://github.com/nearprotocol/nearcore/pull/2983, likely because the overhead introduced by the change. Now we might spend too much time checking the triggers such that some message processing is delayed. This PR fixes it by checking the triggers less frequently.