### PR TITLE
fix: Removing flakiness from block_production.py

### DIFF
--- a/pytest/tests/sanity/block_production.py
+++ b/pytest/tests/sanity/block_production.py
@@ -31,6 +31,14 @@ last_common = [[0 for _ in nodes] for _ in nodes]
 
 height_to_hash = {}
 
+# the test relies on us being able to query heights faster
+# than the blocks are produced. Validating store takes up
+# to 350ms on slower hardware for this test, multiplied
+# by four nodes querying heights every 1 second becomes
+# unfeasible
+for node in nodes:
+    node.stop_checking_store()
+
 
 def min_common():
     return min([min(x) for x in last_common])


### PR DESCRIPTION
The test relies on being able to query all the nodes between every two blocks produced.
Before 7028068 it was likely but flaky, after it the test fails consistently.
It is due to the fact that store validity checks take ~0.35 seconds per `get_status`.
Disabling the validity checks for this test. It is generally OK, because practically
every other test (e.g. transactions.py) is a superset of this test in terms of coverage,
and would catch any storage inconsistency that this test would now miss.

Fixes #3143

Test plan:
---------
http://nayduck.eastus.cloudapp.azure.com:3000/#/run/97