### PR TITLE
fix: Final touch to (almost) remove flakiness from cross_shard_tx

### DIFF
--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -773,6 +773,7 @@ impl Client {
         if Some(&next_block_producer) == self.validator_signer.as_ref().map(|x| x.validator_id()) {
             self.collect_block_approval(&approval, true);
         } else {
+            debug!(target: "client", "Sending an approval {:?} from {} to {} for {}", approval.inner, approval.account_id, next_block_producer.clone(), approval.target_height);
             let approval_message = ApprovalMessage::new(approval, next_block_producer);
             self.network_adapter.do_send(NetworkRequests::Approval { approval_message });
         }

--- a/chain/client/tests/cross_shard_tx.rs
+++ b/chain/client/tests/cross_shard_tx.rs
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn test_cross_shard_tx() {
-        test_cross_shard_tx_common(64, false, false, false, 200, Some(2.4), None);
+        test_cross_shard_tx_common(64, false, false, false, 80, Some(2.4), None);
     }
 
     #[test]


### PR DESCRIPTION
After disabling seals, the minimum block time that `cross_shard_tx` can tolerate dropped drastically, to 80ms.
We recently introduced a check at the end of the test that makes sure that the block prod time is not too high, so that `cross_shard_tx` actually ends up producing lots of forks. That check was failing recently.
With 80ms block time the test passes very consistently.

Fixes #3140

Test plan:
http://nayduck.eastus.cloudapp.azure.com:3000/#/run/154