### PR TITLE
fix(test): fix some tests that failed due to disabling seals

### DIFF
--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -336,23 +336,26 @@ pub(crate) fn block_chunks_exist(
     block: &Block,
 ) -> Result<(), StoreValidatorError> {
     for chunk_header in block.chunks().iter() {
-        if let Some(me) = &sv.me {
-            if sv.runtime_adapter.cares_about_shard(
-                Some(&me),
-                block.header().prev_hash(),
-                chunk_header.inner.shard_id,
-                true,
-            ) || sv.runtime_adapter.will_care_about_shard(
-                Some(&me),
-                block.header().prev_hash(),
-                chunk_header.inner.shard_id,
-                true,
-            ) {
-                unwrap_or_err_db!(
-                    sv.store.get_ser::<ShardChunk>(ColChunks, chunk_header.chunk_hash().as_ref()),
-                    "Can't get Chunk {:?} from storage",
-                    chunk_header
-                );
+        if chunk_header.height_included == block.header().height() {
+            if let Some(me) = &sv.me {
+                if sv.runtime_adapter.cares_about_shard(
+                    Some(&me),
+                    block.header().prev_hash(),
+                    chunk_header.inner.shard_id,
+                    true,
+                ) || sv.runtime_adapter.will_care_about_shard(
+                    Some(&me),
+                    block.header().prev_hash(),
+                    chunk_header.inner.shard_id,
+                    true,
+                ) {
+                    unwrap_or_err_db!(
+                        sv.store
+                            .get_ser::<ShardChunk>(ColChunks, chunk_header.chunk_hash().as_ref()),
+                        "Can't get Chunk {:?} from storage",
+                        chunk_header
+                    );
+                }
             }
         }
     }

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -276,12 +276,13 @@ impl SealsManager {
         match maybe_seal {
             None => match self.past_seals.entry(height) {
                 btree_map::Entry::Vacant(vacant) => {
-                    warn!(
+                    // TODO(#3180): seals are disabled in single shard setting
+                    /*warn!(
                         target: "chunks",
                         "A chunk at height {} with hash {:?} was approved without an active seal demur and no past seals were found at the same height",
                         height,
                         chunk_hash
-                    );
+                    );*/
                     let mut hashes = HashSet::new();
                     hashes.insert(chunk_hash.clone());
                     vacant.insert(hashes);
@@ -289,12 +290,13 @@ impl SealsManager {
                 btree_map::Entry::Occupied(mut occupied) => {
                     let hashes = occupied.get_mut();
                     if !hashes.contains(chunk_hash) {
-                        warn!(
+                        // TODO(#3180): seals are disabled in single shard setting
+                        /*warn!(
                             target: "chunks",
                             "Approved chunk at height {} with hash {:?} was not an active seal demur or a past seal",
                             height,
                             chunk_hash
-                        );
+                        );*/
                         hashes.insert(chunk_hash.clone());
                     }
                 }

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -691,7 +691,9 @@ mod tests {
         SecondAttack,
     }
 
+    // TODO(#3180): seals are disabled in single shard setting
     #[test]
+    #[ignore]
     fn test_chunk_grieving() {
         let validator_groups = 1;
         init_integration_logger();


### PR DESCRIPTION
We disabled seals in #3182 and it caused some tests to fail:
* test_chunk_grieving tests specifically seals and it is now disabled
* `skip_epoch.py` failed due to an issue in store validator that is revealed when seal is disabled since we don't request chunk parts now.

Test plan
---------
Run `skip_epoch.py` 50 times and observe no failures.