### PR TITLE
fix(sync): address a couple suboptimalities

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -904,10 +904,11 @@ impl Chain {
     }
 
     pub fn reset_data_pre_state_sync(&mut self, sync_hash: CryptoHash) -> Result<(), Error> {
+        let head = self.head()?;
         // Get header we were syncing into.
         let header = self.get_block_header(&sync_hash)?;
         let prev_hash = *header.prev_hash();
-        let gc_height = header.height();
+        let gc_height = std::cmp::min(head.height + 1, header.height());
 
         // GC all the data from current tail up to `gc_height`
         let tail = self.store.tail()?;


### PR DESCRIPTION
A couple substandard issues that caused nodes to get stuck during sync:
* In `reset_data_pre_state_sync`, we garbage collect all data up to sync block, but this makes no sense. Let's say we are just joining the network and the head is at genesis and the head of the network is more than 2 million blocks ahead. At this point, we don't actually have any data other than the headers that are just synced during header sync. However, in `reset_data_pre_state_sync`, we will go through all those 2 million heights, trying to garbage collect the data we just synced. 
* In `check_state_needed`, we always try to find the hashes of the blocks that we need to sync first, even if we do not need them and should sync state instead. This means that if we are at genesis and the network is 2 million blocks ahead of us, we will always walk through those 2 million blocks after head sync only to realize we don't need them and should just do state sync instead.

Test plan
---------
Apply this patch on a betanet node that got stuck in syncing before and make sure that it syncs now.