### PR TITLE
Mark PromiseResult::NotReady deprecated

### DIFF
--- a/runtime/near-vm-logic/src/types.rs
+++ b/runtime/near-vm-logic/src/types.rs
@@ -29,7 +29,7 @@ pub enum ReturnData {
 /// calls are available to the contract invoked through the callback.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum PromiseResult {
-    /// [deprecated] NotReady is not used any more, it comes from the early versions of the protocol.
+    /// Current version of the protocol never returns `PromiseResult::NotReady`.
     NotReady,
     #[serde(with = "crate::serde_with::bytes_as_str")]
     Successful(Vec<u8>),

--- a/runtime/near-vm-logic/src/types.rs
+++ b/runtime/near-vm-logic/src/types.rs
@@ -29,6 +29,7 @@ pub enum ReturnData {
 /// calls are available to the contract invoked through the callback.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub enum PromiseResult {
+    /// [deprecated] NotReady is not used any more, it comes from the early versions of the protocol.
     NotReady,
     #[serde(with = "crate::serde_with::bytes_as_str")]
     Successful(Vec<u8>),


### PR DESCRIPTION
`PromiseResult::NotReady` is not used any more. It comes from the early versions of the protocol.
Link the the related chat:
https://discord.com/channels/490367152054992913/510254340120903684/734814189465501867