### PR TITLE
fix(pytest): use python proxy framework to isolate nodes instead of unix utilities

### DIFF
--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -54,7 +54,7 @@ pytest contracts/deploy_call_smart_contract.py
 pytest --timeout=240 contracts/gibberish.py
 
 # python stress tests
-# pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network
+pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart
 # pytest --timeout=2000 stress/stress.py 3 2 4 0 staking transactions node_set
 

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -85,6 +85,7 @@ class BaseNode(object):
     def __init__(self):
         self._start_proxy = None
         self._proxy_local_stopped = None
+        self.proxy = None
 
 
     def _get_command_line(self,

--- a/pytest/lib/proxy.py
+++ b/pytest/lib/proxy.py
@@ -178,7 +178,7 @@ class NodesProxy:
 
     def proxify_node(self, node):
         proxify_node(node, self.ps, self.handler,
-                     self.global_stopped, self.error)
+                     self.global_stopped, self.error, self)
 
 
 async def stop_server(server):
@@ -316,7 +316,7 @@ def start_server(inner_port, outer_port, handler_ctr, global_stopped, local_stop
                          global_stopped, local_stopped, error))
 
 
-def proxify_node(node, ps, handler, global_stopped, error):
+def proxify_node(node, ps, handler, global_stopped, error, proxy):
     inner_port = node.port
     outer_port = inner_port + 100
 
@@ -330,3 +330,4 @@ def proxify_node(node, ps, handler, global_stopped, error):
 
     node.port = outer_port
     node._start_proxy = start_proxy
+    node.proxy = proxy

--- a/pytest/lib/proxy_instances.py
+++ b/pytest/lib/proxy_instances.py
@@ -1,0 +1,29 @@
+import logging, multiprocessing
+from proxy import ProxyHandler, NodesProxy
+
+
+class RejectListHandler(ProxyHandler):
+
+    def __init__(self, reject_list, ordinal):
+        super().__init__(ordinal)
+        self.reject_list = reject_list
+
+    async def handle(self, msg, fr, to):
+        if fr in self.reject_list or to in self.reject_list:
+            logging.info(
+                f'NODE {self.ordinal} blocking message from {fr} to {to}')
+            return False
+        else:
+            return True
+
+
+class RejectListProxy(NodesProxy):
+
+    def __init__(self, reject_list):
+        self.reject_list = reject_list
+        handler = lambda ordinal: RejectListHandler(reject_list, ordinal)
+        super().__init__(handler)
+
+    @staticmethod
+    def create_reject_list(size):
+        return multiprocessing.Array('i', [-1 for _ in range(size)])

--- a/pytest/tests/stress/stress.py
+++ b/pytest/tests/stress/stress.py
@@ -31,7 +31,7 @@ sys.path.append('lib')
 from cluster import init_cluster, spin_up_node, load_config
 from utils import TxContext, Unbuffered
 from transaction import sign_payment_tx, sign_staking_tx
-from network import init_network_pillager, stop_network, resume_network
+from proxy_instances import RejectListProxy
 
 sys.stdout = Unbuffered(sys.stdout)
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
@@ -171,15 +171,18 @@ def monkey_node_restart(stopped, error, nodes, nonces):
 @stress_process
 def monkey_local_network(stopped, error, nodes, nonces):
     while stopped.value == 0:
+        time.sleep(9)
         # "- 2" below is because we don't want to kill the node we use to check stats
         node_idx = random.randint(0, len(nodes) - 2)
-        nodes[node_idx].stop_network()
+        node = nodes[node_idx]
+        logging.info(f'ISOLATING NODE {node_idx}')
+        node.proxy.reject_list[0] = node_idx
         if node_idx == get_the_guy_to_mess_up_with(nodes):
             time.sleep(5)
         else:
             time.sleep(1)
-        nodes[node_idx].resume_network()
-        time.sleep(5)
+        logging.info(f'RESTORING NODE {node_idx} NETWORK')
+        node.proxy.reject_list[0] = -1
 
 
 @stress_process
@@ -228,7 +231,7 @@ def monkey_transactions(stopped, error, nodes, nonces):
                         logging.info("\nTRANSACTION %s" % tx_ord)
                         logging.info("TX tuple: %s" % (tx[1:],))
                         response = nodes[-1].json_rpc(
-                            'tx', [tx[3], "test%s" % tx[1]], timeout=1)
+                            'tx', [tx[3], "test%s" % tx[1]], timeout=5)
                         logging.info("Status: %s", response)
 
                 def revert_txs():
@@ -239,7 +242,7 @@ def monkey_transactions(stopped, error, nodes, nonces):
                         tx_happened = True
 
                         response = nodes[-1].json_rpc(
-                            'tx', [tx[3], "test%s" % tx[1]], timeout=1)
+                            'tx', [tx[3], "test%s" % tx[1]], timeout=5)
 
                         if 'error' in response and 'data' in response[
                                 'error'] and "doesn't exist" in response['error'][
@@ -558,30 +561,14 @@ def doit(s, n, N, k, monkeys, timeout):
          ["block_producer_kickout_threshold", 10],
          ["chunk_producer_kickout_threshold", 10]], local_config_changes)
 
-    started = time.time()
-
-    boot_node = spin_up_node(config, near_root, node_dirs[0], 0, None, None)
-    boot_node.mess_with = False
-    nodes = [boot_node]
-
-    for i in range(1, N + k + 1):
-        node = spin_up_node(config, near_root, node_dirs[i], i,
-                            boot_node.node_key.pk, boot_node.addr())
-        nodes.append(node)
-        if i >= n and i < N:
-            node.kill()
-            node.mess_with = True
-        else:
-            node.mess_with = False
-
     monkey_names = [x.__name__ for x in monkeys]
+    proxy = None
     logging.info(monkey_names)
     if 'monkey_local_network' in monkey_names or 'monkey_global_network' in monkey_names:
-        logging.info(
-            "There are monkeys messing up with network, initializing the infra")
-        if config['local']:
-            init_network_pillager()
-            expect_network_issues()
+        assert config['local'], 'Network stress operations only work on local nodes'
+        reject_list = RejectListProxy.create_reject_list(1)
+        proxy = RejectListProxy(reject_list)
+        expect_network_issues()
         block_timeout += 40
         tx_tolerance += 0.3
     if 'monkey_node_restart' in monkey_names:
@@ -590,6 +577,22 @@ def doit(s, n, N, k, monkeys, timeout):
         block_timeout += 40
         balances_timeout += 10
         tx_tolerance += 0.5
+
+    started = time.time()
+
+    boot_node = spin_up_node(config, near_root, node_dirs[0], 0, None, None, proxy=proxy)
+    boot_node.mess_with = False
+    nodes = [boot_node]
+
+    for i in range(1, N + k + 1):
+        node = spin_up_node(config, near_root, node_dirs[i], i,
+                            boot_node.node_key.pk, boot_node.addr(), proxy=proxy)
+        nodes.append(node)
+        if i >= n and i < N:
+            node.kill()
+            node.mess_with = True
+        else:
+            node.mess_with = False
 
     stopped = Value('i', 0)
     error = Value('i', 0)


### PR DESCRIPTION
The goal of the `local_network` stress test is to ensure the network functions well under the condition that a random node occasionally loses contact with the rest of the network (i.e. experiences a "local network failure"). Previously this test was implemented by restricting access to network interfaces of specific process ids at the OS level. This solution was a little hacky, platform dependent, and not entirely reliable. We now have a proxy framework as part of `pytest` which is exactly meant to change (or drop) messages between nodes. We now make use of this framework in the `local_network` stress test instead of using the Unix utilities.