### PR TITLE
fix(test): state_sync3

### DIFF
--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -12,7 +12,7 @@ pytest sanity/state_sync.py onetx 30
 pytest --timeout=600 sanity/state_sync.py onetx 265
 pytest --timeout=240 sanity/state_sync1.py
 pytest --timeout=900 sanity/state_sync2.py
-pytest --timeout=900 sanity/state_sync3.py
+pytest --timeout=1200 sanity/state_sync3.py
 pytest --timeout=240 sanity/state_sync4.py
 pytest --timeout=600 sanity/state_sync_routed.py manytx 115
 pytest --timeout=300 sanity/state_sync_late.py notx

--- a/pytest/tests/sanity/state_sync3.py
+++ b/pytest/tests/sanity/state_sync3.py
@@ -7,7 +7,6 @@ import base58
 sys.path.append('lib')
 
 from cluster import start_cluster
-from transaction import sign_payment_tx
 
 EPOCH_LENGTH = 1000
 MAX_SYNC_WAIT = 120
@@ -41,7 +40,7 @@ nodes[1].kill()
 print("step 1")
 
 node0_height = 0
-while node0_height <= EPOCH_LENGTH + 600:
+while node0_height <= EPOCH_LENGTH * 2 + 1:
     status = nodes[0].get_status()
     node0_height = status['sync_info']['latest_block_height']
     time.sleep(5)


### PR DESCRIPTION
`state_sync3.py` failed because the head was not far enough behind to trigger state sync in the beginning and caused the test to timeout. Fixes #3165 

Test plan
---------
Run `state_sync3.py` 30 times and observe no failure.