### PR TITLE
fix(store): Fix ColTransactions and ColReceiptIdToShardId

### DIFF
--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -373,9 +373,10 @@ impl StoreValidator {
 mod tests {
     use near_store::test_utils::create_test_store;
 
-    use super::*;
     use crate::test_utils::KeyValueRuntime;
     use crate::{Chain, ChainGenesis, DoomslugThresholdMode};
+
+    use super::*;
 
     fn init() -> (Chain, StoreValidator) {
         let store = create_test_store();

--- a/chain/chain/src/store_validator/validate.rs
+++ b/chain/chain/src/store_validator/validate.rs
@@ -10,7 +10,7 @@ use near_primitives::sharding::{ChunkHash, ShardChunk, StateSyncInfo};
 use near_primitives::syncing::{
     get_num_state_parts, ShardStateSyncResponseHeader, StateHeaderKey, StatePartKey,
 };
-use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
+use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
 use near_primitives::types::{BlockHeight, ChunkExtra, EpochId, ShardId};
 use near_primitives::utils::{get_block_shard_id, index_to_bytes};
 use near_store::{
@@ -304,28 +304,13 @@ pub(crate) fn chunk_tx_exists(
         let tx_hash = tx.get_hash();
         sv.inner.tx_refcount.entry(tx_hash).and_modify(|x| *x += 1).or_insert(1);
     }
-    if let Some(me) = &sv.me {
-        if sv.runtime_adapter.cares_about_shard(
-            Some(me),
-            &shard_chunk.header.inner.prev_block_hash,
-            shard_chunk.header.inner.shard_id,
-            true,
-        ) || sv.runtime_adapter.will_care_about_shard(
-            Some(me),
-            &shard_chunk.header.inner.prev_block_hash,
-            shard_chunk.header.inner.shard_id,
-            true,
-        ) {
-            for tx in shard_chunk.transactions.iter() {
-                let _tx_hash = tx.get_hash();
-                // TODO #2930 Can't get Tx from ColTransactions
-                /* unwrap_or_err_db!(
-                    sv.store.get_ser::<SignedTransaction>(ColTransactions, &tx_hash.as_ref()),
-                    "Can't get Tx from storage for Tx Hash {:?}",
-                    tx_hash
-                ); */
-            }
-        }
+    for tx in shard_chunk.transactions.iter() {
+        let tx_hash = tx.get_hash();
+        unwrap_or_err_db!(
+            sv.store.get_ser::<SignedTransaction>(DBCol::ColTransactions, &tx_hash.as_ref()),
+            "Can't get Tx from storage for Tx Hash {:?}",
+            tx_hash
+        );
     }
     Ok(())
 }

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -12,7 +12,7 @@ pub struct Version {
 pub type DbVersion = u32;
 
 /// Current version of the database.
-pub const DB_VERSION: DbVersion = 8;
+pub const DB_VERSION: DbVersion = 9;
 
 /// Protocol version type.
 pub type ProtocolVersion = u32;

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -18,6 +18,7 @@ use near_primitives::version::DbVersion;
 
 use crate::db::refcount::merge_refcounted_records;
 
+pub(crate) mod migration_utils;
 pub(crate) mod refcount;
 pub(crate) mod v6_to_v7;
 
@@ -297,6 +298,9 @@ pub trait Database: Sync + Send {
         key_prefix: &'a [u8],
     ) -> Box<dyn Iterator<Item = (Box<[u8]>, Box<[u8]>)> + 'a>;
     fn write(&self, batch: DBTransaction) -> Result<(), DBError>;
+    fn as_rocksdb(&self) -> Option<&RocksDB> {
+        None
+    }
 }
 
 impl Database for RocksDB {
@@ -369,6 +373,10 @@ impl Database for RocksDB {
             }
         }
         Ok(self.db.write(batch)?)
+    }
+
+    fn as_rocksdb(&self) -> Option<&RocksDB> {
+        Some(self)
     }
 }
 

--- a/core/store/src/db/migration_utils.rs
+++ b/core/store/src/db/migration_utils.rs
@@ -1,0 +1,28 @@
+use rocksdb::IteratorMode;
+
+use crate::db::RocksDB;
+use crate::DBCol;
+
+impl RocksDB {
+    /// Clears the column using delete_range_cf()
+    pub(crate) fn clear_column(&self, column: DBCol) {
+        let cf_handle = unsafe { &*self.cfs[column as usize] };
+
+        let opt_first = self.db.iterator(IteratorMode::Start).next();
+        let opt_last = self.db.iterator(IteratorMode::End).next();
+        assert_eq!(opt_first.is_some(), opt_last.is_some());
+
+        if let Some((min_key, _)) = opt_first {
+            if let Some((max_key, _)) = opt_last {
+                if min_key != max_key {
+                    self.db
+                        .delete_range_cf(cf_handle, &min_key, &max_key)
+                        .expect("clear column failed");
+                }
+                self.db.delete_cf(cf_handle, max_key).expect("clear column failed");
+            }
+        }
+
+        assert!(self.db.iterator(IteratorMode::Start).next().is_none());
+    }
+}

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -141,6 +141,10 @@ impl Store {
         }
         self.storage.write(transaction).map_err(|e| e.into())
     }
+
+    pub(crate) fn get_rocksdb(&self) -> Option<&RocksDB> {
+        self.storage.as_rocksdb()
+    }
 }
 
 /// Keeps track of current changes to the database and can commit all of them to the database.

--- a/core/store/src/migrations.rs
+++ b/core/store/src/migrations.rs
@@ -14,9 +14,11 @@ use crate::db::{DBCol, RocksDB, VERSION_KEY};
 use crate::migrations::v6_to_v7::{
     col_state_refcount_8byte, migrate_col_transaction_refcount, migrate_receipts_refcount,
 };
+use crate::migrations::v8_to_v9::{repair_col_receipt_id_to_shard_id, repair_col_transactions};
 use crate::{create_store, Store, StoreUpdate};
 
 pub mod v6_to_v7;
+pub mod v8_to_v9;
 
 pub fn get_store_version(path: &str) -> DbVersion {
     RocksDB::get_version(path).expect("Failed to open the database")
@@ -114,4 +116,12 @@ pub fn migrate_7_to_8(path: &String) {
     }
     set_store_version_inner(&mut store_update, 8);
     store_update.commit().expect("Fail to migrate from DB version 7 to DB version 8");
+}
+
+// No format change. Recompute ColTransactions and ColReceiptIdToShardId because they could be inconsistent.
+pub fn migrate_8_to_9(path: &String) {
+    let store = create_store(path);
+    repair_col_transactions(&store);
+    repair_col_receipt_id_to_shard_id(&store);
+    set_store_version(&store, 9);
 }

--- a/core/store/src/migrations/v6_to_v7.rs
+++ b/core/store/src/migrations/v6_to_v7.rs
@@ -63,18 +63,18 @@ pub(crate) fn migrate_col_transaction_refcount(store: &Store, store_update: &mut
     }
 }
 
-fn get_num_shards(store: &Store) -> NumShards {
+pub(crate) fn get_num_shards(store: &Store) -> NumShards {
     store
         .iter(DBCol::ColBlock)
         .map(|(_key, value)| {
             Block::try_from_slice(value.as_ref()).expect("BorshDeserialize should not fail")
         })
-        .map(|block| block.chunks().len())
+        .map(|block| block.chunks().len() as u64)
         .next()
-        .expect("No blocks found") as u64
+        .unwrap_or(1)
 }
 
-fn account_id_to_shard_id_v6(account_id: &AccountId, num_shards: NumShards) -> ShardId {
+pub(crate) fn account_id_to_shard_id_v6(account_id: &AccountId, num_shards: NumShards) -> ShardId {
     let mut cursor = Cursor::new((hash(&account_id.clone().into_bytes()).0).0);
     cursor.read_u64::<LittleEndian>().expect("Must not happened") % (num_shards)
 }

--- a/core/store/src/migrations/v8_to_v9.rs
+++ b/core/store/src/migrations/v8_to_v9.rs
@@ -1,0 +1,74 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+use near_primitives::hash::CryptoHash;
+use near_primitives::receipt::Receipt;
+use near_primitives::sharding::ShardChunk;
+
+use crate::migrations::v6_to_v7::{account_id_to_shard_id_v6, get_num_shards};
+use crate::{DBCol, Store};
+
+/// Clear all data in the column, insert keys and values from iterator.
+/// Uses multiple writes.
+fn recompute_col_rc<Iter>(store: &Store, column: DBCol, values: Iter)
+where
+    Iter: Iterator<Item = (CryptoHash, Vec<u8>)>,
+{
+    assert!(crate::db::IS_COL_RC[column as usize]);
+    let mut batch_size = 0;
+    let batch_size_limit = 250_000_000;
+
+    store.get_rocksdb().unwrap().clear_column(column);
+
+    let mut store_update = store.store_update();
+
+    for (key, value) in values {
+        store_update.update_refcount(column, key.as_ref(), &value, 1);
+        batch_size += key.as_ref().len() + value.len() + 8;
+        if batch_size > batch_size_limit {
+            store_update.commit().expect(&format!("Failed during recomputing column {:?}", column));
+            store_update = store.store_update();
+            batch_size = 0;
+        }
+    }
+
+    if batch_size > 0 {
+        store_update.commit().expect(&format!("Failed during recomputing column {:?}", column));
+    }
+}
+
+// Make ColTransactions match transactions in ColChunks
+pub(crate) fn repair_col_transactions(store: &Store) {
+    recompute_col_rc(
+        store,
+        DBCol::ColTransactions,
+        store
+            .iter(DBCol::ColChunks)
+            .map(|(_key, value)| {
+                ShardChunk::try_from_slice(&value).expect("BorshDeserialize should not fail")
+            })
+            .flat_map(|chunk: ShardChunk| chunk.transactions)
+            .map(|tx| (tx.get_hash(), tx.try_to_vec().unwrap())),
+    )
+}
+
+// Make ColReceiptIdToShardId match receipts in ColOutgoingReceipts
+pub(crate) fn repair_col_receipt_id_to_shard_id(store: &Store) {
+    let num_shards = get_num_shards(&store);
+    recompute_col_rc(
+        store,
+        DBCol::ColReceiptIdToShardId,
+        store
+            .iter(DBCol::ColOutgoingReceipts)
+            .flat_map(|(_key, value)| {
+                <Vec<Receipt>>::try_from_slice(&value).expect("BorshDeserialize should not fail")
+            })
+            .map(|receipt| {
+                (
+                    receipt.receipt_id,
+                    account_id_to_shard_id_v6(&receipt.receiver_id, num_shards)
+                        .try_to_vec()
+                        .unwrap(),
+                )
+            }),
+    )
+}

--- a/neard/src/lib.rs
+++ b/neard/src/lib.rs
@@ -16,7 +16,7 @@ use near_network::{NetworkRecipient, PeerManagerActor};
 use near_rosetta_rpc::start_rosetta_rpc;
 use near_store::migrations::{
     fill_col_outcomes_by_hash, fill_col_transaction_refcount, get_store_version, migrate_6_to_7,
-    migrate_7_to_8, set_store_version,
+    migrate_7_to_8, migrate_8_to_9, set_store_version,
 };
 use near_store::{create_store, Store};
 use near_telemetry::TelemetryActor;
@@ -122,6 +122,12 @@ pub fn apply_store_migrations(path: &String) {
         // version 7 => 8:
         // delete values in column `StateColParts`
         migrate_7_to_8(path);
+    }
+    if db_version <= 8 {
+        info!(target: "near", "Migrate DB from version 8 to 9");
+        // version 8 => 9:
+        // Repair `ColTransactions`, `ColReceiptIdToShardId`
+        migrate_8_to_9(path);
     }
 
     let db_version = get_store_version(path);


### PR DESCRIPTION
Fix inconsistencies between code that writes to storage and gc.

ColTransactions:
one value per transaction per chunk in ColChunks
ColReceiptIdToShardId:
one value per receipt per record in ColOutgoingReceipts

Add a store migration that doesn't change the format, but recomputes
these columns.

Fixes #3247, #2930.

Test plan
---------
re-enable chunk_tx_exists in store-validator