### PR TITLE
fix(store-validator): fix wrong failures on timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "actix",
  "actix-cors",

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -338,7 +338,7 @@ impl StoreValidator {
             }
             if let Some(timeout) = self.timeout {
                 if self.start_time.elapsed() > Duration::from_millis(timeout) {
-                    warn!(target: "adversary", "Store validator hit timeout after {:?} ({:?}/{:?})", col, col as usize, NUM_COLS);
+                    warn!(target: "adversary", "Store validator hit timeout at {:?} ({:?}/{:?})", col, col as usize, NUM_COLS);
                     return;
                 }
             }
@@ -346,6 +346,7 @@ impl StoreValidator {
         if let Some(timeout) = self.timeout {
             // We didn't complete all Column checks and cannot do final checks, returning here
             if self.start_time.elapsed() > Duration::from_millis(timeout) {
+                warn!(target: "adversary", "Store validator hit timeout before final checks");
                 return;
             }
         }

--- a/chain/chain/src/store_validator.rs
+++ b/chain/chain/src/store_validator.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use borsh::BorshDeserialize;
+use log::warn;
 use strum::IntoEnumIterator;
 
 use near_chain_configs::GenesisConfig;
@@ -334,6 +335,12 @@ impl StoreValidator {
         for col in DBCol::iter() {
             if let Err(e) = self.validate_col(col) {
                 self.process_error(e, col.to_string(), col)
+            }
+            if let Some(timeout) = self.timeout {
+                if self.start_time.elapsed() > Duration::from_millis(timeout) {
+                    warn!(target: "adversary", "Store validator hit timeout after {:?} ({:?}/{:?})", col, col as usize, NUM_COLS);
+                    return;
+                }
             }
         }
         if let Some(timeout) = self.timeout {


### PR DESCRIPTION
When store-validator times out, it was still validating
the first value in each column, which is wrong if it skipped
values in previous columns.

Fixes #3420, #3424

Test plan
---------
one_val.py many times