### PR TITLE
fix: avoid unnecessary serialization of state parts

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1443,7 +1443,7 @@ impl Chain {
     ) -> Result<Vec<u8>, Error> {
         // Check cache
         let key = StatePartKey(sync_hash, shard_id, part_id).try_to_vec()?;
-        if let Ok(Some(state_part)) = self.store.owned_store().get_ser(ColStateParts, &key) {
+        if let Ok(Some(state_part)) = self.store.owned_store().get(ColStateParts, &key) {
             return Ok(state_part);
         }
 
@@ -1485,7 +1485,7 @@ impl Chain {
 
         // Saving the part data
         let mut store_update = self.store.owned_store().store_update();
-        store_update.set_ser(ColStateParts, &key, &state_part)?;
+        store_update.set(ColStateParts, &key, &state_part);
         store_update.commit()?;
 
         Ok(state_part)
@@ -1701,7 +1701,7 @@ impl Chain {
         // Saving the part data.
         let mut store_update = self.store.owned_store().store_update();
         let key = StatePartKey(sync_hash, shard_id, part_id).try_to_vec()?;
-        store_update.set_ser(ColStateParts, &key, data)?;
+        store_update.set(ColStateParts, &key, data);
         store_update.commit()?;
         Ok(())
     }
@@ -1718,7 +1718,7 @@ impl Chain {
         let mut parts = vec![];
         for part_id in 0..num_parts {
             let key = StatePartKey(sync_hash, shard_id, part_id).try_to_vec()?;
-            parts.push(self.store.owned_store().get_ser(ColStateParts, &key)?.unwrap());
+            parts.push(self.store.owned_store().get(ColStateParts, &key)?.unwrap());
         }
 
         // Confirm that state matches the parts we received

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -301,7 +301,7 @@ impl StoreValidator {
                 }
                 DBCol::ColStateParts => {
                     let key = StatePartKey::try_from_slice(key_ref)?;
-                    let part = Vec::<u8>::try_from_slice(value_ref)?;
+                    let part = value_ref.to_vec();
                     self.check(&validate::state_part_header_exists, &key, &part, col);
                 }
                 _ => {}

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -12,7 +12,7 @@ pub struct Version {
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 7;
+pub const DB_VERSION: DbVersion = 8;
 
 /// Protocol version type.
 pub type ProtocolVersion = u32;

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -14,7 +14,7 @@ use near_jsonrpc::start_http;
 use near_network::{NetworkRecipient, PeerManagerActor};
 use near_store::migrations::{
     fill_col_outcomes_by_hash, fill_col_transaction_refcount, get_store_version, migrate_6_to_7,
-    set_store_version,
+    migrate_7_to_8, set_store_version,
 };
 use near_store::{create_store, Store};
 use near_telemetry::TelemetryActor;
@@ -114,6 +114,12 @@ pub fn apply_store_migrations(path: &String) {
         // - move ColTransactionRefCount into ColTransactions
         // - make ColReceiptIdToShardId refcounted
         migrate_6_to_7(path);
+    }
+    if db_version <= 7 {
+        info!(target: "near", "Migrate DB from version 7 to 8");
+        // version 7 => 8:
+        // delete values in column `StateColParts`
+        migrate_7_to_8(path);
     }
 
     let db_version = get_store_version(path);


### PR DESCRIPTION
Today when we receive state parts, we borsh serialize them and then write the result to storage. The serialization here is unnecessary and wastes time.

Test plan
---------
Connect a node to testnet and observe that the time spent on `set_state_finalize` reduces by 0.3s after this change.