### PR TITLE
feat: implement gas profiler.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,6 +2777,7 @@ dependencies = [
  "num-rational",
  "serde",
  "serde_json",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2774,8 +2774,10 @@ dependencies = [
  "near-runtime-fees",
  "near-vm-logic",
  "near-vm-runner",
+ "num-rational",
  "serde",
  "serde_json",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2777,7 +2777,6 @@ dependencies = [
  "num-rational",
  "serde",
  "serde_json",
- "strum",
 ]
 
 [[package]]

--- a/runtime/near-vm-logic/src/config.rs
+++ b/runtime/near-vm-logic/src/config.rs
@@ -490,7 +490,7 @@ pub enum ExtCosts {
 // Type of an action, used in fees logic.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, PartialOrd, Ord)]
 #[allow(non_camel_case_types)]
-pub enum Actions {
+pub enum ActionCosts {
     create_account,
     delete_account,
     deploy_contract,
@@ -503,30 +503,15 @@ pub enum Actions {
     new_receipt,
 }
 
-impl fmt::Display for Actions {
+impl fmt::Display for ActionCosts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            vec![
-                "create_account",
-                "delete_account",
-                "deploy_contract",
-                "function_call",
-                "transfer",
-                "stake",
-                "add_key",
-                "delete_key",
-                "value_return",
-                "new_receipt",
-            ][*self as usize]
-        )
+        write!(f, "{}", ActionCosts::name_of(*self as usize))
     }
 }
 
-impl Actions {
+impl ActionCosts {
     pub const fn count() -> usize {
-        Actions::new_receipt as usize + 1
+        ActionCosts::new_receipt as usize + 1
     }
 
     pub fn name_of(index: usize) -> &'static str {
@@ -547,61 +532,7 @@ impl Actions {
 
 impl fmt::Display for ExtCosts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            vec![
-                "base",
-                "contract_compile_base",
-                "contract_compile_bytes",
-                "read_memory_base",
-                "read_memory_byte",
-                "write_memory_base",
-                "write_memory_byte",
-                "read_register_base",
-                "read_register_byte",
-                "write_register_base",
-                "write_register_byte",
-                "utf8_decoding_base",
-                "utf8_decoding_byte",
-                "utf16_decoding_base",
-                "utf16_decoding_byte",
-                "sha256_base",
-                "sha256_byte",
-                "keccak256_base",
-                "keccak256_byte",
-                "keccak512_base",
-                "keccak512_byte",
-                "log_base",
-                "log_byte",
-                "storage_write_base",
-                "storage_write_key_byte",
-                "storage_write_value_byte",
-                "storage_write_evicted_byte",
-                "storage_read_base",
-                "storage_read_key_byte",
-                "storage_read_value_byte",
-                "storage_remove_base",
-                "storage_remove_key_byte",
-                "storage_remove_ret_value_byte",
-                "storage_has_key_base",
-                "storage_has_key_byte",
-                "storage_iter_create_prefix_base",
-                "storage_iter_create_prefix_byte",
-                "storage_iter_create_range_base",
-                "storage_iter_create_from_byte",
-                "storage_iter_create_to_byte",
-                "storage_iter_next_base",
-                "storage_iter_next_key_byte",
-                "storage_iter_next_value_byte",
-                "touching_trie_node",
-                "promise_and_base",
-                "promise_and_per_promise",
-                "promise_return",
-                "validator_stake_base",
-                "validator_total_stake_base",
-            ][*self as usize]
-        )
+        write!(f, "{}", ExtCosts::name_of(*self as usize))
     }
 }
 

--- a/runtime/near-vm-logic/src/config.rs
+++ b/runtime/near-vm-logic/src/config.rs
@@ -1,8 +1,8 @@
 use crate::types::Gas;
+use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use core::fmt;
 
 #[derive(Clone, Copy, Debug, Hash, Serialize, Deserialize)]
 pub enum VMKind {
@@ -505,18 +505,22 @@ pub enum Actions {
 
 impl fmt::Display for Actions {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", vec![
-            "create_account",
-            "delete_account",
-            "deploy_contract",
-            "function_call",
-            "transfer",
-            "stake",
-            "add_key",
-            "delete_key",
-            "value_return",
-            "new_receipt",
-        ][*self as usize])
+        write!(
+            f,
+            "{}",
+            vec![
+                "create_account",
+                "delete_account",
+                "deploy_contract",
+                "function_call",
+                "transfer",
+                "stake",
+                "add_key",
+                "delete_key",
+                "value_return",
+                "new_receipt",
+            ][*self as usize]
+        )
     }
 }
 
@@ -543,57 +547,61 @@ impl Actions {
 
 impl fmt::Display for ExtCosts {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", vec![
-            "base",
-            "contract_compile_base",
-            "contract_compile_bytes",
-            "read_memory_base",
-            "read_memory_byte",
-            "write_memory_base",
-            "write_memory_byte",
-            "read_register_base",
-            "read_register_byte",
-            "write_register_base",
-            "write_register_byte",
-            "utf8_decoding_base",
-            "utf8_decoding_byte",
-            "utf16_decoding_base",
-            "utf16_decoding_byte",
-            "sha256_base",
-            "sha256_byte",
-            "keccak256_base",
-            "keccak256_byte",
-            "keccak512_base",
-            "keccak512_byte",
-            "log_base",
-            "log_byte",
-            "storage_write_base",
-            "storage_write_key_byte",
-            "storage_write_value_byte",
-            "storage_write_evicted_byte",
-            "storage_read_base",
-            "storage_read_key_byte",
-            "storage_read_value_byte",
-            "storage_remove_base",
-            "storage_remove_key_byte",
-            "storage_remove_ret_value_byte",
-            "storage_has_key_base",
-            "storage_has_key_byte",
-            "storage_iter_create_prefix_base",
-            "storage_iter_create_prefix_byte",
-            "storage_iter_create_range_base",
-            "storage_iter_create_from_byte",
-            "storage_iter_create_to_byte",
-            "storage_iter_next_base",
-            "storage_iter_next_key_byte",
-            "storage_iter_next_value_byte",
-            "touching_trie_node",
-            "promise_and_base",
-            "promise_and_per_promise",
-            "promise_return",
-            "validator_stake_base",
-            "validator_total_stake_base",
-        ][*self as usize])
+        write!(
+            f,
+            "{}",
+            vec![
+                "base",
+                "contract_compile_base",
+                "contract_compile_bytes",
+                "read_memory_base",
+                "read_memory_byte",
+                "write_memory_base",
+                "write_memory_byte",
+                "read_register_base",
+                "read_register_byte",
+                "write_register_base",
+                "write_register_byte",
+                "utf8_decoding_base",
+                "utf8_decoding_byte",
+                "utf16_decoding_base",
+                "utf16_decoding_byte",
+                "sha256_base",
+                "sha256_byte",
+                "keccak256_base",
+                "keccak256_byte",
+                "keccak512_base",
+                "keccak512_byte",
+                "log_base",
+                "log_byte",
+                "storage_write_base",
+                "storage_write_key_byte",
+                "storage_write_value_byte",
+                "storage_write_evicted_byte",
+                "storage_read_base",
+                "storage_read_key_byte",
+                "storage_read_value_byte",
+                "storage_remove_base",
+                "storage_remove_key_byte",
+                "storage_remove_ret_value_byte",
+                "storage_has_key_base",
+                "storage_has_key_byte",
+                "storage_iter_create_prefix_base",
+                "storage_iter_create_prefix_byte",
+                "storage_iter_create_range_base",
+                "storage_iter_create_from_byte",
+                "storage_iter_create_to_byte",
+                "storage_iter_next_base",
+                "storage_iter_next_key_byte",
+                "storage_iter_next_value_byte",
+                "touching_trie_node",
+                "promise_and_base",
+                "promise_and_per_promise",
+                "promise_return",
+                "validator_stake_base",
+                "validator_total_stake_base",
+            ][*self as usize]
+        )
     }
 }
 

--- a/runtime/near-vm-logic/src/config.rs
+++ b/runtime/near-vm-logic/src/config.rs
@@ -486,6 +486,42 @@ pub enum ExtCosts {
     validator_total_stake_base,
 }
 
+#[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, PartialOrd, Ord)]
+#[allow(non_camel_case_types)]
+pub enum Actions {
+    create_account,
+    delete_account,
+    deploy_contract,
+    function_call,
+    transfer,
+    stake,
+    add_key,
+    delete_key,
+    value_return,
+    new_receipt,
+}
+
+impl Actions {
+    pub fn count() -> usize {
+        Actions::new_receipt as usize + 1
+    }
+
+    pub fn name_of(index: usize) -> &'static str {
+        vec![
+            "create_account",
+            "delete_account",
+            "deploy_contract",
+            "function_call",
+            "transfer",
+            "stake",
+            "add_key",
+            "delete_key",
+            "value_return",
+            "new_receipt",
+        ][index]
+    }
+}
+
 impl ExtCosts {
     pub fn value(self, config: &ExtCostsConfig) -> Gas {
         use ExtCosts::*;
@@ -540,5 +576,63 @@ impl ExtCosts {
             validator_stake_base => config.validator_stake_base,
             validator_total_stake_base => config.validator_total_stake_base,
         }
+    }
+
+    pub fn count() -> usize {
+        ExtCosts::validator_total_stake_base as usize + 1
+    }
+
+    pub fn name_of(index: usize) -> &'static str {
+        vec![
+            "base",
+            "contract_compile_base",
+            "contract_compile_bytes",
+            "read_memory_base",
+            "read_memory_byte",
+            "write_memory_base",
+            "write_memory_byte",
+            "read_register_base",
+            "read_register_byte",
+            "write_register_base",
+            "write_register_byte",
+            "utf8_decoding_base",
+            "utf8_decoding_byte",
+            "utf16_decoding_base",
+            "utf16_decoding_byte",
+            "sha256_base",
+            "sha256_byte",
+            "keccak256_base",
+            "keccak256_byte",
+            "keccak512_base",
+            "keccak512_byte",
+            "log_base",
+            "log_byte",
+            "storage_write_base",
+            "storage_write_key_byte",
+            "storage_write_value_byte",
+            "storage_write_evicted_byte",
+            "storage_read_base",
+            "storage_read_key_byte",
+            "storage_read_value_byte",
+            "storage_remove_base",
+            "storage_remove_key_byte",
+            "storage_remove_ret_value_byte",
+            "storage_has_key_base",
+            "storage_has_key_byte",
+            "storage_iter_create_prefix_base",
+            "storage_iter_create_prefix_byte",
+            "storage_iter_create_range_base",
+            "storage_iter_create_from_byte",
+            "storage_iter_create_to_byte",
+            "storage_iter_next_base",
+            "storage_iter_next_key_byte",
+            "storage_iter_next_value_byte",
+            "touching_trie_node",
+            "promise_and_base",
+            "promise_and_per_promise",
+            "promise_return",
+            "validator_stake_base",
+            "validator_total_stake_base",
+        ][index]
     }
 }

--- a/runtime/near-vm-logic/src/config.rs
+++ b/runtime/near-vm-logic/src/config.rs
@@ -2,6 +2,7 @@ use crate::types::Gas;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use core::fmt;
 
 #[derive(Clone, Copy, Debug, Hash, Serialize, Deserialize)]
 pub enum VMKind {
@@ -486,6 +487,7 @@ pub enum ExtCosts {
     validator_total_stake_base,
 }
 
+// Type of an action, used in fees logic.
 #[derive(Copy, Clone, Hash, PartialEq, Eq, Debug, PartialOrd, Ord)]
 #[allow(non_camel_case_types)]
 pub enum Actions {
@@ -501,8 +503,25 @@ pub enum Actions {
     new_receipt,
 }
 
+impl fmt::Display for Actions {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", vec![
+            "create_account",
+            "delete_account",
+            "deploy_contract",
+            "function_call",
+            "transfer",
+            "stake",
+            "add_key",
+            "delete_key",
+            "value_return",
+            "new_receipt",
+        ][*self as usize])
+    }
+}
+
 impl Actions {
-    pub fn count() -> usize {
+    pub const fn count() -> usize {
         Actions::new_receipt as usize + 1
     }
 
@@ -519,6 +538,62 @@ impl Actions {
             "value_return",
             "new_receipt",
         ][index]
+    }
+}
+
+impl fmt::Display for ExtCosts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", vec![
+            "base",
+            "contract_compile_base",
+            "contract_compile_bytes",
+            "read_memory_base",
+            "read_memory_byte",
+            "write_memory_base",
+            "write_memory_byte",
+            "read_register_base",
+            "read_register_byte",
+            "write_register_base",
+            "write_register_byte",
+            "utf8_decoding_base",
+            "utf8_decoding_byte",
+            "utf16_decoding_base",
+            "utf16_decoding_byte",
+            "sha256_base",
+            "sha256_byte",
+            "keccak256_base",
+            "keccak256_byte",
+            "keccak512_base",
+            "keccak512_byte",
+            "log_base",
+            "log_byte",
+            "storage_write_base",
+            "storage_write_key_byte",
+            "storage_write_value_byte",
+            "storage_write_evicted_byte",
+            "storage_read_base",
+            "storage_read_key_byte",
+            "storage_read_value_byte",
+            "storage_remove_base",
+            "storage_remove_key_byte",
+            "storage_remove_ret_value_byte",
+            "storage_has_key_base",
+            "storage_has_key_byte",
+            "storage_iter_create_prefix_base",
+            "storage_iter_create_prefix_byte",
+            "storage_iter_create_range_base",
+            "storage_iter_create_from_byte",
+            "storage_iter_create_to_byte",
+            "storage_iter_next_base",
+            "storage_iter_next_key_byte",
+            "storage_iter_next_value_byte",
+            "touching_trie_node",
+            "promise_and_base",
+            "promise_and_per_promise",
+            "promise_return",
+            "validator_stake_base",
+            "validator_total_stake_base",
+        ][*self as usize])
     }
 }
 
@@ -578,7 +653,7 @@ impl ExtCosts {
         }
     }
 
-    pub fn count() -> usize {
+    pub const fn count() -> usize {
         ExtCosts::validator_total_stake_base as usize + 1
     }
 

--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -113,24 +113,7 @@ impl GasCounter {
     #[inline]
     fn update_profile_action(&mut self, action: ActionCosts, _value: u64) {}
 
-    #[cfg(feature = "costs_counting")]
-    #[inline]
-    fn update_profile_wasm(&mut self, value: u64) {
-        match &self.profile {
-            Some(profile) => {
-                *profile.borrow_mut().get_mut(ActionCosts::count() + ExtCosts::count()).unwrap() +=
-                    value
-            }
-            None => {}
-        };
-    }
-
-    #[cfg(not(feature = "costs_counting"))]
-    #[inline]
-    fn update_profile_wasm(&mut self, _value: u64) {}
-
     pub fn pay_wasm_gas(&mut self, value: u64) -> Result<()> {
-        self.update_profile_wasm(value);
         self.deduct_gas(value, value)
     }
 
@@ -158,6 +141,7 @@ impl GasCounter {
     /// * `per_byte_fee`: the fee per byte;
     /// * `num_bytes`: the number of bytes;
     /// * `sir`: whether the receiver_id is same as the current account ID;
+    /// * `action`: what kind of action is charged for;
     pub fn pay_action_per_byte(
         &mut self,
         per_byte_fee: &Fee,
@@ -180,6 +164,7 @@ impl GasCounter {
     /// # Args:
     /// * `base_fee`: base fee for the action;
     /// * `sir`: whether the receiver_id is same as the current account ID;
+    /// * `action`: what kind of action is charged for;
     pub fn pay_action_base(
         &mut self,
         base_fee: &Fee,
@@ -193,6 +178,11 @@ impl GasCounter {
         self.deduct_gas(burn_gas, use_gas)
     }
 
+    /// A helper function to pay base cost gas fee for batching an action.
+    /// # Args:
+    /// * `burn_gas`: amount of gas to burn;
+    /// * `use_gas`: amount of gas to reserve;
+    /// * `action`: what kind of action is charged for;
     pub fn pay_action_accumulated(
         &mut self,
         burn_gas: Gas,

--- a/runtime/near-vm-logic/src/gas_counter.rs
+++ b/runtime/near-vm-logic/src/gas_counter.rs
@@ -1,5 +1,5 @@
-use crate::config::{ExtCosts, ExtCostsConfig};
-use crate::types::Gas;
+use crate::config::{Actions, ExtCosts, ExtCostsConfig};
+use crate::types::{Gas, ProfileData};
 use crate::{HostError, VMLogicError};
 use near_runtime_fees::Fee;
 
@@ -22,6 +22,8 @@ pub struct GasCounter {
     prepaid_gas: Gas,
     is_view: bool,
     ext_costs_config: ExtCostsConfig,
+    /// Where to store profile data, if needed.
+    profile: Option<ProfileData>,
 }
 
 impl GasCounter {
@@ -30,11 +32,20 @@ impl GasCounter {
         max_gas_burnt: Gas,
         prepaid_gas: Gas,
         is_view: bool,
+        profile: Option<ProfileData>,
     ) -> Self {
-        Self { ext_costs_config, burnt_gas: 0, used_gas: 0, max_gas_burnt, prepaid_gas, is_view }
+        Self {
+            ext_costs_config,
+            burnt_gas: 0,
+            used_gas: 0,
+            max_gas_burnt,
+            prepaid_gas,
+            is_view,
+            profile,
+        }
     }
 
-    pub fn deduct_gas(&mut self, burn_gas: Gas, use_gas: Gas) -> Result<()> {
+    fn deduct_gas(&mut self, burn_gas: Gas, use_gas: Gas) -> Result<()> {
         assert!(burn_gas <= use_gas);
         let new_burnt_gas =
             self.burnt_gas.checked_add(burn_gas).ok_or(HostError::IntegerOverflow)?;
@@ -64,7 +75,7 @@ impl GasCounter {
 
     #[cfg(feature = "costs_counting")]
     #[inline]
-    fn inc_ext_costs_counter(&self, cost: ExtCosts, value: u64) {
+    fn inc_ext_costs_counter(&mut self, cost: ExtCosts, value: u64) {
         EXT_COSTS_COUNTER.with(|f| {
             *f.borrow_mut().entry(cost).or_default() += value;
         });
@@ -72,21 +83,73 @@ impl GasCounter {
 
     #[cfg(not(feature = "costs_counting"))]
     #[inline]
-    fn inc_ext_costs_counter(&self, _cost: ExtCosts, _value: u64) {}
+    fn inc_ext_costs_counter(&mut self, _cost: ExtCosts, _value: u64) {}
+
+    #[cfg(feature = "costs_counting")]
+    #[inline]
+    fn update_profile_host(&mut self, cost: ExtCosts, value: u64) {
+        match &self.profile {
+            Some(profile) => *profile.borrow_mut().get_mut(cost as usize).unwrap() += value,
+            None => {}
+        };
+    }
+
+    #[cfg(not(feature = "costs_counting"))]
+    #[inline]
+    fn update_profile_host(&mut self, cost: ExtCosts, _value: u64) {}
+
+    #[cfg(feature = "costs_counting")]
+    #[inline]
+    fn update_profile_action(&mut self, action: Actions, value: u64) {
+        match &self.profile {
+            Some(profile) => {
+                *profile.borrow_mut().get_mut(action as usize + ExtCosts::count()).unwrap() += value
+            }
+            None => {}
+        };
+    }
+
+    #[cfg(not(feature = "costs_counting"))]
+    #[inline]
+    fn update_profile_action(&mut self, action: Actions, _value: u64) {}
+
+    #[cfg(feature = "costs_counting")]
+    #[inline]
+    fn update_profile_wasm(&mut self, value: u64) {
+        match &self.profile {
+            Some(profile) => {
+                *profile.borrow_mut().get_mut(Actions::count() + ExtCosts::count()).unwrap() +=
+                    value
+            }
+            None => {}
+        };
+    }
+
+    #[cfg(not(feature = "costs_counting"))]
+    #[inline]
+    fn update_profile_wasm(&mut self, _value: u64) {}
+
+    pub fn pay_wasm_gas(&mut self, value: u64) -> Result<()> {
+        self.update_profile_wasm(value);
+        self.deduct_gas(value, value)
+    }
 
     /// A helper function to pay per byte gas
     pub fn pay_per_byte(&mut self, cost: ExtCosts, num_bytes: u64) -> Result<()> {
-        self.inc_ext_costs_counter(cost, num_bytes);
         let use_gas = num_bytes
             .checked_mul(cost.value(&self.ext_costs_config))
             .ok_or(HostError::IntegerOverflow)?;
+
+        self.inc_ext_costs_counter(cost, num_bytes);
+        self.update_profile_host(cost, use_gas);
         self.deduct_gas(use_gas, use_gas)
     }
 
     /// A helper function to pay base cost gas
     pub fn pay_base(&mut self, cost: ExtCosts) -> Result<()> {
-        self.inc_ext_costs_counter(cost, 1);
         let base_fee = cost.value(&self.ext_costs_config);
+        self.inc_ext_costs_counter(cost, 1);
+        self.update_profile_host(cost, base_fee);
         self.deduct_gas(base_fee, base_fee)
     }
 
@@ -100,6 +163,7 @@ impl GasCounter {
         per_byte_fee: &Fee,
         num_bytes: u64,
         sir: bool,
+        action: Actions,
     ) -> Result<()> {
         let burn_gas =
             num_bytes.checked_mul(per_byte_fee.send_fee(sir)).ok_or(HostError::IntegerOverflow)?;
@@ -108,7 +172,7 @@ impl GasCounter {
                 num_bytes.checked_mul(per_byte_fee.exec_fee()).ok_or(HostError::IntegerOverflow)?,
             )
             .ok_or(HostError::IntegerOverflow)?;
-
+        self.update_profile_action(action, burn_gas);
         self.deduct_gas(burn_gas, use_gas)
     }
 
@@ -116,11 +180,26 @@ impl GasCounter {
     /// # Args:
     /// * `base_fee`: base fee for the action;
     /// * `sir`: whether the receiver_id is same as the current account ID;
-    pub fn pay_action_base(&mut self, base_fee: &Fee, sir: bool) -> Result<()> {
+    pub fn pay_action_base(&mut self, base_fee: &Fee, sir: bool, action: Actions) -> Result<()> {
         let burn_gas = base_fee.send_fee(sir);
         let use_gas =
             burn_gas.checked_add(base_fee.exec_fee()).ok_or(HostError::IntegerOverflow)?;
+        self.update_profile_action(action, burn_gas);
         self.deduct_gas(burn_gas, use_gas)
+    }
+
+    pub fn pay_action_accumulated(
+        &mut self,
+        burn_gas: Gas,
+        use_gas: Gas,
+        action: Actions,
+    ) -> Result<()> {
+        self.update_profile_action(action, burn_gas);
+        self.deduct_gas(burn_gas, use_gas)
+    }
+
+    pub fn prepay_gas(&mut self, use_gas: Gas) -> Result<()> {
+        self.deduct_gas(0, use_gas)
     }
 
     pub fn burnt_gas(&self) -> Gas {
@@ -136,7 +215,7 @@ mod tests {
     use super::*;
     #[test]
     fn test_deduct_gas() {
-        let mut counter = GasCounter::new(ExtCostsConfig::default(), 10, 10, false);
+        let mut counter = GasCounter::new(ExtCostsConfig::default(), 10, 10, false, None);
         counter.deduct_gas(5, 10).expect("deduct_gas should work");
         assert_eq!(counter.burnt_gas(), 5);
         assert_eq!(counter.used_gas(), 10);
@@ -145,7 +224,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_prepaid_gas_min() {
-        let mut counter = GasCounter::new(ExtCostsConfig::default(), 100, 10, false);
+        let mut counter = GasCounter::new(ExtCostsConfig::default(), 100, 10, false, None);
         counter.deduct_gas(10, 5).unwrap();
     }
 }

--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -8,7 +8,7 @@ pub mod serde_with;
 pub mod types;
 mod utils;
 
-pub use config::{Actions, ExtCosts, ExtCostsConfig, VMConfig, VMKind, VMLimitConfig};
+pub use config::{ActionCosts, ExtCosts, ExtCostsConfig, VMConfig, VMKind, VMLimitConfig};
 pub use context::VMContext;
 pub use dependencies::{External, MemoryLike, ValuePtr};
 pub use logic::{VMLogic, VMOutcome};

--- a/runtime/near-vm-logic/src/lib.rs
+++ b/runtime/near-vm-logic/src/lib.rs
@@ -8,7 +8,7 @@ pub mod serde_with;
 pub mod types;
 mod utils;
 
-pub use config::{ExtCosts, ExtCostsConfig, VMConfig, VMKind, VMLimitConfig};
+pub use config::{Actions, ExtCosts, ExtCostsConfig, VMConfig, VMKind, VMLimitConfig};
 pub use context::VMContext;
 pub use dependencies::{External, MemoryLike, ValuePtr};
 pub use logic::{VMLogic, VMOutcome};

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -1,4 +1,4 @@
-use crate::config::Actions;
+use crate::config::ActionCosts;
 use crate::config::ExtCosts::*;
 use crate::config::VMConfig;
 use crate::context::VMContext;
@@ -867,7 +867,7 @@ impl<'a> VMLogic<'a> {
                 .ok_or(HostError::IntegerOverflow)?;
         }
         use_gas = use_gas.checked_add(burn_gas).ok_or(HostError::IntegerOverflow)?;
-        self.gas_counter.pay_action_accumulated(burn_gas, use_gas, Actions::new_receipt)
+        self.gas_counter.pay_action_accumulated(burn_gas, use_gas, ActionCosts::new_receipt)
     }
 
     /// A helper function to subtract balance on transfer or attached deposit for promises.
@@ -1195,7 +1195,7 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.create_account_cost,
             sir,
-            Actions::create_account,
+            ActionCosts::create_account,
         )?;
 
         self.ext.append_action_create_account(receipt_idx)?;
@@ -1247,13 +1247,13 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.deploy_contract_cost,
             sir,
-            Actions::deploy_contract,
+            ActionCosts::deploy_contract,
         )?;
         self.gas_counter.pay_action_per_byte(
             &self.fees_config.action_creation_config.deploy_contract_cost_per_byte,
             num_bytes,
             sir,
-            Actions::deploy_contract,
+            ActionCosts::deploy_contract,
         )?;
 
         self.ext.append_action_deploy_contract(receipt_idx, code)?;
@@ -1309,13 +1309,13 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.function_call_cost,
             sir,
-            Actions::function_call,
+            ActionCosts::function_call,
         )?;
         self.gas_counter.pay_action_per_byte(
             &self.fees_config.action_creation_config.function_call_cost_per_byte,
             num_bytes,
             sir,
-            Actions::function_call,
+            ActionCosts::function_call,
         )?;
         // Prepaid gas
         self.gas_counter.prepay_gas(gas)?;
@@ -1361,7 +1361,7 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.transfer_cost,
             sir,
-            Actions::transfer,
+            ActionCosts::transfer,
         )?;
 
         self.deduct_balance(amount)?;
@@ -1409,7 +1409,7 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.stake_cost,
             sir,
-            Actions::stake,
+            ActionCosts::stake,
         )?;
 
         self.ext.append_action_stake(receipt_idx, amount, public_key)?;
@@ -1454,7 +1454,7 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.add_key_cost.full_access_cost,
             sir,
-            Actions::add_key,
+            ActionCosts::add_key,
         )?;
 
         self.ext.append_action_add_key_with_full_access(receipt_idx, public_key, nonce)?;
@@ -1514,13 +1514,13 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.add_key_cost.function_call_cost,
             sir,
-            Actions::function_call,
+            ActionCosts::function_call,
         )?;
         self.gas_counter.pay_action_per_byte(
             &self.fees_config.action_creation_config.add_key_cost.function_call_cost_per_byte,
             num_bytes,
             sir,
-            Actions::function_call,
+            ActionCosts::function_call,
         )?;
 
         self.ext.append_action_add_key_with_function_call(
@@ -1571,7 +1571,7 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.delete_key_cost,
             sir,
-            Actions::delete_key,
+            ActionCosts::delete_key,
         )?;
 
         self.ext.append_action_delete_key(receipt_idx, public_key)?;
@@ -1615,7 +1615,7 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.delete_account_cost,
             sir,
-            Actions::delete_account,
+            ActionCosts::delete_account,
         )?;
 
         self.ext.append_action_delete_account(receipt_idx, beneficiary_id)?;
@@ -1771,7 +1771,7 @@ impl<'a> VMLogic<'a> {
                 )
                 .ok_or(HostError::IntegerOverflow)?;
         }
-        self.gas_counter.pay_action_accumulated(burn_gas, burn_gas, Actions::value_return)?;
+        self.gas_counter.pay_action_accumulated(burn_gas, burn_gas, ActionCosts::value_return)?;
         self.return_data = ReturnData::Value(return_val);
         Ok(())
     }

--- a/runtime/near-vm-logic/src/logic.rs
+++ b/runtime/near-vm-logic/src/logic.rs
@@ -1,11 +1,12 @@
+use crate::config::Actions;
 use crate::config::ExtCosts::*;
 use crate::config::VMConfig;
 use crate::context::VMContext;
 use crate::dependencies::{External, MemoryLike};
 use crate::gas_counter::GasCounter;
 use crate::types::{
-    AccountId, Balance, EpochHeight, Gas, PromiseIndex, PromiseResult, ReceiptIndex, ReturnData,
-    StorageUsage,
+    AccountId, Balance, EpochHeight, Gas, ProfileData, PromiseIndex, PromiseResult, ReceiptIndex,
+    ReturnData, StorageUsage,
 };
 use crate::utils::split_method_names;
 use crate::{ExtCosts, HostError, VMLogicError, ValuePtr};
@@ -98,6 +99,7 @@ impl<'a> VMLogic<'a> {
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
         memory: &'a mut dyn MemoryLike,
+        profile: Option<ProfileData>,
     ) -> Self {
         ext.reset_touched_nodes_counter();
         // Overflow should be checked before calling VMLogic.
@@ -114,6 +116,7 @@ impl<'a> VMLogic<'a> {
             max_gas_burnt,
             context.prepaid_gas,
             context.is_view,
+            profile,
         );
         Self {
             ext,
@@ -830,7 +833,7 @@ impl<'a> VMLogic<'a> {
     /// * If we exceed the `prepaid_gas` then returns `GasExceeded`.
     pub fn gas(&mut self, gas_amount: u32) -> Result<()> {
         let value = Gas::from(gas_amount) * Gas::from(self.config.regular_op_cost);
-        self.gas_counter.deduct_gas(value, value)
+        self.gas_counter.pay_wasm_gas(value)
     }
 
     // ################
@@ -864,7 +867,7 @@ impl<'a> VMLogic<'a> {
                 .ok_or(HostError::IntegerOverflow)?;
         }
         use_gas = use_gas.checked_add(burn_gas).ok_or(HostError::IntegerOverflow)?;
-        self.gas_counter.deduct_gas(burn_gas, use_gas)
+        self.gas_counter.pay_action_accumulated(burn_gas, use_gas, Actions::new_receipt)
     }
 
     /// A helper function to subtract balance on transfer or attached deposit for promises.
@@ -1189,8 +1192,11 @@ impl<'a> VMLogic<'a> {
         }
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
 
-        self.gas_counter
-            .pay_action_base(&self.fees_config.action_creation_config.create_account_cost, sir)?;
+        self.gas_counter.pay_action_base(
+            &self.fees_config.action_creation_config.create_account_cost,
+            sir,
+            Actions::create_account,
+        )?;
 
         self.ext.append_action_create_account(receipt_idx)?;
         Ok(())
@@ -1238,12 +1244,16 @@ impl<'a> VMLogic<'a> {
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
 
         let num_bytes = code.len() as u64;
-        self.gas_counter
-            .pay_action_base(&self.fees_config.action_creation_config.deploy_contract_cost, sir)?;
+        self.gas_counter.pay_action_base(
+            &self.fees_config.action_creation_config.deploy_contract_cost,
+            sir,
+            Actions::deploy_contract,
+        )?;
         self.gas_counter.pay_action_per_byte(
             &self.fees_config.action_creation_config.deploy_contract_cost_per_byte,
             num_bytes,
             sir,
+            Actions::deploy_contract,
         )?;
 
         self.ext.append_action_deploy_contract(receipt_idx, code)?;
@@ -1296,15 +1306,19 @@ impl<'a> VMLogic<'a> {
 
         // Input can't be large enough to overflow
         let num_bytes = method_name.len() as u64 + arguments.len() as u64;
-        self.gas_counter
-            .pay_action_base(&self.fees_config.action_creation_config.function_call_cost, sir)?;
+        self.gas_counter.pay_action_base(
+            &self.fees_config.action_creation_config.function_call_cost,
+            sir,
+            Actions::function_call,
+        )?;
         self.gas_counter.pay_action_per_byte(
             &self.fees_config.action_creation_config.function_call_cost_per_byte,
             num_bytes,
             sir,
+            Actions::function_call,
         )?;
         // Prepaid gas
-        self.gas_counter.deduct_gas(0, gas)?;
+        self.gas_counter.prepay_gas(gas)?;
 
         self.deduct_balance(amount)?;
 
@@ -1344,8 +1358,11 @@ impl<'a> VMLogic<'a> {
 
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
 
-        self.gas_counter
-            .pay_action_base(&self.fees_config.action_creation_config.transfer_cost, sir)?;
+        self.gas_counter.pay_action_base(
+            &self.fees_config.action_creation_config.transfer_cost,
+            sir,
+            Actions::transfer,
+        )?;
 
         self.deduct_balance(amount)?;
 
@@ -1389,8 +1406,11 @@ impl<'a> VMLogic<'a> {
 
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
 
-        self.gas_counter
-            .pay_action_base(&self.fees_config.action_creation_config.stake_cost, sir)?;
+        self.gas_counter.pay_action_base(
+            &self.fees_config.action_creation_config.stake_cost,
+            sir,
+            Actions::stake,
+        )?;
 
         self.ext.append_action_stake(receipt_idx, amount, public_key)?;
         Ok(())
@@ -1434,6 +1454,7 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.add_key_cost.full_access_cost,
             sir,
+            Actions::add_key,
         )?;
 
         self.ext.append_action_add_key_with_full_access(receipt_idx, public_key, nonce)?;
@@ -1493,11 +1514,13 @@ impl<'a> VMLogic<'a> {
         self.gas_counter.pay_action_base(
             &self.fees_config.action_creation_config.add_key_cost.function_call_cost,
             sir,
+            Actions::function_call,
         )?;
         self.gas_counter.pay_action_per_byte(
             &self.fees_config.action_creation_config.add_key_cost.function_call_cost_per_byte,
             num_bytes,
             sir,
+            Actions::function_call,
         )?;
 
         self.ext.append_action_add_key_with_function_call(
@@ -1545,8 +1568,11 @@ impl<'a> VMLogic<'a> {
 
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
 
-        self.gas_counter
-            .pay_action_base(&self.fees_config.action_creation_config.delete_key_cost, sir)?;
+        self.gas_counter.pay_action_base(
+            &self.fees_config.action_creation_config.delete_key_cost,
+            sir,
+            Actions::delete_key,
+        )?;
 
         self.ext.append_action_delete_key(receipt_idx, public_key)?;
         Ok(())
@@ -1586,8 +1612,11 @@ impl<'a> VMLogic<'a> {
 
         let (receipt_idx, sir) = self.promise_idx_to_receipt_idx_with_sir(promise_idx)?;
 
-        self.gas_counter
-            .pay_action_base(&self.fees_config.action_creation_config.delete_account_cost, sir)?;
+        self.gas_counter.pay_action_base(
+            &self.fees_config.action_creation_config.delete_account_cost,
+            sir,
+            Actions::delete_account,
+        )?;
 
         self.ext.append_action_delete_account(receipt_idx, beneficiary_id)?;
         Ok(())
@@ -1742,7 +1771,7 @@ impl<'a> VMLogic<'a> {
                 )
                 .ok_or(HostError::IntegerOverflow)?;
         }
-        self.gas_counter.deduct_gas(burn_gas, burn_gas)?;
+        self.gas_counter.pay_action_accumulated(burn_gas, burn_gas, Actions::value_return)?;
         self.return_data = ReturnData::Value(return_val);
         Ok(())
     }

--- a/runtime/near-vm-logic/src/types.rs
+++ b/runtime/near-vm-logic/src/types.rs
@@ -39,5 +39,5 @@ pub enum PromiseResult {
     Failed,
 }
 
-/// Profile of gas consumption, +1 for Wasm bytecode execution cost.
-pub type ProfileData = Rc<RefCell<[u64; ActionCosts::count() + ExtCosts::count() + 1]>>;
+/// Profile of gas consumption.
+pub type ProfileData = Rc<RefCell<[u64; ActionCosts::count() + ExtCosts::count()]>>;

--- a/runtime/near-vm-logic/src/types.rs
+++ b/runtime/near-vm-logic/src/types.rs
@@ -1,7 +1,7 @@
+use crate::{Actions, ExtCosts};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::rc::Rc;
-use crate::{Actions, ExtCosts};
 
 pub type AccountId = String;
 pub type PublicKey = Vec<u8>;

--- a/runtime/near-vm-logic/src/types.rs
+++ b/runtime/near-vm-logic/src/types.rs
@@ -1,4 +1,4 @@
-use crate::{Actions, ExtCosts};
+use crate::{ActionCosts, ExtCosts};
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -40,4 +40,4 @@ pub enum PromiseResult {
 }
 
 /// Profile of gas consumption, +1 for Wasm bytecode execution cost.
-pub type ProfileData = Rc<RefCell<[u64; Actions::count() + ExtCosts::count() + 1]>>;
+pub type ProfileData = Rc<RefCell<[u64; ActionCosts::count() + ExtCosts::count() + 1]>>;

--- a/runtime/near-vm-logic/src/types.rs
+++ b/runtime/near-vm-logic/src/types.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::rc::Rc;
+use crate::{Actions, ExtCosts};
 
 pub type AccountId = String;
 pub type PublicKey = Vec<u8>;
@@ -38,4 +39,5 @@ pub enum PromiseResult {
     Failed,
 }
 
-pub type ProfileData = Rc<RefCell<Vec<u64>>>;
+/// Profile of gas consumption, +1 for Wasm bytecode execution cost.
+pub type ProfileData = Rc<RefCell<[u64; Actions::count() + ExtCosts::count() + 1]>>;

--- a/runtime/near-vm-logic/src/types.rs
+++ b/runtime/near-vm-logic/src/types.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
+use std::rc::Rc;
 
 pub type AccountId = String;
 pub type PublicKey = Vec<u8>;
@@ -35,3 +37,5 @@ pub enum PromiseResult {
     Successful(Vec<u8>),
     Failed,
 }
+
+pub type ProfileData = Rc<RefCell<Vec<u64>>>;

--- a/runtime/near-vm-logic/tests/test_iterators.rs
+++ b/runtime/near-vm-logic/tests/test_iterators.rs
@@ -14,7 +14,7 @@ fn test_iterator_deprecated() {
     let fees = RuntimeFeesConfig::default();
     let promise_results = vec![];
     let mut memory = MockedMemory::default();
-    let mut logic = VMLogic::new(&mut ext, context, &config, &fees, &promise_results, &mut memory);
+    let mut logic = VMLogic::new(&mut ext, context, &config, &fees, &promise_results, &mut memory, None);
 
     assert_eq!(
         Err(VMLogicError::HostError(HostError::Deprecated {

--- a/runtime/near-vm-logic/tests/test_iterators.rs
+++ b/runtime/near-vm-logic/tests/test_iterators.rs
@@ -14,7 +14,8 @@ fn test_iterator_deprecated() {
     let fees = RuntimeFeesConfig::default();
     let promise_results = vec![];
     let mut memory = MockedMemory::default();
-    let mut logic = VMLogic::new(&mut ext, context, &config, &fees, &promise_results, &mut memory, None);
+    let mut logic =
+        VMLogic::new(&mut ext, context, &config, &fees, &promise_results, &mut memory, None);
 
     assert_eq!(
         Err(VMLogicError::HostError(HostError::Deprecated {

--- a/runtime/near-vm-logic/tests/vm_logic_builder.rs
+++ b/runtime/near-vm-logic/tests/vm_logic_builder.rs
@@ -35,6 +35,7 @@ impl VMLogicBuilder {
             &self.fees_config,
             &self.promise_results,
             &mut self.memory,
+            None,
         )
     }
     #[allow(dead_code)]

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -17,15 +17,16 @@ One can use `near-vm-runner-standalone` to test the smart contracts, e.g. with i
 to make sure it has expected behavior once deployed to the blockchain.
 """
 
-
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 clap = "2.33.0"
 base64 = "0.11"
+strum = "0.18"
+num-rational = { version = "0.2.4" }
 
-near-vm-logic = { path = "../near-vm-logic", version = "1.1.0"}
-near-vm-runner = { path = "../near-vm-runner", version = "1.1.0" }
+near-vm-logic = { path = "../near-vm-logic", version = "1.1.0", features = ["costs_counting"]}
+near-vm-runner = { path = "../near-vm-runner", version = "1.1.0", features = ["wasmtime_vm"] }
 near-runtime-fees = { path = "../near-runtime-fees", version = "1.1.0" }
 
 [features]

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -10,7 +10,7 @@ use clap::{App, Arg};
 use near_runtime_fees::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::{MockedExternal, Receipt};
 use near_vm_logic::types::PromiseResult;
-use near_vm_logic::{Actions, ExtCosts, VMConfig, VMContext, VMKind, VMOutcome};
+use near_vm_logic::{ActionCosts, ExtCosts, VMConfig, VMContext, VMKind, VMOutcome};
 use near_vm_runner::{run_vm, run_vm_profiled, VMError};
 use num_rational::Ratio;
 use serde::de::{MapAccess, Visitor};
@@ -235,7 +235,7 @@ fn main() {
         fs::read(matches.value_of("wasm-file").expect("Wasm file needs to be specified")).unwrap();
 
     let fees = RuntimeFeesConfig::default();
-    let profile_data = Rc::new(RefCell::new([0u64; ExtCosts::count() + Actions::count() + 1]));
+    let profile_data = Rc::new(RefCell::new([0u64; ExtCosts::count() + ActionCosts::count() + 1]));
     let do_profile = matches.is_present("profile-gas");
     let (outcome, err) = if do_profile {
         run_vm_profiled(
@@ -287,11 +287,11 @@ fn main() {
         }
 
         let mut action_gas = 0u64;
-        for e in 0..Actions::count() {
+        for e in 0..ActionCosts::count() {
             action_gas += profile_data[e as usize + ExtCosts::count()];
         }
 
-        let wasm_gas = profile_data[Actions::count() + ExtCosts::count()];
+        let wasm_gas = profile_data[ActionCosts::count() + ExtCosts::count()];
         println!("------------------------------");
         println!("Total gas: {}", all_gas);
         println!(
@@ -331,12 +331,12 @@ fn main() {
             }
         }
         println!("------ Actions --------");
-        for e in 0..Actions::count() {
+        for e in 0..ActionCosts::count() {
             let d = profile_data[e + ExtCosts::count()];
             if d != 0 {
                 println!(
                     "{} -> {} [{}% total]",
-                    Actions::name_of(e),
+                    ActionCosts::name_of(e),
                     d,
                     Ratio::new(d * 100, all_gas).to_integer()
                 );

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -235,7 +235,7 @@ fn main() {
         fs::read(matches.value_of("wasm-file").expect("Wasm file needs to be specified")).unwrap();
 
     let fees = RuntimeFeesConfig::default();
-    let profile_data = Rc::new(RefCell::new([0u64; ExtCosts::count() + ActionCosts::count() + 1]));
+    let profile_data = Rc::new(RefCell::new([0u64; ExtCosts::count() + ActionCosts::count()]));
     let do_profile = matches.is_present("profile-gas");
     let (outcome, err) = if do_profile {
         run_vm_profiled(
@@ -291,7 +291,7 @@ fn main() {
             action_gas += profile_data[e as usize + ExtCosts::count()];
         }
 
-        let wasm_gas = profile_data[ActionCosts::count() + ExtCosts::count()];
+        let wasm_gas = all_gas - host_gas - action_gas;
         println!("------------------------------");
         println!("Total gas: {}", all_gas);
         println!(

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -235,7 +235,7 @@ fn main() {
         fs::read(matches.value_of("wasm-file").expect("Wasm file needs to be specified")).unwrap();
 
     let fees = RuntimeFeesConfig::default();
-    let profile_data = Rc::new(RefCell::new(vec![0u64; ExtCosts::count() + Actions::count() + 1]));
+    let profile_data = Rc::new(RefCell::new([0u64; ExtCosts::count() + Actions::count() + 1]));
     let do_profile = matches.is_present("profile-gas");
     let (outcome, err) = if do_profile {
         run_vm_profiled(

--- a/runtime/near-vm-runner-standalone/src/main.rs
+++ b/runtime/near-vm-runner-standalone/src/main.rs
@@ -10,12 +10,15 @@ use clap::{App, Arg};
 use near_runtime_fees::RuntimeFeesConfig;
 use near_vm_logic::mocks::mock_external::{MockedExternal, Receipt};
 use near_vm_logic::types::PromiseResult;
-use near_vm_logic::{VMConfig, VMContext, VMOutcome};
-use near_vm_runner::{run, VMError};
+use near_vm_logic::{Actions, ExtCosts, VMConfig, VMContext, VMKind, VMOutcome};
+use near_vm_runner::{run_vm, run_vm_profiled, VMError};
+use num_rational::Ratio;
 use serde::de::{MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::cell::RefCell;
 use std::collections::HashMap;
+use std::rc::Rc;
 use std::{fmt, fs};
 
 #[derive(Debug, Clone)]
@@ -160,7 +163,28 @@ fn main() {
                 .help("File path that contains the Wasm code to run.")
                 .takes_value(true),
         )
+        .arg(
+            Arg::with_name("vm-kind")
+                .long("vm-kind")
+                .value_name("VM_KIND")
+                .help("Select VM kind to run.")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("profile-gas")
+                .long("profile-gas")
+                .help("Profiles gas consumption.")
+        )
         .get_matches();
+
+    let vm_kind: VMKind = match matches.value_of("vm-kind") {
+        Some(value) => match value {
+            "wasmtime" => VMKind::Wasmtime,
+            "wasmer" => VMKind::Wasmer,
+            _ => VMKind::default(),
+        },
+        None => VMKind::default(),
+    };
 
     let mut context: VMContext = match matches.value_of("context") {
         Some(value) => serde_json::from_str(value).unwrap(),
@@ -211,17 +235,38 @@ fn main() {
         fs::read(matches.value_of("wasm-file").expect("Wasm file needs to be specified")).unwrap();
 
     let fees = RuntimeFeesConfig::default();
-    let (outcome, err) = run(
-        vec![],
-        &code,
-        &method_name,
-        &mut fake_external,
-        context,
-        &config,
-        &fees,
-        &promise_results,
-    );
-
+    let profile_data = Rc::new(RefCell::new(vec![0u64; ExtCosts::count() + Actions::count() + 1]));
+    let do_profile = matches.is_present("profile-gas");
+    let (outcome, err) = if do_profile {
+        run_vm_profiled(
+            vec![],
+            &code,
+            &method_name,
+            &mut fake_external,
+            context,
+            &config,
+            &fees,
+            &promise_results,
+            vm_kind,
+            Rc::clone(&profile_data),
+        )
+    } else {
+        run_vm(
+            vec![],
+            &code,
+            &method_name,
+            &mut fake_external,
+            context,
+            &config,
+            &fees,
+            &promise_results,
+            vm_kind,
+        )
+    };
+    let all_gas = match outcome.clone() {
+        Some(outcome) => outcome.burnt_gas,
+        _ => 1,
+    };
     println!(
         "{}",
         serde_json::to_string(&StandaloneOutput {
@@ -231,5 +276,72 @@ fn main() {
             state: State(fake_external.fake_trie),
         })
         .unwrap()
-    )
+    );
+
+    if do_profile {
+        let profile_data = profile_data.borrow();
+
+        let mut host_gas = 0u64;
+        for e in 0..ExtCosts::count() {
+            host_gas += profile_data[e as usize];
+        }
+
+        let mut action_gas = 0u64;
+        for e in 0..Actions::count() {
+            action_gas += profile_data[e as usize + ExtCosts::count()];
+        }
+
+        let wasm_gas = profile_data[Actions::count() + ExtCosts::count()];
+        println!("------------------------------");
+        println!("Total gas: {}", all_gas);
+        println!(
+            "Host gas: {} [{}% total]",
+            host_gas,
+            Ratio::new(host_gas * 100, all_gas).to_integer()
+        );
+        println!(
+            "Action gas: {} [{}% total]",
+            action_gas,
+            Ratio::new(action_gas * 100, all_gas).to_integer()
+        );
+        println!(
+            "Wasm execution: {} [{}% total]",
+            wasm_gas,
+            Ratio::new(wasm_gas * 100, all_gas).to_integer()
+        );
+        let unaccounted_gas = all_gas - wasm_gas - action_gas - host_gas;
+        if unaccounted_gas > 0 {
+            println!(
+                "Unaccounted: {} [{}% total]",
+                unaccounted_gas,
+                Ratio::new(unaccounted_gas * 100, all_gas).to_integer()
+            );
+        }
+        println!("------ Host functions --------");
+        for e in 0..ExtCosts::count() {
+            let d = profile_data[e];
+            if d != 0 {
+                println!(
+                    "{} -> {} [{}% total, {}% host]",
+                    ExtCosts::name_of(e),
+                    d,
+                    Ratio::new(d * 100, all_gas).to_integer(),
+                    Ratio::new(d * 100, host_gas).to_integer(),
+                );
+            }
+        }
+        println!("------ Actions --------");
+        for e in 0..Actions::count() {
+            let d = profile_data[e + ExtCosts::count()];
+            if d != 0 {
+                println!(
+                    "{} -> {} [{}% total]",
+                    Actions::name_of(e),
+                    d,
+                    Ratio::new(d * 100, all_gas).to_integer()
+                );
+            }
+        }
+        println!("------------------------------");
+    }
 }

--- a/runtime/near-vm-runner/src/lib.rs
+++ b/runtime/near-vm-runner/src/lib.rs
@@ -11,6 +11,7 @@ pub use near_vm_errors::VMError;
 pub use runner::compile_module;
 pub use runner::run;
 pub use runner::run_vm;
+pub use runner::run_vm_profiled;
 pub use runner::with_vm_variants;
 
 #[cfg(feature = "costs_counting")]

--- a/runtime/near-vm-runner/src/runner.rs
+++ b/runtime/near-vm-runner/src/runner.rs
@@ -1,6 +1,6 @@
 use near_runtime_fees::RuntimeFeesConfig;
 use near_vm_errors::VMError;
-use near_vm_logic::types::PromiseResult;
+use near_vm_logic::types::{ProfileData, PromiseResult};
 use near_vm_logic::{External, VMConfig, VMContext, VMKind, VMOutcome};
 
 /// `run` does the following:
@@ -61,6 +61,7 @@ pub fn run_vm<'a>(
             wasm_config,
             fees_config,
             promise_results,
+            None,
         ),
         #[cfg(feature = "wasmtime_vm")]
         VMKind::Wasmtime => run_wasmtime(
@@ -72,6 +73,53 @@ pub fn run_vm<'a>(
             wasm_config,
             fees_config,
             promise_results,
+            None,
+        ),
+        #[cfg(not(feature = "wasmtime_vm"))]
+        VMKind::Wasmtime => {
+            panic!("Wasmtime is not supported, compile with '--features wasmtime_vm'")
+        }
+    }
+}
+
+pub fn run_vm_profiled<'a>(
+    code_hash: Vec<u8>,
+    code: &[u8],
+    method_name: &[u8],
+    ext: &mut dyn External,
+    context: VMContext,
+    wasm_config: &'a VMConfig,
+    fees_config: &'a RuntimeFeesConfig,
+    promise_results: &'a [PromiseResult],
+    vm_kind: VMKind,
+    profile: ProfileData,
+) -> (Option<VMOutcome>, Option<VMError>) {
+    use crate::wasmer_runner::run_wasmer;
+    #[cfg(feature = "wasmtime_vm")]
+    use crate::wasmtime_runner::wasmtime_runner::run_wasmtime;
+    match vm_kind {
+        VMKind::Wasmer => run_wasmer(
+            code_hash,
+            code,
+            method_name,
+            ext,
+            context,
+            wasm_config,
+            fees_config,
+            promise_results,
+            Some(profile),
+        ),
+        #[cfg(feature = "wasmtime_vm")]
+        VMKind::Wasmtime => run_wasmtime(
+            code_hash,
+            code,
+            method_name,
+            ext,
+            context,
+            wasm_config,
+            fees_config,
+            promise_results,
+            Some(profile),
         ),
         #[cfg(not(feature = "wasmtime_vm"))]
         VMKind::Wasmtime => {

--- a/runtime/near-vm-runner/src/wasmer_runner.rs
+++ b/runtime/near-vm-runner/src/wasmer_runner.rs
@@ -4,7 +4,7 @@ use crate::{cache, imports};
 use near_runtime_fees::RuntimeFeesConfig;
 use near_vm_errors::FunctionCallError::{WasmTrap, WasmUnknownError};
 use near_vm_errors::{CompilationError, FunctionCallError, MethodResolveError, VMError};
-use near_vm_logic::types::PromiseResult;
+use near_vm_logic::types::{ProfileData, PromiseResult};
 use near_vm_logic::{External, VMConfig, VMContext, VMLogic, VMLogicError, VMOutcome};
 use wasmer_runtime::Module;
 
@@ -182,6 +182,7 @@ pub fn run_wasmer<'a>(
     wasm_config: &'a VMConfig,
     fees_config: &'a RuntimeFeesConfig,
     promise_results: &'a [PromiseResult],
+    profile: Option<ProfileData>,
 ) -> (Option<VMOutcome>, Option<VMError>) {
     if !cfg!(target_arch = "x86") && !cfg!(target_arch = "x86_64") {
         // TODO(#1940): Remove once NaN is standardized by the VM.
@@ -214,7 +215,7 @@ pub fn run_wasmer<'a>(
     let memory_copy = memory.clone();
 
     let mut logic =
-        VMLogic::new(ext, context, wasm_config, fees_config, promise_results, &mut memory);
+        VMLogic::new(ext, context, wasm_config, fees_config, promise_results, &mut memory, profile);
 
     if logic.add_contract_compile_fee(code.len() as u64).is_err() {
         return (

--- a/runtime/near-vm-runner/src/wasmtime_runner.rs
+++ b/runtime/near-vm-runner/src/wasmtime_runner.rs
@@ -8,7 +8,7 @@ pub mod wasmtime_runner {
     use near_runtime_fees::RuntimeFeesConfig;
     use near_vm_errors::FunctionCallError::{LinkError, WasmUnknownError};
     use near_vm_errors::{FunctionCallError, MethodResolveError, VMError, VMLogicError};
-    use near_vm_logic::types::PromiseResult;
+    use near_vm_logic::types::{ProfileData, PromiseResult};
     use near_vm_logic::{External, MemoryLike, VMConfig, VMContext, VMLogic, VMOutcome};
     use std::ffi::c_void;
     use std::str;
@@ -114,6 +114,7 @@ pub mod wasmtime_runner {
         wasm_config: &'a VMConfig,
         fees_config: &'a RuntimeFeesConfig,
         promise_results: &'a [PromiseResult],
+        profile: Option<ProfileData>,
     ) -> (Option<VMOutcome>, Option<VMError>) {
         let engine = Engine::default();
         let store = Store::new(&engine);
@@ -131,8 +132,15 @@ pub mod wasmtime_runner {
         // Note that we don't clone the actual backing memory, just increase the RC.
         let memory_copy = memory.clone();
         let mut linker = Linker::new(&store);
-        let mut logic =
-            VMLogic::new(ext, context, wasm_config, fees_config, promise_results, &mut memory);
+        let mut logic = VMLogic::new(
+            ext,
+            context,
+            wasm_config,
+            fees_config,
+            promise_results,
+            &mut memory,
+            profile,
+        );
         if logic.add_contract_compile_fee(code.len() as u64).is_err() {
             return (
                 Some(logic.outcome()),


### PR DESCRIPTION
Implement profiler for gas consumption. 

Command like

```
cd runtime/near-vm-runner-standalone  &&  cargo run -- --wasm-file /work/near/near-linkdrop/res/linkdrop.wasm --method-name create_account --input '{"new_account_id": "zest.near", "new_public_key": "ed25519:C1BYE6i7bDoqccHuXfGTHXQzJsdhjN7MQ6h3iCRxycCY" }' --profile-gas
```
produces

```
------------------------------
Total gas: 12849996969996
Host gas: 239484430401 [1% total]
Action gas: 12247300236960 [95% total]
Wasm execution: 363212302635 [2% total]
------ Host functions --------
base -> 5295362220 [0% total, 2% host]
contract_compile_base -> 35445963 [0% total, 0% host]
contract_compile_bytes -> 42827632500 [0% total, 17% host]
read_memory_base -> 28708495200 [0% total, 11% host]
read_memory_byte -> 809683929 [0% total, 0% host]
write_memory_base -> 11215179444 [0% total, 4% host]
write_memory_byte -> 359537904 [0% total, 0% host]
read_register_base -> 7551495558 [0% total, 3% host]
read_register_byte -> 11433192 [0% total, 0% host]
write_register_base -> 8596567458 [0% total, 3% host]
write_register_byte -> 440981424 [0% total, 0% host]
utf8_decoding_base -> 6223558122 [0% total, 2% host]
utf8_decoding_byte -> 4082126706 [0% total, 1% host]
storage_write_base -> 64196736000 [0% total, 26% host]
storage_write_key_byte -> 352414335 [0% total, 0% host]
storage_write_value_byte -> 1706019645 [0% total, 0% host]
storage_read_base -> 56356845750 [0% total, 23% host]
storage_read_key_byte -> 154762665 [0% total, 0% host]
promise_return -> 560152386 [0% total, 0% host]
------ Actions --------
create_account -> 99607375000 [0% total]
function_call -> 2320006835710 [18% total]
transfer -> 115123062500 [0% total]
add_key -> 101765125000 [0% total]
new_receipt -> 9610797838750 [74% total]
------------------------------
```