### PR TITLE
fix: Add NEAR Runtime utils README to be able to publish

### DIFF
--- a/runtime/near-runtime-utils/Cargo.toml
+++ b/runtime/near-runtime-utils/Cargo.toml
@@ -13,4 +13,7 @@ This crate contains utility functions for NEAR runtime.
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+# The crate should't include dependencies on `near-primitives` and `near-crypto` to keep the dependencies limited.
+# Historically, `near-primitives` contained a bunch of dependencies that prevented this crate from being compiled to Wasm.
+
 [dependencies]

--- a/runtime/near-runtime-utils/README.md
+++ b/runtime/near-runtime-utils/README.md
@@ -1,3 +1,6 @@
 # NEAR Runtime utilities
 
 This crate contains utility functions for NEAR runtime.
+
+The crate doesn't include dependencies on `near-primitives` and `near-crypto` to keep the dependencies limited.
+Historically, `near-primitives` contained a bunch of dependencies that prevented this crate from being compiled to Wasm.

--- a/runtime/near-runtime-utils/README.md
+++ b/runtime/near-runtime-utils/README.md
@@ -1,0 +1,3 @@
+# NEAR Runtime utilities
+
+This crate contains utility functions for NEAR runtime.


### PR DESCRIPTION
Missing README for a crate to publish

Going to publish runtime crates at `2.2.0`.

## Test plan:
- publish with dry-run