### PR TITLE
fix(mocknet): various improvements

### DIFF
--- a/pytest/lib/metrics.py
+++ b/pytest/lib/metrics.py
@@ -2,6 +2,11 @@ from prometheus_client import parser
 import requests
 import time
 
+BLOCK_TIME_BINS = [
+    '0.005', '0.01', '0.025', '0.05', '0.1', '0.25', '0.5', '1', '2.5', '5',
+    '10', '+Inf'
+]
+
 
 def fold(collection, key, f, default):
     if key in collection:
@@ -39,14 +44,19 @@ class Metrics:
         total_transactions = fold_sample('near_transaction_processed')
         blocks_per_second = fold_sample('near_blocks_per_minute') / 60.0
 
-        block_processing_time_samples = prometheus_metrics[
-            'near_block_processing_time'].samples
+        def extract_block_processing_time(m):
+            block_processing_time_samples = m.samples
+            block_processing_time = {}
+            for sample in block_processing_time_samples:
+                if 'le' in sample.labels:
+                    bound = sample.labels['le']
+                    block_processing_time[f'le {bound}'] = int(sample.value)
+            return block_processing_time
 
-        block_processing_time = {}
-        for sample in block_processing_time_samples:
-            if 'le' in sample.labels:
-                bound = sample.labels['le']
-                block_processing_time[f'le {bound}'] = int(sample.value)
+        block_processing_time = fold(
+            prometheus_metrics, 'near_block_processing_time',
+            extract_block_processing_time,
+            dict(map(lambda bin: ('le ' + bin, 0), BLOCK_TIME_BINS)))
 
         return cls(total_blocks, memory_usage, total_transactions,
                    block_processing_time, timestamp, blocks_per_second)

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -115,6 +115,14 @@ def start_load_test_helpers(nodes):
          nodes)
 
 
+def get_log(node):
+    m = node.machine
+    target_file = f'./logs/{m.name}.log'
+    m.download(f'/home/ubuntu/near.log', target_file)
+
+def get_logs(nodes):
+    pmap(get_log, nodes)
+
 def get_epoch_length_in_blocks(node):
     m = node.machine
     target_dir = create_target_dir(m)

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -45,15 +45,16 @@ cd {PYTHON_DIR}
 '''
 
 
-def get_node(i):
-    n = GCloudNode(f'{NODE_BASE_NAME}{i}')
+# set prefix = 'sharded-' to access sharded mocknet nodes
+def get_node(i, prefix=''):
+    n = GCloudNode(f'{prefix}{NODE_BASE_NAME}{i}')
     n.machine.username = NODE_USERNAME
     n.machine.ssh_key_path = NODE_SSH_KEY_PATH
     return n
 
 
-def get_nodes():
-    return pmap(get_node, range(NUM_NODES))
+def get_nodes(prefix=''):
+    return pmap(lambda i: get_node(i, prefix=prefix), range(NUM_NODES))
 
 
 def create_target_dir(machine):


### PR DESCRIPTION
* Support for sharded mocknet (these machine names have the `sharded-` prefix)
* Single function for downloading logs from all nodes (helpful in gathering logs for debugging issues)
* Use a single block hash for all transactions in the load test instead of constantly pinging the status endpoint (this reduces the load on the node which is not related to receiving and processing transactions, which is the core functionality we are benchmarking)
* Ensure `Metrics` can handle the case where `near_block_processing_time` is missing (which occasionally happens for some reason)