### PR TITLE
fix: handshake versioning

### DIFF
--- a/chain/network/src/peer.rs
+++ b/chain/network/src/peer.rs
@@ -289,7 +289,7 @@ impl Peer {
                     archival,
                 }) => {
                     let handshake = match act.protocol_version {
-                        37..=PROTOCOL_VERSION => PeerMessage::Handshake(Handshake::new(
+                        39..=PROTOCOL_VERSION => PeerMessage::Handshake(Handshake::new(
                             act.protocol_version,
                             act.node_id(),
                             act.peer_id().unwrap(),
@@ -297,7 +297,7 @@ impl Peer {
                             PeerChainInfoV2 { genesis_id, height, tracked_shards, archival },
                             act.edge_info.as_ref().unwrap().clone(),
                         )),
-                        34..=36 => PeerMessage::HandshakeV2(HandshakeV2::new(
+                        34..=38 => PeerMessage::HandshakeV2(HandshakeV2::new(
                             act.protocol_version,
                             act.node_id(),
                             act.peer_id().unwrap(),


### PR DESCRIPTION
When #3302 started the protocol version was 37 but when it is merged, the protocol version got bumped to 39 and therefore this line https://github.com/nearprotocol/nearcore/blob/6efb708f138ee3858b7ed3c4613c055282a26371/chain/network/src/peer.rs#L292 is inconsistent with the new protocol version introduced in #3302. Currently it only works because node before this change always send `HandShakeV2`, which the new node is able to deserialize. Otherwise a node running current master would not be able to connect to a node on protocol version 38 (current testnet).