### PR TITLE
fix(network): Use version from other peer

### DIFF
--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -756,13 +756,12 @@ impl StreamHandler<Result<Vec<u8>, ReasonForBan>> for Peer {
             (_, PeerStatus::Connecting, PeerMessage::Handshake(handshake)) => {
                 debug!(target: "network", "{:?}: Received handshake {:?}", self.node_info.id, handshake);
 
-                let target_version = std::cmp::min(handshake.version, PROTOCOL_VERSION);
-
                 debug_assert!(
                     OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION <= handshake.version
                         && handshake.version <= PROTOCOL_VERSION
                 );
 
+                let target_version = std::cmp::min(handshake.version, PROTOCOL_VERSION);
                 self.protocol_version = target_version;
 
                 if handshake.chain_info.genesis_id != self.genesis_id {

--- a/core/primitives/src/version.rs
+++ b/core/primitives/src/version.rs
@@ -19,9 +19,6 @@ pub type ProtocolVersion = u32;
 
 /// Current latest version of the protocol.
 pub const PROTOCOL_VERSION: ProtocolVersion = 39;
-/// TODO: Remove in next release. This is to allow nodes with initial version 34
-/// to be compatible with nodes at version 35
-pub const NETWORK_PROTOCOL_VERSION: ProtocolVersion = 34;
 /// Oldest supported version by this client.
 pub const OLDEST_BACKWARD_COMPATIBLE_PROTOCOL_VERSION: ProtocolVersion = 34;
 


### PR DESCRIPTION
When connection is inbound from node with version 34
handshake failed because node with version 39 wasn't
using correct version to communicate.

Test plan
=========
Backward compatible test passes.

Tested on local network with both versions, previosly nodes
compiled with debug mode were panicing, because HandshakeFailure
was passed to recieve_client message. This behavior is fixed.