### PR TITLE
fix: upgradable.py

### DIFF
--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -117,6 +117,8 @@ def main():
     assert 'error' not in res, res
     assert 'Failure' not in res['result']['status'], res
 
+    # hex_account_id = (b"I'm hex!" * 4).hex()
+    hex_account_id = '49276d206865782149276d206865782149276d206865782149276d2068657821'
     tx = sign_payment_tx(key=nodes[0].signer_key,
                          to=hex_account_id,
                          amount=10**25,

--- a/pytest/tests/sanity/upgradable.py
+++ b/pytest/tests/sanity/upgradable.py
@@ -90,22 +90,6 @@ def main():
     assert 'error' not in res, res
     assert 'Failure' not in res['result']['status'], res
 
-    # hex_account_id = (b"I'm hex!" * 4).hex()
-    hex_account_id = '49276d206865782149276d206865782149276d206865782149276d2068657821'
-    tx = sign_payment_tx(key=nodes[0].signer_key,
-                         to=hex_account_id,
-                         amount=10**25,
-                         nonce=3,
-                         blockHash=base58.b58decode(hash.encode('utf8')))
-    res = nodes[0].send_tx_and_wait(tx, timeout=20)
-    # Account doesn't exist
-    assert 'error' not in res, res
-    assert 'Failure' in res['result']['status'], res
-
-    # No account
-    res = nodes[0].get_account(hex_account_id)
-    assert 'error' in res, res
-
     wait_for_blocks_or_timeout(nodes[0], 20, 120)
 
     # Restart stable nodes into new version.


### PR DESCRIPTION
`upgradable.py` depends on the protocol version of the latest rc branch. Since the latest rc branch is already on version 35 now, we need to remove the check for implicit account creation.