### PR TITLE
fix: skip signature verification in produce_chunk

### DIFF
--- a/neard/src/runtime.rs
+++ b/neard/src/runtime.rs
@@ -537,6 +537,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                 &mut state_update,
                 gas_price,
                 &transaction,
+                true,
             ) {
                 Ok(_) => Ok(None),
                 Err(RuntimeError::InvalidTxError(err)) => {
@@ -550,7 +551,7 @@ impl RuntimeAdapter for NightshadeRuntime {
             }
         } else {
             // Doing basic validation without a state root
-            match validate_transaction(&self.runtime.config, gas_price, &transaction) {
+            match validate_transaction(&self.runtime.config, gas_price, &transaction, true) {
                 Ok(_) => Ok(None),
                 Err(RuntimeError::InvalidTxError(err)) => {
                     debug!(target: "runtime", "Tx {:?} validation failed: {:?}", transaction, err);
@@ -594,6 +595,7 @@ impl RuntimeAdapter for NightshadeRuntime {
                             &mut state_update,
                             gas_price,
                             &tx,
+                            false,
                         ) {
                             Ok(verification_result) => {
                                 state_update.commit(StateChangeCause::NotWritableToDisk);

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -236,6 +236,7 @@ impl Runtime {
             state_update,
             apply_state.gas_price,
             signed_transaction,
+            true,
         ) {
             Ok(verification_result) => {
                 near_metrics::inc_counter(&metrics::TRANSACTION_PROCESSED_SUCCESSFULLY_TOTAL);

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -23,6 +23,7 @@ pub fn validate_transaction(
     config: &RuntimeConfig,
     gas_price: Balance,
     signed_transaction: &SignedTransaction,
+    verify_signature: bool,
 ) -> Result<TransactionCost, RuntimeError> {
     let transaction = &signed_transaction.transaction;
     let signer_id = &transaction.signer_id;
@@ -36,11 +37,13 @@ pub fn validate_transaction(
         .into());
     }
 
-    if !signed_transaction
-        .signature
-        .verify(signed_transaction.get_hash().as_ref(), &transaction.public_key)
-    {
-        return Err(InvalidTxError::InvalidSignature.into());
+    if verify_signature {
+        if !signed_transaction
+            .signature
+            .verify(signed_transaction.get_hash().as_ref(), &transaction.public_key)
+        {
+            return Err(InvalidTxError::InvalidSignature.into());
+        }
     }
 
     validate_actions(&config.wasm_config.limit_config, &transaction.actions)
@@ -59,9 +62,10 @@ pub fn verify_and_charge_transaction(
     state_update: &mut TrieUpdate,
     gas_price: Balance,
     signed_transaction: &SignedTransaction,
+    verify_signature: bool,
 ) -> Result<VerificationResult, RuntimeError> {
     let TransactionCost { gas_burnt, gas_remaining, receipt_gas_price, total_cost, burnt_amount } =
-        validate_transaction(config, gas_price, signed_transaction)?;
+        validate_transaction(config, gas_price, signed_transaction, verify_signature)?;
     let transaction = &signed_transaction.transaction;
     let signer_id = &transaction.signer_id;
 
@@ -473,13 +477,19 @@ mod tests {
         expected_err: RuntimeError,
     ) {
         assert_eq!(
-            validate_transaction(&config, gas_price, &signed_transaction)
+            validate_transaction(&config, gas_price, &signed_transaction, true)
                 .expect_err("expected an error"),
             expected_err,
         );
         assert_eq!(
-            verify_and_charge_transaction(&config, state_update, gas_price, &signed_transaction)
-                .expect_err("expected an error"),
+            verify_and_charge_transaction(
+                &config,
+                state_update,
+                gas_price,
+                &signed_transaction,
+                true
+            )
+            .expect_err("expected an error"),
             expected_err,
         );
     }
@@ -501,10 +511,15 @@ mod tests {
             deposit,
             CryptoHash::default(),
         );
-        validate_transaction(&config, gas_price, &transaction).expect("valid transaction");
-        let verification_result =
-            verify_and_charge_transaction(&config, &mut state_update, gas_price, &transaction)
-                .expect("valid transaction");
+        validate_transaction(&config, gas_price, &transaction, true).expect("valid transaction");
+        let verification_result = verify_and_charge_transaction(
+            &config,
+            &mut state_update,
+            gas_price,
+            &transaction,
+            true,
+        )
+        .expect("valid transaction");
         // Should not be free. Burning for sending
         assert!(verification_result.gas_burnt > 0);
         // All burned gas goes to the validators at current gas price
@@ -622,6 +637,7 @@ mod tests {
                     100,
                     CryptoHash::default(),
                 ),
+                false
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
@@ -686,6 +702,7 @@ mod tests {
                     100,
                     CryptoHash::default(),
                 ),
+                true
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::SignerDoesNotExist {
@@ -716,6 +733,7 @@ mod tests {
                     100,
                     CryptoHash::default(),
                 ),
+                true
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::InvalidNonce { tx_nonce: 1, ak_nonce: 2 }),
@@ -762,6 +780,7 @@ mod tests {
                 TESTING_INIT_BALANCE,
                 CryptoHash::default(),
             ),
+            true,
         )
         .expect_err("expected an error");
         if let RuntimeError::InvalidTxError(InvalidTxError::NotEnoughBalance {
@@ -811,6 +830,7 @@ mod tests {
                 })],
                 CryptoHash::default(),
             ),
+            true,
         )
         .expect_err("expected an error");
         if let RuntimeError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
@@ -850,6 +870,7 @@ mod tests {
                     transfer_amount,
                     CryptoHash::default(),
                 ),
+                true
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::LackBalanceForState {
@@ -898,6 +919,7 @@ mod tests {
                     ],
                     CryptoHash::default(),
                 ),
+                true
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
@@ -918,6 +940,7 @@ mod tests {
                     vec![],
                     CryptoHash::default(),
                 ),
+                true
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
@@ -938,6 +961,7 @@ mod tests {
                     vec![Action::CreateAccount(CreateAccountAction {})],
                     CryptoHash::default(),
                 ),
+                true
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
@@ -980,6 +1004,7 @@ mod tests {
                     }),],
                     CryptoHash::default(),
                 ),
+                true
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
@@ -1025,6 +1050,7 @@ mod tests {
                     }),],
                     CryptoHash::default(),
                 ),
+                true
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(
@@ -1067,6 +1093,7 @@ mod tests {
                     }),],
                     CryptoHash::default(),
                 ),
+                true
             )
             .expect_err("expected an error"),
             RuntimeError::InvalidTxError(InvalidTxError::InvalidAccessKeyError(


### PR DESCRIPTION
When we produce a chunk, we have already verified the signature of transactions in the mempool and we don't need to check the same signature again. Even if the key is removed, we can skip the signature check and the access key check will correctly fail in this case. 

Test plan
---------
Existing tests