### PR TITLE
feat: allow querying execution outcomes for a chunk from ViewClient

### DIFF
--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -5,9 +5,10 @@ pub use crate::client::Client;
 pub use crate::client_actor::{start_client, ClientActor};
 pub use crate::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
-    GetExecutionOutcome, GetExecutionOutcomeResponse, GetGasPrice, GetNetworkInfo,
-    GetNextLightClientBlock, GetStateChanges, GetStateChangesInBlock, GetValidatorInfo,
-    GetValidatorOrdered, Query, Status, StatusResponse, SyncStatus, TxStatus, TxStatusError,
+    GetExecutionOutcome, GetExecutionOutcomeForChunk, GetExecutionOutcomeResponse, GetGasPrice,
+    GetNetworkInfo, GetNextLightClientBlock, GetStateChanges, GetStateChangesInBlock,
+    GetValidatorInfo, GetValidatorOrdered, Query, Status, StatusResponse, SyncStatus, TxStatus,
+    TxStatusError,
 };
 #[cfg(feature = "adversarial")]
 pub use crate::view_client::AdversarialControls;

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -14,6 +14,7 @@ use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::sharding::ChunkHash;
+use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockReference, MaybeBlockId, ShardId, TransactionOrReceiptId,
 };
@@ -322,6 +323,15 @@ pub struct GetExecutionOutcomeResponse {
 
 impl Message for GetExecutionOutcome {
     type Result = Result<GetExecutionOutcomeResponse, String>;
+}
+
+pub struct GetExecutionOutcomeForChunk {
+    pub chunk_hash: ChunkHash,
+}
+
+impl Message for GetExecutionOutcomeForChunk {
+    // This is not exposed to rpc so we don't convert the result to a view.
+    type Result = Result<HashMap<CryptoHash, ExecutionOutcomeWithIdAndProof>, String>;
 }
 
 pub struct GetBlockProof {

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -2,17 +2,22 @@ use actix::System;
 use futures::{future, FutureExt};
 
 use near_client::test_utils::setup_no_network;
-use near_client::{GetBlockWithMerkleTree, Query, Status};
-use near_crypto::KeyType;
+use near_client::{
+    GetBlock, GetBlockWithMerkleTree, GetExecutionOutcomeForChunk, Query, Status, TxStatus,
+};
+use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
-use near_network::{NetworkClientMessages, PeerInfo};
+use near_network::{NetworkClientMessages, NetworkClientResponses, PeerInfo};
 use near_primitives::block::{Block, BlockHeader};
-use near_primitives::types::{BlockReference, EpochId};
+use near_primitives::sharding::ChunkHash;
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::types::{BlockId, BlockReference, EpochId};
 use near_primitives::utils::to_timestamp;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{QueryRequest, QueryResponseKind};
 use num_rational::Rational;
+use std::time::Duration;
 
 /// Query account from view client
 #[test]
@@ -88,6 +93,69 @@ fn query_status_not_crash() {
             );
             future::ready(())
         }));
+        near_network::test_utils::wait_or_panic(5000);
+    })
+    .unwrap();
+}
+
+#[test]
+fn test_execution_outcome_for_chunk() {
+    init_test_logger();
+    System::run(|| {
+        let (client, view_client) = setup_no_network(vec!["test"], "test", true, false);
+        let signer = InMemorySigner::from_seed("test", KeyType::ED25519, "test");
+
+        actix::spawn(async move {
+            let block_hash =
+                view_client.send(GetBlock::latest()).await.unwrap().unwrap().header.hash;
+
+            let transaction = SignedTransaction::send_money(
+                1,
+                "test".to_string(),
+                "near".to_string(),
+                &signer,
+                10,
+                block_hash,
+            );
+            let tx_hash = transaction.get_hash();
+            let res = client
+                .send(NetworkClientMessages::Transaction {
+                    transaction,
+                    is_forwarded: false,
+                    check_only: false,
+                })
+                .await
+                .unwrap();
+            assert!(matches!(res, NetworkClientResponses::ValidTx));
+
+            actix::clock::delay_for(Duration::from_millis(500)).await;
+
+            let execution_outcome = view_client
+                .send(TxStatus { tx_hash, signer_account_id: "test".to_string() })
+                .await
+                .unwrap()
+                .unwrap()
+                .unwrap();
+
+            let block = view_client
+                .send(GetBlock(BlockReference::BlockId(BlockId::Hash(
+                    execution_outcome.transaction_outcome.block_hash,
+                ))))
+                .await
+                .unwrap()
+                .unwrap();
+
+            let execution_outcomes_in_chunk = view_client
+                .send(GetExecutionOutcomeForChunk {
+                    chunk_hash: ChunkHash(block.chunks[0].chunk_hash),
+                })
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(execution_outcomes_in_chunk.len(), 1);
+            assert!(execution_outcomes_in_chunk.contains_key(&tx_hash));
+            System::current().stop();
+        });
         near_network::test_utils::wait_or_panic(5000);
     })
     .unwrap();


### PR DESCRIPTION
Fixes #3305.

Test plan
--------
`test_execution_outcome_for_chunk`.