### PR TITLE
feat: add some debug functionalities to state viewer

### DIFF
--- a/test-utils/state-viewer/src/main.rs
+++ b/test-utils/state-viewer/src/main.rs
@@ -5,15 +5,16 @@ use std::sync::Arc;
 use ansi_term::Color::Red;
 use clap::{App, Arg, SubCommand};
 
-use near_chain::types::BlockHeaderInfo;
-use near_chain::{ChainStore, ChainStoreAccess, RuntimeAdapter};
+use near_chain::chain::collect_receipts_from_response;
+use near_chain::types::{ApplyTransactionResult, BlockHeaderInfo};
+use near_chain::{ChainStore, ChainStoreAccess, ChainStoreUpdate, RuntimeAdapter};
 use near_logger_utils::init_integration_logger;
 use near_network::peer_store::PeerStore;
 use near_primitives::block::BlockHeader;
 use near_primitives::hash::CryptoHash;
 use near_primitives::serialize::to_base;
 use near_primitives::state_record::StateRecord;
-use near_primitives::types::{BlockHeight, StateRoot};
+use near_primitives::types::{BlockHeight, ChunkExtra, ShardId, StateRoot};
 use near_store::test_utils::create_test_store;
 use near_store::{create_store, Store, TrieIterator};
 use neard::{get_default_home, get_store_path, load_config, NearConfig, NightshadeRuntime};
@@ -21,19 +22,29 @@ use state_dump::state_dump;
 
 mod state_dump;
 
+#[allow(unused)]
+enum LoadTrieMode {
+    /// Load latest state
+    Latest,
+    /// Load prev state at some height
+    Height(BlockHeight),
+    /// Load the prev state of the last final block from some height
+    LastFinalFromHeight(BlockHeight),
+}
+
 fn load_trie(
     store: Arc<Store>,
     home_dir: &Path,
     near_config: &NearConfig,
 ) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
-    load_trie_stop_at_height(store, home_dir, near_config, None)
+    load_trie_stop_at_height(store, home_dir, near_config, LoadTrieMode::Latest)
 }
 
 fn load_trie_stop_at_height(
     store: Arc<Store>,
     home_dir: &Path,
     near_config: &NearConfig,
-    stop_height: Option<BlockHeight>,
+    mode: LoadTrieMode,
 ) -> (NightshadeRuntime, Vec<StateRoot>, BlockHeader) {
     let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
 
@@ -45,8 +56,8 @@ fn load_trie_stop_at_height(
         near_config.client_config.tracked_shards.clone(),
     );
     let head = chain_store.head().unwrap();
-    let last_block = match stop_height {
-        Some(height) => {
+    let last_block = match mode {
+        LoadTrieMode::LastFinalFromHeight(height) => {
             // find the first final block whose height is at least `height`.
             let mut cur_height = height + 1;
             loop {
@@ -71,7 +82,11 @@ fn load_trie_stop_at_height(
                 }
             }
         }
-        None => chain_store.get_block(&head.last_block_hash).unwrap().clone(),
+        LoadTrieMode::Height(height) => {
+            let block_hash = chain_store.get_block_hash_by_height(height).unwrap();
+            chain_store.get_block(&block_hash).unwrap().clone()
+        }
+        LoadTrieMode::Latest => chain_store.get_block(&head.last_block_hash).unwrap().clone(),
     };
     let state_roots = last_block.chunks().iter().map(|chunk| chunk.inner.prev_state_root).collect();
     (runtime, state_roots, last_block.header().clone())
@@ -178,6 +193,74 @@ fn replay_chain(
     }
 }
 
+fn apply_block_at_height(
+    store: Arc<Store>,
+    home_dir: &Path,
+    near_config: &NearConfig,
+    height: BlockHeight,
+    shard_id: ShardId,
+) {
+    let mut chain_store = ChainStore::new(store.clone(), near_config.genesis.config.genesis_height);
+    let runtime = NightshadeRuntime::new(
+        &home_dir,
+        store,
+        Arc::clone(&near_config.genesis),
+        near_config.client_config.tracked_accounts.clone(),
+        near_config.client_config.tracked_shards.clone(),
+    );
+    let block_hash = chain_store.get_block_hash_by_height(height).unwrap();
+    let block = chain_store.get_block(&block_hash).unwrap().clone();
+    assert_eq!(block.chunks()[shard_id as usize].height_included, height);
+    let chunk =
+        chain_store.get_chunk(&block.chunks()[shard_id as usize].chunk_hash()).unwrap().clone();
+    let prev_block = chain_store.get_block(&block.header().prev_hash()).unwrap().clone();
+    let mut chain_store_update = ChainStoreUpdate::new(&mut chain_store);
+    let receipt_proof_response = chain_store_update
+        .get_incoming_receipts_for_shard(
+            shard_id,
+            block_hash,
+            prev_block.chunks()[shard_id as usize].height_included,
+        )
+        .unwrap();
+    let receipts = collect_receipts_from_response(&receipt_proof_response);
+
+    let apply_result = runtime
+        .apply_transactions(
+            shard_id,
+            &chunk.header.inner.prev_state_root,
+            height,
+            block.header().raw_timestamp(),
+            block.header().prev_hash(),
+            block.hash(),
+            &receipts,
+            &chunk.transactions,
+            &chunk.header.inner.validator_proposals,
+            prev_block.header().gas_price(),
+            chunk.header.inner.gas_limit,
+            &block.header().challenges_result(),
+        )
+        .unwrap();
+    let (outcome_root, _) = ApplyTransactionResult::compute_outcomes_proof(&apply_result.outcomes);
+    let chunk_extra = ChunkExtra::new(
+        &apply_result.new_root,
+        outcome_root,
+        apply_result.validator_proposals,
+        apply_result.total_gas_burnt,
+        chunk.header.inner.gas_limit,
+        apply_result.total_balance_burnt,
+    );
+
+    println!(
+        "apply chunk for shard {} at height {}, resulting chunk extra {:?}",
+        shard_id, height, chunk_extra
+    );
+    if let Ok(chunk_extra) = chain_store.get_chunk_extra(&block_hash, shard_id) {
+        println!("Existing chunk extra: {:?}", chunk_extra);
+    } else {
+        println!("no existing chunk extra available");
+    }
+}
+
 fn main() {
     init_integration_logger();
 
@@ -236,6 +319,23 @@ fn main() {
                 )
                 .help("replay headers from chain"),
         )
+        .subcommand(
+            SubCommand::with_name("apply")
+                .arg(
+                    Arg::with_name("height")
+                        .long("height")
+                        .required(true)
+                        .help("Height of the block to apply")
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("shard_id")
+                        .long("shard_id")
+                        .help("Id of the shard to apply")
+                        .takes_value(true),
+                )
+                .help("apply block at some height for shard"),
+        )
         .get_matches();
 
     let home_dir = matches.value_of("home").map(|dir| Path::new(dir)).unwrap();
@@ -266,8 +366,12 @@ fn main() {
         }
         ("dump_state", Some(args)) => {
             let height = args.value_of("height").map(|s| s.parse::<u64>().unwrap());
+            let mode = match height {
+                Some(h) => LoadTrieMode::LastFinalFromHeight(h),
+                None => LoadTrieMode::Latest,
+            };
             let (runtime, state_roots, header) =
-                load_trie_stop_at_height(store, home_dir, &near_config, height);
+                load_trie_stop_at_height(store, home_dir, &near_config, mode);
             let height = header.height();
             let home_dir = PathBuf::from(&home_dir);
 
@@ -294,6 +398,12 @@ fn main() {
                 args.value_of("start_index").map(|s| s.parse::<u64>().unwrap()).unwrap();
             let end_index = args.value_of("end_index").map(|s| s.parse::<u64>().unwrap()).unwrap();
             replay_chain(store, home_dir, &near_config, start_index, end_index);
+        }
+        ("apply", Some(args)) => {
+            let height = args.value_of("height").map(|s| s.parse::<u64>().unwrap()).unwrap();
+            let shard_id =
+                args.value_of("shard_id").map(|s| s.parse::<u64>().unwrap()).unwrap_or_default();
+            apply_block_at_height(store, home_dir, &near_config, height, shard_id);
         }
         (_, _) => unreachable!(),
     }


### PR DESCRIPTION
From debugging the state transition issue there has emerged some useful commands to be put into state viewer:
* `apply` which applies the state transition at a given height and prints the result
* `view_chain`, which views the block, chunks and chunk extra at a given height.