### PR TITLE
refactor(core): Implement FromStr instead of TryFrom<&str> for PublicKey to enable transparent usage of the type on clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "actix",
  "actix-cors",

--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fmt::Display;
 use std::string::FromUtf8Error;
 use std::time::Duration;
@@ -21,7 +20,6 @@ use near_client::{
     GetNetworkInfo, GetNextLightClientBlock, GetStateChanges, GetStateChangesInBlock,
     GetValidatorInfo, GetValidatorOrdered, Query, Status, TxStatus, TxStatusError, ViewClientActor,
 };
-use near_crypto::PublicKey;
 pub use near_jsonrpc_client as client;
 use near_jsonrpc_client::message::{Message, Request, RpcError};
 use near_jsonrpc_client::ChunkId;
@@ -519,7 +517,8 @@ impl JsonRpcHandler {
                     None => QueryRequest::ViewAccessKeyList { account_id },
                     Some(pk) => QueryRequest::ViewAccessKey {
                         account_id,
-                        public_key: PublicKey::try_from(pk)
+                        public_key: pk
+                            .parse()
                             .map_err(|_| RpcError::server_error(Some("Invalid public key")))?,
                     },
                 },

--- a/chain/jsonrpc/tests/rpc_query.rs
+++ b/chain/jsonrpc/tests/rpc_query.rs
@@ -300,10 +300,9 @@ fn test_query_access_key() {
                 block_reference: BlockReference::latest(),
                 request: QueryRequest::ViewAccessKey {
                     account_id: "test".to_string(),
-                    public_key: PublicKey::try_from(
-                        "ed25519:23vYngy8iL7q94jby3gszBnZ9JptpMf5Hgf7KVVa2yQ2",
-                    )
-                    .unwrap(),
+                    public_key: "ed25519:23vYngy8iL7q94jby3gszBnZ9JptpMf5Hgf7KVVa2yQ2"
+                        .parse()
+                        .unwrap(),
                 },
             })
             .await
@@ -584,8 +583,7 @@ fn test_view_access_key_non_existing_account_id_and_public_key_must_return_error
                 block_reference: BlockReference::latest(),
                 request: QueryRequest::ViewAccessKey {
                     account_id: "\u{0}\u{0}\u{0}\u{0}\u{0}9".to_string(),
-                    public_key: PublicKey::try_from("99999999999999999999999999999999999999999999")
-                        .unwrap(),
+                    public_key: "99999999999999999999999999999999999999999999".parse().unwrap(),
                 },
             })
             .await

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -115,7 +115,7 @@ impl FromStr for PeerInfo {
                 format!("Invalid PeerInfo format: {:?}", chunks),
             )));
         }
-        Ok(PeerInfo { id: PeerId(chunks[0].try_into()?), addr, account_id })
+        Ok(PeerInfo { id: PeerId(chunks[0].parse()?), addr, account_id })
     }
 }
 

--- a/core/primitives/src/transaction.rs
+++ b/core/primitives/src/transaction.rs
@@ -410,8 +410,6 @@ pub fn verify_transaction_signature(
 
 #[cfg(test)]
 mod tests {
-    use std::convert::TryInto;
-
     use borsh::BorshDeserialize;
 
     use near_crypto::{InMemorySigner, KeyType, Signature, Signer};
@@ -449,8 +447,7 @@ mod tests {
     /// If it does - you MUST update all of the dependencies: like nearlib and other clients.
     #[test]
     fn test_serialize_transaction() {
-        let public_key: PublicKey =
-            "22skMptHjFWNyuEWY22ftn2AbLPSYpmYwGJRGwpNHbTV".to_string().try_into().unwrap();
+        let public_key: PublicKey = "22skMptHjFWNyuEWY22ftn2AbLPSYpmYwGJRGwpNHbTV".parse().unwrap();
         let transaction = Transaction {
             signer_id: "test.near".to_string(),
             public_key: public_key.clone(),

--- a/genesis-tools/genesis-csv-to-json/src/serde_with.rs
+++ b/genesis-tools/genesis-csv-to-json/src/serde_with.rs
@@ -31,7 +31,6 @@ pub mod peer_info_to_str {
 pub mod pks_as_str {
     use near_crypto::PublicKey;
     use serde::{Deserialize, Deserializer, Serializer};
-    use std::convert::TryFrom;
 
     pub fn serialize<S>(peer_info: &Vec<PublicKey>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -50,7 +49,7 @@ pub mod pks_as_str {
             Ok(vec![])
         } else {
             s.retain(|c| !c.is_whitespace());
-            Ok(s.split(',').map(|c| PublicKey::try_from(c).unwrap()).collect())
+            Ok(s.split(',').map(|c| c.parse().unwrap()).collect())
         }
     }
 }

--- a/neard/src/genesis_validate.rs
+++ b/neard/src/genesis_validate.rs
@@ -109,7 +109,6 @@ mod test {
     use near_crypto::{KeyType, PublicKey};
     use near_primitives::account::{AccessKey, Account};
     use near_primitives::types::AccountInfo;
-    use std::convert::TryInto;
 
     const VALID_ED25519_RISTRETTO_KEY: &str = "ed25519:KuTCtARNzxZQ3YvXDeLjx83FDqxv2SdQTSbiq876zR7";
 
@@ -119,7 +118,7 @@ mod test {
         let mut genesis = Genesis::default();
         genesis.config.validators = vec![AccountInfo {
             account_id: "test".to_string(),
-            public_key: VALID_ED25519_RISTRETTO_KEY.try_into().unwrap(),
+            public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
         genesis.records = GenesisRecords(vec![StateRecord::Account {
@@ -161,7 +160,7 @@ mod test {
         let mut genesis = Genesis::default();
         genesis.config.validators = vec![AccountInfo {
             account_id: "test".to_string(),
-            public_key: VALID_ED25519_RISTRETTO_KEY.try_into().unwrap(),
+            public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 100,
         }];
         genesis.config.total_supply = 110;
@@ -190,7 +189,7 @@ mod test {
         let mut genesis = Genesis::default();
         genesis.config.validators = vec![AccountInfo {
             account_id: "test".to_string(),
-            public_key: VALID_ED25519_RISTRETTO_KEY.try_into().unwrap(),
+            public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
         genesis.config.total_supply = 110;
@@ -219,7 +218,7 @@ mod test {
         let mut genesis = Genesis::default();
         genesis.config.validators = vec![AccountInfo {
             account_id: "test".to_string(),
-            public_key: VALID_ED25519_RISTRETTO_KEY.try_into().unwrap(),
+            public_key: VALID_ED25519_RISTRETTO_KEY.parse().unwrap(),
             amount: 10,
         }];
         genesis.config.total_supply = 110;

--- a/runtime/runtime-params-estimator/src/cases.rs
+++ b/runtime/runtime-params-estimator/src/cases.rs
@@ -3,7 +3,7 @@ use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 use std::process;
 
 use near_crypto::{InMemorySigner, KeyType, PublicKey};
@@ -330,8 +330,7 @@ pub fn run(mut config: Config, only_compile: bool) -> RuntimeConfig {
     measure_transactions(Metric::ActionDeleteAccessKey, &mut m, &config, None, &mut f, false);
 
     // Measure the speed of staking.
-    let public_key: PublicKey =
-        "22skMptHjFWNyuEWY22ftn2AbLPSYpmYwGJRGwpNHbTV".to_string().try_into().unwrap();
+    let public_key: PublicKey = "22skMptHjFWNyuEWY22ftn2AbLPSYpmYwGJRGwpNHbTV".parse().unwrap();
     measure_actions(
         Metric::ActionStake,
         &mut m,

--- a/runtime/runtime/src/verifier.rs
+++ b/runtime/runtime/src/verifier.rs
@@ -427,7 +427,8 @@ fn validate_delete_account_action(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::sync::Arc;
+
     use near_crypto::{InMemorySigner, KeyType, PublicKey, Signer};
     use near_primitives::account::{AccessKey, Account, FunctionCallPermission};
     use near_primitives::hash::{hash, CryptoHash};
@@ -439,9 +440,9 @@ mod tests {
     use near_primitives::types::{AccountId, Balance, MerkleHash, StateChangeCause};
     use near_primitives::version::PROTOCOL_VERSION;
     use near_store::test_utils::create_tries;
-    use std::convert::TryInto;
-    use std::sync::Arc;
     use testlib::runtime_utils::{alice_account, bob_account, eve_dot_alice_account};
+
+    use super::*;
 
     /// Initial balance used in tests.
     const TESTING_INIT_BALANCE: Balance = 1_000_000_000 * NEAR_BASE;
@@ -1460,9 +1461,7 @@ mod tests {
             &VMLimitConfig::default(),
             &Action::Stake(StakeAction {
                 stake: 100,
-                public_key: "ed25519:KuTCtARNzxZQ3YvXDeLjx83FDqxv2SdQTSbiq876zR7"
-                    .try_into()
-                    .unwrap(),
+                public_key: "ed25519:KuTCtARNzxZQ3YvXDeLjx83FDqxv2SdQTSbiq876zR7".parse().unwrap(),
             }),
         )
         .expect("valid action");


### PR DESCRIPTION
This allows me to use PublicKey type inside clap-decorated structs to automatically validate the input.