### PR TITLE
fix(test): skip_epoch

### DIFF
--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -94,9 +94,9 @@ expensive --timeout=1800 near-client catching_up tests::test_chunk_grieving
 expensive nearcore test_catchup test_catchup
 
 # cross-shard transactions tests
-expensive --timeout=2000 near-client cross_shard_tx tests::test_cross_shard_tx
-expensive --timeout=2000 near-client cross_shard_tx tests::test_cross_shard_tx_doomslug
-expensive --timeout=2000 near-client cross_shard_tx tests::test_cross_shard_tx_drop_chunks
+expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx
+expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx_doomslug
+expensive --timeout=3000 near-client cross_shard_tx tests::test_cross_shard_tx_drop_chunks
 expensive --timeout=5400 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_1
 expensive --timeout=5400 near-client cross_shard_tx tests::test_cross_shard_tx_with_validator_rotation_2
 

--- a/pytest/tests/sanity/skip_epoch.py
+++ b/pytest/tests/sanity/skip_epoch.py
@@ -13,14 +13,15 @@ from transaction import sign_staking_tx
 from utils import TxContext
 
 TIMEOUT = 600
-TWENTY_FIVE = 25
+# the height we spin up the second node
+TARGET_HEIGHT = 35
 
 config = load_config()
 # give more stake to the bootnode so that it can produce the blocks alone
 near_root, node_dirs = init_cluster(
     4, 1, 4, config,
-    [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 7],
-     ["block_producer_kickout_threshold", 40], ["chunk_producer_kickout_threshold", 40]],
+    [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 12],
+     ["block_producer_kickout_threshold", 20], ["chunk_producer_kickout_threshold", 20]],
     {4: {
         "tracked_shards": [0, 1, 2, 3]
     }})
@@ -46,7 +47,7 @@ seen_boot_heights = set()
 sent_txs = False
 largest_height = 0
 
-# 1. Make the first node get to height 25. The second epoch will end around height 15-16,
+# 1. Make the first node get to height 35. The second epoch will end around height 24-25,
 #    which would already result in a stall if the first node can't sync the state from the
 #    observer for the shard it doesn't care about
 while True:
@@ -58,7 +59,7 @@ while True:
     if new_height > largest_height:
         largest_height = new_height
         print(new_height)
-    if new_height >= TWENTY_FIVE:
+    if new_height >= TARGET_HEIGHT:
         break
 
     if new_height > 1 and not sent_txs:
@@ -68,7 +69,7 @@ while True:
 
     time.sleep(0.1)
 
-# 2. Spin up the second node and make sure it gets to 25 as well, and doesn't diverge
+# 2. Spin up the second node and make sure it gets to 35 as well, and doesn't diverge
 node2 = spin_up_node(config, near_root, node_dirs[1], 1, boot_node.node_key.pk,
                      boot_node.addr())
 
@@ -91,7 +92,7 @@ while True:
         largest_height = new_height
         print(new_height)
 
-    if node2_height > TWENTY_FIVE and not node2_syncing:
+    if node2_height > TARGET_HEIGHT and not node2_syncing:
         assert node2_height in seen_boot_heights, "%s not in %s" % (
             node2_height, seen_boot_heights)
         break
@@ -163,7 +164,7 @@ while True:
     if new_height > largest_height:
         largest_height = new_height
         print(new_height)
-    if new_height >= last_height + TWENTY_FIVE:
+    if new_height >= last_height + TARGET_HEIGHT:
         break
 
     if new_height > last_height + 1 and not sent_txs:

--- a/pytest/tests/sanity/skip_epoch.py
+++ b/pytest/tests/sanity/skip_epoch.py
@@ -20,7 +20,7 @@ config = load_config()
 near_root, node_dirs = init_cluster(
     4, 1, 4, config,
     [["min_gas_price", 0], ["max_inflation_rate", [0, 1]], ["epoch_length", 7],
-     ["block_producer_kickout_threshold", 40]],
+     ["block_producer_kickout_threshold", 40], ["chunk_producer_kickout_threshold", 40]],
     {4: {
         "tracked_shards": [0, 1, 2, 3]
     }})
@@ -81,6 +81,7 @@ while True:
 
     status = node2.get_status()
     node2_height = status['sync_info']['latest_block_height']
+    node2_syncing = status['sync_info']['syncing']
 
     status = boot_node.get_status()
     new_height = status['sync_info']['latest_block_height']
@@ -90,7 +91,7 @@ while True:
         largest_height = new_height
         print(new_height)
 
-    if node2_height > TWENTY_FIVE:
+    if node2_height > TWENTY_FIVE and not node2_syncing:
         assert node2_height in seen_boot_heights, "%s not in %s" % (
             node2_height, seen_boot_heights)
         break


### PR DESCRIPTION
Fix skip_epoch.py by setting proper epoch length to avoid the situation where some nodes do not get a seat.

Test plan
---------
Run `skip_epoch.py` 50 times and observe no failure