### PR TITLE
refactor(devops): Slimmed the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
+.git*
 .idea/
 .vscode/
 
+Dockerfile
 docker/
 !docker/scripts/
 ops/
@@ -8,6 +10,9 @@ ops/
 !ops/tendermint-config.toml
 
 **/target
+**/venv
 storage/
 keystore/
 tmp/
+
+*.pyc


### PR DESCRIPTION
This slims the context passing to Docker build from 400MB downto 72KB