### PR TITLE
feat: NEAR Wallet Indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
- "parking_lot",
+ "parking_lot 0.10.2",
  "pin-project",
  "smallvec",
  "tokio",
@@ -214,7 +214,7 @@ dependencies = [
  "lazy_static",
  "log",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.10.2",
  "threadpool",
 ]
 
@@ -464,6 +464,17 @@ name = "bencher"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfdb4953a096c551ce9ace855a604d702e6e62d77fac690575ae347571717f5"
+
+[[package]]
+name = "bigdecimal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460825c9e21708024d67c07057cd5560e5acdccac85de0de624a81d3de51bacb"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "bincode"
@@ -808,6 +819,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,6 +1112,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2de9deab977a153492a1468d1b1c0662c1cf39e5ea87d0c060ecd59ef18d8c"
+dependencies = [
+ "bigdecimal",
+ "bitflags",
+ "byteorder",
+ "diesel_derives",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "pq-sys",
+ "r2d2",
+ "serde_json",
+]
+
+[[package]]
+name = "diesel_derives"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,6 +1186,12 @@ name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dtoa"
@@ -1829,6 +1884,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexer-wallet"
+version = "0.1.0"
+dependencies = [
+ "actix",
+ "bigdecimal",
+ "diesel",
+ "dotenv",
+ "near-indexer",
+ "num-traits",
+ "r2d2",
+ "serde_json",
+ "tokio",
+ "tokio-diesel",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1862,6 +1933,12 @@ dependencies = [
  "number_prefix",
  "regex",
 ]
+
+[[package]]
+name = "instant"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b141fdc7836c525d4d594027d318c84161ca17aaf8113ab1f81ab93ae897485"
 
 [[package]]
 name = "iovec"
@@ -2086,6 +2163,15 @@ name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
 dependencies = [
  "scopeguard",
 ]
@@ -3037,8 +3123,19 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
 dependencies = [
- "lock_api",
- "parking_lot_core",
+ "lock_api 0.3.4",
+ "parking_lot_core 0.7.2",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4893845fa2ca272e647da5d0e46660a314ead9c2fdd9a883aabc32e481a8733"
+dependencies = [
+ "instant",
+ "lock_api 0.4.1",
+ "parking_lot_core 0.8.0",
 ]
 
 [[package]]
@@ -3048,7 +3145,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
  "cfg-if",
- "cloudabi",
+ "cloudabi 0.0.3",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi 0.3.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.1.0",
+ "instant",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -3116,6 +3228,15 @@ name = "ppv-lite86"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
+name = "pq-sys"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac25eee5a0582f45a67e837e350d784e7003bd29a5f460796772061ca49ffda"
+dependencies = [
+ "vcpkg",
+]
 
 [[package]]
 name = "primitive-types"
@@ -3192,6 +3313,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r2d2"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545c5bc2b880973c9c10e4067418407a0ccaa3091781d1671d46eb35107cb26f"
+dependencies = [
+ "log",
+ "parking_lot 0.11.0",
+ "scheduled-thread-pool",
 ]
 
 [[package]]
@@ -3634,6 +3766,15 @@ checksum = "039c25b130bd8c1321ee2d7de7fde2659fa9c2744e4bb29711cfc852ea53cd19"
 dependencies = [
  "lazy_static",
  "winapi 0.3.8",
+]
+
+[[package]]
+name = "scheduled-thread-pool"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f74fd1204073fa02d5d5d68bec8021be4c38690b61264b2fdb48083d0e7d7"
+dependencies = [
+ "parking_lot 0.11.0",
 ]
 
 [[package]]
@@ -4171,6 +4312,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-diesel"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713f06058e12ed5adb542401b9d20f2b18b3fccf6184c5d77b57a31b3d21cc69"
+dependencies = [
+ "async-trait",
+ "diesel",
+ "futures",
+ "r2d2",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4677,7 +4831,7 @@ dependencies = [
  "libc",
  "nix",
  "page_size",
- "parking_lot",
+ "parking_lot 0.10.2",
  "rustc_version",
  "serde",
  "serde-bench",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,8 @@ members = [
     "genesis-tools/genesis-populate",
     "genesis-tools/keypair-generator",
     "tools/restaked",
-    "tools/indexer/example"
+    "tools/indexer/example",
+    "tools/indexer/wallet",
 ]
 
 [dependencies]

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -13,6 +13,7 @@ use actix::System;
 use tokio::sync::mpsc;
 
 use neard;
+pub use neard::NearConfig;
 mod streamer;
 
 pub use self::streamer::{BlockResponse, Outcome};

--- a/tools/indexer/wallet/Cargo.toml
+++ b/tools/indexer/wallet/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "indexer-wallet"
+version = "0.1.0"
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2018"
+
+[dependencies]
+actix = "0.9"
+bigdecimal = "=0.1.0"
+diesel = { version = "1.4.4", features = ["postgres", "numeric", "serde_json"] }
+dotenv = "0.15.0"
+num-traits = "0.2.11"
+r2d2 = "0.8.8"
+serde_json = "1.0.55"
+tokio = { version = "0.2", features = ["full"] }
+tokio-diesel = "0.3.0"
+
+near-indexer = { path = "../../../chain/indexer" }

--- a/tools/indexer/wallet/diesel.toml
+++ b/tools/indexer/wallet/diesel.toml
@@ -1,0 +1,5 @@
+# For documentation on how to configure this file,
+# see diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"

--- a/tools/indexer/wallet/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/tools/indexer/wallet/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/tools/indexer/wallet/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/tools/indexer/wallet/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/tools/indexer/wallet/migrations/2020-07-15-154433_create_access_keys/down.sql
+++ b/tools/indexer/wallet/migrations/2020-07-15-154433_create_access_keys/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE access_keys;

--- a/tools/indexer/wallet/migrations/2020-07-15-154433_create_access_keys/up.sql
+++ b/tools/indexer/wallet/migrations/2020-07-15-154433_create_access_keys/up.sql
@@ -1,0 +1,14 @@
+CREATE TABLE access_keys (
+    public_key text NOT NULL,
+    account_id text NOT NULL,
+    "action" varchar(6) NOT NULL,
+    status varchar(7) NOT NULL,
+    receipt_hash text NOT NULL,
+    block_height numeric(48,0) NOT NULL,
+    "permission" varchar(13) NOT NULL,
+    CONSTRAINT access_keys_pk PRIMARY KEY (public_key, account_id, "action", receipt_hash)
+);
+CREATE INDEX access_keys_public_key_idx ON access_keys (public_key);
+CREATE INDEX access_keys_account_id_idx ON access_keys (account_id);
+CREATE INDEX access_keys_block_height_idx ON access_keys (block_height);
+CREATE INDEX access_keys_receipt_hash_idx ON access_keys (receipt_hash);

--- a/tools/indexer/wallet/src/main.rs
+++ b/tools/indexer/wallet/src/main.rs
@@ -1,0 +1,221 @@
+use std::env;
+
+use bigdecimal::BigDecimal;
+use num_traits::cast::FromPrimitive;
+use tokio::sync::mpsc;
+
+use diesel::{
+    prelude::*,
+    r2d2::{ConnectionManager, Pool},
+};
+#[macro_use]
+extern crate diesel;
+extern crate dotenv;
+use dotenv::dotenv;
+use tokio_diesel::*;
+
+use near_indexer;
+mod schema;
+use schema::access_keys;
+
+const ADD: &str = "ADD";
+const DELETE: &str = "DELETE";
+const PENDING: &str = "PENDING";
+const SUCCESS: &str = "SUCCESS";
+const FAILED: &str = "FAILED";
+const FUNCTION_CALL: &str = "FUNCTION_CALL";
+const FULL_ACCESS: &str = "FULL_ACCESS";
+
+#[derive(Insertable, Queryable)]
+struct AccessKey {
+    public_key: String,
+    account_id: String,
+    action: &'static str,
+    status: &'static str,
+    receipt_hash: String,
+    block_height: BigDecimal,
+    permission: &'static str,
+}
+
+impl AccessKey {
+    pub fn from_receipt_view(
+        receipt: &near_indexer::near_primitives::views::ReceiptView,
+        block_height: u64,
+    ) -> Vec<Self> {
+        let mut access_keys: Vec<Self> = vec![];
+        if let near_indexer::near_primitives::views::ReceiptEnumView::Action { actions, .. } =
+            &receipt.receipt
+        {
+            for action in actions {
+                let access_key = match action {
+                    near_indexer::near_primitives::views::ActionView::AddKey {
+                        public_key,
+                        access_key,
+                    } => Self {
+                        public_key: public_key.to_string(),
+                        account_id: receipt.receiver_id.to_string(),
+                        action: ADD,
+                        status: PENDING,
+                        receipt_hash: receipt.receipt_id.to_string(),
+                        block_height: BigDecimal::from_u64(block_height).expect("Block height must be provided."),
+                        permission: match access_key.permission {
+                            near_indexer::near_primitives::views::AccessKeyPermissionView::FullAccess => {
+                                FULL_ACCESS
+                            },
+                            near_indexer::near_primitives::views::AccessKeyPermissionView::FunctionCall { .. } => {
+                                FUNCTION_CALL
+                            },
+                        },
+                    },
+                    near_indexer::near_primitives::views::ActionView::DeleteKey { public_key } => Self {
+                        public_key: public_key.to_string(),
+                        account_id: receipt.receiver_id.to_string(),
+                        action: DELETE,
+                        status: PENDING,
+                        receipt_hash: receipt.receipt_id.to_string(),
+                        block_height: BigDecimal::from_u64(block_height).expect("Block height must be provided."),
+                        permission: "",
+                    },
+                    _ => { continue },
+                };
+                access_keys.push(access_key);
+            }
+        }
+        access_keys
+    }
+}
+
+fn establish_connection() -> Pool<ConnectionManager<PgConnection>> {
+    dotenv().ok();
+
+    let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set");
+    let manager = ConnectionManager::<PgConnection>::new(&database_url);
+    Pool::builder().build(manager).expect(&format!("Error connecting to {}", database_url))
+}
+
+async fn handle_genesis_public_keys(near_config: near_indexer::NearConfig) {
+    let pool = establish_connection();
+    let genesis_height = near_config.genesis.config.genesis_height.clone();
+    let access_keys = near_config.genesis.records.as_ref()
+        .iter()
+        .filter(|record| match record {
+        near_indexer::near_primitives::state_record::StateRecord::AccessKey { .. } => true,
+        _ => false,
+    })
+        .filter_map(|record| if let near_indexer::near_primitives::state_record::StateRecord::AccessKey { account_id, public_key, access_key} = record {
+        Some(AccessKey {
+            public_key: public_key.to_string(),
+            account_id: account_id.to_string(),
+            action: ADD,
+            status: SUCCESS,
+            receipt_hash: "genesis".to_string(),
+            block_height: BigDecimal::from_u64(genesis_height).expect("genesis_height must be provided"),
+            permission: match access_key.permission {
+                near_indexer::near_primitives::account::AccessKeyPermission::FullAccess => FULL_ACCESS,
+                near_indexer::near_primitives::account::AccessKeyPermission::FunctionCall(_) => FUNCTION_CALL,
+            }
+        })
+    } else { None }).collect::<Vec<AccessKey>>();
+
+    diesel::insert_into(schema::access_keys::table)
+        .values(access_keys)
+        .on_conflict_do_nothing()
+        .execute_async(&pool)
+        .await
+        .unwrap();
+}
+
+async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::BlockResponse>) {
+    let pool = establish_connection();
+
+    while let Some(block) = stream.recv().await {
+        eprintln!("Block height {:?}", block.block.header.height);
+
+        // Handle outcomes
+        let receipt_outcomes = &block
+            .outcomes
+            .iter()
+            .filter_map(|outcome| match outcome {
+                near_indexer::Outcome::Receipt(execution_outcome) => Some(execution_outcome),
+                _ => None,
+            })
+            .collect::<Vec<&near_indexer::near_primitives::views::ExecutionOutcomeWithIdView>>();
+
+        diesel::update(
+            schema::access_keys::table.filter(
+                schema::access_keys::dsl::receipt_hash.eq_any(
+                    receipt_outcomes
+                        .iter()
+                        .filter(|outcome| match &outcome.outcome.status {
+                            near_indexer::near_primitives::views::ExecutionStatusView::Failure(
+                                _,
+                            ) => true,
+                            _ => false,
+                        })
+                        .map(|outcome| outcome.id.clone().to_string())
+                        .collect::<Vec<String>>(),
+                ),
+            ),
+        )
+        .set(schema::access_keys::dsl::status.eq(FAILED))
+        .execute_async(&pool)
+        .await
+        .unwrap();
+
+        diesel::update(
+            schema::access_keys::table.filter(
+                schema::access_keys::dsl::receipt_hash.eq_any(
+                    receipt_outcomes
+                        .iter()
+                        .filter(|outcome| match &outcome.outcome.status {
+                            near_indexer::near_primitives::views::ExecutionStatusView::SuccessReceiptId(
+                                _,
+                            ) | near_indexer::near_primitives::views::ExecutionStatusView::SuccessValue(_) => true,
+                            _ => false,
+                        })
+                        .map(|outcome| outcome.id.clone().to_string())
+                        .collect::<Vec<String>>(),
+                ),
+            ),
+        )
+        .set(schema::access_keys::dsl::status.eq(SUCCESS))
+        .execute_async(&pool)
+        .await
+        .unwrap();
+
+        // Handle receipts
+        for chunk in &block.chunks {
+            diesel::insert_into(schema::access_keys::table)
+                .values(
+                    chunk
+                        .receipts
+                        .iter()
+                        .filter(|receipt| match receipt.receipt {
+                            near_indexer::near_primitives::views::ReceiptEnumView::Action {
+                                ..
+                            } => true,
+                            _ => false,
+                        })
+                        .map(|receipt| {
+                            AccessKey::from_receipt_view(receipt, block.block.header.height.clone())
+                        })
+                        .flatten()
+                        .collect::<Vec<AccessKey>>(),
+                )
+                .execute_async(&pool)
+                .await
+                .unwrap();
+        }
+    }
+}
+
+fn main() {
+    let home_dir: Option<String> = env::args().nth(1);
+
+    let indexer = near_indexer::Indexer::new(home_dir.as_ref().map(AsRef::as_ref));
+    let near_config = indexer.near_config().clone();
+    let stream = indexer.streamer();
+    actix::spawn(handle_genesis_public_keys(near_config));
+    actix::spawn(listen_blocks(stream));
+    indexer.start();
+}

--- a/tools/indexer/wallet/src/schema.rs
+++ b/tools/indexer/wallet/src/schema.rs
@@ -1,0 +1,11 @@
+table! {
+    access_keys (public_key, account_id, action, receipt_hash) {
+        public_key -> Text,
+        account_id -> Text,
+        action -> Varchar,
+        status -> Varchar,
+        receipt_hash -> Text,
+        block_height -> Numeric,
+        permission -> Varchar,
+    }
+}


### PR DESCRIPTION
NEAR Wallet Indexer PoC 

> Syncing all the AddKey actions from successful receipts into a table (public_key -> receiver_id (account id), and we can have multiple public keys for a single account as well as the same public key can be [it is not recommended, but it is not restricted] used by several accounts)

@frol: Given that we can have multiple AddKey and DeleteKey actions throughout the history... [skipped]
We are going to design the Wallet Indexer to expose a single table with the following columns:
```
public key
account id
action (ADD | DELETE)
status (PENDING | SUCCESS | FAILED)
receipt id (we need it to connect Execution Outcome status which only gets known in the next block after we observe the receipt itself)
block height (this way you can get the latest state)
permission (FUNCTION_CALL | FULL_ACCESS)
```
To query the public key you will need to do the following query:
```sql
SELECT action
FROM access_keys
WHERE public_key = :public_key AND account_id = :account_id AND status = "SUCCESS"
ORDER BY block_height DESC
LIMIT 1
```
If the `action` is `"ADD"`, then the latest state is that the key exists and belongs to the account, otherwise, it used to be there, but not anymore.

---

Also before start NEAR Wallet Indexer handles AccessKey addition from genesis, so all the keys from genesis will be added to database.

`tools/indexer/wallet/.env` should be added with your credentials to PostgreSQL database.

Example:
```
DATABASE_URL=postgres://user:password@host/database_name
```