### PR TITLE
fix: Use handshake version 2

### DIFF
--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -103,6 +103,7 @@ mod test {
         let peer_info = PeerInfo::random();
         let fake_handshake = Handshake {
             version: 1,
+            oldest_supported_version: 1,
             peer_id: peer_info.id.clone(),
             target_peer_id: peer_info.id,
             listen_port: None,

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -103,7 +103,6 @@ mod test {
         let peer_info = PeerInfo::random();
         let fake_handshake = Handshake {
             version: 1,
-            oldest_supported_version: 1,
             peer_id: peer_info.id.clone(),
             target_peer_id: peer_info.id,
             listen_port: None,

--- a/chain/network/src/codec.rs
+++ b/chain/network/src/codec.rs
@@ -105,7 +105,7 @@ mod test {
     fn test_peer_message_handshake() {
         let peer_info = PeerInfo::random();
         let fake_handshake = Handshake {
-            version: 1,
+            version: PROTOCOL_VERSION,
             peer_id: peer_info.id.clone(),
             target_peer_id: peer_info.id,
             listen_port: None,

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -143,7 +143,7 @@ pub struct Peer {
     pub peer_status: PeerStatus,
     /// Protocol version to communicate with this peer.
     /// None denotes latest protocol version.
-    pub protocol_version: Option<ProtocolVersion>,
+    pub protocol_version: ProtocolVersion,
     /// Framed wrapper to send messages through the TCP connection.
     framed: FramedWrite<WriteHalf, Codec>,
     /// Handshake timeout.
@@ -188,7 +188,7 @@ impl Peer {
             peer_info: peer_info.into(),
             peer_type,
             peer_status: PeerStatus::Connecting,
-            protocol_version: None,
+            protocol_version: PROTOCOL_VERSION,
             framed,
             handshake_timeout,
             peer_manager_addr,
@@ -680,7 +680,8 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
                                 OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
                             )
                         {
-                            self.protocol_version = Some(target_version);
+                            // Use target_version as protocol_version to talk with this peer
+                            self.protocol_version = target_version;
                             self.send_handshake(ctx);
                         } else {
                             warn!(target: "network", "Unable to connect to a node ({}) due to a network protocol version mismatch. Our version: {:?}, their: {:?}", peer_info, (PROTOCOL_VERSION, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION), (version, oldest_supported_version));

--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -17,7 +17,7 @@ use near_primitives::network::PeerId;
 use near_primitives::unwrap_option_or_return;
 use near_primitives::utils::DisplayOption;
 use near_primitives::version::{
-    ProtocolVersion, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION,
+    ProtocolVersion, NETWORK_PROTOCOL_VERSION, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
 };
 
 use crate::codec::{bytes_to_peer_message, peer_message_to_bytes, Codec};
@@ -188,7 +188,7 @@ impl Peer {
             peer_info: peer_info.into(),
             peer_type,
             peer_status: PeerStatus::Connecting,
-            protocol_version: PROTOCOL_VERSION,
+            protocol_version: NETWORK_PROTOCOL_VERSION,
             framed,
             handshake_timeout,
             peer_manager_addr,
@@ -634,7 +634,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
                     self.send_message(PeerMessage::HandshakeFailure(
                         self.node_info.clone(),
                         HandshakeFailureReason::ProtocolVersionMismatch {
-                            version: PROTOCOL_VERSION,
+                            version: NETWORK_PROTOCOL_VERSION,
                             oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
                         },
                     ));
@@ -684,7 +684,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
                         version,
                         oldest_supported_version,
                     } => {
-                        let target_version = std::cmp::min(version, PROTOCOL_VERSION);
+                        let target_version = std::cmp::min(version, NETWORK_PROTOCOL_VERSION);
 
                         if target_version
                             >= std::cmp::max(
@@ -697,7 +697,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
                             self.send_handshake(ctx);
                             return;
                         } else {
-                            warn!(target: "network", "Unable to connect to a node ({}) due to a network protocol version mismatch. Our version: {:?}, their: {:?}", peer_info, (PROTOCOL_VERSION, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION), (version, oldest_supported_version));
+                            warn!(target: "network", "Unable to connect to a node ({}) due to a network protocol version mismatch. Our version: {:?}, their: {:?}", peer_info, (NETWORK_PROTOCOL_VERSION, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION), (version, oldest_supported_version));
                         }
                     }
                     HandshakeFailureReason::InvalidTarget => {
@@ -712,7 +712,7 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
 
                 debug_assert!(
                     OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION <= handshake.version
-                        && handshake.version <= PROTOCOL_VERSION
+                        && handshake.version <= NETWORK_PROTOCOL_VERSION
                 );
 
                 if handshake.chain_info.genesis_id != self.genesis_id {

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -224,7 +224,7 @@ impl From<Handshake> for HandshakeV2 {
         Self {
             // In previous version of handshake, nodes usually sent the oldest supported version instead of their current version.
             // Computing the current version of the other as the oldest version plus 4, but not letting go bigger than 33.
-            version: std::cmp::min(33, handshake_old.version.saturating_add(4)),
+            version: std::cmp::min(PROTOCOL_VERSION - 1, handshake_old.version.saturating_add(4)),
             oldest_supported_version: handshake_old.version,
             peer_id: handshake_old.peer_id,
             target_peer_id: handshake_old.target_peer_id,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -222,7 +222,7 @@ impl HandshakeV2 {
 impl From<Handshake> for HandshakeV2 {
     fn from(handshake_old: Handshake) -> Self {
         Self {
-            // In previous version of handhsake, nodes usually sent the oldest supported version instead of their current version.
+            // In previous version of handshake, nodes usually sent the oldest supported version instead of their current version.
             // Computing the current version of the other as the oldest version plus 4, but not letting go bigger than 33.
             version: std::cmp::min(33, handshake_old.version.saturating_add(4)),
             oldest_supported_version: handshake_old.version,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -275,10 +275,10 @@ impl BorshDeserialize for HandshakeV2 {
         } else {
             Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                Box::new(HandshakeFailureReason::ProtocolVersionMismatch {
+                HandshakeFailureReason::ProtocolVersionMismatch {
                     version,
                     oldest_supported_version,
-                }),
+                },
             ))
         }
     }

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -218,7 +218,7 @@ pub struct HandshakeV2 {
 
 impl HandshakeV2 {
     pub fn new(
-        version: Option<ProtocolVersion>,
+        version: ProtocolVersion,
         peer_id: PeerId,
         target_peer_id: PeerId,
         listen_port: Option<u16>,
@@ -226,7 +226,7 @@ impl HandshakeV2 {
         edge_info: EdgeInfo,
     ) -> Self {
         Self {
-            version: version.unwrap_or(PROTOCOL_VERSION),
+            version,
             oldest_supported_version: OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
             peer_id,
             target_peer_id,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -241,9 +241,7 @@ impl BorshDeserialize for Handshake {
 
         if OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION <= version && version <= PROTOCOL_VERSION {
             // If we support this version, then try to deserialize with custom deserializer
-            match version {
-                _ => HandshakeAutoDes::deserialize(buf).map(Into::into),
-            }
+            HandshakeAutoDes::deserialize(buf).map(Into::into)
         } else {
             Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -223,8 +223,8 @@ impl From<Handshake> for HandshakeV2 {
     fn from(handshake_old: Handshake) -> Self {
         Self {
             // In previous version of handshake, nodes usually sent the oldest supported version instead of their current version.
-            // Computing the current version of the other as the oldest version plus 4, but not letting go bigger than 33.
-            version: std::cmp::min(PROTOCOL_VERSION - 1, handshake_old.version.saturating_add(4)),
+            // Computing the current version of the other as the oldest version plus 1, but keeping it smaller than current version.
+            version: std::cmp::min(PROTOCOL_VERSION - 1, handshake_old.version.saturating_add(1)),
             oldest_supported_version: handshake_old.version,
             peer_id: handshake_old.peer_id,
             target_peer_id: handshake_old.target_peer_id,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -30,7 +30,8 @@ use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransac
 use near_primitives::types::{AccountId, BlockHeight, BlockReference, EpochId, ShardId};
 use near_primitives::utils::{from_timestamp, to_timestamp};
 use near_primitives::version::{
-    ProtocolVersion, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION, PROTOCOL_VERSION,
+    ProtocolVersion, NETWORK_PROTOCOL_VERSION, OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION,
+    PROTOCOL_VERSION,
 };
 use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest, QueryResponse};
 
@@ -195,7 +196,7 @@ impl Handshake {
         edge_info: EdgeInfo,
     ) -> Self {
         Handshake {
-            version: PROTOCOL_VERSION,
+            version: NETWORK_PROTOCOL_VERSION,
             peer_id,
             target_peer_id,
             listen_port,
@@ -289,7 +290,10 @@ impl From<Handshake> for HandshakeV2 {
         Self {
             // In previous version of handshake, nodes usually sent the oldest supported version instead of their current version.
             // Computing the current version of the other as the oldest version plus 1, but keeping it smaller than current version.
-            version: std::cmp::min(PROTOCOL_VERSION - 1, handshake_old.version.saturating_add(1)),
+            version: std::cmp::min(
+                NETWORK_PROTOCOL_VERSION,
+                handshake_old.version.saturating_add(1),
+            ),
             oldest_supported_version: handshake_old.version,
             peer_id: handshake_old.peer_id,
             target_peer_id: handshake_old.target_peer_id,

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -20,7 +20,7 @@ pub type ProtocolVersion = u32;
 /// Current latest version of the protocol.
 pub const PROTOCOL_VERSION: ProtocolVersion = 35;
 /// Oldest supported version by this client.
-pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 29;
+pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 33;
 
 /// Minimum gas price proposed in NEP 92 and the associated protocol version
 pub const MIN_GAS_PRICE_NEP_92: Balance = 1_000_000_000;

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -19,6 +19,9 @@ pub type ProtocolVersion = u32;
 
 /// Current latest version of the protocol.
 pub const PROTOCOL_VERSION: ProtocolVersion = 35;
+/// TODO: Remove in next release. This is to allow nodes with initial version 34
+/// to be compatible with nodes at version 35
+pub const NETWORK_PROTOCOL_VERSION: ProtocolVersion = 34;
 /// Oldest supported version by this client.
 pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 33;
 

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -20,7 +20,7 @@ pub type ProtocolVersion = u32;
 /// Current latest version of the protocol.
 pub const PROTOCOL_VERSION: ProtocolVersion = 35;
 /// Oldest supported version by this client.
-pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 33;
+pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 29;
 
 /// Minimum gas price proposed in NEP 92 and the associated protocol version
 pub const MIN_GAS_PRICE_NEP_92: Balance = 1_000_000_000;

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -38,7 +38,10 @@ def compile_current():
         subprocess.check_output(['cargo', 'build', '-p', 'near'])
     subprocess.check_output(['cargo', 'build', '-p', 'state-viewer'])
     branch = escaped(branch)
-    os.rename('../target/debug/near', '../target/debug/near-%s' % branch)
+    if os.path.exists('../target/debug/near'):
+        os.rename('../target/debug/near', '../target/debug/near-%s' % branch)
+    else:
+        os.rename('../target/debug/neard', '../target/debug/near-%s' % branch)
     os.rename('../target/debug/state-viewer',
               '../target/debug/state-viewer-%s' % branch)
     subprocess.check_output(['git', 'checkout', '../Cargo.lock'])

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -64,11 +64,11 @@ def download_binary(uname, branch):
 
 def prepare_ab_test(other_branch):
     # Use NEAR_AB_BINARY_EXISTS to avoid rebuild / re-download when testing locally.
-    if not os.environ.get('NEAR_AB_BINARY_EXISTS'):
-        compile_current()
-        uname = os.uname()[0]
-        if other_branch in ['master', 'beta', 'stable'] and uname in ['Linux', 'Darwin']:
-            download_binary(uname, other_branch)
-        else:
-            compile_binary(other_branch)
+    #if not os.environ.get('NEAR_AB_BINARY_EXISTS'):
+    #    compile_current()
+    #    uname = os.uname()[0]
+    #    if other_branch in ['master', 'beta', 'stable'] and uname in ['Linux', 'Darwin']:
+    #        download_binary(uname, other_branch)
+    #    else:
+    compile_binary(other_branch)
     return '../target/debug/', [other_branch, escaped(current_branch())]

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -73,8 +73,11 @@ def prepare_ab_test(other_branch):
     #    if other_branch in ['master', 'beta', 'stable'] and uname in ['Linux', 'Darwin']:
     #        download_binary(uname, other_branch)
     #    else:
-    print(os.getcwd())
     compile_current()
-    compile_binary(other_branch)
     print(os.listdir('../target/debug'))
+    uname = os.uname()[0]
+    try:
+        download_binary(uname, other_branch)
+    except Exception:
+        compile_binary(other_branch)
     return '../target/debug/', [other_branch, escaped(current_branch())]

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -73,8 +73,8 @@ def prepare_ab_test(other_branch):
     #    if other_branch in ['master', 'beta', 'stable'] and uname in ['Linux', 'Darwin']:
     #        download_binary(uname, other_branch)
     #    else:
+    # TODO: re-enable caching
     compile_current()
-    print(os.listdir('../target/debug'))
     uname = os.uname()[0]
     try:
         download_binary(uname, other_branch)

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -73,6 +73,8 @@ def prepare_ab_test(other_branch):
     #    if other_branch in ['master', 'beta', 'stable'] and uname in ['Linux', 'Darwin']:
     #        download_binary(uname, other_branch)
     #    else:
+    print(os.getcwd())
     compile_current()
     compile_binary(other_branch)
+    print(os.listdir('../target/debug'))
     return '../target/debug/', [other_branch, escaped(current_branch())]

--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -73,5 +73,6 @@ def prepare_ab_test(other_branch):
     #    if other_branch in ['master', 'beta', 'stable'] and uname in ['Linux', 'Darwin']:
     #        download_binary(uname, other_branch)
     #    else:
+    compile_current()
     compile_binary(other_branch)
     return '../target/debug/', [other_branch, escaped(current_branch())]

--- a/pytest/lib/messages/network.py
+++ b/pytest/lib/messages/network.py
@@ -15,6 +15,10 @@ class Handshake:
     pass
 
 
+class HandshakeV2:
+    pass
+
+
 class HandshakeFailureReason:
     pass
 
@@ -108,7 +112,9 @@ network_schema = [
                        ['Transaction', SignedTransaction],
                        ['Routed', RoutedMessage],
                        ['Disconnect', ()],
-                       ['Challenge', None]] # TODO
+                       ['Challenge', None], # TODO
+                       ['HandshakeV2', HandshakeV2],
+                       ]
         }
     ],
     [
@@ -117,6 +123,24 @@ network_schema = [
                 'struct',
             'fields': [
                 ['version', 'u32'],
+                ['peer_id', PublicKey],
+                ['target_peer_id', PublicKey],
+                ['listen_port', {
+                    'kind': 'option',
+                    'type': 'u16'
+                }],
+                ['chain_info', PeerChainInfo],
+                ['edge_info', EdgeInfo],
+            ]
+        }
+    ],
+    [
+        HandshakeV2, {
+            'kind':
+                'struct',
+            'fields': [
+                ['version', 'u32'],
+                ['oldest_supported_version', 'u32'],
                 ['peer_id', PublicKey],
                 ['target_peer_id', PublicKey],
                 ['listen_port', {

--- a/pytest/lib/peer.py
+++ b/pytest/lib/peer.py
@@ -6,7 +6,7 @@ import struct
 import base58
 from messages import schema
 from messages.crypto import PublicKey, Signature
-from messages.network import (EdgeInfo, GenesisId, Handshake, PeerChainInfo,
+from messages.network import (EdgeInfo, GenesisId, HandshakeV2, PeerChainInfo,
                               PeerMessage, RoutedMessage, PeerIdOrHash)
 from serializer import BinarySerializer
 from nacl.signing import SigningKey
@@ -97,8 +97,9 @@ def create_handshake(my_key_pair_nacl,
         - genesis_id.hash
         - edge_info.signature
     """
-    handshake = Handshake()
+    handshake = HandshakeV2()
     handshake.version = version
+    handshake.oldest_supported_version = version
     handshake.peer_id = PublicKey()
     handshake.target_peer_id = PublicKey()
     handshake.listen_port = listen_port
@@ -126,8 +127,8 @@ def create_handshake(my_key_pair_nacl,
     handshake.edge_info.signature.data = bytes([0] * 64)
 
     peer_message = PeerMessage()
-    peer_message.enum = 'Handshake'
-    peer_message.Handshake = handshake
+    peer_message.enum = 'HandshakeV2'
+    peer_message.HandshakeV2 = handshake
 
     return peer_message
 
@@ -157,27 +158,27 @@ async def run_handshake(conn: Connection,
                         key_pair: SigningKey,
                         listen_port=12345):
     handshake = create_handshake(key_pair, target_public_key, listen_port)
-    sign_handshake(key_pair, handshake.Handshake)
+    sign_handshake(key_pair, handshake.HandshakeV2)
 
     await conn.send(handshake)
     response = await conn.recv()
 
     if response.enum == 'HandshakeFailure' and response.HandshakeFailure[1].enum == 'GenesisMismatch':
         gm = response.HandshakeFailure[1].GenesisMismatch
-        handshake.Handshake.chain_info.genesis_id.chain_id = gm.chain_id
-        handshake.Handshake.chain_info.genesis_id.hash = gm.hash
-        sign_handshake(key_pair, handshake.Handshake)
+        handshake.HandshakeV2.chain_info.genesis_id.chain_id = gm.chain_id
+        handshake.HandshakeV2.chain_info.genesis_id.hash = gm.hash
+        sign_handshake(key_pair, handshake.HandshakeV2)
         await conn.send(handshake)
         response = await conn.recv()
 
     if response.enum == 'HandshakeFailure' and response.HandshakeFailure[1].enum == 'ProtocolVersionMismatch':
         pvm = response.HandshakeFailure[1].ProtocolVersionMismatch.version
-        handshake.Handshake.version = pvm
-        sign_handshake(key_pair, handshake.Handshake)
+        handshake.HandshakeV2.version = pvm
+        sign_handshake(key_pair, handshake.HandshakeV2)
         await conn.send(handshake)
         response = await conn.recv()
 
-    assert response.enum == 'Handshake', response.enum if response.enum != 'HandshakeFailure' else response.HandshakeFailure[1].enum
+    assert response.enum == 'HandshakeV2', response.enum if response.enum != 'HandshakeFailure' else response.HandshakeFailure[1].enum
 
 
 def create_and_sign_routed_peer_message(routed_msg_body, target_node,

--- a/pytest/lib/peer.py
+++ b/pytest/lib/peer.py
@@ -163,17 +163,17 @@ async def run_handshake(conn: Connection,
     await conn.send(handshake)
     response = await conn.recv()
 
-    if response.enum == 'HandshakeFailure' and response.HandshakeFailure[1].enum == 'GenesisMismatch':
-        gm = response.HandshakeFailure[1].GenesisMismatch
-        handshake.HandshakeV2.chain_info.genesis_id.chain_id = gm.chain_id
-        handshake.HandshakeV2.chain_info.genesis_id.hash = gm.hash
+    if response.enum == 'HandshakeFailure' and response.HandshakeFailure[1].enum == 'ProtocolVersionMismatch':
+        pvm = response.HandshakeFailure[1].ProtocolVersionMismatch.version
+        handshake.HandshakeV2.version = pvm
         sign_handshake(key_pair, handshake.HandshakeV2)
         await conn.send(handshake)
         response = await conn.recv()
 
-    if response.enum == 'HandshakeFailure' and response.HandshakeFailure[1].enum == 'ProtocolVersionMismatch':
-        pvm = response.HandshakeFailure[1].ProtocolVersionMismatch.version
-        handshake.HandshakeV2.version = pvm
+    if response.enum == 'HandshakeFailure' and response.HandshakeFailure[1].enum == 'GenesisMismatch':
+        gm = response.HandshakeFailure[1].GenesisMismatch
+        handshake.HandshakeV2.chain_info.genesis_id.chain_id = gm.chain_id
+        handshake.HandshakeV2.chain_info.genesis_id.hash = gm.hash
         sign_handshake(key_pair, handshake.HandshakeV2)
         await conn.send(handshake)
         response = await conn.recv()

--- a/pytest/lib/utils.py
+++ b/pytest/lib/utils.py
@@ -284,7 +284,8 @@ def obj_to_string(obj, extra='    ', full=False):
         for item in sorted(obj.__dict__))
     elif isinstance(obj, bytes):
         if not full:
-            obj = obj[:7] + b"..."
+            if len(obj) > 10:
+                obj = obj[:7] + b"..."
         return str(obj)
     else:
         return str(obj)

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -41,9 +41,6 @@ def main(near_root, stable_branch, new_branch):
                          '../../../neard/res/genesis_config.json')) as f:
         current_genesis = json.load(f)
         current_protocol_version = current_genesis['protocol_version']
-    if current_protocol_version > stable_protocol_version:
-        print('Protcol upgrade, does not need backward compatible')
-        exit(0)
 
     # Run both binaries at the same time.
     config = {

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -78,7 +78,9 @@ def main(near_root, stable_branch, new_branch):
 
 
 if __name__ == "__main__":
+    other = 'beta' if len(sys.argv) == 1 else sys.argv[1]
+
     near_root, (stable_branch,
-                new_branch) = branches.prepare_ab_test("beta")
+                new_branch) = branches.prepare_ab_test(other)
 
     main(near_root, stable_branch, new_branch)

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -32,16 +32,6 @@ def main(near_root, stable_branch, new_branch):
         "--home=%s" % node_root, "testnet", "--v", "2", "--prefix", "test"
     ])
 
-    with open('/tmp/near/backward/test0/genesis.json') as f:
-        stable_genesis = json.load(f)
-        stable_protocol_version = stable_genesis['protocol_version']
-
-    with open(
-            os.path.join(os.path.dirname(__file__),
-                         '../../../neard/res/genesis_config.json')) as f:
-        current_genesis = json.load(f)
-        current_protocol_version = current_genesis['protocol_version']
-
     # Run both binaries at the same time.
     config = {
         "local": True,

--- a/pytest/tests/sanity/backward_compatible.py
+++ b/pytest/tests/sanity/backward_compatible.py
@@ -75,9 +75,8 @@ def main(near_root, stable_branch, new_branch):
 
 
 if __name__ == "__main__":
-    other = 'beta' if len(sys.argv) == 1 else sys.argv[1]
-
+    # TODO(#3285): use proper branch
     near_root, (stable_branch,
-                new_branch) = branches.prepare_ab_test(other)
+                new_branch) = branches.prepare_ab_test('1.13.0')
 
     main(near_root, stable_branch, new_branch)

--- a/pytest/tests/sanity/db_migration.py
+++ b/pytest/tests/sanity/db_migration.py
@@ -54,7 +54,7 @@ def send_some_tx(node):
 
 def main():
     near_root, (stable_branch,
-                current_branch) = branches.prepare_ab_test("beta")
+                current_branch) = branches.prepare_ab_test("1.13.0")
     node_root = os.path.join(os.path.expanduser("~"), "./near")
 
     logging.info(f"The near root is {near_root}...")

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -26,8 +26,9 @@ def main():
         shutil.rmtree(node_root)
     subprocess.check_output('mkdir -p /tmp/near', shell=True)
 
+    # TODO(#3285): use proper branch
     near_root, (stable_branch,
-                current_branch) = branches.prepare_ab_test("beta")
+                current_branch) = branches.prepare_ab_test("1.13.0")
 
     # Setup local network.
     print([
@@ -113,11 +114,6 @@ def main():
     latest_protocol_version = status3["latest_protocol_version"]
     assert protocol_version == latest_protocol_version, \
         "Latest protocol version %d should match active protocol version %d" % (latest_protocol_version, protocol_version)
-
-    gas_price = nodes[0].json_rpc('gas_price', [None])
-    gas_price = int(gas_price['result']['gas_price'])
-    assert gas_price < 1000000000, gas_price
-    assert gas_price > 100000000, gas_price
 
     hash = status0['sync_info']['latest_block_hash']
 

--- a/pytest/tests/spec/network/future_handshake.py
+++ b/pytest/tests/spec/network/future_handshake.py
@@ -1,0 +1,57 @@
+"""
+Handshake from the Future
+
+Start a real node and connect to it. Send handshake with different layout that it knows
+but with valid future version, and expect to receive HandshakeFailure with current version.
+"""
+import asyncio
+import socket
+import sys
+import time
+import random
+
+sys.path.append('lib')
+
+import base58
+import nacl.signing
+from cluster import start_cluster
+from peer import ED_PREFIX, connect, create_handshake, sign_handshake, BinarySerializer, schema
+from utils import obj_to_string
+
+
+
+nodes = start_cluster(1, 0, 4, None, [], {})
+
+
+async def main():
+    random.seed(0)
+
+    my_key_pair_nacl = nacl.signing.SigningKey.generate()
+
+    conn = await connect(nodes[0].addr())
+
+    handshake = create_handshake(my_key_pair_nacl, nodes[0].node_key.pk, 12345)
+    # Use future version
+    handshake.HandshakeV2.version = 2**32 - 1
+    raw_message = BinarySerializer(schema).serialize(handshake)
+
+    # Keep header (9 bytes)
+    # - 1 byte  PeerMessage::HandshakeV2 enum id
+    # - 4 bytes version
+    # - 4 bytes oldest_supported_version
+    raw_message = raw_message[:9] + bytes([random.randint(0, 255) for _ in range(random.randint(1, 32))])
+
+    # First handshake attempt. Should fail with Protocol Version Mismatch
+    await conn.send_raw(raw_message)
+    response = await conn.recv()
+
+    print(obj_to_string(response))
+
+    assert response.enum == 'HandshakeFailure', response.enum
+    assert response.HandshakeFailure[1].enum == 'ProtocolVersionMismatch', response.HandshakeFailure[1].enum
+    pvm = response.HandshakeFailure[1].ProtocolVersionMismatch.version
+    handshake.HandshakeV2.version = pvm
+
+
+
+asyncio.run(main())

--- a/pytest/tests/spec/network/handshake.py
+++ b/pytest/tests/spec/network/handshake.py
@@ -67,7 +67,7 @@ async def main():
     assert response.Handshake.target_peer_id.data == bytes(
         my_key_pair_nacl.verify_key)
     assert response.Handshake.listen_port == nodes[0].addr()[1]
-    # TODO(#3157): Bring this assert back
+    # TODO(MarX): Fix (uncomment) after old_supporte_version is added in Handshake
     # assert response.Handshake.version == handshake.Handshake.version
 
 

--- a/pytest/tests/spec/network/handshake.py
+++ b/pytest/tests/spec/network/handshake.py
@@ -28,7 +28,7 @@ async def main():
 
     # First handshake attempt. Should fail with Genesis Mismatch
     handshake = create_handshake(my_key_pair_nacl, nodes[0].node_key.pk, 12345)
-    sign_handshake(my_key_pair_nacl, handshake.Handshake)
+    sign_handshake(my_key_pair_nacl, handshake.HandshakeV2)
 
     await conn.send(handshake)
     response = await conn.recv()
@@ -38,9 +38,9 @@ async def main():
 
     # Second handshake attempt. Should fail with Protocol Version Mismatch
     gm = response.HandshakeFailure[1].GenesisMismatch
-    handshake.Handshake.chain_info.genesis_id.chain_id = gm.chain_id
-    handshake.Handshake.chain_info.genesis_id.hash = gm.hash
-    sign_handshake(my_key_pair_nacl, handshake.Handshake)
+    handshake.HandshakeV2.chain_info.genesis_id.chain_id = gm.chain_id
+    handshake.HandshakeV2.chain_info.genesis_id.hash = gm.hash
+    sign_handshake(my_key_pair_nacl, handshake.HandshakeV2)
 
     await conn.send(handshake)
     response = await conn.recv()
@@ -50,25 +50,24 @@ async def main():
 
     # Third handshake attempt. Should succeed
     pvm = response.HandshakeFailure[1].ProtocolVersionMismatch.version
-    handshake.Handshake.version = pvm
-    sign_handshake(my_key_pair_nacl, handshake.Handshake)
+    handshake.HandshakeV2.version = pvm
+    sign_handshake(my_key_pair_nacl, handshake.HandshakeV2)
 
     await conn.send(handshake)
     response = await conn.recv()
 
-    assert response.enum == 'Handshake', response.enum
-    assert response.Handshake.chain_info.genesis_id.chain_id == handshake.Handshake.chain_info.genesis_id.chain_id
-    assert response.Handshake.chain_info.genesis_id.hash == handshake.Handshake.chain_info.genesis_id.hash
-    assert response.Handshake.edge_info.nonce == 1
-    assert response.Handshake.peer_id.keyType == 0
-    assert response.Handshake.peer_id.data == base58.b58decode(
+    assert response.enum == 'HandshakeV2', response.enum
+    assert response.HandshakeV2.chain_info.genesis_id.chain_id == handshake.HandshakeV2.chain_info.genesis_id.chain_id
+    assert response.HandshakeV2.chain_info.genesis_id.hash == handshake.HandshakeV2.chain_info.genesis_id.hash
+    assert response.HandshakeV2.edge_info.nonce == 1
+    assert response.HandshakeV2.peer_id.keyType == 0
+    assert response.HandshakeV2.peer_id.data == base58.b58decode(
         nodes[0].node_key.pk[len(ED_PREFIX):])
-    assert response.Handshake.target_peer_id.keyType == 0
-    assert response.Handshake.target_peer_id.data == bytes(
+    assert response.HandshakeV2.target_peer_id.keyType == 0
+    assert response.HandshakeV2.target_peer_id.data == bytes(
         my_key_pair_nacl.verify_key)
-    assert response.Handshake.listen_port == nodes[0].addr()[1]
-    # TODO(MarX): Fix (uncomment) after old_supporte_version is added in Handshake
-    # assert response.Handshake.version == handshake.Handshake.version
+    assert response.HandshakeV2.listen_port == nodes[0].addr()[1]
+    assert response.HandshakeV2.version == handshake.HandshakeV2.version
 
 
 asyncio.run(main())


### PR DESCRIPTION
This change is only backward compatible with branch latest_supported_version, 
**We must merge and deploy that branch first.**

Fixes #3136 

Test plan
=========

1. Check latest_supported_version_2 branch is backward compatible with
latest_supported_version branch.

    Run `backward.py` with `main(near_root, "latest_supported_version", "latest_supported_version_2")` and check it passes.

2. `handshake.py` pass