### PR TITLE
feat(client): Extended query to be able to refer to the genesis and the earliest [oldest] available blocks

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -2285,6 +2285,11 @@ impl Chain {
         self.store.get_previous_header(header)
     }
 
+    /// Returns hash of the first available block after genesis.
+    pub fn get_earliest_block_hash(&mut self) -> Result<Option<CryptoHash>, Error> {
+        self.store.get_earliest_block_hash()
+    }
+
     /// Check if block exists.
     #[inline]
     pub fn block_exists(&self, hash: &CryptoHash) -> Result<bool, Error> {

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -144,14 +144,26 @@ pub trait ChainStoreAccess {
     fn get_block_hash_by_height(&mut self, height: BlockHeight) -> Result<CryptoHash, Error>;
     /// Returns hash of the first available block after genesis.
     fn get_earliest_block_hash(&mut self) -> Result<Option<CryptoHash>, Error> {
+        // To find the earliest available block we use the `tail` marker primarily
+        // used by garbage collection system.
+        // NOTE: `tail` is the block height at which we can say that there is
+        // at most 1 block available in the range from the genesis height to
+        // the tail. Thus, the strategy is to find the first block AFTER the tail
+        // height, and use the `prev_hash` to get the reference to the earliest
+        // block.
         let head_header_height = self.head_header()?.height();
         let tail = self.tail()?;
+
+        // There is a corner case when there are no blocks after the tail, and
+        // the tail is in fact the earliest block available on the chain.
         if let Ok(block_hash) = self.get_block_hash_by_height(tail) {
             return Ok(Some(block_hash.clone()));
         }
         for height in tail + 1..=head_header_height {
             if let Ok(block_hash) = self.get_block_hash_by_height(height) {
-                return Ok(Some(self.get_block_header(&block_hash)?.prev_hash().clone()));
+                let earliest_block_hash = self.get_block_header(&block_hash)?.prev_hash().clone();
+                debug_assert!(matches!(self.block_exists(&earliest_block_hash), Ok(true)));
+                return Ok(Some(earliest_block_hash));
             }
         }
         Ok(None)

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -15,7 +15,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::sharding::ChunkHash;
 use near_primitives::types::{
-    AccountId, BlockHeight, BlockIdOrFinality, MaybeBlockId, ShardId, TransactionOrReceiptId,
+    AccountId, BlockHeight, BlockReference, MaybeBlockId, ShardId, TransactionOrReceiptId,
 };
 use near_primitives::utils::generate_random_string;
 use near_primitives::views::{
@@ -148,11 +148,11 @@ impl SyncStatus {
 }
 
 /// Actor message requesting block by id or hash.
-pub struct GetBlock(pub BlockIdOrFinality);
+pub struct GetBlock(pub BlockReference);
 
 impl GetBlock {
     pub fn latest() -> Self {
-        Self(BlockIdOrFinality::latest())
+        Self(BlockReference::latest())
     }
 }
 
@@ -161,11 +161,11 @@ impl Message for GetBlock {
 }
 
 /// Get block with the block merkle tree. Used for testing
-pub struct GetBlockWithMerkleTree(pub BlockIdOrFinality);
+pub struct GetBlockWithMerkleTree(pub BlockReference);
 
 impl GetBlockWithMerkleTree {
     pub fn latest() -> Self {
-        Self(BlockIdOrFinality::latest())
+        Self(BlockReference::latest())
     }
 }
 
@@ -188,13 +188,13 @@ impl Message for GetChunk {
 #[derive(Deserialize, Clone)]
 pub struct Query {
     pub query_id: String,
-    pub block_id_or_finality: BlockIdOrFinality,
+    pub block_reference: BlockReference,
     pub request: QueryRequest,
 }
 
 impl Query {
-    pub fn new(block_id_or_finality: BlockIdOrFinality, request: QueryRequest) -> Self {
-        Query { query_id: generate_random_string(10), block_id_or_finality, request }
+    pub fn new(block_reference: BlockReference, request: QueryRequest) -> Self {
+        Query { query_id: generate_random_string(10), block_reference, request }
     }
 }
 

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -166,17 +166,7 @@ impl ViewClientActor {
 
         match synchronization_checkpoint {
             SyncCheckpoint::Genesis => Ok(Some(self.chain.genesis().hash().clone())),
-            SyncCheckpoint::EarliestAvailable => {
-                let head_header_height = self.chain.head_header()?.height();
-                let mut chain_store_update = self.chain.mut_store().store_update();
-                let tail = chain_store_update.tail()?;
-                for height in tail..=head_header_height {
-                    if let Ok(block_hash) = chain_store_update.get_block_hash_by_height(height) {
-                        return Ok(Some(block_hash));
-                    }
-                }
-                Ok(None)
-            }
+            SyncCheckpoint::EarliestAvailable => Ok(self.chain.get_earliest_block_hash()?),
         }
     }
 

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -22,7 +22,7 @@ mod tests {
     use near_primitives::receipt::Receipt;
     use near_primitives::sharding::ChunkHash;
     use near_primitives::transaction::SignedTransaction;
-    use near_primitives::types::{BlockHeight, BlockHeightDelta, BlockIdOrFinality};
+    use near_primitives::types::{BlockHeight, BlockHeightDelta, BlockReference};
     use near_primitives::views::{QueryRequest, QueryResponseKind::ViewAccount};
 
     fn get_validators_and_key_pairs() -> (Vec<Vec<&'static str>>, Vec<PeerInfo>) {
@@ -315,7 +315,7 @@ mod tests {
                                                 connectors1.write().unwrap()[i]
                                                     .1
                                                     .send(Query::new(
-                                                        BlockIdOrFinality::latest(),
+                                                        BlockReference::latest(),
                                                         QueryRequest::ViewAccount {
                                                             account_id: account_to.clone(),
                                                         },
@@ -519,7 +519,7 @@ mod tests {
                                                     connectors1.write().unwrap()[i]
                                                         .1
                                                         .send(Query::new(
-                                                            BlockIdOrFinality::latest(),
+                                                            BlockReference::latest(),
                                                             QueryRequest::ViewAccount {
                                                                 account_id: flat_validators[j]
                                                                     .to_string(),

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -8,7 +8,7 @@ use near_client::test_utils::setup_mock_all_validators;
 use near_client::{ClientActor, Query, ViewClientActor};
 use near_logger_utils::init_integration_logger;
 use near_network::{NetworkRequests, NetworkResponses, PeerInfo};
-use near_primitives::types::BlockIdOrFinality;
+use near_primitives::types::BlockReference;
 use near_primitives::views::{QueryRequest, QueryResponseKind::ViewAccount};
 
 /// Tests that the KeyValueRuntime properly sets balances in genesis and makes them queriable
@@ -53,7 +53,7 @@ fn test_keyvalue_runtime_balances() {
                 connectors_[i]
                     .1
                     .send(Query::new(
-                        BlockIdOrFinality::latest(),
+                        BlockReference::latest(),
                         QueryRequest::ViewAccount { account_id: flat_validators[i].to_string() },
                     ))
                     .then(move |res| {
@@ -95,7 +95,7 @@ mod tests {
     };
     use near_primitives::hash::CryptoHash;
     use near_primitives::transaction::SignedTransaction;
-    use near_primitives::types::{AccountId, BlockIdOrFinality};
+    use near_primitives::types::{AccountId, BlockReference};
     use near_primitives::views::{QueryRequest, QueryResponse, QueryResponseKind::ViewAccount};
 
     fn send_tx(
@@ -200,7 +200,7 @@ mod tests {
                         + (*presumable_epoch.read().unwrap() * 8) % 24]
                         .1
                         .send(Query::new(
-                            BlockIdOrFinality::latest(),
+                            BlockReference::latest(),
                             QueryRequest::ViewAccount { account_id: account_id.clone() },
                         ))
                         .then(move |x| {
@@ -298,7 +298,7 @@ mod tests {
                                 + (*presumable_epoch.read().unwrap() * 8) % 24]
                                 .1
                                 .send(Query::new(
-                                    BlockIdOrFinality::latest(),
+                                    BlockReference::latest(),
                                     QueryRequest::ViewAccount {
                                         account_id: validators[i].to_string(),
                                     },
@@ -352,7 +352,7 @@ mod tests {
                         + (*presumable_epoch.read().unwrap() * 8) % 24]
                         .1
                         .send(Query::new(
-                            BlockIdOrFinality::latest(),
+                            BlockReference::latest(),
                             QueryRequest::ViewAccount { account_id: account_id.clone() },
                         ))
                         .then(move |x| {
@@ -473,7 +473,7 @@ mod tests {
                     connectors_[i + *presumable_epoch.read().unwrap() * 8]
                         .1
                         .send(Query::new(
-                            BlockIdOrFinality::latest(),
+                            BlockReference::latest(),
                             QueryRequest::ViewAccount {
                                 account_id: flat_validators[i].to_string(),
                             },

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -7,7 +7,7 @@ use near_crypto::KeyType;
 use near_logger_utils::init_test_logger;
 use near_network::{NetworkClientMessages, PeerInfo};
 use near_primitives::block::{Block, BlockHeader};
-use near_primitives::types::{BlockIdOrFinality, EpochId};
+use near_primitives::types::{BlockReference, EpochId};
 use near_primitives::utils::to_timestamp;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -23,7 +23,7 @@ fn query_client() {
         actix::spawn(
             view_client
                 .send(Query::new(
-                    BlockIdOrFinality::latest(),
+                    BlockReference::latest(),
                     QueryRequest::ViewAccount { account_id: "test".to_owned() },
                 ))
                 .then(|res| {

--- a/chain/indexer/src/streamer/streamer.rs
+++ b/chain/indexer/src/streamer/streamer.rs
@@ -63,7 +63,7 @@ async fn fetch_latest_block(
     client: &Addr<near_client::ViewClientActor>,
 ) -> Result<views::BlockView, FailedToFetchData> {
     client
-        .send(near_client::GetBlock(types::BlockIdOrFinality::Finality(types::Finality::Final)))
+        .send(near_client::GetBlock(types::BlockReference::Finality(types::Finality::Final)))
         .await?
         .map_err(|err| FailedToFetchData::String(err))
 }
@@ -74,7 +74,7 @@ async fn fetch_block_by_height(
     height: u64,
 ) -> Result<views::BlockView, FailedToFetchData> {
     client
-        .send(near_client::GetBlock(near_primitives::types::BlockIdOrFinality::BlockId(
+        .send(near_client::GetBlock(near_primitives::types::BlockReference::BlockId(
             near_primitives::types::BlockId::Height(height),
         )))
         .await?

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -10,7 +10,7 @@ use near_primitives::rpc::{
     RpcGenesisRecordsRequest, RpcQueryRequest, RpcStateChangesRequest, RpcStateChangesResponse,
     RpcValidatorsOrderedRequest,
 };
-use near_primitives::types::{BlockId, BlockIdOrFinality, MaybeBlockId, ShardId};
+use near_primitives::types::{BlockId, BlockReference, MaybeBlockId, ShardId};
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, GasPriceView,
     GenesisRecordsView, QueryResponse, StatusResponse, ValidatorStakeView,
@@ -217,7 +217,7 @@ impl JsonRpcClient {
         call_method(&self.client, &self.server_addr, "block", [block_id])
     }
 
-    pub fn block(&self, request: BlockIdOrFinality) -> RpcRequest<BlockView> {
+    pub fn block(&self, request: BlockReference) -> RpcRequest<BlockView> {
         call_method(&self.client, &self.server_addr, "block", request)
     }
 

--- a/chain/jsonrpc/tests/rpc_transactions.rs
+++ b/chain/jsonrpc/tests/rpc_transactions.rs
@@ -11,7 +11,7 @@ use near_network::test_utils::WaitOrTimeout;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::serialize::{to_base, to_base64};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::BlockIdOrFinality;
+use near_primitives::types::BlockReference;
 use near_primitives::views::FinalExecutionStatus;
 
 #[macro_use]
@@ -32,7 +32,7 @@ fn test_send_tx_async() {
         let tx_hash2_2 = tx_hash2.clone();
         let signer_account_id = "test1".to_string();
 
-        actix::spawn(client.block(BlockIdOrFinality::latest()).then(move |res| {
+        actix::spawn(client.block(BlockReference::latest()).then(move |res| {
             let block_hash = res.unwrap().header.hash;
             let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
             let tx = SignedTransaction::send_money(
@@ -81,7 +81,7 @@ fn test_send_tx_async() {
 #[test]
 fn test_send_tx_commit() {
     test_with_client!(test_utils::NodeType::Validator, client, async move {
-        let block_hash = client.block(BlockIdOrFinality::latest()).await.unwrap().header.hash;
+        let block_hash = client.block(BlockReference::latest()).await.unwrap().header.hash;
         let signer = InMemorySigner::from_seed("test1", KeyType::ED25519, "test1");
         let tx = SignedTransaction::send_money(
             1,
@@ -113,7 +113,7 @@ fn test_expired_tx() {
                 let block_hash = block_hash.clone();
                 let block_height = block_height.clone();
                 let client = new_client(&format!("http://{}", addr));
-                actix::spawn(client.block(BlockIdOrFinality::latest()).then(move |res| {
+                actix::spawn(client.block(BlockReference::latest()).then(move |res| {
                     let header = res.unwrap().header;
                     let hash = block_hash.lock().unwrap().clone();
                     let height = block_height.lock().unwrap().clone();

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -319,8 +319,8 @@ impl Peer {
             PeerMessage::Routed(message) => {
                 msg_hash = Some(message.hash());
                 match message.body {
-                    RoutedMessageBody::QueryRequest { query_id, block_id_or_finality, request } => {
-                        NetworkViewClientMessages::Query { query_id, block_id_or_finality, request }
+                    RoutedMessageBody::QueryRequest { query_id, block_reference, request } => {
+                        NetworkViewClientMessages::Query { query_id, block_reference, request }
                     }
                     RoutedMessageBody::QueryResponse { query_id, response } => {
                         NetworkViewClientMessages::QueryResponse { query_id, response }

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -1205,11 +1205,11 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                     NetworkResponses::RouteNotFound
                 }
             }
-            NetworkRequests::Query { query_id, account_id, block_id_or_finality, request } => {
+            NetworkRequests::Query { query_id, account_id, block_reference, request } => {
                 if self.send_message_to_account(
                     ctx,
                     &account_id,
-                    RoutedMessageBody::QueryRequest { query_id, block_id_or_finality, request },
+                    RoutedMessageBody::QueryRequest { query_id, block_reference, request },
                 ) {
                     NetworkResponses::NoResponse
                 } else {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -27,7 +27,7 @@ use near_primitives::sharding::{
 };
 use near_primitives::syncing::ShardStateSyncResponse;
 use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
-use near_primitives::types::{AccountId, BlockHeight, BlockIdOrFinality, EpochId, ShardId};
+use near_primitives::types::{AccountId, BlockHeight, BlockReference, EpochId, ShardId};
 use near_primitives::utils::{from_timestamp, to_timestamp};
 use near_primitives::version::FIRST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION;
 use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryResponse};
@@ -236,7 +236,7 @@ pub enum RoutedMessageBody {
     TxStatusResponse(FinalExecutionOutcomeView),
     QueryRequest {
         query_id: String,
-        block_id_or_finality: BlockIdOrFinality,
+        block_reference: BlockReference,
         request: QueryRequest,
     },
     QueryResponse {
@@ -939,7 +939,7 @@ pub enum NetworkRequests {
     Query {
         query_id: String,
         account_id: AccountId,
-        block_id_or_finality: BlockIdOrFinality,
+        block_reference: BlockReference,
         request: QueryRequest,
     },
     /// Request for receipt execution outcome
@@ -1151,7 +1151,7 @@ pub enum NetworkViewClientMessages {
     /// Transaction status response
     TxStatusResponse(Box<FinalExecutionOutcomeView>),
     /// General query
-    Query { query_id: String, block_id_or_finality: BlockIdOrFinality, request: QueryRequest },
+    Query { query_id: String, block_reference: BlockReference, request: QueryRequest },
     /// Query response
     QueryResponse { query_id: String, response: Result<QueryResponse, String> },
     /// Request for receipt outcome

--- a/core/primitives/src/rpc.rs
+++ b/core/primitives/src/rpc.rs
@@ -10,7 +10,7 @@ use validator_derive::Validate;
 use crate::hash::CryptoHash;
 use crate::merkle::MerklePath;
 use crate::transaction::SignedTransaction;
-use crate::types::{AccountId, BlockIdOrFinality, MaybeBlockId, TransactionOrReceiptId};
+use crate::types::{AccountId, BlockReference, MaybeBlockId, TransactionOrReceiptId};
 use crate::views::{
     ExecutionOutcomeWithIdView, LightClientBlockLiteView, QueryRequest, StateChangeWithCauseView,
     StateChangesKindsView, StateChangesRequestView,
@@ -35,7 +35,7 @@ pub struct RpcGenesisRecordsRequest {
 #[derive(Serialize, Deserialize)]
 pub struct RpcQueryRequest {
     #[serde(flatten)]
-    pub block_id_or_finality: BlockIdOrFinality,
+    pub block_reference: BlockReference,
     #[serde(flatten)]
     pub request: QueryRequest,
 }
@@ -43,7 +43,7 @@ pub struct RpcQueryRequest {
 #[derive(Serialize, Deserialize)]
 pub struct RpcStateChangesRequest {
     #[serde(flatten)]
-    pub block_id_or_finality: BlockIdOrFinality,
+    pub block_reference: BlockReference,
     #[serde(flatten)]
     pub state_changes_request: StateChangesRequestView,
 }
@@ -57,7 +57,7 @@ pub struct RpcStateChangesResponse {
 #[derive(Serialize, Deserialize)]
 pub struct RpcStateChangesInBlockRequest {
     #[serde(flatten)]
-    pub block_id_or_finality: BlockIdOrFinality,
+    pub block_reference: BlockReference,
 }
 
 #[derive(Serialize, Deserialize)]

--- a/core/primitives/src/types.rs
+++ b/core/primitives/src/types.rs
@@ -486,12 +486,20 @@ pub type MaybeBlockId = Option<BlockId>;
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum BlockIdOrFinality {
-    BlockId(BlockId),
-    Finality(Finality),
+pub enum SyncCheckpoint {
+    Genesis,
+    EarliestAvailable,
 }
 
-impl BlockIdOrFinality {
+#[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockReference {
+    BlockId(BlockId),
+    Finality(Finality),
+    SyncCheckpoint(SyncCheckpoint),
+}
+
+impl BlockReference {
     pub fn latest() -> Self {
         Self::Finality(Finality::None)
     }

--- a/neard/tests/rpc_nodes.rs
+++ b/neard/tests/rpc_nodes.rs
@@ -15,7 +15,7 @@ use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{compute_root_from_path_and_item, verify_path};
 use near_primitives::serialize::{from_base64, to_base64};
 use near_primitives::transaction::{PartialExecutionStatus, SignedTransaction};
-use near_primitives::types::{BlockId, BlockIdOrFinality, TransactionOrReceiptId};
+use near_primitives::types::{BlockId, BlockReference, TransactionOrReceiptId};
 use near_primitives::views::{
     ExecutionOutcomeView, ExecutionStatusView, FinalExecutionStatus, QueryResponseKind,
 };
@@ -560,7 +560,7 @@ fn test_get_execution_outcome(is_tx_successful: bool) {
                                 view_client1.send(GetExecutionOutcome { id }).then(move |res| {
                                     let execution_outcome_response = res.unwrap().unwrap();
                                     view_client2
-                                        .send(GetBlock(BlockIdOrFinality::BlockId(BlockId::Hash(
+                                        .send(GetBlock(BlockReference::BlockId(BlockId::Hash(
                                             execution_outcome_response.outcome_proof.block_hash,
                                         ))))
                                         .then(move |res| {

--- a/neard/tests/stake_nodes.rs
+++ b/neard/tests/stake_nodes.rs
@@ -15,7 +15,7 @@ use near_network::test_utils::{convert_boot_nodes, open_port, WaitOrTimeout};
 use near_network::NetworkClientMessages;
 use near_primitives::hash::CryptoHash;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockHeightDelta, BlockIdOrFinality, NumSeats};
+use near_primitives::types::{AccountId, BlockHeightDelta, BlockReference, NumSeats};
 use near_primitives::views::{QueryRequest, QueryResponseKind, ValidatorInfo};
 use neard::config::{GenesisExt, TESTING_INIT_BALANCE, TESTING_INIT_STAKE};
 use neard::{load_test_config, start_with_config, NearConfig, NEAR_BASE};
@@ -240,7 +240,7 @@ fn test_validator_kickout() {
                                     test_node1
                                         .view_client
                                         .send(Query::new(
-                                            BlockIdOrFinality::latest(),
+                                            BlockReference::latest(),
                                             QueryRequest::ViewAccount {
                                                 account_id: test_nodes[i as usize]
                                                     .account_id
@@ -269,7 +269,7 @@ fn test_validator_kickout() {
                                     test_node1
                                         .view_client
                                         .send(Query::new(
-                                            BlockIdOrFinality::latest(),
+                                            BlockReference::latest(),
                                             QueryRequest::ViewAccount {
                                                 account_id: test_nodes[i as usize]
                                                     .account_id
@@ -399,7 +399,7 @@ fn test_validator_join() {
                                 test_node1
                                     .view_client
                                     .send(Query::new(
-                                        BlockIdOrFinality::latest(),
+                                        BlockReference::latest(),
                                         QueryRequest::ViewAccount {
                                             account_id: test_nodes[1].account_id.clone(),
                                         },
@@ -418,7 +418,7 @@ fn test_validator_join() {
                                 test_node1
                                     .view_client
                                     .send(Query::new(
-                                        BlockIdOrFinality::latest(),
+                                        BlockReference::latest(),
                                         QueryRequest::ViewAccount {
                                             account_id: test_nodes[2].account_id.clone(),
                                         },

--- a/test-utils/testlib/src/user/rpc_user.rs
+++ b/test-utils/testlib/src/user/rpc_user.rs
@@ -15,7 +15,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::Receipt;
 use near_primitives::serialize::{to_base, to_base64};
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{AccountId, BlockHeight, BlockId, BlockIdOrFinality, MaybeBlockId};
+use near_primitives::types::{AccountId, BlockHeight, BlockId, BlockReference, MaybeBlockId};
 use near_primitives::views::{
     AccessKeyView, AccountView, BlockView, EpochValidatorInfo, ExecutionOutcomeView,
     FinalExecutionOutcomeView, QueryResponse, ViewStateResult,
@@ -111,7 +111,7 @@ impl User for RpcUser {
     }
 
     fn get_block(&self, height: BlockHeight) -> Option<BlockView> {
-        self.actix(move |client| client.block(BlockIdOrFinality::BlockId(BlockId::Height(height))))
+        self.actix(move |client| client.block(BlockReference::BlockId(BlockId::Height(height))))
             .ok()
     }
 


### PR DESCRIPTION
This is based on #2990.

This is necessary for RosettaRPC implementation (#2738) and potentially useful for NEAR Indexer.

Testing Plan
============

Added minimal RPC tests.