### PR TITLE
upgradable.py should be runnable on mac

### DIFF
--- a/pytest/lib/branches.py
+++ b/pytest/lib/branches.py
@@ -112,5 +112,5 @@ def prepare_ab_test(other_branch):
     try:
         download_binary(uname, other_branch)
     except Exception:
-        compile_binary(other_branch)
+        compile_binary(str(other_branch))
     return '../target/debug/', [other_branch, escaped(current_branch())]


### PR DESCRIPTION
Resolves #3318 

When running the test on latest master I noticed the following exception:

```
TypeError: expected str, bytes or os.PathLike object, not VersionInfo
```

And, after coercing the `other_branch` param as a `str`, I was able to get a passing test:

```
(venv) nearcore/pytest [master●] » python tests/sanity/upgradable.py
Latest beta release branch is 1.14.0
   Compiling neard v1.2.0 (/Users/near/code/nearcore/neard)
    Finished dev [unoptimized + debuginfo] target(s) in 38.85s
    Finished dev [unoptimized + debuginfo] target(s) in 1.68s
Updated 1 path from the index
Downloading near & state-viewer for 1.14.0@Darwin
curl: (22) The requested URL returned error: 403 Forbidden
Switched to a new branch '1.14.0'
remote: Enumerating objects: 144, done.
remote: Counting objects: 100% (144/144), done.
remote: Compressing objects: 100% (66/66), done.
remote: Total 153 (delta 96), reused 95 (delta 78), pack-reused 9
Receiving objects: 100% (153/153), 81.98 KiB | 987.00 KiB/s, done.
Resolving deltas: 100% (96/96), completed with 58 local objects.
From github.com:nearprotocol/nearcore
 * [new branch]        1.13.1            -> origin/1.13.1
   c45d559e..dc78646e  add-final-head    -> origin/add-final-head
   c03b0772..05df01a8  evm-gas-est       -> origin/evm-gas-est
 * [new branch]        fix-handshake-tie -> origin/fix-handshake-tie
 + 41f31ca0...a5c6ab25 massive_state_sync_increase_epoch -> origin/massive_state_sync_increase_epoch  (forced update)
   c9e4472e..2598b2cb  master            -> origin/master
   bfccfba1..915908b9  refactor/public-key-parse-from-str -> origin/refactor/public-key-parse-from-str
 * [new branch]        small_limits      -> origin/small_limits
 * [new tag]           1.13.1            -> 1.13.1
   Compiling near-crypto v0.1.0 (/Users/near/code/nearcore/core/crypto)
   Compiling near-primitives v0.1.0 (/Users/near/code/nearcore/core/primitives)
   Compiling near-runtime-configs v0.1.0 (/Users/near/code/nearcore/core/runtime-configs)
   Compiling near-store v0.1.0 (/Users/near/code/nearcore/core/store)
   Compiling near-pool v0.1.0 (/Users/near/code/nearcore/chain/pool)
   Compiling near-jsonrpc-client v0.1.0 (/Users/near/code/nearcore/chain/jsonrpc/client)
   Compiling near-chain-configs v0.1.0 (/Users/near/code/nearcore/core/chain-configs)
   Compiling node-runtime v2.2.0 (/Users/near/code/nearcore/runtime/runtime)
   Compiling near-chain v0.1.0 (/Users/near/code/nearcore/chain/chain)
   Compiling near-network v0.1.0 (/Users/near/code/nearcore/chain/network)
   Compiling near-epoch-manager v0.0.1 (/Users/near/code/nearcore/chain/epoch_manager)
   Compiling near-chunks v0.1.0 (/Users/near/code/nearcore/chain/chunks)
   Compiling near-client v0.1.0 (/Users/near/code/nearcore/chain/client)
   Compiling near-jsonrpc v0.1.0 (/Users/near/code/nearcore/chain/jsonrpc)
   Compiling neard v1.14.0-rc.1 (/Users/near/code/nearcore/neard)
    Finished dev [unoptimized + debuginfo] target(s) in 2m 13s
   Compiling state-viewer v0.1.0 (/Users/near/code/nearcore/test-utils/state-viewer)
    Finished dev [unoptimized + debuginfo] target(s) in 26.17s
Updated 1 path from the index
Switched to branch 'master'
['../target/debug/near-1.14.0', '--home=/tmp/near/upgradable', 'testnet', '--v', '4', '--prefix', 'test']
Sep 23 12:14:31.175  INFO near: Version: 1.14.0-rc.1, Build: effa3b7a-modified, Latest Protocol: 35
Sep 23 12:14:31.237  INFO near: Generated node key, validator key, genesis file in /tmp/near/upgradable/test0
Sep 23 12:14:31.241  INFO near: Generated node key, validator key, genesis file in /tmp/near/upgradable/test1
Sep 23 12:14:31.245  INFO near: Generated node key, validator key, genesis file in /tmp/near/upgradable/test2
Sep 23 12:14:31.250  INFO near: Generated node key, validator key, genesis file in /tmp/near/upgradable/test3
Starting node 0 as BOOT NODE
node 0 started
Starting node 1 with boot=ed25519:He7QeRuwizNEhBioYG3u4DZ8jWXyETiyNzFD3MkTjDMf@127.0.0.1:24577
node 1 started
Starting node 2 with boot=ed25519:He7QeRuwizNEhBioYG3u4DZ8jWXyETiyNzFD3MkTjDMf@127.0.0.1:24577
node 2 started
Starting node 3 with boot=ed25519:He7QeRuwizNEhBioYG3u4DZ8jWXyETiyNzFD3MkTjDMf@127.0.0.1:24577
node 3 started
Cleaning up node 127.0.0.1:24580 on script exit
Executed store validity tests: 0
Cleaning up node 127.0.0.1:24579 on script exit
Executed store validity tests: 0
Cleaning up node 127.0.0.1:24578 on script exit
Executed store validity tests: 0
Cleaning up node 127.0.0.1:24577 on script exit
Executed store validity tests: 0
```

@near/sre