### PR TITLE
fix: remove unnecessary computation in chunk receipt processing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-fees"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "num-rational 0.2.4",
  "serde",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-standalone"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "near-crypto",
  "near-pool",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-errors"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "borsh",
  "near-rpc-error-macro",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64 0.11.0",
  "bs58",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-standalone"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64 0.11.0",
  "clap 2.33.0",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "assert_matches",
  "base64 0.11.0",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "borsh",
  "clap 2.33.0",

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1461,7 +1461,7 @@ impl Chain {
             for receipt_proof in receipt_proofs {
                 let ReceiptProof(receipts, shard_proof) = receipt_proof;
                 let ShardProof { from_shard_id, to_shard_id: _, proof } = shard_proof;
-                let receipts_hash = hash(&ReceiptList(shard_id, receipts.to_vec()).try_to_vec()?);
+                let receipts_hash = hash(&ReceiptList(shard_id, receipts).try_to_vec()?);
                 let from_shard_id = *from_shard_id as usize;
 
                 let root_proof = block.chunks()[from_shard_id].inner.outgoing_receipts_root;
@@ -1690,7 +1690,7 @@ impl Chain {
                     _ => visited_shard_ids.insert(*from_shard_id),
                 };
                 let RootProof(root, block_proof) = &root_proofs[i][j];
-                let receipts_hash = hash(&ReceiptList(shard_id, receipts.to_vec()).try_to_vec()?);
+                let receipts_hash = hash(&ReceiptList(shard_id, receipts).try_to_vec()?);
                 // 4e. Proving the set of receipts is the subset of outgoing_receipts of shard `shard_id`
                 if !verify_path(*root, &proof, &receipts_hash) {
                     byzantine_assert!(false);

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -567,14 +567,14 @@ pub trait RuntimeAdapter: Send + Sync {
                 .cloned()
                 .collect();
             receipts_hashes
-                .push(hash(&ReceiptList(shard_id, shard_receipts).try_to_vec().unwrap()));
+                .push(hash(&ReceiptList(shard_id, &shard_receipts).try_to_vec().unwrap()));
         }
         receipts_hashes
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Serialize, Debug, Clone, Default)]
-pub struct ReceiptList(pub ShardId, pub Vec<Receipt>);
+#[derive(BorshSerialize, Serialize, Debug, Clone)]
+pub struct ReceiptList<'a>(pub ShardId, pub &'a Vec<Receipt>);
 
 /// The last known / checked height and time when we have processed it.
 /// Required to keep track of skipped blocks and not fallback to produce blocks at lower height.

--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -1051,7 +1051,7 @@ impl ShardsManager {
             ) {
                 let ReceiptProof(shard_receipts, receipt_proof) = proof;
                 let receipt_hash =
-                    hash(&ReceiptList(shard_id, shard_receipts.to_vec()).try_to_vec().unwrap());
+                    hash(&ReceiptList(shard_id, shard_receipts).try_to_vec().unwrap());
                 if !verify_path(
                     header.inner.outgoing_receipts_root,
                     &receipt_proof.proof,


### PR DESCRIPTION
Currently we already group receipts in `PartialEncodedChunk` by destination shard id and when we process them, we flatten receipts from all shard again and do the same grouping operation, which doesn't make much sense. This PR removes such redundancy.

Test plan
---------
* Nightly tests
* Test it on testnet.