### PR TITLE
Added trunk as default neard version

### DIFF
--- a/neard/Cargo.toml
+++ b/neard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neard"
-version = "1.2.0"
+version = "0.0.1-master"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 default-run = "neard"


### PR DESCRIPTION
Currently the version is 1.2.0 and we are bumping the versions in release branches. This creates confusion on builds from master as they are in the format:

```
1.2.0 build: <commit>
```

and 

```
0.0.0 (trunk) build: <commit>
```
is a better indication that this is a master build on a specific commit. For an example look the canary node in testnet explorer.