### PR TITLE
fix(rosetta-rpc): fixed duplicates by transaction identifier in /block Data API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,6 +874,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "terminal_size",
+ "termios",
+ "winapi 0.3.8",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1138,6 +1152,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
@@ -1912,7 +1932,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8572bccfb0665e70b7faf44ee28841b8e0823450cd4ad562a76b5a3c4bf48487"
 dependencies = [
- "console",
+ "console 0.10.0",
  "lazy_static",
  "number_prefix",
  "rayon",
@@ -1925,10 +1945,24 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
- "console",
+ "console 0.10.0",
  "lazy_static",
  "number_prefix",
  "regex",
+]
+
+[[package]]
+name = "insta"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3463f26c58ee98b72e4eae1a6b4c28bc3320ab69d4836b55162362c2ec63fa6"
+dependencies = [
+ "console 0.12.0",
+ "difference",
+ "lazy_static",
+ "serde",
+ "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -2696,6 +2730,7 @@ dependencies = [
  "derive_more",
  "futures",
  "hex",
+ "insta",
  "lazy_static",
  "near-chain-configs",
  "near-client",
@@ -4402,6 +4437,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a14cd9f8c72704232f0bfc8455c0e861f0ad4eb60cc9ec8a170e231414c1e13"
+dependencies = [
+ "libc",
+ "winapi 0.3.8",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,18 +819,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clicolors-control"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90082ee5dcdd64dc4e9e0d37fbf3ee325419e39c0092191e0393df65518f741e"
-dependencies = [
- "atty",
- "lazy_static",
- "libc",
- "winapi 0.3.8",
-]
-
-[[package]]
 name = "cloudabi"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,22 +847,6 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6728a28023f207181b193262711102bfbaf47cc9d13bc71d0736607ef8efe88c"
-dependencies = [
- "clicolors-control",
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "termios",
- "unicode-width",
- "winapi 0.3.8",
-]
-
-[[package]]
-name = "console"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b1aacfaffdbff75be81c15a399b4bedf78aaefe840e8af1d299ac2ade885d2"
@@ -882,9 +854,12 @@ dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
+ "regex",
  "terminal_size",
  "termios",
+ "unicode-width",
  "winapi 0.3.8",
+ "winapi-util",
 ]
 
 [[package]]
@@ -1932,7 +1907,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8572bccfb0665e70b7faf44ee28841b8e0823450cd4ad562a76b5a3c4bf48487"
 dependencies = [
- "console 0.10.0",
+ "console",
  "lazy_static",
  "number_prefix",
  "rayon",
@@ -1945,7 +1920,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4"
 dependencies = [
- "console 0.10.0",
+ "console",
  "lazy_static",
  "number_prefix",
  "regex",
@@ -1957,7 +1932,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3463f26c58ee98b72e4eae1a6b4c28bc3320ab69d4836b55162362c2ec63fa6"
 dependencies = [
- "console 0.12.0",
+ "console",
  "difference",
  "lazy_static",
  "serde",

--- a/chain/rosetta-rpc/CHANGELOG.md
+++ b/chain/rosetta-rpc/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.1
+
+* Fixed duplicate transaction identifiers in Data API
+
 ## 0.1.0
 
 * Data API exposes feature-complete balance-changing operations

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-rosetta-rpc"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/chain/rosetta-rpc/Cargo.toml
+++ b/chain/rosetta-rpc/Cargo.toml
@@ -30,3 +30,6 @@ near-chain-configs = { path = "../../core/chain-configs" }
 near-client = { path = "../client" }
 near-network = { path = "../network" }
 near-runtime-configs = { path = "../../core/runtime-configs" }
+
+[dev-dependencies]
+insta = "1"

--- a/chain/rosetta-rpc/src/adapters/snapshots/near_rosetta_rpc__adapters__tests__nfvalidator1_receipt_processing_transaction.snap
+++ b/chain/rosetta-rpc/src/adapters/snapshots/near_rosetta_rpc__adapters__tests__nfvalidator1_receipt_processing_transaction.snap
@@ -1,0 +1,39 @@
+---
+source: chain/rosetta-rpc/src/adapters/mod.rs
+expression: nfvalidator1_receipt_processing_transaction
+---
+Transaction {
+    transaction_identifier: TransactionIdentifier {
+        hash: "receipt:4vJ9JU1bJJE96FWSJKvHsmmFADCg4gpZQff4P3bkLKi",
+    },
+    operations: [
+        Operation {
+            operation_identifier: OperationIdentifier {
+                index: 0,
+                network_index: None,
+            },
+            related_operations: None,
+            type_: Transfer,
+            status: Some(
+                Success,
+            ),
+            account: AccountIdentifier {
+                address: "nfvalidator1.near",
+                sub_account: None,
+            },
+            amount: Some(
+                Amount {
+                    value: SignedDiff(-1000000000000000000),
+                    currency: Currency {
+                        symbol: NEAR,
+                        decimals: 24,
+                    },
+                },
+            ),
+            metadata: None,
+        },
+    ],
+    metadata: TransactionMetadata {
+        type_: Transaction,
+    },
+}

--- a/chain/rosetta-rpc/src/adapters/snapshots/near_rosetta_rpc__adapters__tests__nfvalidator2_action_receipt_gas_reward_transaction.snap
+++ b/chain/rosetta-rpc/src/adapters/snapshots/near_rosetta_rpc__adapters__tests__nfvalidator2_action_receipt_gas_reward_transaction.snap
@@ -1,0 +1,39 @@
+---
+source: chain/rosetta-rpc/src/adapters/mod.rs
+expression: nfvalidator2_action_receipt_gas_reward_transaction
+---
+Transaction {
+    transaction_identifier: TransactionIdentifier {
+        hash: "receipt:8qbHbw2BbbTHBW1sbeqakYXVKRQM8Ne7pLK7m6CVfeR",
+    },
+    operations: [
+        Operation {
+            operation_identifier: OperationIdentifier {
+                index: 0,
+                network_index: None,
+            },
+            related_operations: None,
+            type_: Transfer,
+            status: Some(
+                Success,
+            ),
+            account: AccountIdentifier {
+                address: "nfvalidator2.near",
+                sub_account: None,
+            },
+            amount: Some(
+                Amount {
+                    value: SignedDiff(1000000000000000000),
+                    currency: Currency {
+                        symbol: NEAR,
+                        decimals: 24,
+                    },
+                },
+            ),
+            metadata: None,
+        },
+    ],
+    metadata: TransactionMetadata {
+        type_: Transaction,
+    },
+}

--- a/chain/rosetta-rpc/src/adapters/snapshots/near_rosetta_rpc__adapters__tests__validators_update_transaction.snap
+++ b/chain/rosetta-rpc/src/adapters/snapshots/near_rosetta_rpc__adapters__tests__validators_update_transaction.snap
@@ -1,0 +1,64 @@
+---
+source: chain/rosetta-rpc/src/adapters/mod.rs
+expression: validators_update_transaction
+---
+Transaction {
+    transaction_identifier: TransactionIdentifier {
+        hash: "block-validators-update:11111111111111111111111111111111",
+    },
+    operations: [
+        Operation {
+            operation_identifier: OperationIdentifier {
+                index: 0,
+                network_index: None,
+            },
+            related_operations: None,
+            type_: Transfer,
+            status: Some(
+                Success,
+            ),
+            account: AccountIdentifier {
+                address: "nfvalidator1.near",
+                sub_account: None,
+            },
+            amount: Some(
+                Amount {
+                    value: SignedDiff(1000000000000000000),
+                    currency: Currency {
+                        symbol: NEAR,
+                        decimals: 24,
+                    },
+                },
+            ),
+            metadata: None,
+        },
+        Operation {
+            operation_identifier: OperationIdentifier {
+                index: 1,
+                network_index: None,
+            },
+            related_operations: None,
+            type_: Transfer,
+            status: Some(
+                Success,
+            ),
+            account: AccountIdentifier {
+                address: "nfvalidator2.near",
+                sub_account: None,
+            },
+            amount: Some(
+                Amount {
+                    value: SignedDiff(1000000000000000000),
+                    currency: Currency {
+                        symbol: NEAR,
+                        decimals: 24,
+                    },
+                },
+            ),
+            metadata: None,
+        },
+    ],
+    metadata: TransactionMetadata {
+        type_: Transaction,
+    },
+}

--- a/chain/rosetta-rpc/src/models.rs
+++ b/chain/rosetta-rpc/src/models.rs
@@ -125,13 +125,13 @@ impl std::ops::Neg for Amount {
 
 impl Amount {
     pub(crate) fn from_yoctonear(amount: near_primitives::types::Balance) -> Self {
-        Self { value: amount.into(), currency: Currency::yoctonear() }
+        Self { value: amount.into(), currency: Currency::near() }
     }
 
     pub(crate) fn from_yoctonear_diff(
         amount: crate::utils::SignedDiff<near_primitives::types::Balance>,
     ) -> Self {
-        Self { value: amount, currency: Currency::yoctonear() }
+        Self { value: amount, currency: Currency::near() }
     }
 }
 
@@ -444,8 +444,7 @@ pub(crate) struct ConstructionHashRequest {
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, Apiv2Schema)]
 pub(crate) enum CurrencySymbol {
-    #[serde(rename = "yoctoNEAR")]
-    YoctoNEAR,
+    NEAR,
 }
 
 /// Currency is composed of a canonical Symbol and Decimals. This Decimals value
@@ -471,8 +470,8 @@ pub(crate) struct Currency {
 }
 
 impl Currency {
-    fn yoctonear() -> Self {
-        Self { symbol: CurrencySymbol::YoctoNEAR, decimals: 0 }
+    fn near() -> Self {
+        Self { symbol: CurrencySymbol::NEAR, decimals: 24 }
     }
 }
 

--- a/chain/rosetta-rpc/src/utils.rs
+++ b/chain/rosetta-rpc/src/utils.rs
@@ -127,7 +127,7 @@ where
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub(crate) struct SignedDiff<T>
 where
     T: Copy + PartialEq,
@@ -189,6 +189,15 @@ where
             if self.is_positive { "" } else { "-" },
             self.absolute_difference.to_string()
         )
+    }
+}
+
+impl<T> std::fmt::Debug for SignedDiff<T>
+where
+    T: Copy + PartialEq + std::string::ToString,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SignedDiff({})", self.to_string())
     }
 }
 


### PR DESCRIPTION
*Resolves #3435*

NOTE: The order of transactions in Rosetta /block response is arbitrary. If that is critical, we need to address it separately recovering the order of events processing inside nearcore (validator accounts are updated first, then transactions are translated into receipts, then local receipts are executed, then delayed receipts are executed, then new incoming receipts are executed, then delayed receipts indices are computed)