### PR TITLE
fix(network): properly handle account announcement

### DIFF
--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -905,11 +905,13 @@ impl Handler<NetworkViewClientMessages> for ViewClientActor {
 
                 for (announce_account, last_epoch) in announce_accounts.into_iter() {
                     if let Some(last_epoch) = last_epoch {
+                        // the new announcement should not be in an epoch that is older than the last
+                        // announcement
                         match self
                             .runtime_adapter
                             .compare_epoch_id(&announce_account.epoch_id, &last_epoch)
                         {
-                            Ok(Ordering::Less) => {}
+                            Ok(Ordering::Equal) | Ok(Ordering::Greater) => {}
                             _ => continue,
                         }
                     }

--- a/chain/network/src/routing.rs
+++ b/chain/network/src/routing.rs
@@ -397,7 +397,7 @@ impl RoutingTable {
     // TODO(MarX, #1694): Allow one account id to be routed to several peer id.
     pub fn contains_account(&mut self, announce_account: &AnnounceAccount) -> bool {
         self.get_announce(&announce_account.account_id).map_or(false, |current_announce_account| {
-            current_announce_account.epoch_id == announce_account.epoch_id
+            current_announce_account.peer_id == announce_account.peer_id
         })
     }
 
@@ -702,7 +702,7 @@ impl RoutingTable {
         self.account_peers.value_order().cloned().collect()
     }
 
-    /// Get account announce from
+    /// Get account announcement from account id
     pub fn get_announce(&mut self, account_id: &AccountId) -> Option<AnnounceAccount> {
         if let Some(announce_account) = self.account_peers.cache_get(&account_id) {
             Some(announce_account.clone())
@@ -711,7 +711,7 @@ impl RoutingTable {
                 .get_ser(ColAccountAnnouncements, account_id.as_bytes())
                 .and_then(|res: Option<AnnounceAccount>| {
                     if let Some(announce_account) = res {
-                        self.add_account(announce_account.clone());
+                        self.account_peers.cache_set(account_id.clone(), announce_account.clone());
                         Ok(Some(announce_account))
                     } else {
                         Ok(None)

--- a/chain/network/tests/cache.rs
+++ b/chain/network/tests/cache.rs
@@ -31,7 +31,7 @@ fn announcement_same_epoch() {
 
     routing_table.add_account(announce0.clone());
     assert!(routing_table.contains_account(&announce0));
-    assert!(routing_table.contains_account(&announce1));
+    assert!(!routing_table.contains_account(&announce1));
     assert_eq!(routing_table.get_announce_accounts().len(), 1);
     assert_eq!(routing_table.account_owner(&announce0.account_id).unwrap(), peer_id0);
     routing_table.add_account(announce1.clone());

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -37,6 +37,7 @@ pytest --timeout=300 sanity/gc_after_sync1.py
 pytest --timeout=300 sanity/gc_sync_after_sync.py
 pytest --timeout=300 sanity/gc_sync_after_sync.py swap_nodes
 pytest --timeout=300 sanity/large_messages.py
+pytest sanity/switch_node_key.py
 # TODO: re-enable after #2949 is fixed
 # pytest --timeout=240 sanity/validator_switch_key.py
 pytest sanity/proxy_simple.py

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -346,6 +346,11 @@ class LocalNode(BaseNode):
         with open(os.path.join(self.node_dir, "validator_key.json"), 'w+') as f:
             json.dump(new_key.to_json(), f)
 
+    def reset_node_key(self, new_key):
+        self.node_key = new_key
+        with open(os.path.join(self.node_dir, "node_key.json"), 'w+') as f:
+            json.dump(new_key.to_json(), f)
+
     def cleanup(self):
         if self.cleaned:
             return

--- a/pytest/tests/sanity/switch_node_key.py
+++ b/pytest/tests/sanity/switch_node_key.py
@@ -1,0 +1,41 @@
+# Spin up two validating nodes. Stop one of them and switch node key (peer id) and restart.
+# Make sure that both node can still produce blocks.
+
+import sys, time, base58, nacl.bindings
+
+sys.path.append('lib')
+
+from cluster import start_cluster, Key
+from transaction import sign_staking_tx
+
+EPOCH_LENGTH = 30
+TIMEOUT = 40
+
+nodes = start_cluster(2, 0, 1, None, [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 20],
+                                      ["chunk_producer_kickout_threshold", 20]], {})
+time.sleep(2)
+
+status1 = nodes[1].get_status()
+height1 = status1['sync_info']['latest_block_height']
+while height1 < 5:
+    time.sleep(1)
+    status1 = nodes[1].get_status()
+    height1 = status1['sync_info']['latest_block_height']
+
+nodes[1].kill()
+
+seed = bytes([1] * 32)
+public_key, secret_key = nacl.bindings.crypto_sign_seed_keypair(seed)
+node_key = Key("", base58.b58encode(public_key).decode('utf-8'), base58.b58encode(secret_key).decode('utf-8'))
+nodes[1].reset_node_key(node_key)
+nodes[1].start(nodes[0].node_key.pk, nodes[0].addr())
+time.sleep(2)
+
+start = time.time()
+while height1 < EPOCH_LENGTH + 5:
+    assert time.time() - start < TIMEOUT
+    time.sleep(1)
+    status1 = nodes[1].get_status()
+    height1 = status1['sync_info']['latest_block_height']
+
+assert len(status1['validators']) == 2, f'unexpected number of validators, current validators: {status1["validators"]}'


### PR DESCRIPTION
A validator should be able to switch their peer id when they are validating and still be able to produce blocks. Currently there are several issues that prevents this:
* When we announce account, we only send the announcement if the same account is not announced in the current epoch. Because this information is persisted in storage, it means that if a validator decides to change their peer id within the epoch, they will not be able to do so.
* When we process account announcement, due to the same reason we will not overwrite the account to peer mapping if the epoch id is the same.
* When we process account announcement, the check for whether the current announcement is new seems backwards. We checked instead whether the older announcement is in a new epoch.

In general it seems that we are misusing epoch ids here. It is meant to indicate recency, but somehow we use it to indicate uniqueness. What is important here is the mapping between account id and peer id, not account id and epoch id.

Test plan
---------
* `switch_node_key.py`