### PR TITLE
test: add extra stats to cross_shard_tx

### DIFF
--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -250,8 +250,9 @@ impl BlockStats {
     }
 
     fn add_block(&mut self, block: &Block) {
-        let prev_height = self.hash2height.get(block.header().prev_hash()).map(|v| *v).unwrap_or(0);
         if !self.hash2height.contains_key(block.hash()) {
+            let prev_height =
+                self.hash2height.get(block.header().prev_hash()).map(|v| *v).unwrap_or(0);
             self.hash2height.insert(*block.hash(), prev_height + 1);
             self.num_blocks += 1;
             self.max_chain_length = max(self.max_chain_length, prev_height + 1);

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -250,23 +250,21 @@ impl BlockStats {
     }
 
     fn add_block(&mut self, block: &Block) {
-        if !self.hash2height.contains_key(block.hash()) {
-            let prev_height =
-                self.hash2height.get(block.header().prev_hash()).map(|v| *v).unwrap_or(0);
-            self.hash2height.insert(*block.hash(), prev_height + 1);
-            self.num_blocks += 1;
-            self.max_chain_length = max(self.max_chain_length, prev_height + 1);
-            self.parent.insert(*block.hash(), *block.header().prev_hash());
-
-            if let Some(last_hash2) = self.last_hash {
-                self.max_divergence = max(
-                    self.max_divergence,
-                    self.calculate_distance(last_hash2, block.hash().clone()),
-                );
-            }
-
-            self.last_hash = Some(block.hash().clone());
+        if self.hash2height.contains_key(block.hash()) {
+            return;
         }
+        let prev_height = self.hash2height.get(block.header().prev_hash()).map(|v| *v).unwrap_or(0);
+        self.hash2height.insert(*block.hash(), prev_height + 1);
+        self.num_blocks += 1;
+        self.max_chain_length = max(self.max_chain_length, prev_height + 1);
+        self.parent.insert(*block.hash(), *block.header().prev_hash());
+
+        if let Some(last_hash2) = self.last_hash {
+            self.max_divergence =
+                max(self.max_divergence, self.calculate_distance(last_hash2, block.hash().clone()));
+        }
+
+        self.last_hash = Some(block.hash().clone());
     }
 
     pub fn check_stats(&mut self, force: bool) {

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -204,7 +204,7 @@ fn sample_binary(n: u64, k: u64) -> bool {
 }
 
 pub struct BlockStats {
-    hash2height: HashMap<CryptoHash, u64>,
+    hash2depth: HashMap<CryptoHash, u64>,
     num_blocks: u64,
     max_chain_length: u64,
     last_check: Instant,
@@ -216,7 +216,7 @@ pub struct BlockStats {
 impl BlockStats {
     fn new() -> BlockStats {
         BlockStats {
-            hash2height: HashMap::new(),
+            hash2depth: HashMap::new(),
             num_blocks: 0,
             max_chain_length: 0,
             last_check: Instant::now(),
@@ -227,8 +227,8 @@ impl BlockStats {
     }
 
     fn calculate_distance(&mut self, mut lhs: CryptoHash, mut rhs: CryptoHash) -> u64 {
-        let mut dlhs = *self.hash2height.get(&lhs).unwrap();
-        let mut drhs = *self.hash2height.get(&rhs).unwrap();
+        let mut dlhs = *self.hash2depth.get(&lhs).unwrap();
+        let mut drhs = *self.hash2depth.get(&rhs).unwrap();
 
         let mut result: u64 = 0;
         while dlhs > drhs {
@@ -250,11 +250,11 @@ impl BlockStats {
     }
 
     fn add_block(&mut self, block: &Block) {
-        if self.hash2height.contains_key(block.hash()) {
+        if self.hash2depth.contains_key(block.hash()) {
             return;
         }
-        let prev_height = self.hash2height.get(block.header().prev_hash()).map(|v| *v).unwrap_or(0);
-        self.hash2height.insert(*block.hash(), prev_height + 1);
+        let prev_height = self.hash2depth.get(block.header().prev_hash()).map(|v| *v).unwrap_or(0);
+        self.hash2depth.insert(*block.hash(), prev_height + 1);
         self.num_blocks += 1;
         self.max_chain_length = max(self.max_chain_length, prev_height + 1);
         self.parent.insert(*block.hash(), *block.header().prev_hash());

--- a/chain/client/tests/bug_repros.rs
+++ b/chain/client/tests/bug_repros.rs
@@ -38,7 +38,7 @@ fn repro_1183() {
         let validators2 = validators.clone();
         let last_block: Arc<RwLock<Option<Block>>> = Arc::new(RwLock::new(None));
         let delayed_one_parts: Arc<RwLock<Vec<NetworkRequests>>> = Arc::new(RwLock::new(vec![]));
-        let (_, conn) = setup_mock_all_validators(
+        let (_, conn, _) = setup_mock_all_validators(
             validators.clone(),
             key_pairs.clone(),
             validator_groups,
@@ -49,6 +49,7 @@ fn repro_1183() {
             5,
             false,
             vec![false; validators.iter().map(|x| x.len()).sum()],
+            false,
             Arc::new(RwLock::new(Box::new(move |_account_id: String, msg: &NetworkRequests| {
                 if let NetworkRequests::Block { block } = msg {
                     let mut last_block = last_block.write().unwrap();
@@ -149,7 +150,7 @@ fn test_sync_from_achival_node() {
         > = Arc::new(RwLock::new(Box::new(|_: String, _: &NetworkRequests| {
             (NetworkResponses::NoResponse, true)
         })));
-        let (_, conns) = setup_mock_all_validators(
+        let (_, conns, _) = setup_mock_all_validators(
             validators.clone(),
             key_pairs,
             1,
@@ -160,6 +161,7 @@ fn test_sync_from_achival_node() {
             epoch_length,
             false,
             vec![true, false, false, false],
+            false,
             network_mock.clone(),
         );
         let mut block_counter = 0;

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -135,7 +135,7 @@ mod tests {
             if sync_hold {
                 block_prod_time *= STATE_SYNC_TIMEOUT as u64;
             }
-            let (_, conn) = setup_mock_all_validators(
+            let (_, conn, _) = setup_mock_all_validators(
                 validators.clone(),
                 key_pairs.clone(),
                 validator_groups,
@@ -146,6 +146,7 @@ mod tests {
                 5,
                 false,
                 vec![true; validators.iter().map(|x| x.len()).sum()],
+                false,
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
                         let account_from = "test3.3".to_string();
@@ -432,7 +433,7 @@ mod tests {
                 };
 
             let connectors1 = connectors.clone();
-            let (_, conn) = setup_mock_all_validators(
+            let (_, conn, _) = setup_mock_all_validators(
                 validators.clone(),
                 key_pairs.clone(),
                 validator_groups,
@@ -443,6 +444,7 @@ mod tests {
                 5,
                 false,
                 vec![false; validators.iter().map(|x| x.len()).sum()],
+                false,
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
                         let mut seen_heights_same_block = seen_heights_same_block.write().unwrap();
@@ -631,7 +633,7 @@ mod tests {
 
             let (validators, key_pairs) = get_validators_and_key_pairs();
 
-            let (_, conn) = setup_mock_all_validators(
+            let (_, conn, _) = setup_mock_all_validators(
                 validators.clone(),
                 key_pairs.clone(),
                 validator_groups,
@@ -642,6 +644,7 @@ mod tests {
                 5,
                 false,
                 vec![false; validators.iter().map(|x| x.len()).sum()],
+                false,
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
                         if let NetworkRequests::Block { block } = msg {
@@ -691,7 +694,7 @@ mod tests {
 
             let (validators, key_pairs) = get_validators_and_key_pairs();
 
-            let (_, conn) = setup_mock_all_validators(
+            let (_, conn, _) = setup_mock_all_validators(
                 validators.clone(),
                 key_pairs.clone(),
                 validator_groups,
@@ -702,6 +705,7 @@ mod tests {
                 5,
                 true,
                 vec![false; validators.iter().map(|x| x.len()).sum()],
+                false,
                 Arc::new(RwLock::new(Box::new(
                     move |_account_id: String, msg: &NetworkRequests| {
                         let propagate = if let NetworkRequests::Block { block } = msg {
@@ -764,7 +768,7 @@ mod tests {
             let _connectors1 = connectors.clone();
 
             let block_prod_time: u64 = 1200;
-            let (_, conn) = setup_mock_all_validators(
+            let (_, conn, _) = setup_mock_all_validators(
                 validators.clone(),
                 key_pairs.clone(),
                 validator_groups,
@@ -775,6 +779,7 @@ mod tests {
                 5,
                 true,
                 vec![false; validators.iter().map(|x| x.len()).sum()],
+                false,
                 Arc::new(RwLock::new(Box::new(
                     move |sender_account_id: String, msg: &NetworkRequests| {
                         let mut grieving_chunk_hash = grieving_chunk_hash.write().unwrap();
@@ -917,7 +922,7 @@ mod tests {
             let responded =
                 Arc::new(RwLock::new(HashSet::<(CryptoHash, Vec<u64>, ChunkHash)>::new()));
 
-            let (_, conn) = setup_mock_all_validators(
+            let (_, conn, _) = setup_mock_all_validators(
                 validators.clone(),
                 key_pairs.clone(),
                 validator_groups,
@@ -928,6 +933,7 @@ mod tests {
                 epoch_length,
                 false,
                 vec![false; validators.iter().map(|x| x.len()).sum()],
+                false,
                 Arc::new(RwLock::new(Box::new(
                     move |sender_account_id: String, msg: &NetworkRequests| {
                         let mut seen_chunk_same_sender = seen_chunk_same_sender.write().unwrap();

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -108,7 +108,7 @@ fn chunks_produced_and_distributed_common(
         let mut partial_chunk_msgs = 0;
         let mut partial_chunk_request_msgs = 0;
 
-        let (_, conn) = setup_mock_all_validators(
+        let (_, conn, _) = setup_mock_all_validators(
             validators.clone(),
             key_pairs.clone(),
             validator_groups,
@@ -119,6 +119,7 @@ fn chunks_produced_and_distributed_common(
             5,
             true,
             vec![false; validators.iter().map(|x| x.len()).sum()],
+            false,
             Arc::new(RwLock::new(Box::new(move |from_whom: String, msg: &NetworkRequests| {
                 match msg {
                     NetworkRequests::Block { block } => {

--- a/chain/client/tests/consensus.rs
+++ b/chain/client/tests/consensus.rs
@@ -57,7 +57,7 @@ mod tests {
             let largest_block_height = Arc::new(RwLock::new(0u64));
             let delayed_blocks = Arc::new(RwLock::new(vec![]));
 
-            let (_, conn) = setup_mock_all_validators(
+            let (_, conn, _) = setup_mock_all_validators(
                 validators.clone(),
                 key_pairs.clone(),
                 1,
@@ -68,6 +68,7 @@ mod tests {
                 4,
                 true,
                 vec![true; validators.iter().map(|x| x.len()).sum()],
+                false,
                 Arc::new(RwLock::new(Box::new(move |from_whom: String, msg: &NetworkRequests| {
                     let mut all_blocks: RwLockWriteGuard<BTreeMap<BlockHeight, Block>> =
                         all_blocks.write().unwrap();

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -4,6 +4,7 @@ use std::sync::{Arc, RwLock};
 use actix::{Addr, System};
 use futures::{future, FutureExt};
 
+
 use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, Query, ViewClientActor};
 use near_logger_utils::init_test_logger;

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -512,7 +512,7 @@ mod tests {
     }
 
     #[test]
-    fn test_cross_shard_tx_base() {
+    fn test_cross_shard_tx() {
         test_cross_shard_tx_common(64, false, false, false, 100, Some(3.0), None);
     }
 

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -4,7 +4,6 @@ use std::sync::{Arc, RwLock};
 use actix::{Addr, System};
 use futures::{future, FutureExt};
 
-
 use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, Query, ViewClientActor};
 use near_logger_utils::init_test_logger;

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -301,7 +301,7 @@ fn produce_block_with_approvals_arrived_early() {
         > = Arc::new(RwLock::new(Box::new(|_: String, _: &NetworkRequests| {
             (NetworkResponses::NoResponse, true)
         })));
-        let (_, conns) = setup_mock_all_validators(
+        let (_, conns, _) = setup_mock_all_validators(
             validators.clone(),
             key_pairs,
             1,
@@ -312,6 +312,7 @@ fn produce_block_with_approvals_arrived_early() {
             100,
             true,
             vec![false; validators.iter().map(|x| x.len()).sum()],
+            false,
             network_mock.clone(),
         );
         *network_mock.write().unwrap() =

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -592,7 +592,7 @@ fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
         > = Arc::new(RwLock::new(Box::new(|_: String, _: &NetworkRequests| {
             (NetworkResponses::NoResponse, true)
         })));
-        let (_, conns) = setup_mock_all_validators(
+        let (_, conns, _) = setup_mock_all_validators(
             validators.clone(),
             key_pairs,
             1,
@@ -603,6 +603,7 @@ fn ban_peer_for_invalid_block_common(mode: InvalidBlockMode) {
             100,
             true,
             vec![false; validators.iter().map(|x| x.len()).sum()],
+            false,
             network_mock.clone(),
         );
         *network_mock.write().unwrap() =


### PR DESCRIPTION
The usefulness and flakiness of `cross_shard_tx` depends heavily on the block production time.

This change adds printing block stats every minute, we will print the following:
- ratio of number of blocks to longest chain
- maximum divergence between recently produced blocks

In addition we will fail `cross_shard_tx` test if the ratio is too high or to low, depending on test parameters.

https://github.com/nearprotocol/nearcore/issues/3014