### PR TITLE
test: Further harnessing stress.py

### DIFF
--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -53,6 +53,8 @@ pytest --timeout=240 contracts/gibberish.py
 
 # python stress tests
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions
+pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions packets_drop
+pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network packets_drop
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart packets_drop


### PR DESCRIPTION
Reducing the package drop rate to 5%, and overall tuning constants so that most modes are less flaky.
`node_restart packets_drop` still doesn't pass, #3202 is tracking it.

Test plan:
----------
http://nayduck.eastus.cloudapp.azure.com:3000/#/run/138