### PR TITLE
fix(chunks): properly handle missing block, previously causing chunk signature check to fail

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -921,6 +921,12 @@ impl ShardsManager {
             return Err(Error::InvalidPartMessage);
         }
 
+        // check part merkle proofs
+        let num_total_parts = self.runtime_adapter.num_total_parts();
+        for part_info in forward.parts.iter() {
+            self.validate_part(forward.merkle_root, part_info, num_total_parts)?;
+        }
+
         // check signature
         let valid_signature = self.runtime_adapter.verify_chunk_signature_with_header_parts(
             &forward.chunk_hash,
@@ -932,12 +938,6 @@ impl ShardsManager {
 
         if !valid_signature {
             return Err(Error::InvalidChunkSignature);
-        }
-
-        // check part merkle proofs
-        let num_total_parts = self.runtime_adapter.num_total_parts();
-        for part_info in forward.parts.iter() {
-            self.validate_part(forward.merkle_root, part_info, num_total_parts)?;
         }
 
         Ok(())


### PR DESCRIPTION
Description:
For partial encoded chunks, the signature check includes looking up the chunk producer, based on the epoch ID. In addition it checks whether this chunk producer has been slashed. These checks require the node to know the parent block the chunk header references, and thus fails if it is not present. This change ensures we properly catch and handle such errors since we will be able to process the chunk later when the node eventually learns about the missing block.

Testing plan:
* New unit test for processing a chunk with an unknown parent block