### PR TITLE
fix(script): docker build from a fork has colon in branch name

### DIFF
--- a/scripts/docker-release.sh
+++ b/scripts/docker-release.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-branch=${BUILDKITE_BRANCH}
+branch=${BUILDKITE_BRANCH/:/_}
 commit=${BUILDKITE_COMMIT}
 if [[ ${commit} == "HEAD" ]]; then
     commit=$(git rev-parse HEAD)


### PR DESCRIPTION
it's not allowed by docker, replace it with `_`

Test Plan
---------
This pr is also from fork, it should pass