### PR TITLE
fix(chain): use correct gas price during state sync finalization

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -3355,6 +3355,9 @@ impl<'a> ChainUpdate<'a> {
             }
         }
         let receipts = collect_receipts_from_response(&receipt_proof_response);
+        // Prev block header should be present during state sync, since headers have been synced at this point.
+        let gas_price =
+            self.chain_store_update.get_block_header(block_header.prev_hash())?.gas_price();
 
         let gas_limit = chunk.header.inner.gas_limit;
         let mut apply_result = self.runtime_adapter.apply_transactions(
@@ -3367,7 +3370,7 @@ impl<'a> ChainUpdate<'a> {
             &receipts,
             &chunk.transactions,
             &chunk.header.inner.validator_proposals,
-            block_header.gas_price(),
+            gas_price,
             chunk.header.inner.gas_limit,
             &block_header.challenges_result(),
             *block_header.random_value(),
@@ -3449,7 +3452,7 @@ impl<'a> ChainUpdate<'a> {
             &[],
             &[],
             &chunk_extra.validator_proposals,
-            block_header.gas_price(),
+            prev_block_header.gas_price(),
             chunk_extra.gas_limit,
             &block_header.challenges_result(),
             *block_header.random_value(),

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -35,6 +35,7 @@ use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::verify_hash;
 use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper};
+use near_primitives::syncing::get_num_state_parts;
 use near_primitives::transaction::{
     Action, DeployContractAction, FunctionCallAction, SignedTransaction, Transaction,
 };
@@ -1974,4 +1975,89 @@ fn test_gas_price_change_no_chunk() {
     let block = env.clients[0].produce_block(22).unwrap().unwrap();
     let (_, res) = env.clients[0].process_block(block, Provenance::NONE);
     assert!(res.is_ok());
+}
+
+#[test]
+fn test_catchup_gas_price_change() {
+    init_test_logger();
+    let epoch_length = 5;
+    let min_gas_price = 10000;
+    let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
+    genesis.config.epoch_length = epoch_length;
+    genesis.config.min_gas_price = min_gas_price;
+    genesis.config.gas_limit = 1000000000000;
+    let runtimes: Vec<Arc<dyn RuntimeAdapter>> = vec![
+        Arc::new(neard::NightshadeRuntime::new(
+            Path::new("."),
+            create_test_store(),
+            Arc::new(genesis.clone()),
+            vec![],
+            vec![],
+        )),
+        Arc::new(neard::NightshadeRuntime::new(
+            Path::new("."),
+            create_test_store(),
+            Arc::new(genesis.clone()),
+            vec![],
+            vec![],
+        )),
+    ];
+    let chain_genesis = ChainGenesis::from(Arc::new(genesis));
+    let mut env = TestEnv::new_with_runtime(chain_genesis, 2, 1, runtimes);
+    let genesis_block = env.clients[0].chain.get_block_by_height(0).unwrap().clone();
+    let mut blocks = vec![];
+    for i in 1..3 {
+        let block = env.clients[0].produce_block(i).unwrap().unwrap();
+        blocks.push(block.clone());
+        env.process_block(0, block.clone(), Provenance::PRODUCED);
+        env.process_block(1, block, Provenance::NONE);
+    }
+    let signer = InMemorySigner::from_seed("test0", KeyType::ED25519, "test0");
+    for i in 0..3 {
+        let tx = SignedTransaction::send_money(
+            i + 1,
+            "test0".to_string(),
+            "test1".to_string(),
+            &signer,
+            1,
+            *genesis_block.hash(),
+        );
+        env.clients[0].process_tx(tx, false, false);
+    }
+    for i in 3..=6 {
+        let block = env.clients[0].produce_block(i).unwrap().unwrap();
+        blocks.push(block.clone());
+        env.process_block(0, block.clone(), Provenance::PRODUCED);
+        env.process_block(1, block, Provenance::NONE);
+    }
+
+    assert_ne!(blocks[3].header().gas_price(), blocks[4].header().gas_price());
+    assert!(env.clients[1].chain.get_chunk_extra(blocks[4].hash(), 0).is_err());
+
+    // Simulate state sync
+    let sync_hash = *blocks[5].hash();
+    assert!(env.clients[0].chain.check_sync_hash_validity(&sync_hash).unwrap());
+    let state_sync_header = env.clients[0].chain.get_state_response_header(0, sync_hash).unwrap();
+    let state_root = state_sync_header.chunk.header.inner.prev_state_root;
+    let state_root_node =
+        env.clients[0].runtime_adapter.get_state_root_node(0, &state_root).unwrap();
+    let num_parts = get_num_state_parts(state_root_node.memory_usage);
+    let state_sync_parts = (0..num_parts)
+        .map(|i| env.clients[0].chain.get_state_response_part(0, i, sync_hash).unwrap())
+        .collect::<Vec<_>>();
+
+    env.clients[1].chain.set_state_header(0, sync_hash, state_sync_header).unwrap();
+    for i in 0..num_parts {
+        env.clients[1]
+            .chain
+            .set_state_part(0, sync_hash, i, num_parts, &state_sync_parts[i as usize])
+            .unwrap();
+    }
+    env.clients[1].chain.set_state_finalize(0, sync_hash, num_parts).unwrap();
+    let chunk_extra_after_sync =
+        env.clients[1].chain.get_chunk_extra(blocks[4].hash(), 0).unwrap().clone();
+    let expected_chunk_extra =
+        env.clients[0].chain.get_chunk_extra(blocks[4].hash(), 0).unwrap().clone();
+    // The chunk extra of the prev block of sync block should be the same as the node that it is syncing from
+    assert_eq!(chunk_extra_after_sync, expected_chunk_extra);
 }


### PR DESCRIPTION
As mentioned in #3277, there is an inconsistency in gas price usage during state sync finalization, which can cause the state to diverge if gas price changes between sync block and its prev block.
Fixes #3277.

Test plan
---------
`test_catchup_gas_price_change`.