### PR TITLE
Adding ability to run stress tests on preexisting instances

### DIFF
--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -24,6 +24,7 @@ from proxy import NodesProxy
 os.environ["ADVERSARY_CONSENT"] = "1"
 
 remote_nodes = []
+preexisting = None
 remote_nodes_lock = threading.Lock()
 cleanup_remote_nodes_atexit_registered = False
 
@@ -87,6 +88,8 @@ class BaseNode(object):
         self._start_proxy = None
         self._proxy_local_stopped = None
         self.proxy = None
+        self.store_tests = 0
+        self.is_check_store = True
 
 
     def _get_command_line(self,
@@ -267,8 +270,6 @@ class LocalNode(BaseNode):
         self.near_root = near_root
         self.node_dir = node_dir
         self.binary_name = binary_name
-        self.store_tests = 0
-        self.is_check_store = True
         self.cleaned = False
         with open(os.path.join(node_dir, "config.json")) as f:
             config_json = json.loads(f.read())
@@ -521,6 +522,146 @@ chmod +x near
                             f'/home/{self.machine.username}/.near/')
 
 
+def github_auth():
+    print("Go to the following link in your browser:")
+    print()
+    print("http://nayduck.eastus.cloudapp.azure.com:3000/local_auth")
+    print()
+    code = input("Enter verification code: ")
+    with open(os.path.expanduser('~/.nayduck'), 'w') as f:
+        f.write(code)
+    return code
+
+class AzureNode(BaseNode):
+        def __init__(self, ip, token, node_dir):
+            super(AzureNode, self).__init__()
+            self.ip = ip
+            self.token = token
+            self.near_root = '/datadrive/testnodes/worker/nearcore/target/debug'
+            self.port = 24567
+            self.rpc_port = 3030
+            self.node_dir = node_dir
+            self._upload_config_files(node_dir)
+
+        def _upload_config_files(self, node_dir):
+            post = {'ip': self.ip, 'token': self.token}
+            res = requests.post('http://40.112.59.229:5000/cleanup', json=post)
+            for f in os.listdir(node_dir):
+                if f.endswith(".json"):
+                    with open(os.path.join(node_dir, f), "r") as fl:
+                        cnt = fl.read()
+                    post = {'ip': self.ip, 'cnt': cnt, 'fl_name': f, 'token': self.token}
+                    res = requests.post('http://40.112.59.229:5000/upload', json=post)
+                    json_res = json.loads(res.text)
+                    if json_res['stderr'] != '':
+                        print(json_res['stderr'])
+                        sys.exit()
+            self.validator_key = Key.from_json_file(
+                os.path.join(node_dir, "validator_key.json"))
+            self.node_key = Key.from_json_file(
+                os.path.join(node_dir, "node_key.json"))
+            self.signer_key = Key.from_json_file(
+                os.path.join(node_dir, "validator_key.json"))
+
+        def start(self, boot_key, boot_node_addr):
+            cmd = ('RUST_BACKTRACE=1 ADVERSARY_CONSENT=1 ' + ' '.join(
+                self._get_command_line(self.near_root,
+                                       '.near', boot_key, boot_node_addr)).
+                                     replace("--verbose", '--verbose ""'))
+            post = {'ip': self.ip, 'cmd': cmd, 'token': self.token}
+            res = requests.post('http://40.112.59.229:5000/run_cmd', json=post)
+            json_res = json.loads(res.text)
+            if json_res['stderr'] != '':
+                print(json_res['stderr'])
+                sys.exit()
+
+        def kill(self):
+            cmd = ('killall -9 neard')
+            post = {'ip': self.ip, 'cmd': cmd, 'token': self.token}
+            res = requests.post('http://40.112.59.229:5000/run_cmd', json=post)
+            json_res = json.loads(res.text)
+            if json_res['stderr'] != '':
+                print(json_res['stderr'])
+            sys.exit()
+
+        def addr(self):
+            return (self.ip, self.port)
+
+        def rpc_addr(self):
+            return (self.ip, self.rpc_port)
+
+
+class PreexistingCluster():
+        
+    def __init__(self, num_nodes, node_dirs):
+        if os.path.isfile(os.path.expanduser('~/.nayduck')):
+            with open(os.path.expanduser('~/.nayduck'), 'r') as f:
+                self.token = f.read().strip()
+        else:
+            self.token = github_auth().strip()
+        self.nodes = []
+        sha = subprocess.check_output(['git', 'rev-parse', 'HEAD'], universal_newlines=True).strip()
+        requester = subprocess.check_output(['git', 'config', 'user.name'], universal_newlines=True).strip()
+        post = {'sha': sha, 'requester': requester, 
+                'num_nodes': num_nodes, 'token': self.token}
+        res = requests.post('http://40.112.59.229:5000/request_a_run', json=post)
+        json_res = json.loads(res.text)
+        if json_res['code'] == -1:
+            print(json_res['err'])
+            return
+        self.request_id = json_res['request_id']
+        self.ips = []
+        atexit.register(self.atexit_cleanup_preexist)
+        while True:
+            post = {'num_nodes': num_nodes, 'request_id': self.request_id,
+                    'token': self.token}
+            res = requests.post('http://40.112.59.229:5000/get_instances', json=post)
+            json_res = json.loads(res.text)
+            self.ips = json_res['ips']
+            for i in range(0, num_nodes):
+                node = AzureNode(json_res['ips'][i], self.token, node_dirs[i])
+                self.nodes.append(node)
+            print('Got %s nodes out of %s asked\r' % (len(self.nodes), num_nodes),  end='\r')
+            if len(self.nodes) == num_nodes:
+                break
+            time.sleep(10)
+        print()
+        while True:
+            status = {'BUILDING': 0, 'READY': 0, 'BUILD FAILED': 0}
+            post = {'ips': self.ips, 'token': self.token}
+            res = requests.post('http://40.112.59.229:5000/get_instances_status', json=post)
+            json_res = json.loads(res.text)
+            for _, v in json_res.items():
+                if v in status:
+                    status[v] += 1
+            print('%s nodes are building and %s nodes are ready' % (status['BUILDING'], status['READY']),  end='\r')
+            if status['BUILD FAILED'] > 0:
+                print('Build failed for at least one instance')
+                self.nodes = []
+                break
+            if status['READY'] == num_nodes:
+                break
+            time.sleep(10)
+
+    def get_one_node(self, i):
+        return self.nodes[i]
+
+    def atexit_cleanup_preexist(self):
+        post = {'request_id': self.request_id, 'token': self.token} 
+        print("Starting cleaning up remote instances.")
+        res = requests.post('http://40.112.59.229:5000/cancel_the_run', json=post)
+        json_res = json.loads(res.text)
+        logs = json_res['logs']
+        print("Getting logs from remote instances")
+        for i in range(len(self.ips)):
+            for log in logs:
+                if self.ips[i] in log:
+                    fl = os.path.expanduser('~/.near/test' + str(i) + "/remote.log")
+                    res = requests.get(log)
+                    with open(fl, 'w') as f:
+                        f.write(res.text)
+                    print(f"Logs are available in {fl}")
+
 def spin_up_node(config,
                  near_root,
                  node_dir,
@@ -548,16 +689,20 @@ def spin_up_node(config,
         assert len(
             blacklist) == 0, "Blacklist is only supported in LOCAL deployment."
 
-        instance_name = '{}-{}-{}'.format(
-            config['remote'].get('instance_name', 'near-pytest'), ordinal,
-            uuid.uuid4())
-        zones = config['remote']['zones']
-        zone = zones[ordinal % len(zones)]
-        node = GCloudNode(instance_name, zone, node_dir,
-                          config['remote']['binary'])
-        with remote_nodes_lock:
-            remote_nodes.append(node)
-        print(f"node {ordinal} machine created")
+        if config['preexist']:
+            global preexisting
+            node = preexisting.get_one_node(ordinal)
+        else:
+            instance_name = '{}-{}-{}'.format(
+                config['remote'].get('instance_name', 'near-pytest'), ordinal,
+                uuid.uuid4())
+            zones = config['remote']['zones']
+            zone = zones[ordinal % len(zones)]
+            node = GCloudNode(instance_name, zone, node_dir,
+                            config['remote']['binary'])
+            with remote_nodes_lock:
+                remote_nodes.append(node)
+            print(f"node {ordinal} machine created")
 
     if proxy is not None:
         proxy.proxify_node(node)
@@ -613,6 +758,12 @@ def init_cluster(num_nodes, num_observers, num_shards, config,
             client_config_change = client_config_changes[i]
             apply_config_changes(node_dir, client_config_change)
 
+    if config['preexist']:
+        print("Use preexisting cluster.")
+        # ips of azure nodes with build neard but not yet started.
+        global preexisting
+        preexisting = PreexistingCluster(num_nodes + num_observers, node_dirs)
+    
     return near_root, node_dirs
 
 
@@ -705,6 +856,7 @@ def start_cluster(num_nodes,
 
 DEFAULT_CONFIG = {
     'local': True,
+    'preexist': False,
     'near_root': '../target/debug/',
     'binary_name': 'neard'
 }


### PR DESCRIPTION
If user wants to test her change with several nodes, she can change the config['local'] = False and config['preexist'] = True.
All communication is happening with master instance by sending http requests.
When test starts master returns ips of available instances, where nerd binary is build with current user's sha.
When test is finished or killed, logs from remote instances are copied to .neard/testN/remote.log file.

User also should be auth with nayduck to run any tests