### PR TITLE
fix: address slowness in block sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix",
  "actix-cors",


### PR DESCRIPTION
#3241 introduced an issue during block sync: it maintains `last_block_header` as the block header with largest height in the cache and has this logic that checks whether it is sufficiently close to header head and if it is, then the cache is ignored. However, the issue is that the sync loop runs every 10ms and therefore, it is almost always the case that this condition is triggered and the cache is effectively ignored. This PR fixes it by removing the condition.

Test plan
---------
Sync a node to testnet with this change and observe major improvements in syncing speed.