### PR TITLE
fix(ci): Fixed typo in the release scripts for docker

### DIFF
--- a/scripts/docker-release.sh
+++ b/scripts/docker-release.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-branch=${BUILDKITE_BRANCH/:/_}
-branch=${BUILDKITE_BRANCH/\//_}
+branch=${BUILDKITE_BRANCH//:/_}
+branch=${branch//\//_}
 commit=${BUILDKITE_COMMIT}
 if [[ ${commit} == "HEAD" ]]; then
     commit=$(git rev-parse HEAD)


### PR DESCRIPTION
I made a mistake when doing this, we have to apply it on the branch commit as we are already removing : with _