### PR TITLE
fix: chunk execution outcomes

### DIFF
--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1976,24 +1976,16 @@ impl Chain {
         }
     }
 
-    /// Get execution outcomes generated when the chunk is applied
-    pub fn get_chunk_execution_outcomes(
+    /// Get all execution outcomes generated when the chunk are applied
+    pub fn get_block_execution_outcomes(
         &mut self,
         block_hash: &CryptoHash,
-        shard_id: ShardId,
     ) -> Result<HashMap<CryptoHash, ExecutionOutcomeWithIdAndProof>, Error> {
         let execution_outcome_ids = self.mut_store().get_outcomes_by_block_hash(block_hash)?;
         let mut res = HashMap::new();
-        let runtime_adapter = self.runtime_adapter.clone();
-        // This is inefficient when there are more than one shard
         for id in execution_outcome_ids {
             let execution_outcome = self.get_execution_outcome(&id)?;
-            if runtime_adapter
-                .account_id_to_shard_id(&execution_outcome.outcome_with_id.outcome.executor_id)
-                == shard_id
-            {
-                res.insert(id, execution_outcome.clone());
-            }
+            res.insert(id, execution_outcome.clone());
         }
         Ok(res)
     }

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -1980,14 +1980,12 @@ impl Chain {
     pub fn get_block_execution_outcomes(
         &mut self,
         block_hash: &CryptoHash,
-    ) -> Result<HashMap<CryptoHash, ExecutionOutcomeWithIdAndProof>, Error> {
-        let execution_outcome_ids = self.mut_store().get_outcomes_by_block_hash(block_hash)?;
-        let mut res = HashMap::new();
-        for id in execution_outcome_ids {
-            let execution_outcome = self.get_execution_outcome(&id)?;
-            res.insert(id, execution_outcome.clone());
-        }
-        Ok(res)
+    ) -> Result<Vec<ExecutionOutcomeWithIdAndProof>, Error> {
+        self.mut_store()
+            .get_outcomes_by_block_hash(block_hash)?
+            .into_iter()
+            .map(|id| Ok(self.get_execution_outcome(&id)?.clone()))
+            .collect()
     }
 }
 

--- a/chain/client/src/lib.rs
+++ b/chain/client/src/lib.rs
@@ -5,7 +5,7 @@ pub use crate::client::Client;
 pub use crate::client_actor::{start_client, ClientActor};
 pub use crate::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree, GetChunk,
-    GetExecutionOutcome, GetExecutionOutcomeForChunk, GetExecutionOutcomeResponse, GetGasPrice,
+    GetExecutionOutcome, GetExecutionOutcomeResponse, GetExecutionOutcomesForBlock, GetGasPrice,
     GetNetworkInfo, GetNextLightClientBlock, GetStateChanges, GetStateChangesInBlock,
     GetValidatorInfo, GetValidatorOrdered, Query, Status, StatusResponse, SyncStatus, TxStatus,
     TxStatusError,

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -14,7 +14,6 @@ use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
 use near_primitives::sharding::ChunkHash;
-use near_primitives::transaction::ExecutionOutcomeWithIdAndProof;
 use near_primitives::types::{
     AccountId, BlockHeight, BlockReference, MaybeBlockId, ShardId, TransactionOrReceiptId,
 };
@@ -330,8 +329,7 @@ pub struct GetExecutionOutcomesForBlock {
 }
 
 impl Message for GetExecutionOutcomesForBlock {
-    // This is not exposed to rpc so we don't convert the result to a view.
-    type Result = Result<HashMap<CryptoHash, ExecutionOutcomeWithIdAndProof>, String>;
+    type Result = Result<Vec<ExecutionOutcomeWithIdView>, String>;
 }
 
 pub struct GetBlockProof {

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -325,12 +325,11 @@ impl Message for GetExecutionOutcome {
     type Result = Result<GetExecutionOutcomeResponse, String>;
 }
 
-pub struct GetExecutionOutcomeForChunk {
+pub struct GetExecutionOutcomesForBlock {
     pub block_hash: CryptoHash,
-    pub shard_id: ShardId,
 }
 
-impl Message for GetExecutionOutcomeForChunk {
+impl Message for GetExecutionOutcomesForBlock {
     // This is not exposed to rpc so we don't convert the result to a view.
     type Result = Result<HashMap<CryptoHash, ExecutionOutcomeWithIdAndProof>, String>;
 }

--- a/chain/client/src/types.rs
+++ b/chain/client/src/types.rs
@@ -326,7 +326,8 @@ impl Message for GetExecutionOutcome {
 }
 
 pub struct GetExecutionOutcomeForChunk {
-    pub chunk_hash: ChunkHash,
+    pub block_hash: CryptoHash,
+    pub shard_id: ShardId,
 }
 
 impl Message for GetExecutionOutcomeForChunk {

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -37,7 +37,7 @@ use near_primitives::views::{
 
 use crate::types::{
     Error, GetBlock, GetBlockProof, GetBlockProofResponse, GetBlockWithMerkleTree,
-    GetExecutionOutcome, GetExecutionOutcomeForChunk, GetGasPrice, Query, TxStatus, TxStatusError,
+    GetExecutionOutcome, GetExecutionOutcomesForBlock, GetGasPrice, Query, TxStatus, TxStatusError,
 };
 use crate::{
     sync, GetChunk, GetExecutionOutcomeResponse, GetNextLightClientBlock, GetStateChanges,
@@ -700,13 +700,11 @@ impl Handler<GetExecutionOutcome> for ViewClientActor {
     }
 }
 
-impl Handler<GetExecutionOutcomeForChunk> for ViewClientActor {
+impl Handler<GetExecutionOutcomesForBlock> for ViewClientActor {
     type Result = Result<HashMap<CryptoHash, ExecutionOutcomeWithIdAndProof>, String>;
 
-    fn handle(&mut self, msg: GetExecutionOutcomeForChunk, _: &mut Self::Context) -> Self::Result {
-        self.chain
-            .get_chunk_execution_outcomes(&msg.block_hash, msg.shard_id)
-            .map_err(|e| e.to_string())
+    fn handle(&mut self, msg: GetExecutionOutcomesForBlock, _: &mut Self::Context) -> Self::Result {
+        self.chain.get_block_execution_outcomes(&msg.block_hash).map_err(|e| e.to_string())
     }
 }
 

--- a/chain/client/src/view_client.rs
+++ b/chain/client/src/view_client.rs
@@ -698,6 +698,12 @@ impl Handler<GetExecutionOutcome> for ViewClientActor {
     }
 }
 
+/// Extract the list of execution outcomes that were produced in a given block
+/// (including those created for local receipts).
+///
+/// NOTE: The order of execution outcomes is NOT preserved (that would require
+/// data migration), so the order should be recovered from the transactions
+/// and receipts.
 impl Handler<GetExecutionOutcomesForBlock> for ViewClientActor {
     type Result = Result<Vec<ExecutionOutcomeWithIdView>, String>;
 

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -2063,7 +2063,7 @@ fn test_catchup_gas_price_change() {
 }
 
 #[test]
-fn test_chunk_execution_outcome() {
+fn test_block_execution_outcomes() {
     let epoch_length = 5;
     let min_gas_price = 10000;
     let mut genesis = Genesis::test(vec!["test0", "test1"], 1);
@@ -2140,6 +2140,7 @@ fn test_chunk_execution_outcome() {
     assert!(execution_outcomes_from_block[0].outcome_with_id.id == delayed_receipt_id[0]);
 }
 
+#[test]
 fn test_epoch_protocol_version_change() {
     init_test_logger();
     let epoch_length = 5;

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -2119,7 +2119,7 @@ fn test_chunk_execution_outcome() {
     let chunk = env.clients[0].chain.get_chunk(&block.chunks()[0].hash).unwrap().clone();
     assert_eq!(chunk.transactions.len(), 3);
     let execution_outcomes_from_chunk =
-        env.clients[0].chain.get_chunk_execution_outcomes(block.hash(), 0).unwrap();
+        env.clients[0].chain.get_block_execution_outcomes(block.hash()).unwrap();
     assert_eq!(execution_outcomes_from_chunk.len(), 5);
     for id in expected_outcome_ids {
         assert!(execution_outcomes_from_chunk.contains_key(&id));
@@ -2131,7 +2131,7 @@ fn test_chunk_execution_outcome() {
     assert!(next_chunk.transactions.is_empty());
     assert!(next_chunk.receipts.is_empty());
     let execution_outcomes_from_chunk =
-        env.clients[0].chain.get_chunk_execution_outcomes(next_block.hash(), 0).unwrap();
+        env.clients[0].chain.get_block_execution_outcomes(next_block.hash()).unwrap();
     assert_eq!(execution_outcomes_from_chunk.len(), 1);
     assert!(execution_outcomes_from_chunk.contains_key(&delayed_receipt_id[0]));
 }

--- a/chain/client/tests/process_blocks.rs
+++ b/chain/client/tests/process_blocks.rs
@@ -2099,17 +2099,17 @@ fn test_chunk_execution_outcome() {
         env.produce_block(0, i);
     }
 
-    let mut expected_outcome_ids = vec![];
+    let mut expected_outcome_ids = HashSet::new();
     let mut delayed_receipt_id = vec![];
     // Due to gas limit, the first two transaactions will create local receipts and they get executed
     // in the same block. The last local receipt will become delayed receipt
     for (i, id) in tx_hashes.into_iter().enumerate() {
         let execution_outcome = env.clients[0].chain.get_execution_outcome(&id).unwrap();
         assert_eq!(execution_outcome.outcome_with_id.outcome.receipt_ids.len(), 1);
-        expected_outcome_ids.push(id);
+        expected_outcome_ids.insert(id);
         if i < 2 {
             expected_outcome_ids
-                .push(execution_outcome.outcome_with_id.outcome.receipt_ids[0].clone());
+                .insert(execution_outcome.outcome_with_id.outcome.receipt_ids[0].clone());
         } else {
             delayed_receipt_id
                 .push(execution_outcome.outcome_with_id.outcome.receipt_ids[0].clone())
@@ -2118,20 +2118,24 @@ fn test_chunk_execution_outcome() {
     let block = env.clients[0].chain.get_block_by_height(2).unwrap().clone();
     let chunk = env.clients[0].chain.get_chunk(&block.chunks()[0].hash).unwrap().clone();
     assert_eq!(chunk.transactions.len(), 3);
-    let execution_outcomes_from_chunk =
+    let execution_outcomes_from_block =
         env.clients[0].chain.get_block_execution_outcomes(block.hash()).unwrap();
-    assert_eq!(execution_outcomes_from_chunk.len(), 5);
-    for id in expected_outcome_ids {
-        assert!(execution_outcomes_from_chunk.contains_key(&id));
-    }
+    assert_eq!(execution_outcomes_from_block.len(), 5);
+    assert_eq!(
+        execution_outcomes_from_block
+            .into_iter()
+            .map(|execution_outcome| execution_outcome.outcome_with_id.id)
+            .collect::<HashSet<_>>(),
+        expected_outcome_ids
+    );
 
     // Make sure the chunk outcomes contain the outcome from the delayed receipt.
     let next_block = env.clients[0].chain.get_block_by_height(3).unwrap().clone();
     let next_chunk = env.clients[0].chain.get_chunk(&next_block.chunks()[0].hash).unwrap().clone();
     assert!(next_chunk.transactions.is_empty());
     assert!(next_chunk.receipts.is_empty());
-    let execution_outcomes_from_chunk =
+    let execution_outcomes_from_block =
         env.clients[0].chain.get_block_execution_outcomes(next_block.hash()).unwrap();
-    assert_eq!(execution_outcomes_from_chunk.len(), 1);
-    assert!(execution_outcomes_from_chunk.contains_key(&delayed_receipt_id[0]));
+    assert_eq!(execution_outcomes_from_block.len(), 1);
+    assert!(execution_outcomes_from_block[0].outcome_with_id.id == delayed_receipt_id[0]);
 }

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -9,9 +9,8 @@ use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
 use near_network::{NetworkClientMessages, NetworkClientResponses, PeerInfo};
 use near_primitives::block::{Block, BlockHeader};
-use near_primitives::sharding::ChunkHash;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{BlockId, BlockReference, EpochId};
+use near_primitives::types::{BlockReference, EpochId};
 use near_primitives::utils::to_timestamp;
 use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
@@ -137,17 +136,10 @@ fn test_execution_outcome_for_chunk() {
                 .unwrap()
                 .unwrap();
 
-            let block = view_client
-                .send(GetBlock(BlockReference::BlockId(BlockId::Hash(
-                    execution_outcome.transaction_outcome.block_hash,
-                ))))
-                .await
-                .unwrap()
-                .unwrap();
-
             let execution_outcomes_in_chunk = view_client
                 .send(GetExecutionOutcomeForChunk {
-                    chunk_hash: ChunkHash(block.chunks[0].chunk_hash),
+                    block_hash: execution_outcome.transaction_outcome.block_hash,
+                    shard_id: 0,
                 })
                 .await
                 .unwrap()

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -136,15 +136,15 @@ fn test_execution_outcome_for_chunk() {
                 .unwrap()
                 .unwrap();
 
-            let execution_outcomes_in_chunk = view_client
+            let execution_outcomes_in_block = view_client
                 .send(GetExecutionOutcomesForBlock {
                     block_hash: execution_outcome.transaction_outcome.block_hash,
                 })
                 .await
                 .unwrap()
                 .unwrap();
-            assert_eq!(execution_outcomes_in_chunk.len(), 1);
-            assert!(execution_outcomes_in_chunk.contains_key(&tx_hash));
+            assert_eq!(execution_outcomes_in_block.len(), 1);
+            assert!(execution_outcomes_in_block[0].id == tx_hash);
             System::current().stop();
         });
         near_network::test_utils::wait_or_panic(5000);

--- a/chain/client/tests/query_client.rs
+++ b/chain/client/tests/query_client.rs
@@ -3,7 +3,7 @@ use futures::{future, FutureExt};
 
 use near_client::test_utils::setup_no_network;
 use near_client::{
-    GetBlock, GetBlockWithMerkleTree, GetExecutionOutcomeForChunk, Query, Status, TxStatus,
+    GetBlock, GetBlockWithMerkleTree, GetExecutionOutcomesForBlock, Query, Status, TxStatus,
 };
 use near_crypto::{InMemorySigner, KeyType};
 use near_logger_utils::init_test_logger;
@@ -137,9 +137,8 @@ fn test_execution_outcome_for_chunk() {
                 .unwrap();
 
             let execution_outcomes_in_chunk = view_client
-                .send(GetExecutionOutcomeForChunk {
+                .send(GetExecutionOutcomesForBlock {
                     block_hash: execution_outcome.transaction_outcome.block_hash,
-                    shard_id: 0,
                 })
                 .await
                 .unwrap()


### PR DESCRIPTION
In #3309 I misunderstood what @frol wanted and therefore only return the execution outcomes from transactions and receipts included in the chunk. This PR rectifies the error and it now returns all the execution outcomes generated when the chunk is applied, which includes execution outcomes for local and delayed receipts. Fixes #3305 

Test plan
--------
`test_chunk_execution_outcome`