### PR TITLE
fix: log transient error only when there is an error

### DIFF
--- a/chain/chain/src/error.rs
+++ b/chain/chain/src/error.rs
@@ -182,10 +182,12 @@ pub trait LogTransientStorageError {
 
 impl<T> LogTransientStorageError for Result<T, Error> {
     fn log_storage_error(self, message: &str) -> Self {
-        error!(target: "client",
-               "Transient storage error: {}",
-               message
-        );
+        if let Err(ref e) = self {
+            error!(target: "client",
+                   "Transient storage error: {}, {}",
+                   message, e
+            );
+        }
         self
     }
 }


### PR DESCRIPTION
We currently unconditionally logs an error inside `log_storage_error`, even if there is no error.