### PR TITLE
fix(genesis): Don't write genesis records on restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2428,6 +2428,7 @@ dependencies = [
  "num-rational 0.2.4",
  "serde",
  "serde_json",
+ "sha2",
  "smart-default",
 ]
 

--- a/core/chain-configs/Cargo.toml
+++ b/core/chain-configs/Cargo.toml
@@ -11,6 +11,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 smart-default = "0.6"
 num-rational = { version = "0.2.4", features = ["serde"] }
+sha2 = "0.8"
 
 near-crypto = { path = "../crypto" }
 near-primitives = { path = "../primitives" }

--- a/core/chain-configs/src/genesis_config.rs
+++ b/core/chain-configs/src/genesis_config.rs
@@ -3,6 +3,8 @@
 //! NOTE: chain-configs is not the best place for `GenesisConfig` since it
 //! contains `RuntimeConfig`, but we keep it here for now until we figure
 //! out the better place.
+use std::fs::File;
+use std::io::BufReader;
 use std::marker::PhantomData;
 use std::path::Path;
 
@@ -11,6 +13,7 @@ use num_rational::Rational;
 use serde::{Deserialize, Serialize};
 use smart_default::SmartDefault;
 
+use near_primitives::hash::CryptoHash;
 use near_primitives::serialize::{u128_dec_format, u128_dec_format_compatible};
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::{
@@ -160,9 +163,8 @@ impl GenesisConfig {
     /// It panics if file cannot be open or read, or the contents cannot be parsed from JSON to the
     /// GenesisConfig structure.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Self {
-        Self::from_json(
-            &std::fs::read_to_string(path).expect("Could not read genesis config file."),
-        )
+        let reader = BufReader::new(File::open(path).expect("Could not open genesis config file."));
+        serde_json::from_reader(reader).expect("Failed to deserialize the genesis records.")
     }
 
     /// Writes GenesisConfig to the file.
@@ -188,9 +190,8 @@ impl GenesisRecords {
     /// It panics if file cannot be open or read, or the contents cannot be parsed from JSON to the
     /// GenesisConfig structure.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Self {
-        Self::from_json(
-            &std::fs::read_to_string(path).expect("Could not read genesis records file."),
-        )
+        let reader = BufReader::new(File::open(path).expect("Could not open genesis config file."));
+        serde_json::from_reader(reader).expect("Failed to deserialize the genesis records.")
     }
 
     /// Writes GenesisRecords to the file.
@@ -212,8 +213,8 @@ impl Genesis {
 
     /// Reads Genesis from a single file.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Self {
-        serde_json::from_str(&std::fs::read_to_string(path).expect("Could not read genesis file."))
-            .expect("Failed to deserialize the genesis records.")
+        let reader = BufReader::new(File::open(path).expect("Could not open genesis config file."));
+        serde_json::from_reader(reader).expect("Failed to deserialize the genesis records.")
     }
 
     /// Reads Genesis from config and records files.
@@ -234,6 +235,16 @@ impl Genesis {
             serde_json::to_vec_pretty(self).expect("Error serializing the genesis config."),
         )
         .expect("Failed to create / write a genesis config file.");
+    }
+
+    /// Hash of the json-serialized input.
+    /// DEVNOTE: the representation is not unique, and could change on upgrade.
+    pub fn json_hash(&self) -> CryptoHash {
+        let mut digest = sha2::Sha256::default();
+        use sha2::digest::Digest;
+        serde_json::to_writer_pretty(&mut digest, self)
+            .expect("Error serializing the genesis config.");
+        CryptoHash(near_primitives::hash::Digest(digest.result().into()))
     }
 }
 

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -235,7 +235,7 @@ pub const LATEST_KNOWN_KEY: &[u8; 12] = b"LATEST_KNOWN";
 pub const LARGEST_TARGET_HEIGHT_KEY: &[u8; 21] = b"LARGEST_TARGET_HEIGHT";
 pub const VERSION_KEY: &[u8; 7] = b"VERSION";
 pub const GENESIS_JSON_HASH_KEY: &[u8; 17] = b"GENESIS_JSON_HASH";
-pub const GENESIS_STATE_ROOTS_KEY: &[u8; 19] = b"GENESIS_STATE_ROTOS";
+pub const GENESIS_STATE_ROOTS_KEY: &[u8; 19] = b"GENESIS_STATE_ROOTS";
 
 pub struct DBTransaction {
     pub ops: Vec<DBOp>,

--- a/core/store/src/db.rs
+++ b/core/store/src/db.rs
@@ -234,6 +234,8 @@ pub const FINAL_HEAD_KEY: &[u8; 10] = b"FINAL_HEAD";
 pub const LATEST_KNOWN_KEY: &[u8; 12] = b"LATEST_KNOWN";
 pub const LARGEST_TARGET_HEIGHT_KEY: &[u8; 21] = b"LARGEST_TARGET_HEIGHT";
 pub const VERSION_KEY: &[u8; 7] = b"VERSION";
+pub const GENESIS_JSON_HASH_KEY: &[u8; 17] = b"GENESIS_JSON_HASH";
+pub const GENESIS_STATE_ROOTS_KEY: &[u8; 19] = b"GENESIS_STATE_ROTOS";
 
 pub struct DBTransaction {
     pub ops: Vec<DBOp>,

--- a/core/store/src/lib.rs
+++ b/core/store/src/lib.rs
@@ -3,7 +3,9 @@ extern crate lazy_static;
 
 use std::fs::File;
 use std::io::{Read, Write};
+use std::ops::Deref;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::{fmt, io};
 
@@ -24,18 +26,18 @@ use near_primitives::hash::CryptoHash;
 use near_primitives::receipt::{Receipt, ReceivedData};
 use near_primitives::serialize::to_base;
 use near_primitives::trie_key::{trie_key_parsers, TrieKey};
-use near_primitives::types::AccountId;
+use near_primitives::types::{AccountId, StateRoot};
 
 pub use crate::db::refcount::decode_value_with_rc;
 use crate::db::refcount::encode_value_with_rc;
-use crate::db::{DBOp, DBTransaction, Database, RocksDB};
+use crate::db::{
+    DBOp, DBTransaction, Database, RocksDB, GENESIS_JSON_HASH_KEY, GENESIS_STATE_ROOTS_KEY,
+};
 pub use crate::trie::{
     iterator::TrieIterator, update::TrieUpdate, update::TrieUpdateIterator,
     update::TrieUpdateValuePtr, KeyForStateChanges, PartialStorage, ShardTries, Trie, TrieChanges,
     WrappedTrieChanges,
 };
-use std::ops::Deref;
-use std::pin::Pin;
 
 mod db;
 pub mod migrations;
@@ -464,4 +466,24 @@ pub fn remove_account(
         state_update.remove(TrieKey::ContractData { account_id: account_id.clone(), key });
     }
     Ok(())
+}
+
+pub fn get_genesis_state_roots(store: &Store) -> Result<Option<Vec<StateRoot>>, std::io::Error> {
+    store.get_ser::<Vec<StateRoot>>(DBCol::ColBlockMisc, GENESIS_STATE_ROOTS_KEY)
+}
+
+pub fn get_genesis_hash(store: &Store) -> Result<Option<CryptoHash>, std::io::Error> {
+    store.get_ser::<CryptoHash>(DBCol::ColBlockMisc, GENESIS_JSON_HASH_KEY)
+}
+
+pub fn set_genesis_hash(store_update: &mut StoreUpdate, genesis_hash: &CryptoHash) {
+    store_update
+        .set_ser::<CryptoHash>(DBCol::ColBlockMisc, GENESIS_JSON_HASH_KEY, genesis_hash)
+        .expect("Borsh cannot fail");
+}
+
+pub fn set_genesis_state_roots(store_update: &mut StoreUpdate, genesis_roots: &Vec<StateRoot>) {
+    store_update
+        .set_ser::<Vec<StateRoot>>(DBCol::ColBlockMisc, GENESIS_STATE_ROOTS_KEY, genesis_roots)
+        .expect("Borsh cannot fail");
 }

--- a/core/store/src/trie/update.rs
+++ b/core/store/src/trie/update.rs
@@ -134,6 +134,24 @@ impl TrieUpdate {
         Ok((trie_changes, state_changes))
     }
 
+    pub fn finalize_genesis(self) -> Result<TrieChanges, StorageError> {
+        assert!(self.prospective.is_empty(), "Finalize cannot be called with uncommitted changes.");
+        let TrieUpdate { trie, root, committed, .. } = self;
+        let trie_changes = trie.update(
+            &root,
+            committed.into_iter().map(|(k, changes_with_trie_key)| {
+                let data = changes_with_trie_key
+                    .changes
+                    .into_iter()
+                    .last()
+                    .expect("Committed entry should have at least one change")
+                    .data;
+                (k, data)
+            }),
+        )?;
+        Ok(trie_changes)
+    }
+
     /// Returns Error if the underlying storage fails
     pub fn iter(&self, key_prefix: &[u8]) -> Result<TrieUpdateIterator<'_>, StorageError> {
         TrieUpdateIterator::new(self, key_prefix, b"", None)

--- a/neard/src/runtime.rs
+++ b/neard/src/runtime.rs
@@ -238,7 +238,7 @@ impl NightshadeRuntime {
     }
 
     fn genesis_state_from_records(store: Arc<Store>, genesis: &Genesis) -> Vec<StateRoot> {
-        info!(target: "near", "Genesis state has {} records, computing state roots", genesis.records.0.len());
+        info!(target: "runtime", "Genesis state has {} records, computing state roots", genesis.records.0.len());
         let mut store_update = store.store_update();
         let mut state_roots = vec![];
         let num_shards = genesis.config.num_block_producer_seats_per_shard.len() as NumShards;

--- a/runtime/runtime/src/lib.rs
+++ b/runtime/runtime/src/lib.rs
@@ -43,6 +43,7 @@ use crate::config::{
 use crate::verifier::validate_receipt;
 pub use crate::verifier::{validate_transaction, verify_and_charge_transaction};
 use near_primitives::version::{ProtocolVersion, IMPLICIT_ACCOUNT_CREATION_PROTOCOL_VERSION};
+use std::borrow::Borrow;
 use std::rc::Rc;
 
 mod actions;
@@ -1277,11 +1278,14 @@ impl Runtime {
 
     /// It's okay to use unsafe math here, because this method should only be called on the trusted
     /// state records (e.g. at launch from genesis)
-    pub fn compute_storage_usage(&self, records: &[StateRecord]) -> HashMap<AccountId, u64> {
+    pub fn compute_storage_usage<Record: Borrow<StateRecord>>(
+        &self,
+        records: &[Record],
+    ) -> HashMap<AccountId, u64> {
         let mut result = HashMap::new();
         let config = &self.config.transaction_costs.storage_usage_config;
         for record in records {
-            let account_and_storage = match record {
+            let account_and_storage = match record.borrow() {
                 StateRecord::Account { account_id, .. } => {
                     Some((account_id.clone(), config.num_bytes_account))
                 }
@@ -1313,18 +1317,18 @@ impl Runtime {
     }
 
     /// Balances are account, publickey, initial_balance, initial_tx_stake
-    pub fn apply_genesis_state(
+    pub fn apply_genesis_state<Record: Borrow<StateRecord>>(
         &self,
         tries: ShardTries,
         shard_id: ShardId,
         validators: &[(AccountId, PublicKey, Balance)],
-        records: &[StateRecord],
+        records: &[Record],
     ) -> (StoreUpdate, StateRoot) {
         let mut state_update = tries.new_trie_update(shard_id, MerkleHash::default());
         let mut postponed_receipts: Vec<Receipt> = vec![];
         let mut delayed_receipts_indices = DelayedReceiptIndices::default();
         for record in records {
-            match record.clone() {
+            match record.borrow().clone() {
                 StateRecord::Account { account_id, account } => {
                     set_account(&mut state_update, account_id, &account);
                 }
@@ -1421,10 +1425,9 @@ impl Runtime {
             set_account(&mut state_update, account_id.clone(), &account);
         }
         state_update.commit(StateChangeCause::InitialState);
-        let trie_changes = state_update.finalize().expect("Genesis state update failed").0;
+        let trie_changes = state_update.finalize_genesis().expect("Genesis state update failed");
 
-        let (store_update, state_root) =
-            tries.apply_all(&trie_changes, shard_id).expect("Genesis state update failed");
+        let (store_update, state_root) = tries.apply_genesis(trie_changes, shard_id);
         (store_update, state_root)
     }
 }


### PR DESCRIPTION
- When the node starts for the first time, save the hash of genesis in
storage, and assert on every restart that same genesis is used.

- Save the genesis state roots on first start, and don't rebuild the
trie on every restart.

Fixes #3151
Fixes #3063

Test plan
---------
existing tests