### PR TITLE
fix: Batch edges on routing table sync

### DIFF
--- a/chain/network/tests/cache_edges.rs
+++ b/chain/network/tests/cache_edges.rs
@@ -157,7 +157,7 @@ impl RoutingTableTest {
         let peer0 = self.get_peer(peer0).clone();
         let peer1 = self.get_peer(peer1).clone();
         let edge = Edge::new(peer0, peer1, nonce, Signature::default(), Signature::default());
-        self.routing_table.process_edge(edge);
+        self.routing_table.process_edges(vec![edge]);
     }
 
     fn update(&mut self) {

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -40,6 +40,7 @@ pytest --timeout=300 sanity/large_messages.py
 pytest sanity/controlled_edge_nonce.py
 pytest sanity/repro_2916.py
 pytest --timeout=240 sanity/switch_node_key.py
+pytest --timeout=300 sanity/saturate_routing_table.py
 # TODO: re-enable after #2949 is fixed
 # pytest --timeout=240 sanity/validator_switch_key.py
 pytest sanity/proxy_simple.py


### PR DESCRIPTION
When a node receives a batch of edges process them all first, and update routing table in the end only once.

Add test that checks PeerManagerActor is not blocked for long time.

Test plan
=======
saturate_routing_table.py should pass

