### PR TITLE
fix(test): fix test_4_20_kill1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,6 +2803,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
+ "near-actix-utils",
  "near-chain-configs",
  "near-crypto",
  "near-jsonrpc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ serde_json = "1"
 futures = "0.3"
 
 near-logger-utils = { path = "./test-utils/logger" }
+near-actix-utils = { path = "./utils/actix" }
 near-chain-configs = { path = "./core/chain-configs" }
 near-crypto = { path = "./core/crypto" }
 near-primitives = { path = "./core/primitives" }

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -159,11 +159,11 @@ lib near-chunks test::test_seal_removal
 lib --timeout=300 near-chain store::tests::test_clear_old_data_too_many_heights
 
 # other tests
-expensive nearcore test_simple test::test_2_10_multiple_nodes
-expensive nearcore test_simple test::test_4_10_multiple_nodes
-expensive nearcore test_simple test::test_7_10_multiple_nodes
+expensive --timeout=600 nearcore test_simple test::test_2_10_multiple_nodes
+expensive --timeout=600 nearcore test_simple test::test_4_10_multiple_nodes
+expensive --timeout=600 nearcore test_simple test::test_7_10_multiple_nodes
 
-expensive nearcore test_rejoin test::test_4_20_kill1
-expensive nearcore test_rejoin test::test_4_20_kill1_two_shards
-expensive nearcore test_rejoin test::test_4_20_kill2
+expensive --timeout=1200 nearcore test_rejoin test::test_4_20_kill1
+expensive --timeout=1200 nearcore test_rejoin test::test_4_20_kill1_two_shards
+expensive --timeout=1200 nearcore test_rejoin test::test_4_20_kill2
 

--- a/tests/test_rejoin.rs
+++ b/tests/test_rejoin.rs
@@ -53,6 +53,8 @@ mod test {
 
     fn test_kill_1(num_nodes: usize, num_trials: usize, two_shards: bool, test_prefix: &str) {
         warmup();
+        near_actix_utils::init_stop_on_panic();
+
         // Start all nodes, crash node#2, proceed, restart node #2 but crash node #3
         let crash1 = 2;
         let crash2 = 3;


### PR DESCRIPTION
Fixes #3141
Test was failing because it tried to query nodes before they were ready.
The fix is to properly wait until the node starts.
Also increase timeouts for tests that run nodes this way.

Test plan
---------
test_4_20_kill1