### PR TITLE
fix(upgradability): address suboptimalities in upgradability

### DIFF
--- a/chain/chain/src/store.rs
+++ b/chain/chain/src/store.rs
@@ -2335,7 +2335,8 @@ impl<'a> ChainStoreUpdate<'a> {
             | DBCol::ColEpochInfo
             | DBCol::ColEpochStart
             | DBCol::ColBlockOrdinal
-            | DBCol::_ColTransactionRefCount => {
+            | DBCol::_ColTransactionRefCount
+            | DBCol::ColEpochId => {
                 unreachable!();
             }
         }

--- a/chain/epoch_manager/src/lib.rs
+++ b/chain/epoch_manager/src/lib.rs
@@ -15,7 +15,9 @@ use near_primitives::types::{
     AccountId, ApprovalStake, Balance, BlockChunkValidatorStats, BlockHeight, EpochId, ShardId,
     ValidatorId, ValidatorKickoutReason, ValidatorStake, ValidatorStats,
 };
-use near_primitives::version::ProtocolVersion;
+use near_primitives::version::{
+    ProtocolVersion, PROTOCOL_VERSION, UPGRADABILITY_FIX_PROTOCOL_VERSION,
+};
 use near_primitives::views::{
     CurrentEpochValidatorInfo, EpochValidatorInfo, NextEpochValidatorInfo, ValidatorKickoutView,
 };
@@ -233,6 +235,12 @@ impl EpochManager {
             .map(|&id| epoch_info.validators[*id as usize].stake)
             .sum();
 
+        let protocol_version = if PROTOCOL_VERSION >= UPGRADABILITY_FIX_PROTOCOL_VERSION {
+            next_epoch_info.protocol_version
+        } else {
+            epoch_info.protocol_version
+        };
+
         let next_version = if let Some((&version, stake)) =
             versions.into_iter().max_by(|left, right| left.1.cmp(&right.1))
         {
@@ -243,10 +251,10 @@ impl EpochManager {
             {
                 version
             } else {
-                epoch_info.protocol_version
+                protocol_version
             }
         } else {
-            epoch_info.protocol_version
+            protocol_version
         };
 
         // Gather slashed validators and add them to kick out first.
@@ -2966,6 +2974,72 @@ mod tests {
         );
         assert_eq!(
             epoch_manager.get_epoch_info(&EpochId(h[20])).unwrap().protocol_version,
+            PROTOCOL_VERSION
+        );
+    }
+
+    #[test]
+    fn test_protocol_version_switch_after_switch() {
+        let store = create_test_store();
+        let config = epoch_config(2, 1, 2, 0, 90, 60, 0);
+        let amount_staked = 1_000_000;
+        let validators = vec![stake("test1", amount_staked), stake("test2", amount_staked)];
+        let mut epoch_manager = EpochManager::new(
+            store.clone(),
+            config.clone(),
+            0,
+            default_reward_calculator(),
+            validators.clone(),
+        )
+        .unwrap();
+        let h = hash_range(10);
+        record_block(&mut epoch_manager, CryptoHash::default(), h[0], 0, vec![]);
+        for i in 1..3 {
+            let mut block_info = block_info(
+                i as u64,
+                i as u64 - 1,
+                h[i - 1],
+                h[i - 1],
+                h[0],
+                vec![],
+                DEFAULT_TOTAL_SUPPLY,
+            );
+            block_info.latest_protocol_version = PROTOCOL_VERSION - 1;
+            epoch_manager.record_block_info(&h[i], block_info, [0; 32]).unwrap();
+        }
+
+        for i in 3..5 {
+            record_block(&mut epoch_manager, h[i - 1], h[i], i as u64, vec![]);
+        }
+
+        for i in 5..7 {
+            let mut block_info = block_info(
+                i as u64,
+                i as u64 - 1,
+                h[i - 1],
+                h[i - 1],
+                h[0],
+                vec![],
+                DEFAULT_TOTAL_SUPPLY,
+            );
+            if i == 5 {
+                block_info.latest_protocol_version = PROTOCOL_VERSION - 1;
+            }
+            epoch_manager.record_block_info(&h[i], block_info, [0; 32]).unwrap();
+        }
+
+        assert_eq!(
+            epoch_manager.get_epoch_info(&EpochId(h[2])).unwrap().protocol_version,
+            PROTOCOL_VERSION - 1
+        );
+
+        assert_eq!(
+            epoch_manager.get_epoch_info(&EpochId(h[4])).unwrap().protocol_version,
+            PROTOCOL_VERSION
+        );
+
+        assert_eq!(
+            epoch_manager.get_epoch_info(&EpochId(h[6])).unwrap().protocol_version,
             PROTOCOL_VERSION
         );
     }

--- a/chain/epoch_manager/src/proposals.rs
+++ b/chain/epoch_manager/src/proposals.rs
@@ -41,7 +41,7 @@ pub(crate) fn find_threshold(
 pub fn proposals_to_epoch_info(
     epoch_config: &EpochConfig,
     rng_seed: RngSeed,
-    epoch_info: &EpochInfo,
+    prev_epoch_info: &EpochInfo,
     proposals: Vec<ValidatorStake>,
     mut validator_kickout: HashMap<AccountId, ValidatorKickoutReason>,
     validator_reward: HashMap<AccountId, Balance>,
@@ -67,7 +67,7 @@ pub fn proposals_to_epoch_info(
             ordered_proposals.insert(p.account_id.clone(), p);
         }
     }
-    for r in epoch_info.validators.iter() {
+    for r in prev_epoch_info.validators.iter() {
         if validator_kickout.contains_key(&r.account_id) {
             stake_change.insert(r.account_id.clone(), 0);
             continue;
@@ -77,7 +77,7 @@ pub fn proposals_to_epoch_info(
         stake_change.insert(p.account_id.clone(), p.stake);
     }
 
-    for r in epoch_info.fishermen.iter() {
+    for r in prev_epoch_info.fishermen.iter() {
         if validator_kickout.contains_key(&r.account_id) {
             stake_change.insert(r.account_id.clone(), 0);
             continue;
@@ -107,8 +107,8 @@ pub fn proposals_to_epoch_info(
             fishermen.push(p);
         } else {
             *stake_change.get_mut(&account_id).unwrap() = 0;
-            if epoch_info.validator_to_index.contains_key(&account_id)
-                || epoch_info.fishermen_to_index.contains_key(&account_id)
+            if prev_epoch_info.validator_to_index.contains_key(&account_id)
+                || prev_epoch_info.fishermen_to_index.contains_key(&account_id)
             {
                 validator_kickout.insert(
                     account_id,
@@ -156,8 +156,8 @@ pub fn proposals_to_epoch_info(
             fishermen.push(p);
         } else {
             stake_change.insert(p.account_id.clone(), 0);
-            if epoch_info.validator_to_index.contains_key(&p.account_id)
-                || epoch_info.fishermen_to_index.contains_key(&p.account_id)
+            if prev_epoch_info.validator_to_index.contains_key(&p.account_id)
+                || prev_epoch_info.fishermen_to_index.contains_key(&p.account_id)
             {
                 validator_kickout.insert(p.account_id, ValidatorKickoutReason::DidNotGetASeat);
             }
@@ -195,7 +195,7 @@ pub fn proposals_to_epoch_info(
         .collect::<HashMap<_, _>>();
 
     Ok(EpochInfo {
-        epoch_height: epoch_info.epoch_height + 1,
+        epoch_height: prev_epoch_info.epoch_height + 1,
         validators: final_proposals,
         fishermen,
         validator_to_index,

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -12,7 +12,7 @@ pub struct Version {
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 8;
+pub const DB_VERSION: DbVersion = 9;
 
 /// Protocol version type.
 pub type ProtocolVersion = u32;

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -18,7 +18,7 @@ pub const DB_VERSION: DbVersion = 8;
 pub type ProtocolVersion = u32;
 
 /// Current latest version of the protocol.
-pub const PROTOCOL_VERSION: ProtocolVersion = 35;
+pub const PROTOCOL_VERSION: ProtocolVersion = 36;
 /// TODO: Remove in next release. This is to allow nodes with initial version 34
 /// to be compatible with nodes at version 35
 pub const NETWORK_PROTOCOL_VERSION: ProtocolVersion = 34;
@@ -37,3 +37,5 @@ pub const CORRECT_RANDOM_VALUE_PROTOCOL_VERSION: ProtocolVersion = 33;
 
 /// See [NEP 71](https://github.com/nearprotocol/NEPs/pull/71)
 pub const IMPLICIT_ACCOUNT_CREATION_PROTOCOL_VERSION: ProtocolVersion = 35;
+
+pub const UPGRADABILITY_FIX_PROTOCOL_VERSION: ProtocolVersion = 36;

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -109,10 +109,12 @@ pub enum DBCol {
     _ColTransactionRefCount = 43,
     /// Heights of blocks that have been processed
     ColProcessedBlockHeights = 44,
+    /// Epoch id to prev epoch id
+    ColEpochId = 45,
 }
 
 // Do not move this line from enum DBCol
-pub const NUM_COLS: usize = 45;
+pub const NUM_COLS: usize = 46;
 
 impl std::fmt::Display for DBCol {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
@@ -162,6 +164,7 @@ impl std::fmt::Display for DBCol {
             Self::ColOutcomesByBlockHash => "outcomes by block hash",
             Self::_ColTransactionRefCount => "refcount per transaction (deprecated)",
             Self::ColProcessedBlockHeights => "processed block heights",
+            Self::ColEpochId => "epoch id to prev epoch id",
         };
         write!(formatter, "{}", desc)
     }

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -16,7 +16,7 @@ use near_network::{NetworkRecipient, PeerManagerActor};
 use near_rosetta_rpc::start_rosetta_rpc;
 use near_store::migrations::{
     fill_col_outcomes_by_hash, fill_col_transaction_refcount, get_store_version, migrate_6_to_7,
-    migrate_7_to_8, set_store_version,
+    migrate_7_to_8, migrate_8_to_9, set_store_version,
 };
 use near_store::{create_store, Store};
 use near_telemetry::TelemetryActor;
@@ -122,6 +122,12 @@ pub fn apply_store_migrations(path: &String) {
         // version 7 => 8:
         // delete values in column `StateColParts`
         migrate_7_to_8(path);
+    }
+    if db_version <= 8 {
+        info!(target: "near", "Migrate DB from version 8 to 9");
+        // version 8 => 9
+        // add column `ColEpochId`
+        migrate_8_to_9(path);
     }
 
     let db_version = get_store_version(path);

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -107,7 +107,7 @@ def main():
         nodes[i].binary_name = config['binary_name']
         nodes[i].start(nodes[0].node_key.pk, nodes[0].addr())
 
-    wait_for_blocks_or_timeout(nodes[3], 60, 120)
+    wait_for_blocks_or_timeout(nodes[3], 100, 240)
     status0 = nodes[0].get_status()
     status3 = nodes[3].get_status()
     protocol_version = status0['protocol_version']


### PR DESCRIPTION
Addresses a couple of suboptimalities mentioned in #3288:
* Use the last voted protocol version instead of current epoch protocol version when there is no change.
* Use `protocol_upgrade_num_epochs`.

Test plan
----------
* unit tests
* `upgradable.py`
* test migration on a real testnet node