### PR TITLE
Fix(controlled_edge_nonce) Increase nonce above 1000

### DIFF
--- a/pytest/tests/sanity/controlled_edge_nonce.py
+++ b/pytest/tests/sanity/controlled_edge_nonce.py
@@ -29,7 +29,7 @@ async def main():
 
     # First handshake attempt. Should fail with Genesis Mismatch
     handshake = create_handshake(my_key_pair_nacl, nodes[0].node_key.pk, 12345)
-    handshake.Handshake.edge_info.nonce = 5
+    handshake.Handshake.edge_info.nonce = 1505
     sign_handshake(my_key_pair_nacl, handshake.Handshake)
 
     await conn.send(handshake)


### PR DESCRIPTION
Currently we use as an heuristic edge nonce increase of at most
1000. This test detects that a node doesn't accept higher increases,
i.e. nonce should be > 1000.

Fixes #3166 

Test plan
========

controlled_edge_nonce.py should pass