### PR TITLE
Fix(network): Resolve handshake ties properly

### DIFF
--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1015,6 +1015,7 @@ pub enum ConsolidateResponse {
 pub struct Unregister {
     pub peer_id: PeerId,
     pub peer_type: PeerType,
+    pub remove_from_peer_store: bool,
 }
 
 pub struct PeerList {

--- a/nightly/nightly.txt
+++ b/nightly/nightly.txt
@@ -37,6 +37,7 @@ pytest --timeout=300 sanity/gc_after_sync1.py
 pytest --timeout=300 sanity/gc_sync_after_sync.py
 pytest --timeout=300 sanity/gc_sync_after_sync.py swap_nodes
 pytest --timeout=300 sanity/large_messages.py
+pytest --timeout=120 sanity/handshake_tie_resolution.py
 pytest sanity/controlled_edge_nonce.py
 pytest sanity/repro_2916.py
 pytest --timeout=240 sanity/switch_node_key.py

--- a/pytest/tests/sanity/handshake_tie_resolution.py
+++ b/pytest/tests/sanity/handshake_tie_resolution.py
@@ -1,0 +1,32 @@
+"""
+Spawn a cluster with four nodes. Check that no node tries to
+connect to another node that is currently connected.
+"""
+
+import sys, time
+
+sys.path.append('lib')
+
+from cluster import start_cluster
+from utils import LogTracker
+
+
+TIMEOUT = 150
+BLOCKS = 20
+
+nodes = start_cluster(4, 0, 4, None, [], {})
+
+started = time.time()
+
+
+trackers = [LogTracker(node) for node in nodes]
+
+while True:
+    assert time.time() - started < TIMEOUT
+
+    status = nodes[0].get_status()
+    height = status['sync_info']['latest_block_height']
+    if height >= BLOCKS:
+        break
+
+assert all(not tracker.check('Dropping handshake (Active Peer).') for tracker in trackers)


### PR DESCRIPTION
There existed a situation if two peers A and B initiated the handshake
almost at the same time, the a tie happens, and it is resolved in favor
of the connection initiated by the peer with smaller PeerId.

Let's say A < B. There is a situation in which both started connection
at the same time, and connection initiated from A is resolved first, so
both peers successfully consolidate connection with each other. However
when the second connection is removed, B call Unregister (this is always
called when a PeerActor is stopped) removing A from the set of active
peers incorrectly.

This situation was surfaced after decreasing the retry timeout to the
order of milliseconds, letting such connections happenning almost
simulatenously.

Solution: Add a flag to the Unregister signal, such that a peer is only
removed from the active peer and the peer store (as connected) if this
PeerActor was connected at some point in the past.

Testplan
========
handshake_tie_resolution.py should pass