### PR TITLE
fix(sync): address some minor issues in block sync

### DIFF
--- a/chain/chain/tests/sync_chain.rs
+++ b/chain/chain/tests/sync_chain.rs
@@ -2,6 +2,8 @@ use near_chain::test_utils::setup;
 use near_chain::Block;
 use near_logger_utils::init_test_logger;
 use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::validator_signer::ValidatorSigner;
+use std::sync::{Arc, Mutex};
 
 #[test]
 fn chain_sync_headers() {
@@ -23,4 +25,30 @@ fn chain_sync_headers() {
         })
         .unwrap();
     assert_eq!(chain.sync_head().unwrap().height, 4);
+}
+
+#[test]
+fn test_received_blocks() {
+    init_test_logger();
+    let (mut chain, _, signer) = setup();
+    let genesis = chain.get_block(&chain.genesis().hash().clone()).unwrap().clone();
+    let b2 = Block::empty_with_height(&genesis, 10, &*signer);
+    chain.save_orphan(&b2);
+    let received_blocks = chain.blocks_received().unwrap();
+    assert_eq!(received_blocks, 1);
+    let blocks_accepted = Arc::new(Mutex::new(vec![]));
+    chain
+        .check_orphans(
+            &Some(signer.validator_id().to_string()),
+            *genesis.hash(),
+            |b| {
+                blocks_accepted.lock().unwrap().push(b);
+            },
+            |_| {},
+            |_| {},
+        )
+        .unwrap();
+    assert_eq!(blocks_accepted.lock().unwrap().len(), 1);
+    let received_blocks = chain.blocks_received().unwrap();
+    assert_eq!(received_blocks, 1);
 }

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -37,8 +37,8 @@ const MAX_BLOCK_REQUEST: usize = 100;
 /// Maximum number of blocks to ask from single peer.
 const MAX_PEER_BLOCK_REQUEST: usize = 10;
 
-const BLOCK_REQUEST_TIMEOUT: i64 = 6;
-const BLOCK_SOME_RECEIVED_TIMEOUT: i64 = 1;
+const BLOCK_REQUEST_TIMEOUT: i64 = 10;
+const BLOCK_SOME_RECEIVED_TIMEOUT: i64 = 5;
 const BLOCK_REQUEST_BROADCAST_OFFSET: u64 = 2;
 
 /// Sync state download timeout in seconds.
@@ -444,8 +444,8 @@ impl BlockSync {
     }
 
     /// Check if we should run block body sync and ask for more full blocks.
-    fn block_sync_due(&mut self, chain: &Chain) -> Result<bool, near_chain::Error> {
-        let blocks_received = self.blocks_received(chain)?;
+    fn block_sync_due(&mut self, chain: &mut Chain) -> Result<bool, near_chain::Error> {
+        let blocks_received = chain.blocks_received()?;
 
         // Some blocks have been requested.
         if self.blocks_requested > 0 {
@@ -471,14 +471,6 @@ impl BlockSync {
         }
 
         Ok(false)
-    }
-
-    /// Total number of received blocks by the chain.
-    fn blocks_received(&self, chain: &Chain) -> Result<u64, near_chain::Error> {
-        Ok((chain.head()?).height
-            + chain.orphans_len() as u64
-            + chain.blocks_with_missing_chunks_len() as u64
-            + chain.orphans_evicted_len() as u64)
     }
 }
 


### PR DESCRIPTION
Address a couple issues related to block sync:
* `blocks_received` is incorrectly calculated. It should not increase when we do not receive any new blocks, but currently if some heights are skipped and we accept a block that was previously orphaned, it does increase.
* The timeout for progress is too short. This is not a problem per se. However, every time block sync is due we recompute the hashes of blocks that we need to sync. When the epoch is long and we just start block sync, this could mean going through 40k blocks every 1-2s, which is fairly suboptimal. The proper fix would be to implement caching for the requested hashes and do not recompute every time block sync is due, but given that we plan to rewrite block sync in the future, I don't see the need to change it now.

Test plan
--------
* `test_blocks_received`.