### PR TITLE
fix(mocknet): use the chain itself to measure bps and tps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ pytest/.consent
 
 # empty contract Cargo.lock, this would prevent cargo update latest git version of near-bindgen
 /pytest/empty-contract-rs/Cargo.lock
+
+# logs from mocknet nodes
+/pytest/logs/

--- a/pytest/lib/data.py
+++ b/pytest/lib/data.py
@@ -1,0 +1,51 @@
+import numpy as np
+from sklearn.linear_model import LinearRegression
+
+
+def flatten(ll):
+    '''
+    Flattens a list of lists into a single list
+    '''
+    return [item for sublist in ll for item in sublist]
+
+
+def compute_cumulative(xs):
+    '''
+    Computes a running total (i.e. cumulative sum)
+    for the given list.
+    E.g. given [1, 2, 3, 4] the return value will be
+    [1, 3, 6, 10].
+    '''
+    total = xs[0]
+    result = [total]
+    for x in xs[1:]:
+        total += x
+        result.append(total)
+    return result
+
+
+def linear_regression(xs, ys):
+    '''
+    Fits a line `y = mx + b` to the given data points
+    '''
+    x = np.array(xs).reshape((-1, 1))
+    y = np.array(ys)
+    model = LinearRegression().fit(x, y)
+    return {
+        'slope': model.coef_[0],
+        'intercept': model.intercept_,
+        'R^2': model.score(x, y),
+    }
+
+
+def compute_rate(timestamps):
+    '''
+    Given a list of timestamps indicating the times
+    some event occured, returns the average rate at
+    which the events happen. If the units of the
+    timestamps are seconds, then the output units will
+    be `events/s`.
+    '''
+    cumulative_events = [i for i in range(1, len(timestamps) + 1)]
+    fit = linear_regression(timestamps, cumulative_events)
+    return fit['slope']

--- a/pytest/lib/mocknet.py
+++ b/pytest/lib/mocknet.py
@@ -2,6 +2,7 @@ import base58
 from cluster import GCloudNode, Key
 from metrics import Metrics
 from transaction import sign_payment_tx_and_get_hash, sign_staking_tx_and_get_hash
+import data
 import json
 import os
 import statistics
@@ -15,6 +16,7 @@ NODE_USERNAME = 'ubuntu'
 NODE_SSH_KEY_PATH = '~/.ssh/near_ops'
 KEY_TARGET_ENV_VAR = 'NEAR_PYTEST_KEY_TARGET'
 DEFAULT_KEY_TARGET = '/tmp/mocknet'
+TX_OUT_FILE = '/home/ubuntu/tx_events'
 
 TMUX_STOP_SCRIPT = '''
 while tmux has-session -t near; do
@@ -96,24 +98,25 @@ def setup_python_environments(nodes, wasm_contract):
     pmap(lambda n: setup_python_environment(n, wasm_contract), nodes)
 
 
-def start_load_test_helper_script(index, pk, sk):
+def start_load_test_helper_script(script, index, pk, sk):
     return f'''
         cd {PYTHON_DIR}
-        nohup ./venv/bin/python load_testing_helper.py {index} "{pk}" "{sk}" > load_test.out 2> load_test.err < /dev/null &
+        nohup ./venv/bin/python {script} {index} "{pk}" "{sk}" > load_test.out 2> load_test.err < /dev/null &
     '''
 
 
-def start_load_test_helper(node, pk, sk):
+def start_load_test_helper(node, script, pk, sk):
     m = node.machine
     print(f'INFO: Starting load_test_helper on {m.name}')
     index = int(m.name.split('node')[-1])
-    m.run('bash', input=start_load_test_helper_script(index, pk, sk))
+    m.run('bash', input=start_load_test_helper_script(script, index, pk, sk))
 
 
-def start_load_test_helpers(nodes):
+def start_load_test_helpers(nodes, script):
     account = get_validator_account(get_node(0))
-    pmap(lambda node: start_load_test_helper(node, account.pk, account.sk),
-         nodes)
+    pmap(
+        lambda node: start_load_test_helper(node, script, account.pk, account.sk
+                                           ), nodes)
 
 
 def get_log(node):
@@ -121,8 +124,10 @@ def get_log(node):
     target_file = f'./logs/{m.name}.log'
     m.download(f'/home/ubuntu/near.log', target_file)
 
+
 def get_logs(nodes):
     pmap(get_log, nodes)
+
 
 def get_epoch_length_in_blocks(node):
     m = node.machine
@@ -138,6 +143,65 @@ def get_metrics(node):
     (addr, port) = node.rpc_addr()
     metrics_url = f'http://{addr}:{port}/metrics'
     return Metrics.from_url(metrics_url)
+
+
+def get_timestamp(block):
+    return block['header']['timestamp'] / 1e9
+
+
+# Measure bps and tps by directly checking block timestamps and number of transactions
+# in each block.
+def chain_measure_bps_and_tps(archival_node,
+                              start_time,
+                              end_time,
+                              duration=None):
+    latest_block_hash = archival_node.get_status(
+    )['sync_info']['latest_block_hash']
+    curr_block = archival_node.get_block(latest_block_hash)['result']
+    curr_time = get_timestamp(curr_block)
+
+    if end_time is None:
+        end_time = curr_time
+    if start_time is None:
+        start_time = end_time - duration
+
+    # one entry per block, equal to the timestamp of that block
+    block_times = []
+    # one entry per block (because there is only one shard), equal to the number of transactions
+    tx_count = []
+    while curr_time > start_time:
+        if curr_time < end_time:
+            block_times.append(curr_time)
+            chunk_hash = curr_block['chunks'][0]['chunk_hash']
+            chunk = archival_node.get_chunk(chunk_hash)['result']
+            tx_count.append(len(chunk['transactions']))
+        prev_hash = curr_block['header']['prev_hash']
+        curr_block = archival_node.get_block(prev_hash)['result']
+        curr_time = get_timestamp(curr_block)
+    block_times.reverse()
+    tx_count.reverse()
+    tx_cumulative = data.compute_cumulative(tx_count)
+    bps = data.compute_rate(block_times)
+    tps_fit = data.linear_regression(block_times, tx_cumulative)
+    return {'bps': bps, 'tps': tps_fit['slope']}
+
+
+def get_tx_events_single_node(node):
+    try:
+        m = node.machine
+        target_file = f'./logs/{m.name}_txs'
+        m.download(TX_OUT_FILE, target_file)
+        with open(target_file) as f:
+            return [float(line.strip()) for line in f.readlines()]
+    except:
+        return []
+
+
+def get_tx_events(nodes):
+    run('mkdir ./logs/')
+    run('rm -rf ./logs/*_txs')
+    all_events = pmap(get_tx_events_single_node, nodes)
+    return sorted(data.flatten(all_events))
 
 
 # Sends the transaction to the network via `node` and checks for success.
@@ -267,3 +331,23 @@ def start_node(node):
     if pid == '':
         start_process = m.run('sudo -u ubuntu -i', input=TMUX_START_SCRIPT)
         assert start_process.returncode == 0, m.name + '\n' + start_process.stderr
+
+
+def reset_data(node, retries=0):
+    try:
+        m = node.machine
+        stop_node(node)
+        print(f'INFO: Clearing data directory of node {m.name}')
+        start_process = m.run('bash',
+                              input='/home/ubuntu/near unsafe_reset_data')
+        assert start_process.returncode == 0, m.name + '\n' + start_process.stderr
+    except:
+        if retries < 3:
+            print(
+                f'WARN: And error occured while clearing data directory, retrying'
+            )
+            reset_data(node, retries=retries + 1)
+        else:
+            raise Exception(
+                f'ERROR: Could not clear data directory for {node.machine.name}'
+            )

--- a/pytest/requirements.txt
+++ b/pytest/requirements.txt
@@ -11,3 +11,5 @@ python-rc==0.3.9
 tqdm
 deepdiff
 pynacl
+numpy
+sklearn


### PR DESCRIPTION
Previously blocks per second (bps) and transactions per second (tps) were computed based on metrics exposed by the node. However, these metrics may not always be an accurate measure (e.g. transactions will be double-counted in the case of a fork of the chain, and the bps metrics is an instantaneous snapshot rather than an average over a particular period of interest). Here, we change things so that bps and tps are measured based on the actual blockchain that is created by querying an archival node.

The `reset_data` function is also added to the mocknet library since it is useful when comparing different versions of the node or different configurations of the node (each run can start from a clean state to avoid possible interactions with existing state).