### PR TITLE
fix(chunks): refactor `receipts_recipient_filter` to avoid excessive calls to `account_id_to_shard_id`

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -730,34 +730,39 @@ impl ShardsManager {
             .reintroduce_transactions(transactions.clone());
     }
 
+    pub fn group_receipts_by_shard(
+        &self,
+        receipts: Vec<Receipt>,
+    ) -> HashMap<ShardId, Vec<Receipt>> {
+        let mut result = HashMap::with_capacity(self.runtime_adapter.num_shards() as usize);
+        for receipt in receipts {
+            let shard_id = self.runtime_adapter.account_id_to_shard_id(&receipt.receiver_id);
+            let entry = result.entry(shard_id).or_insert_with(Vec::new);
+            entry.push(receipt)
+        }
+        result
+    }
+
     pub fn receipts_recipient_filter(
         &self,
         from_shard_id: ShardId,
-        tracking_shards: &HashSet<ShardId>,
-        receipts: &Vec<Receipt>,
+        tracking_shards: Vec<ShardId>,
+        receipts_by_shard: &HashMap<ShardId, Vec<Receipt>>,
         proofs: &Vec<MerklePath>,
     ) -> Vec<ReceiptProof> {
-        let mut part_receipt_proofs = vec![];
-        for to_shard_id in 0..self.runtime_adapter.num_shards() {
-            if tracking_shards.contains(&to_shard_id) {
-                part_receipt_proofs.push(ReceiptProof(
-                    receipts
-                        .iter()
-                        .filter(|&receipt| {
-                            self.runtime_adapter.account_id_to_shard_id(&receipt.receiver_id)
-                                == to_shard_id
-                        })
-                        .cloned()
-                        .collect(),
-                    ShardProof {
-                        from_shard_id,
-                        to_shard_id,
-                        proof: proofs[to_shard_id as usize].clone(),
-                    },
-                ))
-            }
-        }
-        part_receipt_proofs
+        tracking_shards
+            .into_iter()
+            .map(|to_shard_id| {
+                let receipts =
+                    receipts_by_shard.get(&to_shard_id).cloned().unwrap_or_else(Vec::new);
+                let shard_proof = ShardProof {
+                    from_shard_id,
+                    to_shard_id,
+                    proof: proofs[to_shard_id as usize].clone(),
+                };
+                ReceiptProof(receipts, shard_proof)
+            })
+            .collect()
     }
 
     pub fn process_partial_encoded_chunk_request(
@@ -1303,7 +1308,7 @@ impl ShardsManager {
             self.create_and_persist_partial_chunk(
                 &encoded_chunk,
                 merkle_paths,
-                &shard_chunk.receipts,
+                shard_chunk.receipts.clone(),
                 &mut store_update,
             );
 
@@ -1329,17 +1334,28 @@ impl ShardsManager {
         &mut self,
         encoded_chunk: &EncodedShardChunk,
         merkle_paths: Vec<MerklePath>,
-        outgoing_receipts: &Vec<Receipt>,
+        outgoing_receipts: Vec<Receipt>,
         store_update: &mut ChainStoreUpdate<'_>,
     ) {
         let shard_id = encoded_chunk.header.inner.shard_id;
         let outgoing_receipts_hashes =
-            self.runtime_adapter.build_receipts_hashes(outgoing_receipts);
+            self.runtime_adapter.build_receipts_hashes(&outgoing_receipts);
         let (outgoing_receipts_root, outgoing_receipts_proofs) =
             merklize(&outgoing_receipts_hashes);
         assert_eq!(encoded_chunk.header.inner.outgoing_receipts_root, outgoing_receipts_root);
 
         // Save this chunk into encoded_chunks & process encoded chunk to add to the store.
+        let mut receipts_by_shard = self.group_receipts_by_shard(outgoing_receipts);
+        let receipts = outgoing_receipts_proofs
+            .into_iter()
+            .enumerate()
+            .map(|(to_shard_id, proof)| {
+                let to_shard_id = to_shard_id as u64;
+                let receipts = receipts_by_shard.remove(&to_shard_id).unwrap_or_else(Vec::new);
+                let shard_proof = ShardProof { from_shard_id: shard_id, to_shard_id, proof };
+                (to_shard_id, ReceiptProof(receipts, shard_proof))
+            })
+            .collect();
         let cache_entry = EncodedChunksCacheEntry {
             header: encoded_chunk.header.clone(),
             parts: encoded_chunk
@@ -1355,16 +1371,7 @@ impl ShardsManager {
                     (part_ord, PartialEncodedChunkPart { part_ord, part, merkle_proof })
                 })
                 .collect(),
-            receipts: self
-                .receipts_recipient_filter(
-                    shard_id,
-                    &(0..self.runtime_adapter.num_shards()).collect(),
-                    outgoing_receipts,
-                    &outgoing_receipts_proofs,
-                )
-                .into_iter()
-                .map(|receipt_proof| (receipt_proof.1.to_shard_id, receipt_proof))
-                .collect(),
+            receipts,
         };
 
         // Save the partial chunk for data availability
@@ -1400,6 +1407,8 @@ impl ShardsManager {
             entry.push(part_ord);
         }
 
+        let receipts_by_shard = self.group_receipts_by_shard(outgoing_receipts);
+
         for (to_whom, part_ords) in block_producer_mapping {
             let tracking_shards = (0..self.runtime_adapter.num_shards())
                 .filter(|chunk_shard_id| {
@@ -1414,8 +1423,8 @@ impl ShardsManager {
 
             let part_receipt_proofs = self.receipts_recipient_filter(
                 shard_id,
-                &tracking_shards,
-                &outgoing_receipts,
+                tracking_shards,
+                &receipts_by_shard,
                 &outgoing_receipts_proofs,
             );
             let partial_encoded_chunk = encoded_chunk.create_partial_encoded_chunk(

--- a/chain/client/tests/challenges.rs
+++ b/chain/client/tests/challenges.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -469,10 +468,11 @@ fn test_receive_invalid_chunk_as_chunk_producer() {
     // But everyone who doesn't track this shard have accepted.
     let receipts_hashes = env.clients[0].runtime_adapter.build_receipts_hashes(&receipts);
     let (_receipts_root, receipts_proofs) = merklize(&receipts_hashes);
+    let receipts_by_shard = env.clients[0].shards_mgr.group_receipts_by_shard(receipts.clone());
     let one_part_receipt_proofs = env.clients[0].shards_mgr.receipts_recipient_filter(
         0,
-        &HashSet::default(),
-        &receipts,
+        Vec::default(),
+        &receipts_by_shard,
         &receipts_proofs,
     );
 


### PR DESCRIPTION
This calling `account_id_to_shard_id` many times was causing a performance issue in `ShardsManager::distribute_encoded_chunk` because `receipts_recipient_filter` is called inside a loop, and `account_id_to_shard_id` has a non-trivial computation cost since it computes a hash.

This change is part of an ongoing effort to improve the performance of the node under load. This change does not "solve" the current performance issues, but it does give a small improvement.