### PR TITLE
fix: Fix validator_switch.py

### DIFF
--- a/pytest/tests/sanity/validator_switch.py
+++ b/pytest/tests/sanity/validator_switch.py
@@ -13,10 +13,7 @@ from transaction import sign_staking_tx
 EPOCH_LENGTH = 20
 tracked_shards = {"tracked_shards": [0, 1, 2, 3]}
 
-nodes = start_cluster(3, 1, 4, {
-    'local': True,
-    'near_root': '../target/debug/'
-}, [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
+nodes = start_cluster(3, 1, 4, None, [["epoch_length", EPOCH_LENGTH], ["block_producer_kickout_threshold", 10],
     ["chunk_producer_kickout_threshold", 10]], {
         0: tracked_shards,
         1: tracked_shards


### PR DESCRIPTION
For some reason it had the config hardcoded (while not having it any
different from the default), and the new remove testing infra broke it.

Test plan
---------
It passes