### PR TITLE
fix: generate validator key when chain-id is mainnet

### DIFF
--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -694,7 +694,7 @@ fn state_records_account_with_key(
     ]
 }
 
-/// Generate validator key if account is not `None`.
+/// Generate a validator key and save it to the file path.
 fn generate_validator_key(account_id: &str, path: &Path) {
     let signer = InMemoryValidatorSigner::from_random(account_id.to_string(), KeyType::ED25519);
     info!(target: "near", "Use key {} for {} to stake.", signer.public_key(), account_id);

--- a/neard/src/config.rs
+++ b/neard/src/config.rs
@@ -695,14 +695,10 @@ fn state_records_account_with_key(
 }
 
 /// Generate validator key if account is not `None`.
-fn generate_validator_key(account_id: Option<&str>, path: &Path) {
-    if let Some(account_id) =
-        account_id.and_then(|x| if x.is_empty() { None } else { Some(x.to_string()) })
-    {
-        let signer = InMemoryValidatorSigner::from_random(account_id.clone(), KeyType::ED25519);
-        info!(target: "near", "Use key {} for {} to stake.", signer.public_key(), account_id);
-        signer.write_to_file(path);
-    }
+fn generate_validator_key(account_id: &str, path: &Path) {
+    let signer = InMemoryValidatorSigner::from_random(account_id.to_string(), KeyType::ED25519);
+    info!(target: "near", "Use key {} for {} to stake.", signer.public_key(), account_id);
+    signer.write_to_file(path);
 }
 
 /// Initializes genesis and client configs and stores in the given folder
@@ -742,7 +738,9 @@ pub fn init_configs(
                     .expect("Failed to convert genesis file into string"),
             )
             .expect("Failed to deserialize MainNet genesis");
-            generate_validator_key(account_id, &dir.join(config.validator_key_file));
+            if let Some(account_id) = account_id {
+                generate_validator_key(account_id, &dir.join(config.validator_key_file));
+            }
 
             let network_signer = InMemorySigner::from_random("".to_string(), KeyType::ED25519);
             network_signer.write_to_file(&dir.join(config.node_key_file));
@@ -758,7 +756,9 @@ pub fn init_configs(
             config.telemetry.endpoints.push(NETWORK_TELEMETRY_URL.replace("{}", &chain_id));
             config.write_to_file(&dir.join(CONFIG_FILENAME));
 
-            generate_validator_key(account_id, &dir.join(config.validator_key_file));
+            if let Some(account_id) = account_id {
+                generate_validator_key(account_id, &dir.join(config.validator_key_file));
+            }
 
             let network_signer = InMemorySigner::from_random("".to_string(), KeyType::ED25519);
             network_signer.write_to_file(&dir.join(config.node_key_file));

--- a/neard/src/main.rs
+++ b/neard/src/main.rs
@@ -127,7 +127,8 @@ fn main() {
         ("init", Some(args)) => {
             // TODO: Check if `home` exists. If exists check what networks we already have there.
             let chain_id = args.value_of("chain-id");
-            let account_id = args.value_of("account-id");
+            let account_id =
+                args.value_of("account-id").and_then(|x| if x.is_empty() { None } else { Some(x) });
             let test_seed = args.value_of("test-seed");
             let genesis = args.value_of("genesis");
             let download = args.is_present("download-genesis");


### PR DESCRIPTION
Fixes #3286.

Test plan
---------
Test locally that when `chain-id` is `mainnet` and we pass an account id to neard, validator key is indeed generated.