### PR TITLE
fix(rpc): add validators_ordered endpoint for bridge

### DIFF
--- a/chain/chain/src/lib.rs
+++ b/chain/chain/src/lib.rs
@@ -4,7 +4,7 @@ extern crate lazy_static;
 pub use chain::{collect_receipts, Chain, MAX_ORPHAN_SIZE};
 pub use doomslug::{Doomslug, DoomslugBlockProductionReadiness, DoomslugThresholdMode};
 pub use error::{Error, ErrorKind};
-pub use lightclient::create_light_client_block_view;
+pub use lightclient::{create_light_client_block_view, get_epoch_block_producers_view};
 pub use store::{ChainStore, ChainStoreAccess, ChainStoreUpdate};
 pub use store_validator::{ErrorMessage, StoreValidator};
 pub use types::{

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -6,8 +6,8 @@ pub use crate::client_actor::{start_client, ClientActor};
 pub use crate::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
     GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice, GetNetworkInfo,
-    GetNextLightClientBlock, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo, Query,
-    Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
+    GetNextLightClientBlock, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo,
+    GetValidatorOrdered, Query, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
 };
 pub use crate::view_client::{start_view_client, ViewClientActor};
 

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -22,6 +22,7 @@ use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, ExecutionOutcomeWithIdView,
     FinalExecutionOutcomeView, GasPriceView, LightClientBlockLiteView, LightClientBlockView,
     QueryRequest, QueryResponse, StateChangesKindsView, StateChangesRequestView, StateChangesView,
+    ValidatorStakeView,
 };
 pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 
@@ -283,6 +284,14 @@ pub struct GetValidatorInfo {
 
 impl Message for GetValidatorInfo {
     type Result = Result<EpochValidatorInfo, String>;
+}
+
+pub struct GetValidatorOrdered {
+    pub block_id: MaybeBlockId,
+}
+
+impl Message for GetValidatorOrdered {
+    type Result = Result<Vec<ValidatorStakeView>, String>;
 }
 
 pub struct GetStateChanges {

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use near_primitives::hash::CryptoHash;
 use near_primitives::rpc::{
     RpcGenesisRecordsRequest, RpcQueryRequest, RpcStateChangesRequest, RpcStateChangesResponse,
+    RpcValidatorsOrderedRequest,
 };
 use near_primitives::types::{BlockId, BlockIdOrFinality, MaybeBlockId, ShardId};
 use near_primitives::views::{
@@ -231,9 +232,9 @@ impl JsonRpcClient {
     #[allow(non_snake_case)]
     pub fn EXPERIMENTAL_validators_ordered(
         &self,
-        block_id: BlockId,
+        request: RpcValidatorsOrderedRequest,
     ) -> RpcRequest<Vec<ValidatorStakeView>> {
-        call_method(&self.client, &self.server_addr, "EXPERIMENTAL_validators_ordered", [block_id])
+        call_method(&self.client, &self.server_addr, "EXPERIMENTAL_validators_ordered", request)
     }
 }
 

--- a/chain/jsonrpc/client/src/lib.rs
+++ b/chain/jsonrpc/client/src/lib.rs
@@ -12,7 +12,7 @@ use near_primitives::rpc::{
 use near_primitives::types::{BlockId, BlockIdOrFinality, MaybeBlockId, ShardId};
 use near_primitives::views::{
     BlockView, ChunkView, EpochValidatorInfo, FinalExecutionOutcomeView, GasPriceView,
-    GenesisRecordsView, QueryResponse, StatusResponse,
+    GenesisRecordsView, QueryResponse, StatusResponse, ValidatorStakeView,
 };
 
 use crate::message::{from_slice, Message, RpcError};
@@ -226,6 +226,14 @@ impl JsonRpcClient {
         request: RpcStateChangesRequest,
     ) -> RpcRequest<RpcStateChangesResponse> {
         call_method(&self.client, &self.server_addr, "EXPERIMENTAL_changes", request)
+    }
+
+    #[allow(non_snake_case)]
+    pub fn EXPERIMENTAL_validators_ordered(
+        &self,
+        block_id: BlockId,
+    ) -> RpcRequest<Vec<ValidatorStakeView>> {
+        call_method(&self.client, &self.server_addr, "EXPERIMENTAL_validators_ordered", [block_id])
     }
 }
 

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -38,7 +38,7 @@ use near_primitives::rpc::{
     RpcBroadcastTxSyncResponse, RpcGenesisRecordsRequest, RpcLightClientExecutionProofRequest,
     RpcLightClientExecutionProofResponse, RpcQueryRequest, RpcStateChangesInBlockRequest,
     RpcStateChangesInBlockResponse, RpcStateChangesRequest, RpcStateChangesResponse,
-    TransactionInfo,
+    RpcValidatorsOrderedRequest, TransactionInfo,
 };
 use near_primitives::serialize::{from_base, from_base64, BaseEncode};
 use near_primitives::transaction::SignedTransaction;
@@ -724,7 +724,8 @@ impl JsonRpcHandler {
     /// This endpoint is solely used for bridge currently and is not intended for other external use
     /// cases.
     async fn validators_ordered(&self, params: Option<Value>) -> Result<Value, RpcError> {
-        let (block_id,) = parse_params::<(MaybeBlockId,)>(params)?;
+        let RpcValidatorsOrderedRequest { block_id } =
+            parse_params::<RpcValidatorsOrderedRequest>(params)?;
         jsonify(self.view_client_addr.send(GetValidatorOrdered { block_id }).await)
     }
 }

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -22,7 +22,7 @@ use near_chain_configs::Genesis;
 use near_client::{
     ClientActor, GetBlock, GetBlockProof, GetChunk, GetExecutionOutcome, GetGasPrice,
     GetNetworkInfo, GetNextLightClientBlock, GetStateChanges, GetStateChangesInBlock,
-    GetValidatorInfo, Query, Status, TxStatus, TxStatusError, ViewClientActor,
+    GetValidatorInfo, GetValidatorOrdered, Query, Status, TxStatus, TxStatusError, ViewClientActor,
 };
 use near_crypto::PublicKey;
 pub use near_jsonrpc_client as client;
@@ -217,6 +217,7 @@ impl JsonRpcHandler {
             "broadcast_tx_commit" => self.send_tx_commit(request.params).await,
             "EXPERIMENTAL_check_tx" => self.check_tx(request.params).await,
             "validators" => self.validators(request.params).await,
+            "EXPERIMENTAL_validators_ordered" => self.validators_ordered(request.params).await,
             "query" => self.query(request.params).await,
             "health" => self.health().await,
             "status" => self.status().await,
@@ -717,6 +718,14 @@ impl JsonRpcHandler {
     async fn validators(&self, params: Option<Value>) -> Result<Value, RpcError> {
         let (block_id,) = parse_params::<(MaybeBlockId,)>(params)?;
         jsonify(self.view_client_addr.send(GetValidatorInfo { block_id }).await)
+    }
+
+    /// Returns the current epoch validators ordered in the block producer order with repetition.
+    /// This endpoint is solely used for bridge currently and is not intended for other external use
+    /// cases.
+    async fn validators_ordered(&self, params: Option<Value>) -> Result<Value, RpcError> {
+        let (block_id,) = parse_params::<(MaybeBlockId,)>(params)?;
+        jsonify(self.view_client_addr.send(GetValidatorOrdered { block_id }).await)
     }
 }
 

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -451,6 +451,17 @@ fn test_health_ok() {
     });
 }
 
+#[test]
+fn test_validators_ordered() {
+    test_with_client!(test_utils::NodeType::Validator, client, async move {
+        let validators = client.EXPERIMENTAL_validators_ordered(BlockId::Height(0)).await.unwrap();
+        assert_eq!(
+            validators.into_iter().map(|v| v.account_id).collect::<Vec<_>>(),
+            vec!["test1".to_string(), "test2".to_string()]
+        )
+    });
+}
+
 /// Retrieve genesis config via JSON RPC.
 /// WARNING: Be mindful about changing genesis structure as it is part of the public protocol!
 #[test]

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -10,6 +10,7 @@ use near_logger_utils::init_test_logger;
 use near_network::test_utils::WaitOrTimeout;
 use near_primitives::account::{AccessKey, AccessKeyPermission};
 use near_primitives::hash::CryptoHash;
+use near_primitives::rpc::RpcValidatorsOrderedRequest;
 use near_primitives::rpc::{RpcGenesisRecordsRequest, RpcPagination, RpcQueryRequest};
 use near_primitives::types::{BlockId, BlockIdOrFinality, Finality, ShardId};
 use near_primitives::version::PROTOCOL_VERSION;
@@ -454,7 +455,10 @@ fn test_health_ok() {
 #[test]
 fn test_validators_ordered() {
     test_with_client!(test_utils::NodeType::Validator, client, async move {
-        let validators = client.EXPERIMENTAL_validators_ordered(BlockId::Height(0)).await.unwrap();
+        let validators = client
+            .EXPERIMENTAL_validators_ordered(RpcValidatorsOrderedRequest { block_id: None })
+            .await
+            .unwrap();
         assert_eq!(
             validators.into_iter().map(|v| v.account_id).collect::<Vec<_>>(),
             vec!["test1".to_string(), "test2".to_string()]

--- a/core/primitives/src/rpc.rs
+++ b/core/primitives/src/rpc.rs
@@ -10,7 +10,7 @@ use validator_derive::Validate;
 use crate::hash::CryptoHash;
 use crate::merkle::MerklePath;
 use crate::transaction::SignedTransaction;
-use crate::types::{AccountId, BlockIdOrFinality, TransactionOrReceiptId};
+use crate::types::{AccountId, BlockIdOrFinality, MaybeBlockId, TransactionOrReceiptId};
 use crate::views::{
     ExecutionOutcomeWithIdView, LightClientBlockLiteView, QueryRequest, StateChangeWithCauseView,
     StateChangesKindsView, StateChangesRequestView,
@@ -91,4 +91,9 @@ pub struct RpcLightClientExecutionProofResponse {
 pub enum TransactionInfo {
     Transaction(SignedTransaction),
     TransactionId { hash: CryptoHash, account_id: AccountId },
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct RpcValidatorsOrderedRequest {
+    pub block_id: MaybeBlockId,
 }


### PR DESCRIPTION
Bridge currently uses `validator` rpc for retrieving validator information. However, the validator info returned there is not ordered in the block producer order, which caused incompatibility with `next_bps` returned by light client. This PR adds a separate endpoint `EXPERIMENTAL_validators_ordered` just for that purpose.

Test plan
---------
`test_validators_ordered`