### PR TITLE
fix(chain): garbage collect genesis block

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -930,14 +930,27 @@ impl Chain {
         let sync_height = header.height();
         let gc_height = std::cmp::min(head.height + 1, sync_height);
 
-        // GC all the data from current tail up to `gc_height`
+        // GC all the data from current tail up to `gc_height`. In case tail points to a height where
+        // there is no block, we need to make sure that the last block before tail is cleaned.
         let tail = self.store.tail()?;
+        let mut tail_prev_block_cleaned = false;
         for height in tail..gc_height {
             if let Ok(blocks_current_height) = self.store.get_all_block_hashes_by_height(height) {
                 let blocks_current_height =
                     blocks_current_height.values().flatten().cloned().collect::<Vec<_>>();
                 for block_hash in blocks_current_height {
                     let mut chain_store_update = self.mut_store().store_update();
+                    if !tail_prev_block_cleaned {
+                        let prev_block_hash =
+                            *chain_store_update.get_block_header(&block_hash)?.prev_hash();
+                        if chain_store_update.get_block(&prev_block_hash).is_ok() {
+                            chain_store_update.clear_block_data(
+                                prev_block_hash,
+                                GCMode::StateSync { clear_block_info: true },
+                            )?;
+                        }
+                        tail_prev_block_cleaned = true;
+                    }
                     chain_store_update.clear_block_data(
                         block_hash,
                         GCMode::StateSync { clear_block_info: block_hash != prev_hash },

--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -1982,9 +1982,6 @@ impl<'a> ChainStoreUpdate<'a> {
     pub fn clear_chunk_data(&mut self, min_chunk_height: BlockHeight) -> Result<(), Error> {
         let chunk_tail = self.chunk_tail()?;
         for height in chunk_tail..min_chunk_height {
-            if height == self.get_genesis_height() {
-                continue;
-            }
             let chunk_hashes = self.get_all_chunk_hashes_by_height(height)?;
             for chunk_hash in chunk_hashes {
                 // 1. Delete chunk-related data
@@ -2000,7 +1997,6 @@ impl<'a> ChainStoreUpdate<'a> {
                 // 2. Delete chunk_hash-indexed data
                 let chunk_header_hash = chunk_hash.clone().into();
                 self.gc_col(ColChunks, &chunk_header_hash);
-                self.gc_col(ColChunkExtra, &chunk_header_hash);
                 self.gc_col(ColPartialChunks, &chunk_header_hash);
                 self.gc_col(ColInvalidChunks, &chunk_header_hash);
             }
@@ -2078,23 +2074,15 @@ impl<'a> ChainStoreUpdate<'a> {
             .expect("block data is not expected to be already cleaned")
             .clone();
         let height = block.header().height();
-        if height == self.get_genesis_height() {
-            if let GCMode::Fork(_) = gc_mode {
-                // Broken GC prerequisites found
-                assert!(false);
-            }
-            // Don't clean Genesis Block
-            self.merge(store_update);
-            return Ok(());
-        }
 
         // 2. Delete shard_id-indexed data (Receipts, State Headers and Parts, etc.)
         for shard_id in 0..block.header().chunk_mask().len() as ShardId {
-            let height_shard_id = get_block_shard_id(&block_hash, shard_id);
-            self.gc_col(ColOutgoingReceipts, &height_shard_id);
-            self.gc_col(ColIncomingReceipts, &height_shard_id);
-            self.gc_col(ColChunkPerHeightShard, &height_shard_id);
-            self.gc_col(ColNextBlockWithNewChunk, &height_shard_id);
+            let block_shard_id = get_block_shard_id(&block_hash, shard_id);
+            self.gc_col(ColOutgoingReceipts, &block_shard_id);
+            self.gc_col(ColIncomingReceipts, &block_shard_id);
+            self.gc_col(ColChunkPerHeightShard, &block_shard_id);
+            self.gc_col(ColNextBlockWithNewChunk, &block_shard_id);
+            self.gc_col(ColChunkExtra, &block_shard_id);
 
             // For incoming State Parts it's done in chain.clear_downloaded_parts()
             // The following code is mostly for outgoing State Parts.
@@ -3088,10 +3076,8 @@ mod tests {
         let trie = chain.runtime_adapter.get_tries();
         assert!(chain.clear_data(trie, 100).is_ok());
 
-        assert!(chain.get_block(&blocks[0].hash()).is_ok());
-
         // epoch didn't change so no data is garbage collected.
-        for i in 1..15 {
+        for i in 0..15 {
             println!("height = {} hash = {}", i, blocks[i].hash());
             if i < 8 {
                 assert!(chain.get_block(&blocks[i].hash()).is_err());
@@ -3120,6 +3106,7 @@ mod tests {
             DBCol::ColChunkPerHeightShard,
             DBCol::ColBlockRefCount,
             DBCol::ColOutcomesByBlockHash,
+            DBCol::ColChunkExtra,
         ];
         for col in DBCol::iter() {
             println!("current column is {:?}", col);
@@ -3133,7 +3120,7 @@ mod tests {
                             &col.try_to_vec().expect("Failed to serialize DBCol")
                         )
                         .unwrap(),
-                    Some(7)
+                    Some(8)
                 );
             } else {
                 assert_eq!(
@@ -3276,10 +3263,8 @@ mod tests {
             println!("ITERATION #{:?}", iter);
             assert!(chain.clear_data(trie.clone(), gc_blocks_limit).is_ok());
 
-            assert!(chain.get_block(&blocks[0].hash()).is_ok());
-
             // epoch didn't change so no data is garbage collected.
-            for i in 1..1000 {
+            for i in 0..1000 {
                 if i < (iter + 1) * gc_blocks_limit as usize {
                     assert!(chain.get_block(&blocks[i].hash()).is_err());
                     assert!(chain

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -14,7 +14,7 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunk, StateSyncInfo};
 use near_primitives::syncing::{ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey};
 use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
-use near_primitives::types::{AccountId, BlockHeight, EpochId, GCCount, ShardId};
+use near_primitives::types::{AccountId, BlockHeight, ChunkExtra, EpochId, GCCount, ShardId};
 use near_primitives::utils::get_block_shard_id_rev;
 use near_store::{DBCol, Store, TrieChanges, NUM_COLS, SHOULD_COL_GC, SKIP_COL_GC};
 use validate::StoreValidatorError;
@@ -187,6 +187,11 @@ impl StoreValidator {
                     );
                     // Check that all Txs in Chunk exist
                     self.check(&validate::chunk_tx_exists, &chunk_hash, &shard_chunk, col);
+                }
+                DBCol::ColChunkExtra => {
+                    let (block_hash, _) = get_block_shard_id_rev(key_ref)?;
+                    let chunk_extra = ChunkExtra::try_from_slice(value_ref)?;
+                    self.check(&validate::chunk_extra_block_exists, &block_hash, &chunk_extra, col);
                 }
                 DBCol::ColTrieChanges => {
                     let (block_hash, shard_id) = get_block_shard_id_rev(key_ref)?;

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -1023,6 +1023,8 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
     chain_genesis.epoch_length = epoch_length;
     let mut env = TestEnv::new_with_runtime(chain_genesis, 1, 1, runtimes);
     let mut blocks = vec![];
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    blocks.push(genesis_block);
     for i in 1..=epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         let block = env.clients[0].produce_block(i).unwrap().unwrap();
         env.process_block(0, block.clone(), Provenance::PRODUCED);
@@ -1033,10 +1035,10 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
 
         blocks.push(block);
     }
-    for i in 1..=epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
+    for i in 0..=epoch_length * (NUM_EPOCHS_TO_KEEP_STORE_DATA + 1) {
         println!("height = {}", i);
         if i < epoch_length {
-            let block_hash = *blocks[i as usize - 1].hash();
+            let block_hash = *blocks[i as usize].hash();
             assert!(matches!(
                 env.clients[0].chain.get_block(&block_hash).unwrap_err().kind(),
                 ErrorKind::BlockMissing(missing_block_hash) if missing_block_hash == block_hash
@@ -1051,7 +1053,7 @@ fn test_gc_with_epoch_length_common(epoch_length: NumBlocks) {
                 .get_all_block_hashes_by_height(i as BlockHeight)
                 .is_err());
         } else {
-            assert!(env.clients[0].chain.get_block(&blocks[i as usize - 1].hash()).is_ok());
+            assert!(env.clients[0].chain.get_block(&blocks[i as usize].hash()).is_ok());
             assert!(env.clients[0].chain.get_block_by_height(i).is_ok());
             assert!(env.clients[0]
                 .chain

--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -14,6 +14,7 @@ pytest --timeout=240 sanity/state_sync1.py
 pytest --timeout=900 sanity/state_sync2.py
 pytest --timeout=1200 sanity/state_sync3.py
 pytest --timeout=240 sanity/state_sync4.py
+pytest --timeout=240 sanity/state_sync5.py
 pytest --timeout=600 sanity/state_sync_routed.py manytx 115
 pytest --timeout=300 sanity/state_sync_late.py notx
 pytest --timeout=900 sanity/state_sync_massive.py

--- a/pytest/tests/sanity/state_sync5.py
+++ b/pytest/tests/sanity/state_sync5.py
@@ -1,0 +1,61 @@
+# Spin up one validator node and let it run for a while
+# Spin up another node that does state sync. Keep sending
+# transactions to that node and make sure it doesn't crash.
+
+import sys, time, base58
+
+sys.path.append('lib')
+
+from cluster import start_cluster, Key
+from transaction import sign_payment_tx
+
+MAX_SYNC_WAIT = 30
+EPOCH_LENGTH = 20
+
+node1_config = {
+    "consensus": {
+        "sync_step_period": {
+            "secs": 0,
+            "nanos": 200000000
+        }
+    },
+    "tracked_shards": [0]
+}
+nodes = start_cluster(
+    1, 1, 1, None,
+    [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
+     ["chunk_producer_kickout_threshold", 10]], {1: node1_config})
+time.sleep(2)
+nodes[1].kill()
+print('node1 is killed')
+
+status = nodes[0].get_status()
+block_hash = status['sync_info']['latest_block_hash']
+cur_height = status['sync_info']['latest_block_height']
+
+target_height = 60
+while cur_height < target_height:
+    status = nodes[0].get_status()
+    cur_height = status['sync_info']['latest_block_height']
+    time.sleep(1)
+
+genesis_block = nodes[0].json_rpc('block', [0])
+genesis_hash = genesis_block['result']['header']['hash']
+
+nodes[1].start(nodes[1].node_key.pk, nodes[1].addr())
+time.sleep(1)
+
+start_time = time.time()
+node1_height = 0
+nonce = 1
+while node1_height <= cur_height:
+    if time.time() - start_time > MAX_SYNC_WAIT:
+        assert False, "state sync timed out"
+    if nonce % 5 == 0:
+        status1 = nodes[1].get_status()
+        print(status1)
+        node1_height = status1['sync_info']['latest_block_height']
+    tx = sign_payment_tx(nodes[0].signer_key, 'test1', 1, nonce, base58.b58decode(genesis_hash.encode('utf8')))
+    nodes[1].send_tx(tx)
+    nonce += 1
+    time.sleep(0.05)


### PR DESCRIPTION
Fix a couple of issues with garbage collection:
* Garbage collect genesis block. Currently we garbage collect genesis state, but not genesis block before state sync. This causes an issue where if the node receives any request that requires it to fetch the state, the node will crash (for example, if it receives a transaction)
* Correctly garbage collect chunk_extra. Currently we save chunk extra on key (block_hash, shard_id) but garbage collect it on key chunk_hash. Needless to say, this doesn't really work.
* Add chunk extra validation to store validator

Test plan
---------
* `state_sync5.py`
* Run nightly to make sure there is no regression.