### PR TITLE
fix: Properly handling stalls due to 1-height differences

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -4,7 +4,7 @@
 use std::collections::{HashMap, HashSet};
 use std::iter;
 use std::sync::{Arc, RwLock};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use cached::{Cached, SizedCache};
 use chrono::Utc;
@@ -77,6 +77,9 @@ pub struct Client {
     rs: ReedSolomonWrapper,
     /// Blocks that have been re-broadcast recently. They should not be broadcast again.
     rebroadcasted_blocks: SizedCache<CryptoHash, ()>,
+    /// Last time the head was updated, or our head was rebroadcasted. Used to re-broadcast the head
+    /// again to prevent network from stalling if a large percentage of the network missed a block
+    last_time_head_progress_made: Instant,
 }
 
 impl Client {
@@ -144,7 +147,19 @@ impl Client {
             challenges: Default::default(),
             rs: ReedSolomonWrapper::new(data_parts, parity_parts),
             rebroadcasted_blocks: SizedCache::with_size(NUM_REBROADCAST_BLOCKS),
+            last_time_head_progress_made: Instant::now(),
         })
+    }
+
+    // Checks if it's been at least `stall_timeout` since the last time the head was updated, or
+    // this method was called. If yes, rebroadcasts the current head.
+    pub fn check_head_progress_stalled(&mut self, stall_timeout: Duration) -> Result<(), Error> {
+        if Instant::now() > self.last_time_head_progress_made + stall_timeout {
+            let block = self.chain.get_block(&self.chain.head()?.last_block_hash)?;
+            self.network_adapter.do_send(NetworkRequests::Block { block: block.clone() });
+            self.last_time_head_progress_made = Instant::now();
+        }
+        Ok(())
     }
 
     pub fn remove_transactions_for_block(&mut self, me: AccountId, block: &Block) {
@@ -646,6 +661,10 @@ impl Client {
                 },
                 _ => {}
             }
+        }
+
+        if let Ok(Some(_)) = result {
+            self.last_time_head_progress_made = Instant::now();
         }
 
         // Request any missing chunks

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -57,9 +57,9 @@ use delay_detector::DelayDetector;
 const STATUS_WAIT_TIME_MULTIPLIER: u64 = 10;
 /// Drop blocks whose height are beyond head + horizon.
 const BLOCK_HORIZON: u64 = 500;
-/// How many intervals of max_block_production_delay to wait being several blocks behind before
-/// kicking off syncing
-const SEVERAL_BLOCKS_BEHIND_WAIT_MULTIPLIER: u32 = 5;
+/// `max_block_production_time` times this multiplier is how long we wait before rebroadcasting
+/// the current `head`
+const HEAD_STALL_MULTIPLIER: u32 = 4;
 
 pub struct ClientActor {
     /// Adversarial controls
@@ -759,6 +759,11 @@ impl ClientActor {
                 ctx,
                 |act, _ctx| act.try_handle_block_production(),
             );
+
+            let _ = self.client.check_head_progress_stalled(
+                self.client.config.max_block_production_delay * HEAD_STALL_MULTIPLIER,
+            );
+
             delay = core::cmp::min(
                 delay,
                 self.block_production_next_attempt.signed_duration_since(now).to_std().unwrap(),
@@ -995,7 +1000,7 @@ impl ClientActor {
         let mut is_syncing = self.client.sync_status.is_syncing();
 
         let full_peer_info = if let Some(full_peer_info) =
-            highest_height_peer(&self.network_info.highest_height_peers, head.height)
+            highest_height_peer(&self.network_info.highest_height_peers)
         {
             full_peer_info
         } else {
@@ -1025,21 +1030,6 @@ impl ClientActor {
                     full_peer_info.chain_info.height,
                 );
                 is_syncing = true;
-            } else {
-                if let SyncStatus::NoSyncSeveralBlocksBehind { since_when, our_height } =
-                    self.client.sync_status
-                {
-                    let now = Utc::now();
-                    if now > since_when
-                        && (now - since_when).to_std().unwrap()
-                            >= self.client.config.max_block_production_delay
-                                * SEVERAL_BLOCKS_BEHIND_WAIT_MULTIPLIER
-                        && our_height == head.height
-                    {
-                        info!(target: "sync", "Have been at the same height for too long, while peers have newer bocks. Forcing synchronization");
-                        is_syncing = true;
-                    }
-                }
             }
         }
         Ok((is_syncing, full_peer_info.chain_info.height))
@@ -1167,27 +1157,6 @@ impl ClientActor {
                 self.check_send_announce_account(head.prev_block_hash);
             }
             wait_period = self.client.config.sync_check_period;
-
-            // Handle the case in which we failed to receive a block, and our inactivity prevents
-            // the network from making progress
-            if let Ok(head) = self.client.chain.head() {
-                match self.client.sync_status {
-                    SyncStatus::NoSync => {
-                        if head.height < highest_height {
-                            self.client.sync_status = SyncStatus::NoSyncSeveralBlocksBehind {
-                                since_when: Utc::now(),
-                                our_height: head.height,
-                            }
-                        }
-                    }
-                    SyncStatus::NoSyncSeveralBlocksBehind { our_height, .. } => {
-                        if head.height > our_height {
-                            self.client.sync_status = SyncStatus::NoSync;
-                        }
-                    }
-                    _ => {}
-                }
-            }
         } else {
             // Run each step of syncing separately.
             unwrap_or_run_later!(self.client.header_sync.run(
@@ -1257,7 +1226,7 @@ impl ClientActor {
                         self.client.sync_status = SyncStatus::StateSync(sync_hash, new_shard_sync);
                         if fetch_block {
                             if let Some(peer_info) =
-                                highest_height_peer(&self.network_info.highest_height_peers, 0)
+                                highest_height_peer(&self.network_info.highest_height_peers)
                             {
                                 if let Ok(header) = self.client.chain.get_block_header(&sync_hash) {
                                     for hash in

--- a/chain/client/src/info.rs
+++ b/chain/client/src/info.rs
@@ -168,9 +168,7 @@ fn display_sync_status(
 ) -> String {
     match sync_status {
         SyncStatus::AwaitingPeers => format!("#{:>8} Waiting for peers", head.height),
-        SyncStatus::NoSync | SyncStatus::NoSyncSeveralBlocksBehind { .. } => {
-            format!("#{:>8} {:>44}", head.height, head.last_block_hash)
-        }
+        SyncStatus::NoSync => format!("#{:>8} {:>44}", head.height, head.last_block_hash),
         SyncStatus::HeaderSync { current_height, highest_height } => {
             let percent = if *highest_height <= genesis_height {
                 0

--- a/chain/client/src/sync.rs
+++ b/chain/client/src/sync.rs
@@ -52,19 +52,12 @@ pub const MAX_PENDING_PART: u64 = MAX_STATE_PART_REQUEST * 10000;
 pub const NS_PER_SECOND: u128 = 1_000_000_000;
 
 /// Get random peer from the hightest height peers.
-pub fn highest_height_peer(
-    highest_height_peers: &Vec<FullPeerInfo>,
-    min_height: BlockHeight,
-) -> Option<FullPeerInfo> {
+pub fn highest_height_peer(highest_height_peers: &Vec<FullPeerInfo>) -> Option<FullPeerInfo> {
     if highest_height_peers.len() == 0 {
         return None;
     }
 
-    match highest_height_peers
-        .iter()
-        .filter(|peer| peer.chain_info.height > min_height)
-        .choose(&mut thread_rng())
-    {
+    match highest_height_peers.iter().choose(&mut thread_rng()) {
         None => highest_height_peers.choose(&mut thread_rng()).cloned(),
         Some(peer) => Some(peer.clone()),
     }
@@ -122,9 +115,7 @@ impl HeaderSync {
             SyncStatus::HeaderSync { .. }
             | SyncStatus::BodySync { .. }
             | SyncStatus::StateSyncDone => true,
-            SyncStatus::NoSync
-            | SyncStatus::NoSyncSeveralBlocksBehind { .. }
-            | SyncStatus::AwaitingPeers => {
+            SyncStatus::NoSync | SyncStatus::AwaitingPeers => {
                 let sync_head = chain.sync_head()?;
                 debug!(target: "sync", "Sync: initial transition to Header sync. Sync head: {} at {}, resetting to {} at {}",
                     sync_head.last_block_hash, sync_head.height,
@@ -143,7 +134,7 @@ impl HeaderSync {
                 SyncStatus::HeaderSync { current_height: header_head.height, highest_height };
             let header_head = chain.header_head()?;
             self.syncing_peer = None;
-            if let Some(peer) = highest_height_peer(&highest_height_peers, 0) {
+            if let Some(peer) = highest_height_peer(&highest_height_peers) {
                 if peer.chain_info.height > header_head.height {
                     self.syncing_peer = self.request_headers(chain, peer);
                 }
@@ -183,9 +174,7 @@ impl HeaderSync {
 
         // Always enable header sync on initial state transition from NoSync / NoSyncFewBlocksBehind / AwaitingPeers.
         let force_sync = match sync_status {
-            SyncStatus::NoSync
-            | SyncStatus::NoSyncSeveralBlocksBehind { .. }
-            | SyncStatus::AwaitingPeers => true,
+            SyncStatus::NoSync | SyncStatus::AwaitingPeers => true,
             _ => false,
         };
 

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -121,8 +121,6 @@ pub enum SyncStatus {
     AwaitingPeers,
     /// Not syncing / Done syncing.
     NoSync,
-    /// Not syncing, but have a peer that is one block ahead.
-    NoSyncSeveralBlocksBehind { since_when: DateTime<Utc>, our_height: BlockHeight },
     /// Downloading block headers for fast sync.
     HeaderSync { current_height: BlockHeight, highest_height: BlockHeight },
     /// State sync, with different states of state sync for different shards.
@@ -142,7 +140,7 @@ impl SyncStatus {
     /// True if currently engaged in syncing the chain.
     pub fn is_syncing(&self) -> bool {
         match self {
-            SyncStatus::NoSync | SyncStatus::NoSyncSeveralBlocksBehind { .. } => false,
+            SyncStatus::NoSync => false,
             _ => true,
         }
     }

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -54,7 +54,7 @@ pytest contracts/deploy_call_smart_contract.py
 pytest --timeout=240 contracts/gibberish.py
 
 # python stress tests
-# pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network
+pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart
 # pytest --timeout=2000 stress/stress.py 3 2 4 0 staking transactions node_set
 

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -85,6 +85,7 @@ class BaseNode(object):
     def __init__(self):
         self._start_proxy = None
         self._proxy_local_stopped = None
+        self.proxy = None
 
 
     def _get_command_line(self,

--- a/pytest/lib/proxy.py
+++ b/pytest/lib/proxy.py
@@ -178,7 +178,7 @@ class NodesProxy:
 
     def proxify_node(self, node):
         proxify_node(node, self.ps, self.handler,
-                     self.global_stopped, self.error)
+                     self.global_stopped, self.error, self)
 
 
 async def stop_server(server):
@@ -316,7 +316,7 @@ def start_server(inner_port, outer_port, handler_ctr, global_stopped, local_stop
                          global_stopped, local_stopped, error))
 
 
-def proxify_node(node, ps, handler, global_stopped, error):
+def proxify_node(node, ps, handler, global_stopped, error, proxy):
     inner_port = node.port
     outer_port = inner_port + 100
 
@@ -330,3 +330,4 @@ def proxify_node(node, ps, handler, global_stopped, error):
 
     node.port = outer_port
     node._start_proxy = start_proxy
+    node.proxy = proxy

--- a/pytest/lib/proxy_instances.py
+++ b/pytest/lib/proxy_instances.py
@@ -1,0 +1,29 @@
+import logging, multiprocessing
+from proxy import ProxyHandler, NodesProxy
+
+
+class RejectListHandler(ProxyHandler):
+
+    def __init__(self, reject_list, ordinal):
+        super().__init__(ordinal)
+        self.reject_list = reject_list
+
+    async def handle(self, msg, fr, to):
+        if fr in self.reject_list or to in self.reject_list:
+            logging.info(
+                f'NODE {self.ordinal} blocking message from {fr} to {to}')
+            return False
+        else:
+            return True
+
+
+class RejectListProxy(NodesProxy):
+
+    def __init__(self, reject_list):
+        self.reject_list = reject_list
+        handler = lambda ordinal: RejectListHandler(reject_list, ordinal)
+        super().__init__(handler)
+
+    @staticmethod
+    def create_reject_list(size):
+        return multiprocessing.Array('i', [-1 for _ in range(size)])

--- a/pytest/lib/proxy_instances.py
+++ b/pytest/lib/proxy_instances.py
@@ -10,8 +10,9 @@ class RejectListHandler(ProxyHandler):
 
     async def handle(self, msg, fr, to):
         if fr in self.reject_list or to in self.reject_list:
+            msg_type = msg.enum if msg.enum != 'Routed' else msg.Routed.body.enum
             logging.info(
-                f'NODE {self.ordinal} blocking message from {fr} to {to}')
+                f'NODE {self.ordinal} blocking message {msg_type} from {fr} to {to}')
             return False
         else:
             return True

--- a/pytest/tests/stress/stress.py
+++ b/pytest/tests/stress/stress.py
@@ -31,7 +31,7 @@ sys.path.append('lib')
 from cluster import init_cluster, spin_up_node, load_config
 from utils import TxContext, Unbuffered
 from transaction import sign_payment_tx, sign_staking_tx
-from network import init_network_pillager, stop_network, resume_network
+from proxy_instances import RejectListProxy
 
 sys.stdout = Unbuffered(sys.stdout)
 logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
@@ -171,15 +171,18 @@ def monkey_node_restart(stopped, error, nodes, nonces):
 @stress_process
 def monkey_local_network(stopped, error, nodes, nonces):
     while stopped.value == 0:
+        time.sleep(9)
         # "- 2" below is because we don't want to kill the node we use to check stats
         node_idx = random.randint(0, len(nodes) - 2)
-        nodes[node_idx].stop_network()
+        node = nodes[node_idx]
+        logging.info(f'ISOLATING NODE {node_idx}')
+        node.proxy.reject_list[0] = node_idx
         if node_idx == get_the_guy_to_mess_up_with(nodes):
             time.sleep(5)
         else:
             time.sleep(1)
-        nodes[node_idx].resume_network()
-        time.sleep(5)
+        logging.info(f'RESTORING NODE {node_idx} NETWORK')
+        node.proxy.reject_list[0] = -1
 
 
 @stress_process
@@ -228,7 +231,7 @@ def monkey_transactions(stopped, error, nodes, nonces):
                         logging.info("\nTRANSACTION %s" % tx_ord)
                         logging.info("TX tuple: %s" % (tx[1:],))
                         response = nodes[-1].json_rpc(
-                            'tx', [tx[3], "test%s" % tx[1]], timeout=1)
+                            'tx', [tx[3], "test%s" % tx[1]], timeout=5)
                         logging.info("Status: %s", response)
 
                 def revert_txs():
@@ -239,7 +242,7 @@ def monkey_transactions(stopped, error, nodes, nonces):
                         tx_happened = True
 
                         response = nodes[-1].json_rpc(
-                            'tx', [tx[3], "test%s" % tx[1]], timeout=1)
+                            'tx', [tx[3], "test%s" % tx[1]], timeout=5)
 
                         if 'error' in response and 'data' in response[
                                 'error'] and "doesn't exist" in response['error'][
@@ -558,32 +561,14 @@ def doit(s, n, N, k, monkeys, timeout):
          ["block_producer_kickout_threshold", 10],
          ["chunk_producer_kickout_threshold", 10]], local_config_changes)
 
-    started = time.time()
-
-    boot_node = spin_up_node(config, near_root, node_dirs[0], 0, None, None)
-    boot_node.stop_checking_store()
-    boot_node.mess_with = False
-    nodes = [boot_node]
-
-    for i in range(1, N + k + 1):
-        node = spin_up_node(config, near_root, node_dirs[i], i,
-                            boot_node.node_key.pk, boot_node.addr())
-        node.stop_checking_store()
-        nodes.append(node)
-        if i >= n and i < N:
-            node.kill()
-            node.mess_with = True
-        else:
-            node.mess_with = False
-
     monkey_names = [x.__name__ for x in monkeys]
+    proxy = None
     logging.info(monkey_names)
     if 'monkey_local_network' in monkey_names or 'monkey_global_network' in monkey_names:
-        logging.info(
-            "There are monkeys messing up with network, initializing the infra")
-        if config['local']:
-            init_network_pillager()
-            expect_network_issues()
+        assert config['local'], 'Network stress operations only work on local nodes'
+        reject_list = RejectListProxy.create_reject_list(1)
+        proxy = RejectListProxy(reject_list)
+        expect_network_issues()
         block_timeout += 40
         tx_tolerance += 0.3
     if 'monkey_node_restart' in monkey_names:
@@ -592,6 +577,24 @@ def doit(s, n, N, k, monkeys, timeout):
         block_timeout += 40
         balances_timeout += 10
         tx_tolerance += 0.5
+
+    started = time.time()
+
+    boot_node = spin_up_node(config, near_root, node_dirs[0], 0, None, None, proxy=proxy)
+    boot_node.stop_checking_store()
+    boot_node.mess_with = False
+    nodes = [boot_node]
+
+    for i in range(1, N + k + 1):
+        node = spin_up_node(config, near_root, node_dirs[i], i,
+                            boot_node.node_key.pk, boot_node.addr(), proxy=proxy)
+        node.stop_checking_store()
+        nodes.append(node)
+        if i >= n and i < N:
+            node.kill()
+            node.mess_with = True
+        else:
+            node.mess_with = False
 
     stopped = Value('i', 0)
     error = Value('i', 0)


### PR DESCRIPTION
This change builds on top of Michael's changes to introduce `local_network` mode to stress.py

The nodes only learn about their peer's highest height via Block messages, and thus if a block message is lost and two nodes are exactly one height away from each other, the one behind will never learn it needs to catch up.
If now such a 1-height difference is split across two rouhgly even halves of the block producers, the system will stall.
    
Fixing it by re-broadcasting `head` if during some reasonable time the network made no progress.
    
With this change `local_network` mode passes in nayduck.
    
Test plan:
---------
Before this change stress.py local_network fails consistently due to chain stalling.
After:
http://nayduck.eastus.cloudapp.azure.com:3000/#/run/104
    
Out of five failures the first one is new (and needs debugging), but the chain is not stalled.
The remaining four are #3169
