### PR TITLE
fix: do not garbage collect prev block of sync block before state sync

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -893,9 +893,8 @@ impl Chain {
     pub fn reset_data_pre_state_sync(&mut self, sync_hash: CryptoHash) -> Result<(), Error> {
         // Get header we were syncing into.
         let header = self.get_block_header(&sync_hash)?;
-        // Do not garbage collect anything related to the prev block hash of the sync block
         let prev_hash = *header.prev_hash();
-        let gc_height = self.get_block_header(&prev_hash)?.height();
+        let gc_height = header.height();
 
         // GC all the data from current tail up to `gc_height`
         let tail = self.store.tail()?;
@@ -905,7 +904,10 @@ impl Chain {
                     blocks_current_height.values().flatten().cloned().collect::<Vec<_>>();
                 for block_hash in blocks_current_height {
                     let mut chain_store_update = self.mut_store().store_update();
-                    chain_store_update.clear_block_data(block_hash, GCMode::StateSync)?;
+                    chain_store_update.clear_block_data(
+                        block_hash,
+                        GCMode::StateSync { clear_block_info: block_hash != prev_hash },
+                    )?;
                     chain_store_update.commit()?;
                 }
             }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -893,7 +893,9 @@ impl Chain {
     pub fn reset_data_pre_state_sync(&mut self, sync_hash: CryptoHash) -> Result<(), Error> {
         // Get header we were syncing into.
         let header = self.get_block_header(&sync_hash)?;
-        let gc_height = header.height();
+        // Do not garbage collect anything related to the prev block hash of the sync block
+        let prev_hash = *header.prev_hash();
+        let gc_height = self.get_block_header(&prev_hash)?.height();
 
         // GC all the data from current tail up to `gc_height`
         let tail = self.store.tail()?;

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -64,7 +64,7 @@ const CHUNK_CACHE_SIZE: usize = 1;
 pub enum GCMode {
     Fork(ShardTries),
     Canonical(ShardTries),
-    StateSync,
+    StateSync { clear_block_info: bool },
 }
 
 fn get_height_shard_id(height: BlockHeight, shard_id: ShardId) -> Vec<u8> {
@@ -2004,7 +2004,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 // Set `block_hash` on previous one
                 block_hash = *self.get_block_header(&block_hash)?.prev_hash();
             }
-            GCMode::StateSync => {
+            GCMode::StateSync { .. } => {
                 // Not apply the data from ColTrieChanges
                 for shard_id in 0..header.chunk_mask().len() as ShardId {
                     self.gc_col(ColTrieChanges, &get_block_shard_id(&block_hash, shard_id));
@@ -2076,7 +2076,10 @@ impl<'a> ChainStoreUpdate<'a> {
             self.gc_col(ColTransactionResult, &outcome_id.as_ref().into());
         }
         self.gc_col(ColOutcomesByBlockHash, &block_hash_vec);
-        self.gc_col(ColBlockInfo, &block_hash_vec);
+        match gc_mode {
+            GCMode::StateSync { clear_block_info: false } => {}
+            _ => self.gc_col(ColBlockInfo, &block_hash_vec),
+        }
         self.gc_col(ColStateDlInfos, &block_hash_vec);
 
         // 4. Update or delete block_hash_per_height
@@ -2098,7 +2101,7 @@ impl<'a> ChainStoreUpdate<'a> {
                 }
                 self.clear_chunk_data(min_chunk_height)?;
             }
-            GCMode::StateSync => {
+            GCMode::StateSync { .. } => {
                 // 7. State Sync clearing
                 // Chunks deleted separately
             }

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -960,9 +960,11 @@ fn test_gc_after_state_sync() {
         env.process_block(1, block, Provenance::NONE);
     }
     let sync_height = epoch_length * 4 + 1;
-    let sync_hash = *env.clients[0].chain.get_block_by_height(sync_height).unwrap().hash();
+    let sync_block = env.clients[0].chain.get_block_by_height(sync_height).unwrap().clone();
+    let sync_hash = *sync_block.hash();
+    let prev_block_hash = *sync_block.header().prev_hash();
     // reset cache
-    for i in epoch_length * 3..sync_height {
+    for i in epoch_length * 3 - 1..sync_height - 1 {
         let block_hash = *env.clients[0].chain.get_block_by_height(i).unwrap().hash();
         assert!(env.clients[1].chain.runtime_adapter.get_epoch_start_height(&block_hash).is_ok());
     }
@@ -971,6 +973,8 @@ fn test_gc_after_state_sync() {
         env.clients[1].runtime_adapter.get_gc_stop_height(&sync_hash).unwrap_err().kind(),
         ErrorKind::DBNotFoundErr(_)
     ));
+    // mimic what we do in possible_targets
+    assert!(env.clients[1].runtime_adapter.get_epoch_id_from_prev_block(&prev_block_hash).is_ok());
     let tries = env.clients[1].runtime_adapter.get_tries();
     assert!(env.clients[1].chain.clear_data(tries, 2).is_ok());
 }


### PR DESCRIPTION
When we do `reset_data_pre_state_sync` before running state sync, we garbage collect everything up to sync block, which includes the prev block of the sync block. However, when we run state sync, we use `prev_hash` of sync block inside `possible_targets` [here](https://github.com/nearprotocol/nearcore/blob/f65d2441d66fa13f7933c23ba833311677ce1e96/chain/client/src/sync.rs#L801). Therefore, we cannot garbage collect `prev_hash` of sync block. Fixes #3042.

Test plan
---------
`test_data_reset_before_state_sync`