### PR TITLE
fix(gc): properly update chunk tail

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1906,7 +1906,9 @@ impl<'a> ChainStoreUpdate<'a> {
 
     pub fn update_tail(&mut self, height: BlockHeight) {
         self.tail = Some(height);
-        if self.chunk_tail.is_none() {
+        let genesis_height = self.get_genesis_height();
+        let chunk_tail = self.chunk_tail().unwrap_or_else(|_| genesis_height);
+        if chunk_tail == genesis_height {
             // For consistency, Chunk Tail should be set if Tail is set
             self.chunk_tail = Some(self.get_genesis_height());
         }

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -876,6 +876,21 @@ fn test_gc_block_skips() {
 }
 
 #[test]
+fn test_gc_chunk_tail() {
+    let mut chain_genesis = ChainGenesis::test();
+    let epoch_length = 100;
+    chain_genesis.epoch_length = epoch_length;
+    let mut env = TestEnv::new(chain_genesis.clone(), 1, 1);
+    let mut chunk_tail = 0;
+    for i in (1..10).chain(101..epoch_length * 6) {
+        env.produce_block(0, i);
+        let cur_chunk_tail = env.clients[0].chain.store().chunk_tail().unwrap();
+        assert!(cur_chunk_tail >= chunk_tail);
+        chunk_tail = cur_chunk_tail;
+    }
+}
+
+#[test]
 fn test_gc_execution_outcome() {
     let epoch_length = 5;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);


### PR DESCRIPTION
In `update_tail`, we incorrectly update `chunk_tail` if it is `None`, because even if `chunk_tail` inside `ChainStoreUpdate` is none, it doesn't mean that chunk_tail doesn't exist. Therefore, in `clear_data`, when we loop through some height where there is no block, we end up overwriting `chunk_tail` to be `genesis_height`, thereby causing garbage collection to be extremely slow.

Test plan
---------
`test_gc_chunk_tail` passes.