### PR TITLE
fix(rpc): include method as label in rpc request total metric

### DIFF
--- a/chain/jsonrpc/src/lib.rs
+++ b/chain/jsonrpc/src/lib.rs
@@ -199,6 +199,7 @@ impl JsonRpcHandler {
     }
 
     async fn process_request(&self, request: Request) -> Result<Value, RpcError> {
+        near_metrics::inc_counter_vec(&metrics::HTTP_RPC_REQUEST_COUNT, &[request.method.as_ref()]);
         let _rpc_processing_time = near_metrics::start_timer(&metrics::RPC_PROCESSING_TIME);
 
         #[cfg(feature = "adversarial")]
@@ -854,8 +855,6 @@ fn rpc_handler(
     message: web::Json<Message>,
     handler: web::Data<JsonRpcHandler>,
 ) -> impl Future<Output = Result<HttpResponse, HttpError>> {
-    near_metrics::inc_counter(&metrics::HTTP_RPC_REQUEST_COUNT);
-
     let response = async move {
         let message = handler.process(message.0).await?;
         Ok(HttpResponse::Ok().json(message))

--- a/chain/jsonrpc/src/metrics.rs
+++ b/chain/jsonrpc/src/metrics.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use near_metrics::{Histogram, IntCounter};
+use near_metrics::{Histogram, IntCounter, IntCounterVec};
 
 lazy_static! {
     pub static ref RPC_PROCESSING_TIME: near_metrics::Result<Histogram> =
@@ -17,10 +17,11 @@ lazy_static! {
             "http_prometheus_requests_total",
             "Total count of Prometheus requests received"
         );
-    pub static ref HTTP_RPC_REQUEST_COUNT: near_metrics::Result<IntCounter> =
-        near_metrics::try_create_int_counter(
+    pub static ref HTTP_RPC_REQUEST_COUNT: near_metrics::Result<IntCounterVec> =
+        near_metrics::try_create_int_counter_vec(
             "http_rpc_requests_total",
-            "Total count of HTTP RPC requests received"
+            "Total count of HTTP RPC requests received, by method",
+            &["method"]
         );
     pub static ref HTTP_STATUS_REQUEST_COUNT: near_metrics::Result<IntCounter> =
         near_metrics::try_create_int_counter(


### PR DESCRIPTION
fix: include method as label in rpc request total metric

Expose the RPC request method as a prometheus label so we can get a better sense of how RPC nodes are used.

Test plan
---------
* Spun up `neard` locally, hit `status` and `health` RPC methods, checked `/metrics`
```
# HELP http_rpc_requests_total Total count of HTTP RPC requests received, by method
# TYPE http_rpc_requests_total counter
http_rpc_requests_total{method="health"} 1
http_rpc_requests_total{method="status"} 1
```
* Will see these on `testnet` and `betanet` deploys

FYI @chefsale @mhalambek 