### PR TITLE
fix: remove legacy config on block weight

### DIFF
--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -483,7 +483,6 @@ impl RuntimeAdapter for KeyValueRuntime {
         _gas_limit: Gas,
         _shard_id: ShardId,
         _state_root: StateRoot,
-        _max_number_of_transactions: usize,
         transactions: &mut dyn PoolIterator,
         _chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
     ) -> Result<Vec<SignedTransaction>, Error> {

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -178,7 +178,6 @@ pub trait RuntimeAdapter: Send + Sync {
         gas_limit: Gas,
         shard_id: ShardId,
         state_root: StateRoot,
-        max_number_of_transactions: usize,
         pool_iterator: &mut dyn PoolIterator,
         chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
     ) -> Result<Vec<SignedTransaction>, Error>;

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -538,7 +538,7 @@ impl Client {
         chunk_extra: &ChunkExtra,
         prev_block_header: &BlockHeader,
     ) -> Vec<SignedTransaction> {
-        let Self { chain, shards_mgr, config, runtime_adapter, .. } = self;
+        let Self { chain, shards_mgr, runtime_adapter, .. } = self;
         let transactions = if let Some(mut iter) = shards_mgr.get_pool_iterator(shard_id) {
             let transaction_validity_period = chain.transaction_validity_period;
             runtime_adapter
@@ -547,7 +547,6 @@ impl Client {
                     chunk_extra.gas_limit,
                     shard_id,
                     chunk_extra.state_root.clone(),
-                    config.block_expected_weight as usize,
                     &mut iter,
                     &mut |tx: &SignedTransaction| -> bool {
                         chain

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -25,8 +25,6 @@ pub struct ClientConfig {
     pub max_block_wait_delay: Duration,
     /// Duration to reduce the wait for each missed block by validator.
     pub reduce_wait_for_missing_block: Duration,
-    /// Expected block weight (num of tx, gas, etc).
-    pub block_expected_weight: u32,
     /// Skip waiting for sync (for testing or single node testnet).
     pub skip_sync_wait: bool,
     /// How often to check that we are not out of sync.
@@ -101,7 +99,6 @@ impl ClientConfig {
             max_block_production_delay: Duration::from_millis(max_block_prod_time),
             max_block_wait_delay: Duration::from_millis(3 * min_block_prod_time),
             reduce_wait_for_missing_block: Duration::from_millis(0),
-            block_expected_weight: 1000,
             skip_sync_wait,
             sync_check_period: Duration::from_millis(100),
             sync_step_period: Duration::from_millis(10),

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -546,7 +546,6 @@ impl NearConfig {
                 max_block_production_delay: config.consensus.max_block_production_delay,
                 max_block_wait_delay: config.consensus.max_block_wait_delay,
                 reduce_wait_for_missing_block: config.consensus.reduce_wait_for_missing_block,
-                block_expected_weight: 1000,
                 skip_sync_wait: config.network.skip_sync_wait,
                 sync_check_period: config.consensus.sync_check_period,
                 sync_step_period: config.consensus.sync_step_period,

--- a/neard/src/runtime.rs
+++ b/neard/src/runtime.rs
@@ -562,7 +562,6 @@ impl RuntimeAdapter for NightshadeRuntime {
         gas_limit: Gas,
         shard_id: ShardId,
         state_root: StateRoot,
-        max_number_of_transactions: usize,
         pool_iterator: &mut dyn PoolIterator,
         chain_validate: &mut dyn FnMut(&SignedTransaction) -> bool,
     ) -> Result<Vec<SignedTransaction>, Error> {
@@ -575,9 +574,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         let mut transactions = vec![];
         let mut num_checked_transactions = 0;
 
-        while transactions.len() < max_number_of_transactions
-            && total_gas_burnt < transactions_gas_limit
-        {
+        while total_gas_burnt < transactions_gas_limit {
             if let Some(iter) = pool_iterator.next() {
                 while let Some(tx) = iter.next() {
                     num_checked_transactions += 1;

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -214,7 +214,14 @@ fn test_tx_status_with_light_client() {
                         actix::spawn(
                             client
                                 .broadcast_tx_async(to_base64(&bytes))
-                                .map_err(|err| panic!("{:?}", err))
+                                .map_err(|err| {
+                                    if !serde_json::to_string(&err.data.clone().unwrap_or_default())
+                                        .unwrap()
+                                        .contains("IsSyncing")
+                                    {
+                                        panic!("{:?}", err)
+                                    }
+                                })
                                 .map_ok(move |result| {
                                     assert_eq!(String::from(&tx_hash_clone), result)
                                 })
@@ -287,7 +294,14 @@ fn test_tx_status_with_light_client1() {
                         actix::spawn(
                             client
                                 .broadcast_tx_async(to_base64(&bytes))
-                                .map_err(|err| panic!("{}", err.to_string()))
+                                .map_err(|err| {
+                                    if !serde_json::to_string(&err.data.clone().unwrap_or_default())
+                                        .unwrap()
+                                        .contains("IsSyncing")
+                                    {
+                                        panic!("{:?}", err)
+                                    }
+                                })
                                 .map_ok(move |result| {
                                     assert_eq!(String::from(&tx_hash_clone), result)
                                 })

--- a/pytest/tests/stress/hundred_nodes/collect_logs.py
+++ b/pytest/tests/stress/hundred_nodes/collect_logs.py
@@ -10,7 +10,7 @@ machines = gcloud.list()
 node_prefix = sys.argv[1] if len(sys.argv) >= 2 else f"pytest-node-{user_name()}"
 nodes = list(filter(lambda m: m.name.startswith(node_prefix), machines))
 
-log_file = sys.argv[2] if len(sys.argv) >= 3 else "produce_record.txt"
+log_file = sys.argv[2] if len(sys.argv) >= 3 else "/tmp/python-rc.log"
 
 collected_place = f'/tmp/near/collected_logs_{datetime.datetime.strftime(datetime.datetime.now(),"%Y%m%d")}'
 
@@ -18,7 +18,7 @@ run(['mkdir', '-p', collected_place])
 
 def collect_file(node):
     print(f'Download file from {node.name}')
-    node.download('/tmp/python-rc.log', f'{collected_place}/{node.name}.txt')
+    node.download(f'{log_file}', f'{collected_place}/{node.name}.txt')
     print(f'Download file from {node.name} finished')
 
 


### PR DESCRIPTION
We are not using `block_weight` any more, but for some reason we still use it in `prepare_transactions` and therefore limit number of transactions in a chunk to 1000 for no good reason.