### PR TITLE
fix: remove sync head

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-fees"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "num-rational 0.2.4",
  "serde",
@@ -2690,7 +2690,7 @@ dependencies = [
 
 [[package]]
 name = "near-runtime-standalone"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "near-crypto",
  "near-pool",
@@ -2738,7 +2738,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-errors"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "borsh",
  "near-rpc-error-macro",
@@ -2747,7 +2747,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-logic"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64 0.11.0",
  "bs58",
@@ -2762,7 +2762,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -2781,7 +2781,7 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner-standalone"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64 0.11.0",
  "clap 2.33.0",
@@ -2889,7 +2889,7 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "assert_matches",
  "base64 0.11.0",
@@ -3659,7 +3659,7 @@ dependencies = [
 
 [[package]]
 name = "runtime-params-estimator"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "borsh",
  "clap 2.33.0",

--- a/chain/chain/tests/sync_chain.rs
+++ b/chain/chain/tests/sync_chain.rs
@@ -7,7 +7,7 @@ use near_primitives::merkle::PartialMerkleTree;
 fn chain_sync_headers() {
     init_test_logger();
     let (mut chain, _, bls_signer) = setup();
-    assert_eq!(chain.sync_head().unwrap().height, 0);
+    assert_eq!(chain.header_head().unwrap().height, 0);
     let mut blocks = vec![chain.get_block(&chain.genesis().hash().clone()).unwrap().clone()];
     let mut block_merkle_tree = PartialMerkleTree::default();
     for i in 0..4 {
@@ -22,5 +22,5 @@ fn chain_sync_headers() {
             panic!("Unexpected")
         })
         .unwrap();
-    assert_eq!(chain.sync_head().unwrap().height, 4);
+    assert_eq!(chain.header_head().unwrap().height, 4);
 }

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -57,6 +57,8 @@ use crate::StatusResponse;
 
 /// Multiplier on `max_block_time` to wait until deciding that chain stalled.
 const STATUS_WAIT_TIME_MULTIPLIER: u64 = 10;
+/// Drop blocks whose height are beyond head + horizon if it is not in the current epoch.
+const BLOCK_HORIZON: u64 = 500;
 /// `max_block_production_time` times this multiplier is how long we wait before rebroadcasting
 /// the current `head`
 const HEAD_STALL_MULTIPLIER: u32 = 4;
@@ -906,6 +908,16 @@ impl ClientActor {
     fn receive_block(&mut self, block: Block, peer_id: PeerId, was_requested: bool) {
         let hash = *block.hash();
         debug!(target: "client", "{:?} Received block {} <- {} at {} from {}, requested: {}", self.client.validator_signer.as_ref().map(|vs| vs.validator_id()), hash, block.header().prev_hash(), block.header().height(), peer_id, was_requested);
+        let head = unwrap_or_return!(self.client.chain.head());
+        if block.header().height() >= head.height + BLOCK_HORIZON
+            // ideally we should check whether we know about prev_hash,
+            // but we also want to avoid storage read here, so we use this simple heuristic.
+            && block.header().prev_hash() != &head.last_block_hash
+            && block.header().prev_hash() != &head.prev_block_hash
+        {
+            debug!(target: "client", "dropping block {} that is too far ahead. Block height {} current head height {}", block.hash(), block.header().height(), head.height);
+            return;
+        }
         let prev_hash = *block.header().prev_hash();
         let provenance =
             if was_requested { near_chain::Provenance::SYNC } else { near_chain::Provenance::NONE };

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -224,7 +224,6 @@ pub const HEAD_KEY: &[u8; 4] = b"HEAD";
 pub const TAIL_KEY: &[u8; 4] = b"TAIL";
 pub const CHUNK_TAIL_KEY: &[u8; 10] = b"CHUNK_TAIL";
 pub const FORK_TAIL_KEY: &[u8; 9] = b"FORK_TAIL";
-pub const SYNC_HEAD_KEY: &[u8; 9] = b"SYNC_HEAD";
 pub const HEADER_HEAD_KEY: &[u8; 11] = b"HEADER_HEAD";
 pub const LATEST_KNOWN_KEY: &[u8; 12] = b"LATEST_KNOWN";
 pub const LARGEST_TARGET_HEIGHT_KEY: &[u8; 21] = b"LARGEST_TARGET_HEIGHT";

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -14,7 +14,7 @@ use cached::{Cached, SizedCache};
 pub use db::DBCol::{self, *};
 pub use db::{
     CHUNK_TAIL_KEY, FORK_TAIL_KEY, HEADER_HEAD_KEY, HEAD_KEY, LARGEST_TARGET_HEIGHT_KEY,
-    LATEST_KNOWN_KEY, NUM_COLS, SHOULD_COL_GC, SKIP_COL_GC, SYNC_HEAD_KEY, TAIL_KEY,
+    LATEST_KNOWN_KEY, NUM_COLS, SHOULD_COL_GC, SKIP_COL_GC, TAIL_KEY,
 };
 use near_crypto::PublicKey;
 use near_primitives::account::{AccessKey, Account};


### PR DESCRIPTION
Address several issues related to syncing:
* `sync_head` is not really useful and caused issues because it can go backward during header sync. Therefore we decide to remove it.
* `get_locator` assumed that genesis height is 0.
* We removed the check for block height when we receive a block. This caused us to waste time processing blocks that are too far in the future only to reject them as orphans.

Test plan
----------
* Nightly tests http://nayduck.eastus.cloudapp.azure.com:3000/run#/run/241