### PR TITLE
fix: fetching chunks from peers that track shard and stress.py improv…

### DIFF
--- a/chain/chunks/src/lib.rs
+++ b/chain/chunks/src/lib.rs
@@ -19,7 +19,7 @@ use near_network::types::{
 };
 use near_network::NetworkRequests;
 use near_pool::{PoolIteratorWrapper, TransactionPool};
-use near_primitives::block::BlockHeader;
+use near_primitives::block::{BlockHeader, Tip};
 use near_primitives::hash::{hash, CryptoHash};
 use near_primitives::merkle::{merklize, verify_path, MerklePath};
 use near_primitives::receipt::Receipt;
@@ -37,6 +37,7 @@ use near_primitives::validator_signer::ValidatorSigner;
 
 use crate::chunk_cache::{EncodedChunksCache, EncodedChunksCacheEntry};
 pub use crate::types::Error;
+use rand::Rng;
 
 mod chunk_cache;
 pub mod test_utils;
@@ -455,21 +456,14 @@ impl ShardsManager {
             shard_id,
         )?;
 
-        let shard_representative_target =
-            if !request_own_parts_from_others && !request_from_archival {
-                AccountIdOrPeerTrackingShard::AccountId(chunk_producer_account_id.clone())
-            } else {
-                match self.get_random_target_tracking_shard(
-                    &parent_hash,
-                    shard_id,
-                    request_from_archival,
-                ) {
-                    Ok(Some(someone)) => someone,
-                    Ok(None) | Err(_) => {
-                        AccountIdOrPeerTrackingShard::AccountId(chunk_producer_account_id.clone())
-                    }
-                }
-            };
+        let shard_representative_target = if !request_own_parts_from_others
+            && !request_from_archival
+            && Some(chunk_producer_account_id) != self.me.as_ref()
+        {
+            AccountIdOrPeerTrackingShard::from_account(shard_id, chunk_producer_account_id.clone())
+        } else {
+            self.get_random_target_tracking_shard(&parent_hash, shard_id, request_from_archival)?
+        };
 
         let seal = self.seals_mgr.get_seal(chunk_hash, parent_hash, height, shard_id)?;
 
@@ -499,7 +493,7 @@ impl ShardsManager {
                         // If missing own part, request it from the chunk producer / node tracking shard
                         shard_representative_target.clone()
                     } else {
-                        AccountIdOrPeerTrackingShard::AccountId(part_owner)
+                        AccountIdOrPeerTrackingShard::from_account(shard_id, part_owner)
                     }
                 };
 
@@ -521,11 +515,7 @@ impl ShardsManager {
 
         for (target, part_ords) in bp_to_parts {
             // extra check that we are not sending request to ourselves.
-            if self
-                .me
-                .clone()
-                .map_or(true, |me| AccountIdOrPeerTrackingShard::AccountId(me) != target)
-            {
+            if self.me.clone().map_or(true, |me| Some(me) != target.account_id) {
                 let request = PartialEncodedChunkRequestMsg {
                     chunk_hash: chunk_hash.clone(),
                     part_ords,
@@ -554,7 +544,7 @@ impl ShardsManager {
         parent_hash: &CryptoHash,
         shard_id: ShardId,
         request_from_archival: bool,
-    ) -> Result<Option<AccountIdOrPeerTrackingShard>, Error> {
+    ) -> Result<AccountIdOrPeerTrackingShard, near_chain::Error> {
         let mut block_producers = vec![];
         let epoch_id = self.runtime_adapter.get_epoch_id_from_prev_block(parent_hash).unwrap();
         for (validator_stake, is_slashed) in
@@ -575,14 +565,11 @@ impl ShardsManager {
 
         let maybe_account_id = block_producers.choose(&mut rand::thread_rng()).cloned();
 
-        Ok(if request_from_archival {
-            Some(AccountIdOrPeerTrackingShard::PeerTrackingShard {
-                shard_id,
-                only_archival: true,
-                fallback_account_id: maybe_account_id,
-            })
-        } else {
-            maybe_account_id.map(|x| AccountIdOrPeerTrackingShard::AccountId(x))
+        Ok(AccountIdOrPeerTrackingShard {
+            shard_id,
+            only_archival: request_from_archival,
+            account_id: maybe_account_id,
+            prefer_peer: request_from_archival || rand::thread_rng().gen::<bool>(),
         })
     }
 
@@ -599,7 +586,7 @@ impl ShardsManager {
             .collect::<HashSet<_>>()
     }
 
-    pub fn request_chunks<T>(&mut self, chunks_to_request: T, header_head: &CryptoHash)
+    pub fn request_chunks<T>(&mut self, chunks_to_request: T, header_head: &Tip)
     where
         T: IntoIterator<Item = ShardChunkHeader>,
     {
@@ -634,10 +621,12 @@ impl ShardsManager {
             );
 
             let fetch_from_archival = self.runtime_adapter
-                .chunk_needs_to_be_fetched_from_archival(&parent_hash, header_head).unwrap_or_else(|err| {
+                .chunk_needs_to_be_fetched_from_archival(&parent_hash, &header_head.last_block_hash).unwrap_or_else(|err| {
                 error!(target: "chunks", "Error during requesting partial encoded chunk. Cannot determine whether to request from an archival node, defaulting to not: {}", err);
                 false
             });
+            let old_block = header_head.last_block_hash != parent_hash
+                && header_head.prev_block_hash != parent_hash;
 
             let request_result = self.request_partial_encoded_chunk(
                 height,
@@ -645,7 +634,7 @@ impl ShardsManager {
                 shard_id,
                 &chunk_hash,
                 false,
-                false,
+                old_block,
                 fetch_from_archival,
             );
             if let Err(err) = request_result {
@@ -655,15 +644,18 @@ impl ShardsManager {
     }
 
     /// Resends chunk requests if haven't received it within expected time.
-    pub fn resend_chunk_requests(&mut self, header_head: &CryptoHash) {
+    pub fn resend_chunk_requests(&mut self, header_head: &Tip) {
         // Process chunk one part requests.
         let requests = self.requested_partial_encoded_chunks.fetch();
         for (chunk_hash, chunk_request) in requests {
             let fetch_from_archival = self.runtime_adapter
-                .chunk_needs_to_be_fetched_from_archival(&chunk_request.parent_hash, header_head).unwrap_or_else(|err| {
+                .chunk_needs_to_be_fetched_from_archival(&chunk_request.parent_hash, &header_head.last_block_hash).unwrap_or_else(|err| {
                 error!(target: "chunks", "Error during re-requesting partial encoded chunk. Cannot determine whether to request from an archival node, defaulting to not: {}", err);
                 false
             });
+            let old_block = header_head.last_block_hash != chunk_request.parent_hash
+                && header_head.prev_block_hash != chunk_request.parent_hash;
+
             match self.request_partial_encoded_chunk(
                 chunk_request.height,
                 &chunk_request.parent_hash,
@@ -671,8 +663,9 @@ impl ShardsManager {
                 &chunk_hash,
                 chunk_request.added.elapsed()
                     > self.requested_partial_encoded_chunks.switch_to_full_fetch_duration,
-                chunk_request.added.elapsed()
-                    > self.requested_partial_encoded_chunks.switch_to_others_duration,
+                old_block
+                    || chunk_request.added.elapsed()
+                        > self.requested_partial_encoded_chunks.switch_to_others_duration,
                 fetch_from_archival,
             ) {
                 Ok(()) => {}
@@ -1515,18 +1508,20 @@ mod test {
     };
     use near_chain::test_utils::KeyValueRuntime;
     use near_network::test_utils::MockNetworkAdapter;
-    use near_primitives::hash::hash;
+    use near_primitives::hash::{hash, CryptoHash};
     use near_primitives::sharding::ChunkHash;
     use near_store::test_utils::create_test_store;
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
+    use near_network::NetworkRequests;
+    use near_primitives::block::Tip;
+    use near_primitives::types::EpochId;
     #[cfg(feature = "expensive_tests")]
     use {
         crate::ACCEPTING_SEAL_PERIOD_MS, near_chain::ChainStore, near_chain::RuntimeAdapter,
         near_crypto::KeyType, near_logger_utils::init_test_logger,
-        near_primitives::hash::CryptoHash, near_primitives::merkle::merklize,
-        near_primitives::sharding::ReedSolomonWrapper,
+        near_primitives::merkle::merklize, near_primitives::sharding::ReedSolomonWrapper,
         near_primitives::validator_signer::InMemoryValidatorSigner,
     };
 
@@ -1548,8 +1543,24 @@ mod test {
             },
         );
         std::thread::sleep(Duration::from_millis(2 * CHUNK_REQUEST_RETRY_MS));
-        shards_manager.resend_chunk_requests(&Default::default());
-        assert!(network_adapter.requests.read().unwrap().is_empty());
+        shards_manager.resend_chunk_requests(&Tip {
+            height: 0,
+            last_block_hash: CryptoHash::default(),
+            prev_block_hash: CryptoHash::default(),
+            epoch_id: EpochId::default(),
+            next_epoch_id: EpochId::default(),
+        });
+
+        // For the chunks that would otherwise be requested from self we expect a request to be
+        // sent to any peer tracking shard
+        if let NetworkRequests::PartialEncodedChunkRequest { target, .. } =
+            network_adapter.requests.read().unwrap()[0].clone()
+        {
+            assert!(target.account_id == None);
+        } else {
+            println!("{:?}", network_adapter.requests.read().unwrap());
+            assert!(false);
+        };
     }
 
     #[cfg(feature = "expensive_tests")]

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -611,8 +611,14 @@ impl Client {
             Provenance::PRODUCED | Provenance::SYNC => true,
             Provenance::NONE => false,
         };
-        // drop the block if a) it is not requested and b) we already processed this height.
-        if !is_requested {
+        // drop the block if a) it is not requested, b) we already processed this height, c) it is not building on top of current head
+        if !is_requested
+            && block.header().prev_hash()
+                != &self
+                    .chain
+                    .head()
+                    .map_or_else(|_| CryptoHash::default(), |tip| tip.last_block_hash)
+        {
             match self.chain.mut_store().is_height_processed(block.header().height()) {
                 Ok(true) => return (vec![], Ok(None)),
                 Ok(false) => {}
@@ -684,8 +690,7 @@ impl Client {
             &self
                 .chain
                 .header_head()
-                .expect("header_head must be available when processing a block")
-                .last_block_hash,
+                .expect("header_head must be available when processing a block"),
         );
 
         let unwrapped_accepted_blocks = accepted_blocks.write().unwrap().drain(..).collect();
@@ -724,10 +729,8 @@ impl Client {
                 Ok(self.process_blocks_with_missing_chunks(prev_block_hash))
             }
             ProcessPartialEncodedChunkResult::NeedMorePartsOrReceipts(chunk_header) => {
-                self.shards_mgr.request_chunks(
-                    iter::once(*chunk_header),
-                    &self.chain.header_head()?.last_block_hash,
-                );
+                self.shards_mgr
+                    .request_chunks(iter::once(*chunk_header), &self.chain.header_head()?);
                 Ok(vec![])
             }
             ProcessPartialEncodedChunkResult::NeedBlock => {
@@ -1002,8 +1005,7 @@ impl Client {
             &self
                 .chain
                 .header_head()
-                .expect("header_head must be avaiable when processing blocks with missing chunks")
-                .last_block_hash,
+                .expect("header_head must be avaiable when processing blocks with missing chunks"),
         );
 
         let unwrapped_accepted_blocks = accepted_blocks.write().unwrap().drain(..).collect();
@@ -1404,7 +1406,7 @@ impl Client {
                             .unwrap()
                             .drain(..)
                             .flat_map(|missing_chunks| missing_chunks.into_iter()),
-                        &self.chain.header_head()?.last_block_hash,
+                        &self.chain.header_head()?,
                     );
 
                     let unwrapped_accepted_blocks =

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -770,7 +770,7 @@ impl ClientActor {
             ctx,
             |act, _ctx| {
                 if let Ok(header_head) = act.client.chain.header_head() {
-                    act.client.shards_mgr.resend_chunk_requests(&header_head.last_block_hash)
+                    act.client.shards_mgr.resend_chunk_requests(&header_head)
                 }
             },
         );
@@ -835,7 +835,7 @@ impl ClientActor {
                             );
                             self.client.shards_mgr.request_chunks(
                                 missing_chunks,
-                                &self.client.chain.header_head().expect("header_head must be available when processing newly produced block").last_block_hash,
+                                &self.client.chain.header_head().expect("header_head must be available when processing newly produced block"),
                             );
                             Ok(())
                         }
@@ -955,12 +955,9 @@ impl ClientActor {
                     );
                     self.client.shards_mgr.request_chunks(
                         missing_chunks,
-                        &self
-                            .client
-                            .chain
-                            .header_head()
-                            .expect("header_head should always be available when block is received")
-                            .last_block_hash,
+                        &self.client.chain.header_head().expect(
+                            "header_head should always be available when block is received",
+                        ),
                     );
                 }
                 _ => {
@@ -1088,8 +1085,20 @@ impl ClientActor {
         for _ in 0..self.client.config.state_fetch_horizon {
             sync_hash = *self.client.chain.get_block_header(&sync_hash)?.prev_hash();
         }
-        let epoch_start_sync_hash =
+        let mut epoch_start_sync_hash =
             StateSync::get_epoch_start_sync_hash(&mut self.client.chain, &sync_hash)?;
+
+        if &epoch_start_sync_hash == self.client.chain.genesis().hash() {
+            // If we are within `state_fetch_horizon` blocks of the second epoch, the sync hash will
+            // be the first block of the first epoch (or, the genesis block). Due to implementation
+            // details of the state sync, we can't state sync to the genesis block, so redo the
+            // search without going back `state_fetch_horizon` blocks.
+            epoch_start_sync_hash = StateSync::get_epoch_start_sync_hash(
+                &mut self.client.chain,
+                &header_head.last_block_hash,
+            )?;
+            assert_ne!(&epoch_start_sync_hash, self.client.chain.genesis().hash());
+        }
         Ok(epoch_start_sync_hash)
     }
 
@@ -1286,8 +1295,7 @@ impl ClientActor {
                                 .client
                                 .chain
                                 .header_head()
-                                .expect("header_head must be available during sync")
-                                .last_block_hash,
+                                .expect("header_head must be available during sync"),
                         );
 
                         self.client.sync_status =

--- a/chain/client/src/test_utils.rs
+++ b/chain/client/src/test_utils.rs
@@ -21,8 +21,8 @@ use near_crypto::{InMemorySigner, KeyType, PublicKey};
 use near_network::recorder::MetricRecorder;
 use near_network::routing::EdgeInfo;
 use near_network::types::{
-    AccountIdOrPeerTrackingShard, AccountOrPeerIdOrHash, NetworkInfo, NetworkViewClientMessages,
-    NetworkViewClientResponses, PeerChainInfoV2,
+    AccountOrPeerIdOrHash, NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses,
+    PeerChainInfoV2,
 };
 use near_network::{
     FullPeerInfo, NetworkAdapter, NetworkClientMessages, NetworkClientResponses, NetworkRecipient,
@@ -488,13 +488,8 @@ pub fn setup_mock_all_validators(
                                 .insert(*block.header().hash(), block.header().height());
                         }
                         NetworkRequests::PartialEncodedChunkRequest { target, request } => {
-                            if let AccountIdOrPeerTrackingShard::PeerTrackingShard { .. } = target {
-                                assert!(false); // Currently is not possible in client tests
-                            }
                             for (i, name) in validators_clone2.iter().flatten().enumerate() {
-                                if &AccountIdOrPeerTrackingShard::AccountId(name.to_string())
-                                    == target
-                                {
+                                if Some(&name.to_string()) == target.account_id.as_ref() {
                                     if !drop_chunks || !sample_binary(1, 10) {
                                         connectors1.read().unwrap()[i].0.do_send(
                                             NetworkClientMessages::PartialEncodedChunkRequest(

--- a/chain/client/tests/catching_up.rs
+++ b/chain/client/tests/catching_up.rs
@@ -768,11 +768,15 @@ mod tests {
                             ChunkGrievingPhases::SecondAttack => {
                                 if let NetworkRequests::PartialEncodedChunkRequest {
                                     request,
-                                    target: AccountIdOrPeerTrackingShard::AccountId(account_id),
+                                    target:
+                                        AccountIdOrPeerTrackingShard {
+                                            account_id: Some(account_id),
+                                            ..
+                                        },
                                 } = msg
                                 {
                                     if request.chunk_hash == *grieving_chunk_hash {
-                                        if *account_id == malicious_node {
+                                        if account_id == &malicious_node {
                                             // holding grieving_chunk_hash by malicious node
                                             return (NetworkResponses::NoResponse, false);
                                         }

--- a/chain/client/tests/chunks_management.rs
+++ b/chain/client/tests/chunks_management.rs
@@ -205,7 +205,7 @@ fn chunks_produced_and_distributed_common(
                         partial_chunk_msgs += 1;
                     }
                     NetworkRequests::PartialEncodedChunkRequest {
-                        target: AccountIdOrPeerTrackingShard::AccountId(to_whom),
+                        target: AccountIdOrPeerTrackingShard { account_id: Some(to_whom), .. },
                         request: _,
                     } => {
                         if drop_from_1_to_4 && from_whom == "test4" && to_whom == "test1" {

--- a/chain/network/src/peer_manager.rs
+++ b/chain/network/src/peer_manager.rs
@@ -33,12 +33,12 @@ use crate::peer_store::{PeerStore, TrustLevel};
 use crate::recorder::{MetricRecorder, PeerMessageMetadata};
 use crate::routing::{Edge, EdgeInfo, EdgeType, ProcessEdgeResult, RoutingTable};
 use crate::types::{
-    AccountIdOrPeerTrackingShard, AccountOrPeerIdOrHash, Ban, BlockedPorts, Consolidate,
-    ConsolidateResponse, FullPeerInfo, InboundTcpConnect, KnownPeerStatus, KnownProducer,
-    NetworkInfo, NetworkViewClientMessages, NetworkViewClientResponses, OutboundTcpConnect,
-    PeerIdOrHash, PeerList, PeerManagerRequest, PeerMessage, PeerRequest, PeerResponse, PeerType,
-    PeersRequest, PeersResponse, Ping, Pong, QueryPeerStats, RawRoutedMessage, ReasonForBan,
-    RoutedMessage, RoutedMessageBody, RoutedMessageFrom, SendMessage, SyncData, Unregister,
+    AccountOrPeerIdOrHash, Ban, BlockedPorts, Consolidate, ConsolidateResponse, FullPeerInfo,
+    InboundTcpConnect, KnownPeerStatus, KnownProducer, NetworkInfo, NetworkViewClientMessages,
+    NetworkViewClientResponses, OutboundTcpConnect, PeerIdOrHash, PeerList, PeerManagerRequest,
+    PeerMessage, PeerRequest, PeerResponse, PeerType, PeersRequest, PeersResponse, Ping, Pong,
+    QueryPeerStats, RawRoutedMessage, ReasonForBan, RoutedMessage, RoutedMessageBody,
+    RoutedMessageFrom, SendMessage, SyncData, Unregister,
 };
 use crate::types::{
     EdgeList, KnownPeerState, NetworkClientMessages, NetworkConfig, NetworkRequests,
@@ -1215,70 +1215,62 @@ impl Handler<NetworkRequests> for PeerManagerActor {
                 self.announce_account(ctx, announce_account);
                 NetworkResponses::NoResponse
             }
-            NetworkRequests::PartialEncodedChunkRequest { target, request } => match target {
-                AccountIdOrPeerTrackingShard::AccountId(account_id) => {
-                    if self.send_message_to_account(
-                        ctx,
-                        &account_id,
-                        RoutedMessageBody::PartialEncodedChunkRequest(request),
-                    ) {
-                        NetworkResponses::NoResponse
-                    } else {
-                        NetworkResponses::RouteNotFound
-                    }
-                }
-                AccountIdOrPeerTrackingShard::PeerTrackingShard {
-                    shard_id,
-                    only_archival,
-                    fallback_account_id,
-                } => {
-                    let mut matching_peers = vec![];
-                    for (peer_id, active_peer) in self.active_peers.iter() {
-                        if (active_peer.full_peer_info.chain_info.archival || !only_archival)
-                            && active_peer
-                                .full_peer_info
-                                .chain_info
-                                .tracked_shards
-                                .contains(&shard_id)
-                        {
-                            matching_peers.push(peer_id.clone());
-                        }
-                    }
+            NetworkRequests::PartialEncodedChunkRequest { target, request } => {
+                let mut success = false;
 
-                    match matching_peers.iter().choose(&mut thread_rng()) {
-                        Some(matching_peer) => {
+                // Make two attempts to send the message. First following the preference of `prefer_peer`,
+                // and if it fails, against the preference.
+                for prefer_peer in &[target.prefer_peer, !target.prefer_peer] {
+                    if !prefer_peer {
+                        if let Some(account_id) = target.account_id.as_ref() {
+                            if self.send_message_to_account(
+                                ctx,
+                                &account_id,
+                                RoutedMessageBody::PartialEncodedChunkRequest(request.clone()),
+                            ) {
+                                success = true;
+                                break;
+                            }
+                        }
+                    } else {
+                        let mut matching_peers = vec![];
+                        for (peer_id, active_peer) in self.active_peers.iter() {
+                            if (active_peer.full_peer_info.chain_info.archival
+                                || !target.only_archival)
+                                && active_peer
+                                    .full_peer_info
+                                    .chain_info
+                                    .tracked_shards
+                                    .contains(&target.shard_id)
+                            {
+                                matching_peers.push(peer_id.clone());
+                            }
+                        }
+
+                        if let Some(matching_peer) = matching_peers.iter().choose(&mut thread_rng())
+                        {
                             if self.send_message_to_peer(
                                 ctx,
                                 RawRoutedMessage {
                                     target: AccountOrPeerIdOrHash::PeerId(matching_peer.clone()),
-                                    body: RoutedMessageBody::PartialEncodedChunkRequest(request),
+                                    body: RoutedMessageBody::PartialEncodedChunkRequest(
+                                        request.clone(),
+                                    ),
                                 },
                             ) {
-                                NetworkResponses::NoResponse
-                            } else {
-                                NetworkResponses::RouteNotFound
-                            }
-                        }
-                        None => {
-                            if let Some(fallback_account_id) = fallback_account_id {
-                                warn!("Chunk request for shard {} cannot be properly sent, because no known peer runs {} node tracking the shard. Falling back to sending to the block producer from the corresponding epoch.", shard_id, if only_archival { "an archival" } else { "a" });
-                                if self.send_message_to_account(
-                                    ctx,
-                                    &fallback_account_id,
-                                    RoutedMessageBody::PartialEncodedChunkRequest(request),
-                                ) {
-                                    NetworkResponses::NoResponse
-                                } else {
-                                    NetworkResponses::RouteNotFound
-                                }
-                            } else {
-                                error!("Chunk request for shard {} cannot be properly sent, because no known peer runs {} node tracking the shard. Dropping the request.", shard_id, if only_archival { "an archival" } else { "a" });
-                                NetworkResponses::NoResponse
+                                success = true;
+                                break;
                             }
                         }
                     }
                 }
-            },
+
+                if success {
+                    NetworkResponses::NoResponse
+                } else {
+                    NetworkResponses::RouteNotFound
+                }
+            }
             NetworkRequests::PartialEncodedChunkResponse { route_back, response } => {
                 if self.send_message_to_peer(
                     ctx,

--- a/chain/network/src/types.rs
+++ b/chain/network/src/types.rs
@@ -521,17 +521,23 @@ pub enum PeerIdOrHash {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Hash)]
-pub enum AccountIdOrPeerTrackingShard {
-    AccountId(AccountId),
-    // The request should be sent to any peer tracking shard.
-    // `fallback_account_id` is the account to sent the message to if no such peer exist. It is used
-    // to provide the block producer owning the part to cover situations when no peer is tracking
-    // shard, but the corresponding block producer is still online.
-    PeerTrackingShard {
-        shard_id: ShardId,
-        only_archival: bool,
-        fallback_account_id: Option<AccountId>,
-    },
+// Defines the destination for a network request.
+// The request should be sent either to the `account_id` as a routed message, or directly to
+// any peer that tracks the shard.
+// If `prefer_peer` is `true`, should be sent to the peer, unless no peer tracks the shard, in which
+// case fall back to sending to the account.
+// Otherwise, send to the account, unless we do not know the route, in which case send to the peer.
+pub struct AccountIdOrPeerTrackingShard {
+    pub shard_id: ShardId,
+    pub only_archival: bool,
+    pub account_id: Option<AccountId>,
+    pub prefer_peer: bool,
+}
+
+impl AccountIdOrPeerTrackingShard {
+    pub fn from_account(shard_id: ShardId, account_id: AccountId) -> Self {
+        Self { shard_id, only_archival: false, account_id: Some(account_id), prefer_peer: false }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize, Serialize, Hash)]

--- a/nightly/tests_for_nayduck.txt
+++ b/nightly/tests_for_nayduck.txt
@@ -57,11 +57,11 @@ pytest --timeout=240 contracts/gibberish.py
 
 # python stress tests
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions
-pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions packets_drop
-pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions local_network packets_drop
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart
 pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart packets_drop
+pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart wipe_data
+pytest --timeout=2000 stress/stress.py 3 3 3 0 staking transactions node_restart packets_drop wipe_data
 # pytest --timeout=2000 stress/stress.py 3 2 4 0 staking transactions node_set
 
 # pytest stress/network_stress.py

--- a/pytest/lib/cluster.py
+++ b/pytest/lib/cluster.py
@@ -139,8 +139,8 @@ class BaseNode(object):
                              [base64.b64encode(signed_tx).decode('utf8')],
                              timeout=timeout)
 
-    def get_status(self, check_storage=True):
-        r = requests.get("http://%s:%s/status" % self.rpc_addr(), timeout=2)
+    def get_status(self, check_storage=True, timeout=2):
+        r = requests.get("http://%s:%s/status" % self.rpc_addr(), timeout=timeout)
         r.raise_for_status()
         status = json.loads(r.content)
         if check_storage and status['sync_info']['syncing'] == False:

--- a/pytest/lib/proxy.py
+++ b/pytest/lib/proxy.py
@@ -195,16 +195,14 @@ def check_finish(server, global_stopped, local_stopped, error):
         local_stopped.value = 2
 
 
-async def bridge(reader, writer, handler_fn, global_stopped, local_stopped, error):
+async def bridge(reader, writer, handler_fn, global_stopped, local_stopped, bridge_stopped, error):
     bridge_id = random.randint(0, 10**10)
     logging.debug(f"Start bridge. port={_MY_PORT} bridge_id={bridge_id}")
 
     try:
-        while 0 == global_stopped.value and 0 >= local_stopped.value and 0 == error.value:
+        while 0 == global_stopped.value and 0 >= local_stopped.value and 0 == error.value and 0 == bridge_stopped[0]:
             header = await reader.read(4)
             if not header:
-                writer.close()
-                await writer.wait_closed()
                 logging.debug(
                     f"Endpoint closed (Reader). port={_MY_PORT} bridge_id={bridge_id}")
                 break
@@ -228,9 +226,19 @@ async def bridge(reader, writer, handler_fn, global_stopped, local_stopped, erro
                 writer.write(raw_message)
                 await writer.drain()
 
+        bridge_stopped[0] = 1
+        writer.close()
+        await writer.wait_closed()
+
         logging.debug(
             f"Gracefully close bridge. port={_MY_PORT} bridge_id={bridge_id}")
     except (ConnectionResetError, BrokenPipeError):
+        bridge_stopped[0] = 1
+        try:
+            writer.close()
+            await writer.wait_closed()
+        except:
+            pass
         logging.debug(
             f"Endpoint closed (Writer). port={_MY_PORT} bridge_id={bridge_id}")
 
@@ -244,16 +252,17 @@ async def handle_connection(outer_reader, outer_writer, inner_port, outer_port, 
 
         my_port = [outer_port]
         peer_port_holder = [None]
+        bridge_stopped = [0]
 
         inner_to_outer = bridge(inner_reader, outer_writer, functools.partial(
             handler._handle, writer=inner_writer, sender_port_holder=my_port, receiver_port_holder=peer_port_holder,
             ordinal_to_writer=handler.recv_from_map,
-        ), global_stopped, local_stopped, error)
+        ), global_stopped, local_stopped, bridge_stopped, error)
 
         outer_to_inner = bridge(outer_reader, inner_writer, functools.partial(
             handler._handle, writer=outer_writer, sender_port_holder=peer_port_holder, receiver_port_holder=my_port,
             ordinal_to_writer=handler.send_to_map,
-        ), global_stopped, local_stopped, error)
+        ), global_stopped, local_stopped, bridge_stopped, error)
 
         await asyncio.gather(inner_to_outer, outer_to_inner)
         logging.debug(


### PR DESCRIPTION
…ements

1. Adding `wipe_data` mode that, in conjunction with `node_reset`,
clears the data folder from time to time when the nodes are restarted
Making it a separate mode, because the timeouts are higher when nodes
need to resync, and the test with and without `wipe_data` tests
different scenarios.

2. Changing the way we fetch chunks. The request for chunk now always
includes the shard, and the preferred account_id, as well as the flag
indicating whether account_id or a peer tracking shard should be
preferred. The network code then first tries the preferred method, and
if it fails, falls back to the non-preferred. This fixes numerous
problems with syncing:

    1. A full node today fails to process the `Sync` message when it
    starts, because it doesn't have the information about the latest
    epoch. Thus, by the time it syncs to the current epoch, without the
    above change its attempts to request chunk parts fail, because no
    route to the chunk owners is known.

    2. If enough full nodes crash in the current validator set to not
    have data available among themselves, without the above change they
    cannot sync at all, even if some non-block producing full nodes
    exist that have all the chunks.

3. Also, for chunks that are not in the head / don't build on top of
head skip waiting for 400ms before we start fetching them from others.
The delay is needed because shortly after the chunk is produced only the
chunk producer has it (for others it is still being distributed), but
for chunks that are more than one block old this doesn't apply.

4. Fixing proxies not closing connections (Marcelo implemented it, I am
squashing it into my commit).

5. Fixing an issue that `node_restart` process was not killable when the
nodes are proxied, because the proxy processes were child processes for
the `node_restart`. Fixing it by iterating over proxies and explicitly
killing them half way into the cleanup timeout (we can't do it
immediatley, because some workers might still be running and expecting
the nodes to be live during the cleanup).

6. Changing the logic that rejects blocks at heights that were
previously processed to not reject any block that builds on top of the
current head. It is necessary, because otherwise a node that rejected
the current head early on due to `EpochOutOfBound`, and then syncs to
one height before the current head, will never accept the current head,
unless more blocks are built on top of it, because it will never request
the head, and will be rejecting it when it is sent to it proactively by
other nodes.

7. Fixing a minor bug that if a state sync is started less than
`STATE_FETCH_HORIZON` from the end of the first epoch, the sync hash
ends up being `CryptoHash::default()`, and state sync fails trying to
fetch the header.

8. Various small fixes in stress.py itself that decrease flakiness. Most
have a comment next to them.

Various modes still ocasionally fail. One failure is due to account
announces getting lost at the beginning of syncing. Marcelo provided me
with a temp fix for testing, but we are not pushing it at this moment,
so failures will stay for now.

Several more failures need further investigation.

Test plan
---------
Ran stress.py many times in Nayduck.