### PR TITLE
fix: Bump runtime crates version to 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-fees"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "num-rational",
  "serde",
@@ -2676,7 +2676,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-standalone"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "near-crypto",
  "near-pool",
@@ -2724,7 +2724,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-errors"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "near-rpc-error-macro",
@@ -2733,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "base64 0.11.0",
  "bs58",
@@ -2748,7 +2748,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2767,7 +2767,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-standalone"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "base64 0.11.0",
  "clap 2.33.0",
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "assert_matches",
  "base64 0.11.0",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "borsh",
  "clap 2.33.0",

--- a/runtime/CHANGELOG.md
+++ b/runtime/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0
+
+- Same as `1.2.0`, but since it contained incompatible change, we had to bump major version.
+
 ## 1.2.0
 
 - Implement gas profiler [#3038](https://github.com/nearprotocol/nearcore/pull/3038)

--- a/runtime/near-runtime-fees/Cargo.toml
+++ b/runtime/near-runtime-fees/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-runtime-fees"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-errors/Cargo.toml
+++ b/runtime/near-vm-errors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-errors"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/runtime/near-vm-logic/Cargo.toml
+++ b/runtime/near-vm-logic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-logic"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,8 +20,8 @@ serde = { version = "1", features = ["derive"] }
 sha2 = "0.8"
 sha3 = "0.8"
 
-near-runtime-fees = { path = "../near-runtime-fees", version = "1.2.0" }
-near-vm-errors = { path = "../near-vm-errors", version = "1.2.0" }
+near-runtime-fees = { path = "../near-runtime-fees", version = "2.0.0" }
+near-vm-errors = { path = "../near-vm-errors", version = "2.0.0" }
 
 [dev-dependencies]
 serde_json = {version= "1", features= ["preserve_order"]}

--- a/runtime/near-vm-runner-standalone/Cargo.toml
+++ b/runtime/near-vm-runner-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner-standalone"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -25,9 +25,9 @@ base64 = "0.11"
 strum = "0.18"
 num-rational = { version = "0.2.4" }
 
-near-vm-logic = { path = "../near-vm-logic", version = "1.2.0", features = ["costs_counting"]}
-near-vm-runner = { path = "../near-vm-runner", version = "1.2.0", features = ["wasmtime_vm"] }
-near-runtime-fees = { path = "../near-runtime-fees", version = "1.2.0" }
+near-vm-logic = { path = "../near-vm-logic", version = "2.0.0", features = ["costs_counting"]}
+near-vm-runner = { path = "../near-vm-runner", version = "2.0.0", features = ["wasmtime_vm"] }
+near-runtime-fees = { path = "../near-runtime-fees", version = "2.0.0" }
 
 [features]
 default = []

--- a/runtime/near-vm-runner/Cargo.toml
+++ b/runtime/near-vm-runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-vm-runner"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 license = "Apache-2.0"
@@ -20,9 +20,9 @@ pwasm-utils = "0.12"
 parity-wasm = "0.41"
 wasmtime = { version = "0.17.0", features = ["lightbeam"], default-features = false, optional = true }
 anyhow = { version = "1.0.19", optional = true }
-near-runtime-fees = { path="../near-runtime-fees", version = "1.2.0" }
-near-vm-logic = { path="../near-vm-logic", version = "1.2.0", default-features = false, features = []}
-near-vm-errors = { path = "../near-vm-errors", version = "1.2.0" }
+near-runtime-fees = { path="../near-runtime-fees", version = "2.0.0" }
+near-vm-logic = { path="../near-vm-logic", version = "2.0.0", default-features = false, features = []}
+near-vm-errors = { path = "../near-vm-errors", version = "2.0.0" }
 
 [dev-dependencies]
 assert_matches = "1.3"

--- a/runtime/runtime-params-estimator/Cargo.toml
+++ b/runtime/runtime-params-estimator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runtime-params-estimator"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/runtime/runtime-standalone/Cargo.toml
+++ b/runtime/runtime-standalone/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-runtime-standalone"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/runtime/runtime/Cargo.toml
+++ b/runtime/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-runtime"
-version = "1.2.0"
+version = "2.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 


### PR DESCRIPTION
## 2.0.0

- Same as `1.2.0`, but since it contained incompatible change, we had to bump major version.

## Test plan
- CI