### PR TITLE
refactor: remove deprecated DevNet

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ If applicable, add screenshots to help explain your problem.
 - nearcore commit/branch
 - rust version (if local)
 - docker (if using docker)
-- mainnet/testnet/betanet/devnet/local
+- mainnet/testnet/betanet/local
 
 **Additional context**
 Add any other context about the problem here.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ curl --proto '=https' --tlsv1.2 -sSfL https://up.near.dev | python3
 You can join all the active networks:
 * TestNet: `nearup testnet`
 * BetaNet: `nearup betanet`
-* DevNet: `nearup devnet`
 
 Check `nearup` repository for [more details](https://github.com/near/nearup) how to run with or without docker.
 

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -727,7 +727,7 @@ pub fn init_configs(
             genesis.to_file(&dir.join(config.genesis_file));
             info!(target: "near", "Generated MainNet genesis file in {}", dir.to_str().unwrap());
         }
-        "testnet" | "betanet" | "devnet" => {
+        "testnet" | "betanet" => {
             if test_seed.is_some() {
                 panic!("Test seed is not supported for official TestNet");
             }


### PR DESCRIPTION
DevNet no longer exists and mentions of it have been removed from this repository.