### PR TITLE
fix(store): commit migrations

### DIFF
--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -60,6 +60,7 @@ pub fn fill_col_outcomes_by_hash(store: &Store) {
             .set_ser(DBCol::ColOutcomesByBlockHash, block_hash.as_ref(), &hash_set)
             .expect("BorshSerialize should not fail");
     }
+    store_update.commit().expect("Failed to migrate");
 }
 
 pub fn fill_col_transaction_refcount(store: &Store) {
@@ -80,4 +81,5 @@ pub fn fill_col_transaction_refcount(store: &Store) {
             .set_ser(DBCol::ColTransactionRefCount, tx_hash.as_ref(), &refcount)
             .expect("BorshSerialize should not fail");
     }
+    store_update.commit().expect("Failed to migrate");
 }


### PR DESCRIPTION
@mikhailOK pointed that `fill_col_outcomes_by_hash` and `fill_col_transaction_refcount` are not committing into Store Update. This bug is fixed in https://github.com/nearprotocol/nearcore/pull/2961 however as we decided to postpone Dynamic Resharding, the fix has not been added separately by mistake.