### PR TITLE
fix: increase timeout for `test_gc_star_large`

### DIFF
--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -149,7 +149,7 @@ expensive --timeout=1200 near-chain gc tests::test_gc_not_remove_fork_large
 expensive --timeout=1200 near-chain gc tests::test_gc_boundaries_large
 expensive --timeout=900 near-chain gc tests::test_gc_random_large
 expensive --timeout=600 near-chain gc tests::test_gc_pine
-expensive --timeout=600 near-chain gc tests::test_gc_star_large
+expensive --timeout=700 near-chain gc tests::test_gc_star_large
 expensive near-client process_blocks test_gc_after_state_sync
 
 # lib tests


### PR DESCRIPTION
The test takes between 8-10 minutes, so with the 600 seconds timeout is
hitting timeouts

Test plan
---------
http://nayduck.eastus.cloudapp.azure.com:3000/#/run/265