### PR TITLE
fix(rpc): fix chunk producer computation

### DIFF
--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -473,11 +473,9 @@ impl Handler<GetChunk> for ViewClientActor {
             }
         }
         .and_then(|chunk| {
-            self.chain
-                .get_block_by_height(chunk.header.height_included)
-                .map(|block| (block.header().epoch_id().clone(), chunk))
-        })
-        .and_then(|(epoch_id, chunk)| {
+            let epoch_id = self
+                .runtime_adapter
+                .get_epoch_id_from_prev_block(&chunk.header.inner.prev_block_hash)?;
             self.runtime_adapter
                 .get_chunk_producer(
                     &epoch_id,


### PR DESCRIPTION
When retrieving a chunk from rpc, we also compute its author. However, the computation uses `height_included`, which is not reliable and will give an unexpected error when there is a fork and the chunk is in fact included in a block with higher height. This PR switches to using `get_epoch_id_from_prev_block` to accurately compute epoch id and the chunk producer.