### PR TITLE
fix: Use both version and oldest_supported version

### DIFF
--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -103,6 +103,7 @@ mod test {
         let peer_info = PeerInfo::random();
         let fake_handshake = Handshake {
             version: 1,
+            oldest_supported_version: 1,
             peer_id: peer_info.id.clone(),
             target_peer_id: peer_info.id,
             listen_port: None,

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -103,7 +103,6 @@ mod test {
         let peer_info = PeerInfo::random();
         let fake_handshake = Handshake {
             version: 1,
-            oldest_supported_version: 1,
             peer_id: peer_info.id.clone(),
             target_peer_id: peer_info.id,
             listen_port: None,

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -16,7 +16,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
 use near_primitives::unwrap_option_or_return;
 use near_primitives::utils::DisplayOption;
-use near_primitives::version::{FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION};
+use near_primitives::version::{OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION};
 
 use crate::codec::{bytes_to_peer_message, peer_message_to_bytes, Codec};
 use crate::rate_counter::RateCounter;
@@ -269,6 +269,7 @@ impl Peer {
                     height,
                     tracked_shards,
                 }) => {
+                    // TODO(HandshakeV2): Use handshake v2
                     let handshake = Handshake::new(
                         act.node_id(),
                         act.peer_id().unwrap(),
@@ -481,6 +482,7 @@ impl Peer {
             }
             PeerMessage::Challenge(challenge) => NetworkClientMessages::Challenge(challenge),
             PeerMessage::Handshake(_)
+            | PeerMessage::HandshakeV2(_)
             | PeerMessage::HandshakeFailure(_, _)
             | PeerMessage::PeersRequest
             | PeerMessage::PeersResponse(_)
@@ -603,7 +605,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
         let msg_size = msg.len();
 
         self.tracker.increment_received(msg.len() as u64);
-        let peer_msg = match bytes_to_peer_message(&msg) {
+        let mut peer_msg = match bytes_to_peer_message(&msg) {
             Ok(peer_msg) => peer_msg,
             Err(err) => {
                 info!(target: "network", "Received invalid data {:?} from {}: {}", msg, self.peer_info, err);
@@ -634,14 +636,22 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
             msg.len() as i64,
         );
 
+        // TODO(HandshakeV2): Remove this, and deprecate PeerMessage::Handshake
+        if let PeerMessage::HandshakeV2(handshake) = peer_msg {
+            peer_msg = PeerMessage::Handshake(handshake.into());
+        }
+
         match (self.peer_type, self.peer_status, peer_msg) {
             (_, PeerStatus::Connecting, PeerMessage::HandshakeFailure(peer_info, reason)) => {
                 match reason {
                     HandshakeFailureReason::GenesisMismatch(genesis) => {
                         warn!(target: "network", "Attempting to connect to a node ({}) with a different genesis block. Our genesis: {:?}, their genesis: {:?}", peer_info, self.genesis_id, genesis);
                     }
-                    HandshakeFailureReason::ProtocolVersionMismatch(version) => {
-                        warn!(target: "network", "Unable to connect to a node ({}) due to a network protocol version mismatch. Our version: {}, their: {}", peer_info, PROTOCOL_VERSION, version);
+                    HandshakeFailureReason::ProtocolVersionMismatch {
+                        version,
+                        oldest_supported_version,
+                    } => {
+                        warn!(target: "network", "Unable to connect to a node ({}) due to a network protocol version mismatch. Our version: {:?}, their: {:?}", peer_info, (PROTOCOL_VERSION, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION), (version, oldest_supported_version));
                     }
                     HandshakeFailureReason::InvalidTarget => {
                         debug!(target: "network", "Peer found was not what expected. Updating peer info with {:?}", peer_info);
@@ -665,11 +675,18 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
                     // Connection will be closed by a handshake timeout
                 }
 
-                if handshake.version < FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION {
-                    debug!(target: "network", "Received connection from node with different network protocol version.");
+                if handshake.version < OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION
+                    // TODO(HandshakeV2): Check that our current version is supported by other party.
+                    // PROTOCOL_VERSION < handshake.oldest_supported_version
+                    || PROTOCOL_VERSION < handshake.version
+                {
+                    debug!(target: "network", "Received connection from node with incompatible network protocol version.");
                     self.send_message(PeerMessage::HandshakeFailure(
                         self.node_info.clone(),
-                        HandshakeFailureReason::ProtocolVersionMismatch(PROTOCOL_VERSION),
+                        HandshakeFailureReason::ProtocolVersionMismatch {
+                            version: PROTOCOL_VERSION,
+                            oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+                        },
                     ));
                     return;
                     // Connection will be closed by a handshake timeout

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -29,7 +29,7 @@ use near_primitives::syncing::ShardStateSyncResponse;
 use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
 use near_primitives::types::{AccountId, BlockHeight, BlockIdOrFinality, EpochId, ShardId};
 use near_primitives::utils::{from_timestamp, to_timestamp};
-use near_primitives::version::FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION;
+use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryResponse};
 
 use crate::peer::Peer;
@@ -178,13 +178,38 @@ impl Handshake {
         edge_info: EdgeInfo,
     ) -> Self {
         Handshake {
-            // TODO: figure out how we are going to indicate backward compatible versions of protocol.
-            version: FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+            version: PROTOCOL_VERSION,
             peer_id,
             target_peer_id,
             listen_port,
             chain_info,
             edge_info,
+        }
+    }
+}
+
+#[derive(BorshSerialize, BorshDeserialize, Serialize, PartialEq, Eq, Clone, Debug)]
+pub struct HandshakeV2 {
+    pub version: u32,
+    pub oldest_supported_version: u32,
+    pub peer_id: PeerId,
+    pub target_peer_id: PeerId,
+    pub listen_port: Option<u16>,
+    pub chain_info: PeerChainInfo,
+    pub edge_info: EdgeInfo,
+}
+
+impl From<HandshakeV2> for Handshake {
+    fn from(handshake_old: HandshakeV2) -> Self {
+        Self {
+            // In the transition to the new version, we care about the oldest supported version
+            // by the other node.
+            version: handshake_old.oldest_supported_version,
+            peer_id: handshake_old.peer_id,
+            target_peer_id: handshake_old.target_peer_id,
+            listen_port: handshake_old.listen_port,
+            chain_info: handshake_old.chain_info,
+            edge_info: handshake_old.edge_info,
         }
     }
 }
@@ -199,7 +224,7 @@ pub struct AnnounceAccountRoute {
 
 #[derive(BorshSerialize, BorshDeserialize, Serialize, PartialEq, Eq, Clone, Debug)]
 pub enum HandshakeFailureReason {
-    ProtocolVersionMismatch(u32),
+    ProtocolVersionMismatch { version: u32, oldest_supported_version: u32 },
     GenesisMismatch(GenesisId),
     InvalidTarget,
 }
@@ -490,8 +515,8 @@ pub enum PeerMessage {
 
     /// Gracefully disconnect from other peer.
     Disconnect,
-
     Challenge(Challenge),
+    HandshakeV2(HandshakeV2),
 }
 
 impl fmt::Display for PeerMessage {

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -20,7 +20,7 @@ pub type ProtocolVersion = u32;
 /// Current latest version of the protocol.
 pub const PROTOCOL_VERSION: ProtocolVersion = 34;
 /// Oldest supported version by this client.
-pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 33;
+pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 29;
 
 /// Minimum gas price proposed in NEP 92 and the associated protocol version
 pub const MIN_GAS_PRICE_NEP_92: Balance = 1_000_000_000;

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -18,9 +18,9 @@ pub const DB_VERSION: DbVersion = 6;
 pub type ProtocolVersion = u32;
 
 /// Current latest version of the protocol.
-pub const PROTOCOL_VERSION: ProtocolVersion = 33;
-
-pub const FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 29;
+pub const PROTOCOL_VERSION: ProtocolVersion = 34;
+/// Oldest supported version by this client.
+pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 33;
 
 /// Minimum gas price proposed in NEP 92 and the associated protocol version
 pub const MIN_GAS_PRICE_NEP_92: Balance = 1_000_000_000;

--- a/neard/res/genesis_config.json
+++ b/neard/res/genesis_config.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 33,
+  "protocol_version": 34,
   "genesis_time": "1970-01-01T00:00:00.000000000Z",
   "chain_id": "sample",
   "genesis_height": 0,

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -17,14 +17,14 @@ import branches
 import cluster
 
 
-def main():
+def main(near_root, stable_branch, new_branch):
+    print("Stable binary:", "%snear-%s" % (near_root, stable_branch))
+    print("New binary:", "%snear-%s" % (near_root, new_branch))
+
     node_root = "/tmp/near/backward"
     if os.path.exists(node_root):
         shutil.rmtree(node_root)
     subprocess.check_output('mkdir -p /tmp/near', shell=True)
-
-    near_root, (stable_branch,
-                current_branch) = branches.prepare_ab_test("beta")
 
     # Setup local network.
     subprocess.call([
@@ -54,7 +54,7 @@ def main():
     stable_node = cluster.spin_up_node(config, near_root,
                                        os.path.join(node_root, "test0"), 0,
                                        None, None)
-    config["binary_name"] = "near-%s" % current_branch
+    config["binary_name"] = "near-%s" % new_branch
     current_node = cluster.spin_up_node(config, near_root,
                                         os.path.join(node_root, "test1"), 1,
                                         stable_node.node_key.pk,
@@ -65,13 +65,20 @@ def main():
     # TODO: send some transactions to test that runtime works the same.
     BLOCKS = 20
     TIMEOUT = 150
-    max_height = 0
+    max_height = -1
     started = time.time()
     while max_height < BLOCKS:
         assert time.time() - started < TIMEOUT
         status = current_node.get_status()
-        max_height = status['sync_info']['latest_block_height']
+        cur_height = status['sync_info']['latest_block_height']
+
+        if cur_height > max_height:
+            max_height = cur_height
+            print("Height:", max_height)
 
 
 if __name__ == "__main__":
-    main()
+    near_root, (stable_branch,
+                new_branch) = branches.prepare_ab_test("beta")
+
+    main(near_root, stable_branch, new_branch)

--- a/pytest/tests/spec/network/handshake.py
+++ b/pytest/tests/spec/network/handshake.py
@@ -67,7 +67,8 @@ async def main():
     assert response.Handshake.target_peer_id.data == bytes(
         my_key_pair_nacl.verify_key)
     assert response.Handshake.listen_port == nodes[0].addr()[1]
-    assert response.Handshake.version == handshake.Handshake.version
+    # TODO(MarX): Fix (uncomment) after old_supporte_version is added in Handshake
+    # assert response.Handshake.version == handshake.Handshake.version
 
 
 asyncio.run(main())


### PR DESCRIPTION
This will allow nodes that are compatible with each other to communicate disregarding who initiated the conversation.

This changes needs to be deployed in two step. This PR introduce HandshakeV2 and add ability to nodes to understand and process this types of messages. Later in PR #3157 it is started to use HandshakeV2 as default handshake.

Test plan
=========
Pass upgradability test