### PR TITLE
feat(rosetta-rpc): Populate signature type in the /construction/payloads response

### DIFF
--- a/chain/rosetta-rpc/src/lib.rs
+++ b/chain/rosetta-rpc/src/lib.rs
@@ -612,9 +612,19 @@ async fn construction_payloads(
         metadata,
     }) = body;
 
-    let signer_public_access_key = public_keys.into_iter().next().ok_or_else(|| {
-        errors::ErrorKind::InvalidInput("exactly one public key is expected".to_string())
-    })?;
+    let signer_public_access_key: near_crypto::PublicKey = public_keys
+        .iter()
+        .next()
+        .ok_or_else(|| {
+            errors::ErrorKind::InvalidInput("exactly one public key is expected".to_string())
+        })?
+        .try_into()
+        .map_err(|err| {
+            errors::ErrorKind::InvalidInput(format!(
+                "public key could not be parsed due to: {:?}",
+                err
+            ))
+        })?;
 
     // TODO: reduce copy-paste
     let status = client_addr
@@ -644,12 +654,7 @@ async fn construction_payloads(
             ))
         })?,
         signer_id: signer_account_id.clone(),
-        public_key: (&signer_public_access_key).try_into().map_err(|err| {
-            errors::ErrorKind::InvalidInput(format!(
-                "public key could not be parsed due to: {:?}",
-                err
-            ))
-        })?,
+        public_key: signer_public_access_key.clone(),
         nonce: signer_public_access_key_nonce,
         receiver_id: receiver_account_id,
         actions,
@@ -661,7 +666,7 @@ async fn construction_payloads(
         unsigned_transaction: unsigned_transaction.into(),
         payloads: vec![models::SigningPayload {
             account_identifier: signer_account_id.into(),
-            signature_type: None,
+            signature_type: Some(signer_public_access_key.key_type().into()),
             hex_bytes: transaction_hash.as_ref().to_owned().into(),
         }],
     }))

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -1086,15 +1086,12 @@ impl TryFrom<&Signature> for near_crypto::Signature {
     fn try_from(
         Signature { signature_type, hex_bytes, .. }: &Signature,
     ) -> Result<Self, Self::Error> {
-        let key_type = match signature_type {
-            SignatureType::Ed25519 => near_crypto::KeyType::ED25519,
-        };
-        near_crypto::Signature::from_parts(key_type, hex_bytes.as_ref())
+        near_crypto::Signature::from_parts((*signature_type).into(), hex_bytes.as_ref())
     }
 }
 
 /// SignatureType is the type of a cryptographic signature.
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum SignatureType {
     /// `R (32-byte) || s (32-bytes)` - `64 bytes`
@@ -1111,4 +1108,23 @@ pub(crate) enum SignatureType {
      * /// implemented by Zilliqa where both `r` and `s` are scalars encoded as
      * /// `32-bytes` values, most significant byte first.)
      * Schnorr1, */
+}
+
+impl From<near_crypto::KeyType> for SignatureType {
+    fn from(key_type: near_crypto::KeyType) -> Self {
+        match key_type {
+            near_crypto::KeyType::ED25519 => Self::Ed25519,
+            near_crypto::KeyType::SECP256K1 => {
+                unimplemented!("SECP256K1 keys are not implemented in Rosetta yet")
+            }
+        }
+    }
+}
+
+impl From<SignatureType> for near_crypto::KeyType {
+    fn from(signature_type: SignatureType) -> Self {
+        match signature_type {
+            SignatureType::Ed25519 => Self::ED25519,
+        }
+    }
 }


### PR DESCRIPTION
Given the public key, it is trivial to populate the expected signature type, so we do it now.