### PR TITLE
feat(indexer): Explicitly add local receipts to StreamerMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2535,6 +2535,7 @@ dependencies = [
  "near-crypto",
  "near-primitives",
  "neard",
+ "node-runtime",
  "rocksdb",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix",
  "futures",

--- a/chain/indexer/CHANGELOG.md
+++ b/chain/indexer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+# 0.2.0
+
+* Refactor the way of fetching `ExecutionOutcome`s (use the new way to get all of them for specific block)
+* Change `Streamer.outcomes` type to `HashMap<CryptoHash, ExecutionOutcomeWithId>` and now it includes only `ExecutionOutcome`s for receipts (no transactions)
+* Introduce `IndexerTransactionWithOutcome` struct to contain `SignedTransactionView` and `ExecutionOutcomeWithId` for the transaction
+* Introduce `IndexerChunkView` to replace `StreamerMessage.chunks` to include `IndexerTransactionWithOutcome` vec in `transactions` 

--- a/chain/indexer/CHANGELOG.md
+++ b/chain/indexer/CHANGELOG.md
@@ -3,6 +3,6 @@
 # 0.2.0
 
 * Refactor the way of fetching `ExecutionOutcome`s (use the new way to get all of them for specific block)
-* Change `Streamer.outcomes` type to `HashMap<CryptoHash, ExecutionOutcomeWithId>` and now it includes only `ExecutionOutcome`s for receipts (no transactions)
+* Rename `StreamerMessage.outcomes` field to `receipt_execution_outcomes` and change type to `HashMap<CryptoHash, ExecutionOutcomeWithId>` and now it includes only `ExecutionOutcome`s for receipts (no transactions)
 * Introduce `IndexerTransactionWithOutcome` struct to contain `SignedTransactionView` and `ExecutionOutcomeWithId` for the transaction
 * Introduce `IndexerChunkView` to replace `StreamerMessage.chunks` to include `IndexerTransactionWithOutcome` vec in `transactions` 

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -15,3 +15,4 @@ neard = { path = "../../neard" }
 near-client = { path = "../client" }
 near-crypto = { path = "../../core/crypto" }
 near-primitives = { path = "../../core/primitives" }
+node-runtime = { path = "../../runtime/runtime" }

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-indexer"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 pub use neard::{get_default_home, init_configs, NearConfig};
 mod streamer;
 
-pub use self::streamer::{IndexerTransactionWithOutcome, StreamerMessage};
+pub use self::streamer::{IndexerChunkView, IndexerTransactionWithOutcome, StreamerMessage};
 pub use near_primitives;
 
 /// Enum to define a mode of syncing for NEAR Indexer

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -69,6 +69,7 @@ impl Indexer {
         actix::spawn(streamer::start(
             self.view_client.clone(),
             self.client.clone(),
+            self.near_config.clone(),
             self.indexer_config.clone(),
             sender,
         ));

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -13,7 +13,7 @@ use tokio::sync::mpsc;
 pub use neard::{get_default_home, init_configs, NearConfig};
 mod streamer;
 
-pub use self::streamer::{Outcome, StreamerMessage};
+pub use self::streamer::{IndexerTransactionWithOutcome, StreamerMessage};
 pub use near_primitives;
 
 /// Enum to define a mode of syncing for NEAR Indexer

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -1,3 +1,3 @@
 mod streamer;
 pub(crate) use self::streamer::start;
-pub use self::streamer::{IndexerTransactionWithOutcome, StreamerMessage};
+pub use self::streamer::{IndexerChunkView, IndexerTransactionWithOutcome, StreamerMessage};

--- a/chain/indexer/src/streamer/mod.rs
+++ b/chain/indexer/src/streamer/mod.rs
@@ -1,3 +1,3 @@
 mod streamer;
 pub(crate) use self::streamer::start;
-pub use self::streamer::{Outcome, StreamerMessage};
+pub use self::streamer::{IndexerTransactionWithOutcome, StreamerMessage};

--- a/chain/indexer/src/streamer/streamer.rs
+++ b/chain/indexer/src/streamer/streamer.rs
@@ -100,9 +100,7 @@ async fn fetch_block_by_hash(
     hash: CryptoHash,
 ) -> Result<views::BlockView, FailedToFetchData> {
     client
-        .send(near_client::GetBlock(near_primitives::types::BlockReference::BlockId(
-            near_primitives::types::BlockId::Hash(hash),
-        )))
+        .send(near_client::GetBlock(near_primitives::types::BlockId::Hash(hash).into()))
         .await?
         .map_err(|err| FailedToFetchData::String(err))
 }
@@ -246,7 +244,7 @@ async fn fetch_single_chunk(
 }
 
 /// Fetch all ExecutionOutcomeWithId for current block
-/// Returns the Hash where the key is Receipt or Transaction id and the value is ExecutionOutcomeWithId
+/// Returns a HashMap where the key is Receipt id or Transaction hash and the value is ExecutionOutcome wth id and proof
 async fn fetch_outcomes(
     client: &Addr<near_client::ViewClientActor>,
     block_hash: CryptoHash,

--- a/chain/indexer/src/streamer/streamer.rs
+++ b/chain/indexer/src/streamer/streamer.rs
@@ -226,7 +226,6 @@ pub(crate) async fn start(
 
     // TODO: implement proper error handling
     let db = DB::open_default(indexer_db_path).unwrap();
-    // let mut outcomes_to_get = Vec::<types::TransactionOrReceiptId>::new();
     let mut last_synced_block_height: Option<types::BlockHeight> = None;
 
     'main: loop {

--- a/tools/indexer/example/src/main.rs
+++ b/tools/indexer/example/src/main.rs
@@ -185,7 +185,7 @@ async fn listen_blocks(mut stream: mpsc::Receiver<near_indexer::StreamerMessage>
             streamer_message.chunks.len(),
             streamer_message.chunks.iter().map(|chunk| chunk.transactions.len()).sum::<usize>(),
             streamer_message.chunks.iter().map(|chunk| chunk.receipts.len()).sum::<usize>(),
-            streamer_message.outcomes.len(),
+            streamer_message.receipt_execution_outcomes.len(),
         );
     }
 }


### PR DESCRIPTION
As we found out some `AddKey` actions for transactions where signer is receiver (sir) the receipt created as "local" and is not included into `ChunkView`. But we need those receipts for indexing purposes altogether with `ExecutionOutcome` for such receipts. @bowenwang1996 addressed the issue https://github.com/nearprotocol/nearcore/issues/3305 to help us collect `ExecutionOutcomes` for specific block more easily (corresponding PR #3312) 

So in this update:

* `StreamerMessage` changes:
  * We add `local_receipts: Vec<near_primitives::views::ReceiptView>` to include local receipts
  * Rename `outcomes` field to `receipt_execution_outcomes`
  * `receipt_execution_outcomes` field type changed to be `HashMap<CryptoHash, near_primitives::views::ExecutionOutcomeWithIdView>` and includes **only Execution Outcomes for receipts**
  * `chunks` field type changes to be `Vec<IndexerChunkView>` where `transactions` field changes the type to `IndexerTransactionWithOutcome` (it is a wrapper around `near_primitives::views::SignedTransactionView`, it contains `transaction` itself and `outcome` for that transaction)