### PR TITLE
fix(network): Support unverified accounts.

### DIFF
--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -275,7 +275,7 @@ pub trait RuntimeAdapter: Send + Sync {
     ) -> Result<Vec<SignedTransaction>, Error>;
 
     /// Verify validator signature for the given epoch.
-    /// Note: doesnt't account for slashed accounts within given epoch. USE WITH CAUTION.
+    /// Note: doesn't account for slashed accounts within given epoch. USE WITH CAUTION.
     fn verify_validator_signature(
         &self,
         epoch_id: &EpochId,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -1425,7 +1425,7 @@ pub enum NetworkViewClientResponses {
     /// Response to state request.
     StateResponse(Box<StateResponseInfo>),
     /// Valid announce accounts.
-    AnnounceAccount(Vec<AnnounceAccount>),
+    AnnounceAccount(Vec<(AnnounceAccount, bool)>),
     /// Ban peer for malicious behavior.
     Ban { ban_reason: ReasonForBan },
     /// Response not needed

--- a/chain/network/tests/cache.rs
+++ b/chain/network/tests/cache.rs
@@ -1,5 +1,5 @@
 use near_crypto::Signature;
-use near_network::routing::RoutingTable;
+use near_network::routing::{AnnounceAccountVerified, RoutingTable};
 use near_network::test_utils::{random_epoch_id, random_peer_id};
 use near_primitives::network::AnnounceAccount;
 use near_store::test_utils::create_test_store;
@@ -29,12 +29,12 @@ fn announcement_same_epoch() {
         signature: Signature::default(),
     };
 
-    routing_table.add_account(announce0.clone());
+    routing_table.add_account(announce0.clone(), AnnounceAccountVerified::True);
     assert!(routing_table.contains_account(&announce0));
     assert!(routing_table.contains_account(&announce1));
     assert_eq!(routing_table.get_announce_accounts().len(), 1);
     assert_eq!(routing_table.account_owner(&announce0.account_id).unwrap(), peer_id0);
-    routing_table.add_account(announce1.clone());
+    routing_table.add_account(announce1.clone(), AnnounceAccountVerified::True);
     assert_eq!(routing_table.get_announce_accounts().len(), 1);
     assert_eq!(routing_table.account_owner(&announce1.account_id).unwrap(), peer_id1);
 }
@@ -65,8 +65,8 @@ fn dont_load_on_build() {
         signature: Signature::default(),
     };
 
-    routing_table.add_account(announce0.clone());
-    routing_table.add_account(announce1.clone());
+    routing_table.add_account(announce0.clone(), AnnounceAccountVerified::True);
+    routing_table.add_account(announce1.clone(), AnnounceAccountVerified::True);
     let accounts = routing_table.get_announce_accounts();
     assert!(vec![announce0.clone(), announce1.clone()]
         .iter()
@@ -95,7 +95,7 @@ fn load_from_disk() {
     };
 
     // Announcement is added to cache of the first routing table and to disk
-    routing_table.add_account(announce0.clone());
+    routing_table.add_account(announce0.clone(), AnnounceAccountVerified::True);
     assert_eq!(routing_table.get_announce_accounts().len(), 1);
     // Cache of second routing table is empty
     assert_eq!(routing_table1.get_announce_accounts().len(), 0);

--- a/chain/network/tests/infinite_loop.rs
+++ b/chain/network/tests/infinite_loop.rs
@@ -41,7 +41,7 @@ pub fn make_peer_manager(
                     counter1.fetch_add(1, Ordering::SeqCst);
                 }
                 Box::new(Some(NetworkViewClientResponses::AnnounceAccount(
-                    accounts.clone().into_iter().map(|obj| obj.0).collect(),
+                    accounts.clone().into_iter().map(|obj| (obj.0, true)).collect(),
                 )))
             }
             NetworkViewClientMessages::GetChainInfo => {


### PR DESCRIPTION
Account Id from validators that can't be verified due to
EpochOutOfBonds will be saved anyway in a temporal cache
so that routing is active from the beginning, even before
catching up.

The strategy is not fully implemented, and right now this
cache can be abused, but only during the syncing stage. After
the node is fully sync and can verify futher announcements
it can't be abused anymore.

Test plan
=========
Current routing tests.
stress.py test that surfaced this issue