### PR TITLE
fix: enforce block sync for archival nodes

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -832,6 +832,7 @@ impl Chain {
     pub fn check_state_needed(
         &mut self,
         block_fetch_horizon: BlockHeightDelta,
+        force_block_sync: bool,
     ) -> Result<BlockSyncResponse, Error> {
         let block_head = self.head()?;
         let header_head = self.header_head()?;
@@ -848,7 +849,9 @@ impl Chain {
 
         // Don't run State Sync if header head is not more than one epoch ahead.
         if block_head.epoch_id != header_head.epoch_id && next_epoch_id != header_head.epoch_id {
-            if block_head.height < header_head.height.saturating_sub(block_fetch_horizon) {
+            if block_head.height < header_head.height.saturating_sub(block_fetch_horizon)
+                && !force_block_sync
+            {
                 // Epochs are different and we are too far from horizon, State Sync is needed
                 return Ok(BlockSyncResponse::StateNeeded);
             }

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -107,9 +107,8 @@ impl Client {
             config.header_sync_stall_ban_timeout,
             config.header_sync_expected_height_per_second,
         );
-        let block_fetch_horizon =
-            if config.archive { u64::MAX } else { config.block_fetch_horizon };
-        let block_sync = BlockSync::new(network_adapter.clone(), block_fetch_horizon);
+        let block_sync =
+            BlockSync::new(network_adapter.clone(), config.block_fetch_horizon, config.archive);
         let state_sync = StateSync::new(network_adapter.clone());
         let num_block_producer_seats = config.num_block_producer_seats as usize;
         let data_parts = runtime_adapter.num_data_parts();

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -107,7 +107,9 @@ impl Client {
             config.header_sync_stall_ban_timeout,
             config.header_sync_expected_height_per_second,
         );
-        let block_sync = BlockSync::new(network_adapter.clone(), config.block_fetch_horizon);
+        let block_fetch_horizon =
+            if config.archive { u64::MAX } else { config.block_fetch_horizon };
+        let block_sync = BlockSync::new(network_adapter.clone(), block_fetch_horizon);
         let state_sync = StateSync::new(network_adapter.clone());
         let num_block_producer_seats = config.num_block_producer_seats as usize;
         let data_parts = runtime_adapter.num_data_parts();

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -350,12 +350,15 @@ pub struct BlockSync {
     prev_blocks_received: NumBlocks,
     /// How far to fetch blocks vs fetch state.
     block_fetch_horizon: BlockHeightDelta,
+    /// Whether to enforce block sync
+    archive: bool,
 }
 
 impl BlockSync {
     pub fn new(
         network_adapter: Arc<dyn NetworkAdapter>,
         block_fetch_horizon: BlockHeightDelta,
+        archive: bool,
     ) -> Self {
         BlockSync {
             network_adapter,
@@ -363,6 +366,7 @@ impl BlockSync {
             receive_timeout: Utc::now(),
             prev_blocks_received: 0,
             block_fetch_horizon,
+            archive,
         }
     }
 
@@ -395,7 +399,7 @@ impl BlockSync {
         highest_height_peers: &[FullPeerInfo],
         block_fetch_horizon: BlockHeightDelta,
     ) -> Result<bool, near_chain::Error> {
-        match chain.check_state_needed(block_fetch_horizon)? {
+        match chain.check_state_needed(block_fetch_horizon, self.archive)? {
             BlockSyncResponse::StateNeeded => {
                 return Ok(true);
             }

--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -24,6 +24,7 @@ pytest --timeout=240 sanity/lightclnt.py
 pytest sanity/rpc_light_client_execution_outcome_proof.py
 pytest --timeout=240 sanity/rpc_query.py
 pytest --timeout=240 sanity/block_sync.py
+pytest --timeout=360 sanity/block_sync_archival.py
 pytest --timeout=240 sanity/validator_switch.py
 pytest --timeout=240 sanity/restaked.py
 pytest --timeout=240 sanity/rpc_state_changes.py

--- a/pytest/tests/sanity/block_sync_archival.py
+++ b/pytest/tests/sanity/block_sync_archival.py
@@ -1,0 +1,45 @@
+# Spins up one validating node and one non-validating node that is archival. Let the validating node run
+# for a while and make sure that the archival node will sync all blocks.
+
+import sys, time
+
+sys.path.append('lib')
+
+from cluster import start_cluster
+
+TARGET_HEIGHT = 100
+TIMEOUT = 120
+
+client_config0 = { "archive": True }
+client_config1 = {
+    "archive": True,
+    "tracked_shards": [0],
+}
+
+nodes = start_cluster(
+    1, 1, 1, None,
+    [["epoch_length", 10], ["block_producer_kickout_threshold", 80]], {0: client_config0, 1: client_config1})
+
+nodes[1].kill()
+
+node0_height = 0
+started = time.time()
+while node0_height < TARGET_HEIGHT:
+    assert time.time() - started < TIMEOUT
+    status = nodes[0].get_status()
+    node0_height = status['sync_info']['latest_block_height']
+    time.sleep(2)
+
+nodes[1].start(nodes[1].node_key.pk, nodes[1].addr())
+time.sleep(2)
+
+node1_height = 0
+while node1_height < TARGET_HEIGHT:
+    assert time.time() - started < TIMEOUT
+    status = nodes[1].get_status()
+    node1_height = status['sync_info']['latest_block_height']
+    time.sleep(2)
+
+for i in range(TARGET_HEIGHT):
+    block = nodes[1].json_rpc('block', [i], timeout=15)
+    assert 'error' not in block, block


### PR DESCRIPTION
@nearmisterwhite requested that they be able to sync every block from genesis. Currently archival nodes do not always sync blocks and may use state sync, which will skip the blocks in between. This PR enforces archival node to sync all blocks.

Test plan
----------
Run `block_sync_archival.py` 30 times and observe no failure.