### PR TITLE
fix(test): start_from_genesis.py

### DIFF
--- a/pytest/tests/adversarial/start_from_genesis.py
+++ b/pytest/tests/adversarial/start_from_genesis.py
@@ -20,7 +20,7 @@ BLOCKS = 30
 client_config_change = {"consensus":{"sync_check_period": {"secs": 0, "nanos": 100000000}}}
 
 nodes = start_cluster(
-    2, 1, 2, None,
+    2, 0, 2, None,
     [["epoch_length", 100], ["block_producer_kickout_threshold", 80]], {0: client_config_change})
 if not doomslug:
     # we expect inconsistency in store in node 0


### PR DESCRIPTION
Disable observer node.
Fixes #3422

Test plan
---------
run many times